### PR TITLE
Phase C: health CLI — .chitin metrics + pass/warn/fail surface

### DIFF
--- a/apps/cli/src/commands/health.ts
+++ b/apps/cli/src/commands/health.ts
@@ -8,6 +8,9 @@ export interface HealthReport {
   hook_failure_count: number;
   schema_drift_count: number;
   orphaned_chains: number;
+  dir_exists: boolean;
+  clock_skew_suspected: boolean;
+  latest_event_ts?: string;
 }
 
 export function registerHealth(program: Command): void {
@@ -24,11 +27,24 @@ export function registerHealth(program: Command): void {
         ['health', '--dir', chitinDir, '--window-hours', opts.windowHours],
         { encoding: 'utf8' },
       );
+      if (res.error) {
+        console.error(`chitin health: failed to start ${kernelBin}: ${res.error.message}`);
+        process.exit(3);
+      }
       if (res.status !== 0) {
-        console.error(res.stderr);
+        if (res.stderr) console.error(res.stderr);
         process.exit(res.status ?? 3);
       }
-      const report = JSON.parse(res.stdout) as HealthReport;
+      let report: HealthReport;
+      try {
+        report = JSON.parse(res.stdout) as HealthReport;
+      } catch (err) {
+        const snippet = res.stdout.slice(0, 200);
+        console.error(
+          `chitin health: could not parse kernel output: ${String(err)}\nstdout: ${snippet}`,
+        );
+        process.exit(3);
+      }
       printReport(report, chitinDir);
       process.exit(exitCode(report));
     });
@@ -42,6 +58,10 @@ export function renderReport(r: HealthReport, chitinDir: string): string[] {
   };
 
   lines.push(`chitin health — ${chitinDir}`);
+  if (!r.dir_exists) {
+    add('chitin dir', 'MISSING', 'fail');
+    return lines;
+  }
   add('events total', r.events_total, r.events_total > 0 ? 'pass' : 'warn');
   for (const [surface, count] of Object.entries(r.events_by_window)) {
     add(`  events / ${surface}`, count, count > 0 ? 'pass' : 'warn');
@@ -49,6 +69,9 @@ export function renderReport(r: HealthReport, chitinDir: string): string[] {
   add('hook failures', r.hook_failure_count, r.hook_failure_count === 0 ? 'pass' : 'fail');
   add('schema drift', r.schema_drift_count, r.schema_drift_count === 0 ? 'pass' : 'fail');
   add('orphaned chains', r.orphaned_chains, r.orphaned_chains === 0 ? 'pass' : 'warn');
+  if (r.clock_skew_suspected) {
+    add('clock skew', 'suspected', 'warn');
+  }
   return lines;
 }
 
@@ -57,6 +80,7 @@ function printReport(r: HealthReport, chitinDir: string): void {
 }
 
 export function exitCode(r: HealthReport): number {
+  if (!r.dir_exists) return 1;
   if (r.hook_failure_count > 0 || r.schema_drift_count > 0) return 1;
   return 0;
 }

--- a/apps/cli/src/commands/health.ts
+++ b/apps/cli/src/commands/health.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'node:child_process';
+import { resolveChitinDir } from '@chitin/contracts';
+import type { Command } from 'commander';
+
+interface HealthReport {
+  events_total: number;
+  events_by_window: Record<string, number>;
+  hook_failure_count: number;
+  schema_drift_count: number;
+  orphaned_chains: number;
+}
+
+export function registerHealth(program: Command): void {
+  program
+    .command('health')
+    .description('Dogfooding health metrics for the current .chitin')
+    .option('--window-hours <n>', 'window size in hours', '24')
+    .option('--chitin-dir <path>', 'override .chitin dir (default: resolve from cwd)')
+    .action((opts: { windowHours: string; chitinDir?: string }) => {
+      const chitinDir = opts.chitinDir ?? resolveChitinDir(process.cwd(), '');
+      const kernelBin = process.env.CHITIN_KERNEL_BINARY ?? 'chitin-kernel';
+      const res = spawnSync(
+        kernelBin,
+        ['health', '--dir', chitinDir, '--window-hours', opts.windowHours],
+        { encoding: 'utf8' },
+      );
+      if (res.status !== 0) {
+        console.error(res.stderr);
+        process.exit(res.status ?? 3);
+      }
+      const report = JSON.parse(res.stdout) as HealthReport;
+      printReport(report, chitinDir);
+      process.exit(exitCode(report));
+    });
+}
+
+function printReport(r: HealthReport, chitinDir: string): void {
+  const line = (label: string, value: string | number, status: 'pass' | 'warn' | 'fail') => {
+    const tag = status === 'pass' ? '[PASS]' : status === 'warn' ? '[WARN]' : '[FAIL]';
+    console.log(`${tag}  ${label.padEnd(28)} ${value}`);
+  };
+
+  console.log(`chitin health — ${chitinDir}`);
+  line('events total', r.events_total, r.events_total > 0 ? 'pass' : 'warn');
+  for (const [surface, count] of Object.entries(r.events_by_window)) {
+    line(`  events / ${surface}`, count, count > 0 ? 'pass' : 'warn');
+  }
+  line('hook failures', r.hook_failure_count, r.hook_failure_count === 0 ? 'pass' : 'fail');
+  line('schema drift', r.schema_drift_count, r.schema_drift_count === 0 ? 'pass' : 'fail');
+  line('orphaned chains', r.orphaned_chains, r.orphaned_chains === 0 ? 'pass' : 'warn');
+}
+
+function exitCode(r: HealthReport): number {
+  if (r.hook_failure_count > 0 || r.schema_drift_count > 0) return 1;
+  return 0;
+}

--- a/apps/cli/src/commands/health.ts
+++ b/apps/cli/src/commands/health.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { resolveChitinDir } from '@chitin/contracts';
 import type { Command } from 'commander';
 
-interface HealthReport {
+export interface HealthReport {
   events_total: number;
   events_by_window: Record<string, number>;
   hook_failure_count: number;
@@ -34,23 +34,29 @@ export function registerHealth(program: Command): void {
     });
 }
 
-function printReport(r: HealthReport, chitinDir: string): void {
-  const line = (label: string, value: string | number, status: 'pass' | 'warn' | 'fail') => {
+export function renderReport(r: HealthReport, chitinDir: string): string[] {
+  const lines: string[] = [];
+  const add = (label: string, value: string | number, status: 'pass' | 'warn' | 'fail') => {
     const tag = status === 'pass' ? '[PASS]' : status === 'warn' ? '[WARN]' : '[FAIL]';
-    console.log(`${tag}  ${label.padEnd(28)} ${value}`);
+    lines.push(`${tag}  ${label.padEnd(28)} ${value}`);
   };
 
-  console.log(`chitin health — ${chitinDir}`);
-  line('events total', r.events_total, r.events_total > 0 ? 'pass' : 'warn');
+  lines.push(`chitin health — ${chitinDir}`);
+  add('events total', r.events_total, r.events_total > 0 ? 'pass' : 'warn');
   for (const [surface, count] of Object.entries(r.events_by_window)) {
-    line(`  events / ${surface}`, count, count > 0 ? 'pass' : 'warn');
+    add(`  events / ${surface}`, count, count > 0 ? 'pass' : 'warn');
   }
-  line('hook failures', r.hook_failure_count, r.hook_failure_count === 0 ? 'pass' : 'fail');
-  line('schema drift', r.schema_drift_count, r.schema_drift_count === 0 ? 'pass' : 'fail');
-  line('orphaned chains', r.orphaned_chains, r.orphaned_chains === 0 ? 'pass' : 'warn');
+  add('hook failures', r.hook_failure_count, r.hook_failure_count === 0 ? 'pass' : 'fail');
+  add('schema drift', r.schema_drift_count, r.schema_drift_count === 0 ? 'pass' : 'fail');
+  add('orphaned chains', r.orphaned_chains, r.orphaned_chains === 0 ? 'pass' : 'warn');
+  return lines;
 }
 
-function exitCode(r: HealthReport): number {
+function printReport(r: HealthReport, chitinDir: string): void {
+  for (const line of renderReport(r, chitinDir)) console.log(line);
+}
+
+export function exitCode(r: HealthReport): number {
   if (r.hook_failure_count > 0 || r.schema_drift_count > 0) return 1;
   return 0;
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -7,6 +7,7 @@ import { initClaudeCodeCommand } from './commands/init-claude-code.js';
 import { registerRun } from './commands/run.js';
 import { registerEventsTree } from './commands/events-tree.js';
 import { registerInstall } from './commands/install.js';
+import { registerHealth } from './commands/health.js';
 
 const program = new Command();
 program.name('chitin').description('Observability-first substrate for AI coding agents');
@@ -37,6 +38,7 @@ program.command('replay <session_id>')
 registerRun(program);
 registerEventsTree(events);
 registerInstall(program);
+registerHealth(program);
 
 program.parseAsync(process.argv).catch((err) => {
   console.error(err);

--- a/apps/cli/tests/health.test.ts
+++ b/apps/cli/tests/health.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { exitCode, renderReport, type HealthReport } from '../src/commands/health';
+
+function mkReport(overrides: Partial<HealthReport> = {}): HealthReport {
+  return {
+    events_total: 0,
+    events_by_window: {},
+    hook_failure_count: 0,
+    schema_drift_count: 0,
+    orphaned_chains: 0,
+    ...overrides,
+  };
+}
+
+describe('exitCode', () => {
+  it('returns 0 when everything is zero', () => {
+    expect(exitCode(mkReport())).toBe(0);
+  });
+
+  it('returns 0 when only events_total is nonzero', () => {
+    expect(exitCode(mkReport({ events_total: 42 }))).toBe(0);
+  });
+
+  it('returns 1 on hook failures', () => {
+    expect(exitCode(mkReport({ hook_failure_count: 1 }))).toBe(1);
+  });
+
+  it('returns 1 on schema drift', () => {
+    expect(exitCode(mkReport({ schema_drift_count: 3 }))).toBe(1);
+  });
+
+  it('returns 1 when both hook failures and schema drift', () => {
+    expect(exitCode(mkReport({ hook_failure_count: 2, schema_drift_count: 5 }))).toBe(1);
+  });
+});
+
+describe('renderReport', () => {
+  it('renders WARN on zero events_total', () => {
+    const lines = renderReport(mkReport(), '/tmp/x');
+    expect(lines[0]).toBe('chitin health — /tmp/x');
+    expect(lines).toContain('[WARN]  events total                 0');
+  });
+
+  it('renders PASS on nonzero events_total', () => {
+    const lines = renderReport(mkReport({ events_total: 5 }), '/tmp/x');
+    expect(lines.some((l) => l.startsWith('[PASS]') && l.includes('events total'))).toBe(true);
+  });
+
+  it('renders one row per surface', () => {
+    const r = mkReport({
+      events_total: 3,
+      events_by_window: { 'claude-code': 2, 'gh-actions': 1 },
+    });
+    const lines = renderReport(r, '/tmp/x');
+    expect(lines.some((l) => l.includes('events / claude-code'))).toBe(true);
+    expect(lines.some((l) => l.includes('events / gh-actions'))).toBe(true);
+  });
+
+  it('renders FAIL on hook_failure_count > 0', () => {
+    const lines = renderReport(mkReport({ hook_failure_count: 4 }), '/tmp/x');
+    expect(lines.some((l) => l.startsWith('[FAIL]') && l.includes('hook failures'))).toBe(true);
+  });
+
+  it('renders FAIL on schema_drift_count > 0', () => {
+    const lines = renderReport(mkReport({ schema_drift_count: 2 }), '/tmp/x');
+    expect(lines.some((l) => l.startsWith('[FAIL]') && l.includes('schema drift'))).toBe(true);
+  });
+
+  it('renders WARN on orphaned_chains > 0', () => {
+    const lines = renderReport(mkReport({ orphaned_chains: 1 }), '/tmp/x');
+    expect(lines.some((l) => l.startsWith('[WARN]') && l.includes('orphaned chains'))).toBe(true);
+  });
+});

--- a/apps/cli/tests/health.test.ts
+++ b/apps/cli/tests/health.test.ts
@@ -8,6 +8,8 @@ function mkReport(overrides: Partial<HealthReport> = {}): HealthReport {
     hook_failure_count: 0,
     schema_drift_count: 0,
     orphaned_chains: 0,
+    dir_exists: true,
+    clock_skew_suspected: false,
     ...overrides,
   };
 }
@@ -31,6 +33,14 @@ describe('exitCode', () => {
 
   it('returns 1 when both hook failures and schema drift', () => {
     expect(exitCode(mkReport({ hook_failure_count: 2, schema_drift_count: 5 }))).toBe(1);
+  });
+
+  it('returns 1 when chitin dir is missing', () => {
+    expect(exitCode(mkReport({ dir_exists: false }))).toBe(1);
+  });
+
+  it('clock skew alone does not force exit 1', () => {
+    expect(exitCode(mkReport({ clock_skew_suspected: true }))).toBe(0);
   });
 });
 
@@ -69,5 +79,23 @@ describe('renderReport', () => {
   it('renders WARN on orphaned_chains > 0', () => {
     const lines = renderReport(mkReport({ orphaned_chains: 1 }), '/tmp/x');
     expect(lines.some((l) => l.startsWith('[WARN]') && l.includes('orphaned chains'))).toBe(true);
+  });
+
+  it('renders FAIL with chitin dir MISSING and skips other rows when dir missing', () => {
+    const lines = renderReport(mkReport({ dir_exists: false }), '/bogus/path');
+    expect(lines[0]).toBe('chitin health — /bogus/path');
+    expect(lines.some((l) => l.startsWith('[FAIL]') && l.includes('chitin dir') && l.includes('MISSING'))).toBe(true);
+    expect(lines.some((l) => l.includes('events total'))).toBe(false);
+    expect(lines.some((l) => l.includes('hook failures'))).toBe(false);
+  });
+
+  it('renders a clock skew WARN row when suspected', () => {
+    const lines = renderReport(mkReport({ clock_skew_suspected: true }), '/tmp/x');
+    expect(lines.some((l) => l.startsWith('[WARN]') && l.includes('clock skew'))).toBe(true);
+  });
+
+  it('does not render a clock skew row when not suspected', () => {
+    const lines = renderReport(mkReport({ clock_skew_suspected: false }), '/tmp/x');
+    expect(lines.some((l) => l.includes('clock skew'))).toBe(false);
   });
 });

--- a/docs/observations/runbooks/health.md
+++ b/docs/observations/runbooks/health.md
@@ -1,0 +1,71 @@
+# `chitin health` runbook
+
+What each output row means and what to do when it's not green.
+
+`chitin health` exits **0** iff every row is `[PASS]` or `[WARN]`. Exits **1**
+if any row is `[FAIL]` or the `.chitin` dir is missing. CI should gate on the
+exit code; humans should read the table.
+
+## Output rows
+
+### `chitin dir MISSING` — [FAIL]
+
+The `.chitin/` state dir at the resolved path does not exist.
+
+**Do:**
+
+1. If on a fresh box: run `chitin install --surface claude-code --global`. This creates `$HOME/.chitin/` and wires the Claude Code hook.
+2. If on an existing box: the resolver may have walked up from cwd and fallen back to `$HOME/.chitin/` which you haven't created. Check `pwd` — if you expected to report on a repo-local `.chitin/`, it isn't there. `chitin-kernel init --dir .chitin` creates one in the current dir.
+3. If passing `--chitin-dir` directly: verify the path. A typo here currently reads as "cleanly installed but no events," which this row is designed to catch.
+
+### `events total 0` — [WARN]
+
+No events in the window. Either nothing has run through the hook in the last 24h, or the hook isn't wired.
+
+**Do:**
+
+1. Run anything through Claude Code in a dir with `.chitin/`. Re-run `chitin health`.
+2. If still zero: check `cat ~/.claude/settings.json` for a `PreToolUse` hook entry pointing at chitin. `chitin install --surface claude-code --global` will repair it.
+3. If events arrive but the window is empty, widen: `chitin health --window-hours 168`.
+
+### `hook failures > 0` — [FAIL]
+
+`kernel-errors.log` has non-empty lines — the hook crashed N times.
+
+**Do (shed order):**
+
+1. **Stop before autopsy.** Check `tail -n 20 .chitin/kernel-errors.log` to see the last errors. If they are `parse_event` on malformed JSON, the hook is wedged and every Claude Code invocation is failing silently — priority one.
+2. Identify the failure class:
+   - `parse_event` → adapter is sending malformed envelopes; check adapter version.
+   - `sqlite_busy` → concurrent emits; rare but possible on heavy parallel agents.
+   - `chitindir_resolve` → resolver can't find a writable `.chitin/`; check `$HOME` perms.
+3. After fixing, truncate the log: `: > .chitin/kernel-errors.log` — then re-run `chitin health` to confirm.
+
+### `schema drift > 0` — [FAIL]
+
+Events that violate the v2 contract (parse fail, missing `schema_version`, `schema_version != "2"`, empty `surface`, unparseable `ts`).
+
+**Do:**
+
+1. Most common cause: legacy events from a pre-v2 kernel still in `events.jsonl`. Confirm with `head -1 .chitin/events.jsonl | jq .`. If `schema_version` is null or `"1"`, archive the file (`mv .chitin/events.jsonl .chitin/events.jsonl.legacy-$(date +%s)`) and let the kernel start fresh.
+2. Less common: a corrupted line (truncated mid-write, partial UTF-8). Use `jq -c . .chitin/events.jsonl > /dev/null` to find the bad line.
+3. If the drift persists after archiving legacy data, the adapter is emitting malformed envelopes — file a ledger entry.
+
+### `orphaned chains > 0` — [WARN]
+
+Reserved. Not yet computed; always 0. Will be wired in Phase D via an `events.db` scan.
+
+### `clock skew suspected` — [WARN]
+
+An event has a `ts` > 1h in the future.
+
+**Do:**
+
+1. `timedatectl status` (linux) / `sntp -sS time.apple.com` (mac) to resync.
+2. If containerized: check the container's epoch. A container booted from a bad clock will stamp events in the future; fix at the container runtime.
+3. After resync, re-run `chitin health`. The warning will clear on the next event write; existing misstamped events will age out of the window.
+
+## Known limitations (tracked for Phase D ledger)
+
+- **Large JSONL scans are O(n) with no timeout.** A 1GB `events.jsonl` can take minutes; no progress indicator. Future: cap scan duration, return partial with `truncated: true`.
+- **Silent `$HOME/.chitin` fallback.** If cwd has no `.chitin/`, the resolver quietly uses `$HOME/.chitin/`. The output header labels the resolved dir, but operators skim. Future: render a `[WARN]` when resolved dir ≠ cwd-local `.chitin/`.

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -363,12 +363,21 @@ func cmdHealth(args []string) {
 	dir := fs.String("dir", ".chitin", "path to .chitin state dir")
 	windowHours := fs.Int("window-hours", 24, "window size in hours")
 	fs.Parse(args)
-	absDir, _ := filepath.Abs(*dir)
+	if *windowHours <= 0 {
+		exitErr("invalid_window_hours", "--window-hours must be > 0")
+	}
+	absDir, err := filepath.Abs(*dir)
+	if err != nil {
+		exitErr("health_abs", err.Error())
+	}
 	rep, err := health.Gather(absDir, time.Duration(*windowHours)*time.Hour)
 	if err != nil {
 		exitErr("health", err.Error())
 	}
-	out, _ := json.Marshal(rep)
+	out, err := json.Marshal(rep)
+	if err != nil {
+		exitErr("health_marshal", err.Error())
+	}
 	fmt.Println(string(out))
 }
 

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/emit"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/health"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/hookinstall"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/ingest"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/kstate"
@@ -41,6 +43,8 @@ func main() {
 		cmdInstall(args)
 	case "uninstall":
 		cmdUninstall(args)
+	case "health":
+		cmdHealth(args)
 	default:
 		exitErr("unknown_subcommand", sub)
 	}
@@ -352,6 +356,20 @@ func cmdUninstall(args []string) {
 		exitErr("unknown_surface", *surface)
 	}
 	fmt.Println(`{"ok":true}`)
+}
+
+func cmdHealth(args []string) {
+	fs := flag.NewFlagSet("health", flag.ExitOnError)
+	dir := fs.String("dir", ".chitin", "path to .chitin state dir")
+	windowHours := fs.Int("window-hours", 24, "window size in hours")
+	fs.Parse(args)
+	absDir, _ := filepath.Abs(*dir)
+	rep, err := health.Gather(absDir, time.Duration(*windowHours)*time.Hour)
+	if err != nil {
+		exitErr("health", err.Error())
+	}
+	out, _ := json.Marshal(rep)
+	fmt.Println(string(out))
 }
 
 func exitErr(kind, msg string) {

--- a/go/execution-kernel/internal/health/health.go
+++ b/go/execution-kernel/internal/health/health.go
@@ -15,26 +15,41 @@ import (
 
 // Report is the shape `chitin health` presents.
 type Report struct {
-	WindowStart      time.Time      `json:"window_start"`
-	EventsByWindow   map[string]int `json:"events_by_window"`
-	EventsTotal      int            `json:"events_total"`
-	HookFailureCount int            `json:"hook_failure_count"`
-	SchemaDriftCount int            `json:"schema_drift_count"`
-	OrphanedChains   int            `json:"orphaned_chains"`
+	WindowStart         time.Time      `json:"window_start"`
+	DirExists           bool           `json:"dir_exists"`
+	EventsByWindow      map[string]int `json:"events_by_window"`
+	EventsTotal         int            `json:"events_total"`
+	HookFailureCount    int            `json:"hook_failure_count"`
+	SchemaDriftCount    int            `json:"schema_drift_count"`
+	OrphanedChains      int            `json:"orphaned_chains"`
+	LatestEventTs       time.Time      `json:"latest_event_ts,omitempty"`
+	ClockSkewSuspected  bool           `json:"clock_skew_suspected"`
 }
+
+// clockSkewFutureTolerance bounds how far ahead of wall-clock an event ts may
+// be before we flag it. 1h absorbs NTP jitter + cross-box clock drift without
+// swallowing real skew (NTP resync across DST, resumed laptop, container
+// with bad epoch).
+const clockSkewFutureTolerance = 1 * time.Hour
 
 // Gather scans a single .chitin directory and produces a Report for the
 // window ending now and lasting `window` duration.
 func Gather(chitinDir string, window time.Duration) (Report, error) {
+	now := time.Now().UTC()
 	r := Report{
-		WindowStart:    time.Now().Add(-window).UTC(),
+		WindowStart:    now.Add(-window),
 		EventsByWindow: map[string]int{},
 	}
 
 	entries, err := os.ReadDir(chitinDir)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return r, nil
+		}
 		return r, fmt.Errorf("read .chitin dir: %w", err)
 	}
+	r.DirExists = true
+
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -92,6 +107,12 @@ func scanJSONL(path string, r *Report) error {
 		if err != nil {
 			r.SchemaDriftCount++
 			continue
+		}
+		if t.After(r.LatestEventTs) {
+			r.LatestEventTs = t
+		}
+		if t.After(time.Now().UTC().Add(clockSkewFutureTolerance)) {
+			r.ClockSkewSuspected = true
 		}
 		if t.Before(r.WindowStart) {
 			continue

--- a/go/execution-kernel/internal/health/health.go
+++ b/go/execution-kernel/internal/health/health.go
@@ -55,14 +55,21 @@ func Gather(chitinDir string, window time.Duration) (Report, error) {
 	return r, nil
 }
 
+// Invariant: an event counts toward EventsTotal/EventsByWindow iff it parses,
+// has schema_version == "2", has a non-empty surface, and has ts inside the
+// window. Any other shape is schema drift (bumped exactly once per line) and
+// does not count as a real event.
 func scanJSONL(path string, r *Report) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil // missing jsonl is fine
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("open jsonl %q: %w", path, err)
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 1<<20), 1<<24) // allow long lines
+	sc.Buffer(make([]byte, 1<<20), 1<<24)
 	for sc.Scan() {
 		var ev struct {
 			TS      string `json:"ts"`
@@ -73,11 +80,17 @@ func scanJSONL(path string, r *Report) error {
 			r.SchemaDriftCount++
 			continue
 		}
-		if ev.Schema != "" && ev.Schema != "2" {
+		if ev.Schema != "2" {
 			r.SchemaDriftCount++
+			continue
+		}
+		if ev.Surface == "" {
+			r.SchemaDriftCount++
+			continue
 		}
 		t, err := time.Parse(time.RFC3339, ev.TS)
 		if err != nil {
+			r.SchemaDriftCount++
 			continue
 		}
 		if t.Before(r.WindowStart) {
@@ -92,7 +105,10 @@ func scanJSONL(path string, r *Report) error {
 func scanErrorLog(path string, r *Report) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil // missing is fine
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("open error log: %w", err)
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)

--- a/go/execution-kernel/internal/health/health.go
+++ b/go/execution-kernel/internal/health/health.go
@@ -1,0 +1,107 @@
+// Package health gathers dogfooding health metrics.
+package health
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Report is the shape `chitin health` presents.
+type Report struct {
+	WindowStart      time.Time      `json:"window_start"`
+	EventsByWindow   map[string]int `json:"events_by_window"`
+	EventsTotal      int            `json:"events_total"`
+	HookFailureCount int            `json:"hook_failure_count"`
+	SchemaDriftCount int            `json:"schema_drift_count"`
+	OrphanedChains   int            `json:"orphaned_chains"`
+}
+
+// Gather scans a single .chitin directory and produces a Report for the
+// window ending now and lasting `window` duration.
+func Gather(chitinDir string, window time.Duration) (Report, error) {
+	r := Report{
+		WindowStart:    time.Now().Add(-window).UTC(),
+		EventsByWindow: map[string]int{},
+	}
+
+	entries, err := os.ReadDir(chitinDir)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return r, fmt.Errorf("read .chitin dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		if err := scanJSONL(filepath.Join(chitinDir, name), &r); err != nil {
+			return r, err
+		}
+	}
+
+	errLog := filepath.Join(chitinDir, "kernel-errors.log")
+	if err := scanErrorLog(errLog, &r); err != nil {
+		return r, err
+	}
+	return r, nil
+}
+
+func scanJSONL(path string, r *Report) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil // missing jsonl is fine
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<24) // allow long lines
+	for sc.Scan() {
+		var ev struct {
+			TS      string `json:"ts"`
+			Surface string `json:"surface"`
+			Schema  string `json:"schema_version"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &ev); err != nil {
+			r.SchemaDriftCount++
+			continue
+		}
+		if ev.Schema != "" && ev.Schema != "2" {
+			r.SchemaDriftCount++
+		}
+		t, err := time.Parse(time.RFC3339, ev.TS)
+		if err != nil {
+			continue
+		}
+		if t.Before(r.WindowStart) {
+			continue
+		}
+		r.EventsTotal++
+		r.EventsByWindow[ev.Surface]++
+	}
+	return sc.Err()
+}
+
+func scanErrorLog(path string, r *Report) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil // missing is fine
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		r.HookFailureCount++
+	}
+	return sc.Err()
+}

--- a/go/execution-kernel/internal/health/health_test.go
+++ b/go/execution-kernel/internal/health/health_test.go
@@ -19,7 +19,9 @@ func TestGather_CountsEventsInLastWindow(t *testing.T) {
 		`{"schema_version":"2","ts":"` + recent + `","event_type":"session_start","surface":"claude-code"}`,
 		`{"schema_version":"2","ts":"` + recent + `","event_type":"session_end","surface":"claude-code"}`,
 	}
-	os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+	if err := os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
 
 	rep, err := Gather(dir, 24*time.Hour)
 	if err != nil {
@@ -31,12 +33,17 @@ func TestGather_CountsEventsInLastWindow(t *testing.T) {
 	if rep.HookFailureCount != 0 {
 		t.Errorf("want 0 hook failures, got %d", rep.HookFailureCount)
 	}
+	if rep.SchemaDriftCount != 0 {
+		t.Errorf("want 0 schema drift, got %d", rep.SchemaDriftCount)
+	}
 }
 
 func TestGather_DetectsHookFailureRecords(t *testing.T) {
 	dir := t.TempDir()
 	log := filepath.Join(dir, "kernel-errors.log")
-	os.WriteFile(log, []byte(`{"ts":"2026-04-19T10:00:00Z","error":"emit","message":"parse_event"}`+"\n"), 0o644)
+	if err := os.WriteFile(log, []byte(`{"ts":"2026-04-19T10:00:00Z","error":"emit","message":"parse_event"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
 
 	rep, err := Gather(dir, 24*time.Hour)
 	if err != nil {
@@ -44,5 +51,77 @@ func TestGather_DetectsHookFailureRecords(t *testing.T) {
 	}
 	if rep.HookFailureCount != 1 {
 		t.Errorf("want 1 hook failure, got %d", rep.HookFailureCount)
+	}
+}
+
+// Drift invariant: an event counts toward EventsTotal iff it parses, has
+// schema_version == "2", has non-empty surface, and has a parseable ts. Any
+// other shape bumps SchemaDriftCount exactly once and is NOT counted as a
+// real event.
+func TestGather_SchemaDriftRules(t *testing.T) {
+	dir := t.TempDir()
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	lines := []string{
+		// Valid — counted
+		`{"schema_version":"2","ts":"` + recent + `","event_type":"session_start","surface":"claude-code"}`,
+		// Drift: parse failure
+		`{not json`,
+		// Drift: schema_version missing
+		`{"ts":"` + recent + `","surface":"claude-code"}`,
+		// Drift: schema_version != "2"
+		`{"schema_version":"1","ts":"` + recent + `","surface":"claude-code"}`,
+		// Drift: surface missing
+		`{"schema_version":"2","ts":"` + recent + `"}`,
+		// Drift: surface empty
+		`{"schema_version":"2","ts":"` + recent + `","surface":""}`,
+		// Drift: unparseable ts
+		`{"schema_version":"2","ts":"not-a-date","surface":"claude-code"}`,
+	}
+	jsonl := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.EventsTotal != 1 {
+		t.Errorf("want 1 valid event, got %d", rep.EventsTotal)
+	}
+	if rep.SchemaDriftCount != 6 {
+		t.Errorf("want 6 drift events, got %d", rep.SchemaDriftCount)
+	}
+}
+
+// Open-error propagation: a non-ErrNotExist error on a *.jsonl file must not
+// be silenced into a zero report. Simulate by making the file unreadable.
+func TestGather_PropagatesNonErrNotExistOnJSONL(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file mode permission checks")
+	}
+	dir := t.TempDir()
+	jsonl := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o000); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(jsonl, 0o644) })
+
+	_, err := Gather(dir, 24*time.Hour)
+	if err == nil {
+		t.Errorf("want permission error, got nil")
+	}
+}
+
+// ErrNotExist on jsonl is still silenced — missing files are the normal path
+// for a fresh .chitin.
+func TestGather_SilencesMissingJSONL(t *testing.T) {
+	dir := t.TempDir()
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("want no error on empty dir, got %v", err)
+	}
+	if rep.EventsTotal != 0 {
+		t.Errorf("want 0 events, got %d", rep.EventsTotal)
 	}
 }

--- a/go/execution-kernel/internal/health/health_test.go
+++ b/go/execution-kernel/internal/health/health_test.go
@@ -1,0 +1,48 @@
+package health
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGather_CountsEventsInLastWindow(t *testing.T) {
+	dir := t.TempDir()
+	jsonl := filepath.Join(dir, "events.jsonl")
+	now := time.Now().UTC()
+	old := now.Add(-48 * time.Hour).Format(time.RFC3339)
+	recent := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	lines := []string{
+		`{"schema_version":"2","ts":"` + old + `","event_type":"session_start","surface":"claude-code"}`,
+		`{"schema_version":"2","ts":"` + recent + `","event_type":"session_start","surface":"claude-code"}`,
+		`{"schema_version":"2","ts":"` + recent + `","event_type":"session_end","surface":"claude-code"}`,
+	}
+	os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.EventsByWindow["claude-code"] != 2 {
+		t.Errorf("want 2 recent claude-code events, got %d", rep.EventsByWindow["claude-code"])
+	}
+	if rep.HookFailureCount != 0 {
+		t.Errorf("want 0 hook failures, got %d", rep.HookFailureCount)
+	}
+}
+
+func TestGather_DetectsHookFailureRecords(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "kernel-errors.log")
+	os.WriteFile(log, []byte(`{"ts":"2026-04-19T10:00:00Z","error":"emit","message":"parse_event"}`+"\n"), 0o644)
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.HookFailureCount != 1 {
+		t.Errorf("want 1 hook failure, got %d", rep.HookFailureCount)
+	}
+}

--- a/go/execution-kernel/internal/health/health_test.go
+++ b/go/execution-kernel/internal/health/health_test.go
@@ -124,4 +124,62 @@ func TestGather_SilencesMissingJSONL(t *testing.T) {
 	if rep.EventsTotal != 0 {
 		t.Errorf("want 0 events, got %d", rep.EventsTotal)
 	}
+	if !rep.DirExists {
+		t.Errorf("want DirExists=true for extant tempdir")
+	}
+}
+
+// When the .chitin dir itself doesn't exist, DirExists must be false and no
+// error returned — the caller decides how to surface the missing dir.
+func TestGather_AbsentDirSetsDirExistsFalse(t *testing.T) {
+	parent := t.TempDir()
+	missing := filepath.Join(parent, "nope")
+	rep, err := Gather(missing, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("want no error on missing dir, got %v", err)
+	}
+	if rep.DirExists {
+		t.Errorf("want DirExists=false for nonexistent dir")
+	}
+	if rep.EventsTotal != 0 {
+		t.Errorf("want 0 events, got %d", rep.EventsTotal)
+	}
+}
+
+// Clock-skew detection: an event stamped more than 1h in the future flags
+// ClockSkewSuspected. Events without skew do not.
+func TestGather_DetectsClockSkewFromFutureTs(t *testing.T) {
+	dir := t.TempDir()
+	future := time.Now().UTC().Add(48 * time.Hour).Format(time.RFC3339)
+	jsonl := filepath.Join(dir, "events.jsonl")
+	line := `{"schema_version":"2","ts":"` + future + `","event_type":"session_start","surface":"claude-code"}`
+	if err := os.WriteFile(jsonl, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.ClockSkewSuspected {
+		t.Errorf("want ClockSkewSuspected=true for future-stamped event")
+	}
+}
+
+func TestGather_NoClockSkewOnRecentEvents(t *testing.T) {
+	dir := t.TempDir()
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	jsonl := filepath.Join(dir, "events.jsonl")
+	line := `{"schema_version":"2","ts":"` + recent + `","event_type":"session_start","surface":"claude-code"}`
+	if err := os.WriteFile(jsonl, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.ClockSkewSuspected {
+		t.Errorf("want ClockSkewSuspected=false for recent event")
+	}
 }


### PR DESCRIPTION
## Summary

Phase C of the dogfood-debt-ledger plan. Gives the kernel and CLI a way to answer *is dogfooding actually happening* without hand-grepping JSONL.

- **C1** `internal/health.Gather(dir, window)` — counts JSONL events per-surface inside the window, counts `kernel-errors.log` non-empty lines as hook failures, bumps `schema_drift_count` on parse failure or `schema_version ≠ "2"`. Missing dir/files return zeros silently (designed so a fresh box doesn't false-FAIL).
- **C2** `chitin-kernel health --dir <path> --window-hours <n>` — JSON report to stdout.
- **C3** `chitin health` CLI wrapper — resolves `.chitin` via the shared contracts helper, shells out to the kernel, prints a `[PASS]/[WARN]/[FAIL]` table. Exit 1 iff `hook_failure_count > 0` or `schema_drift_count > 0`.

Plan reference: \`docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md\` §Phase C.

## Test Plan

- [x] \`go test ./internal/health/... -v\` — 2 pass (window boundary, hook failure detection)
- [x] \`go test ./...\` full kernel suite — all pass
- [x] \`nx build execution-kernel\` — builds clean
- [x] \`nx run cli:test\` — 7 pass
- [x] Smoke: \`chitin-kernel health --dir /tmp/chk/.chitin\` against a 1-event fixture returns \`"events_total":1\`
- [x] Smoke: \`chitin health\` renders pass/warn/fail table, exits 0 on clean state
- [ ] Copilot review
- [ ] Adversarial review

## Out of scope

- \`orphaned_chains\` detection (placeholder 0; Phase D will wire this via events.db scan).
- Typecheck breakage in \`libs/contracts/src/\` (missing \`.js\` extensions under nodenext) is pre-existing on \`main\` — tracked separately.

## Scope handoff

Per the Knuth soul note: Phase C is the last boundary-correctness scope for this lens. On merge, swap back to da Vinci for Phase D/E/F (cross-surface architecture — ledger tooling, CI composite action, openclaw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)