### PR TITLE
Phase C follow-up: address missed Copilot findings + Hamilton strike

### DIFF
--- a/apps/cli/src/commands/health.ts
+++ b/apps/cli/src/commands/health.ts
@@ -11,6 +11,7 @@ export interface HealthReport {
   dir_exists: boolean;
   clock_skew_suspected: boolean;
   latest_event_ts?: string;
+  failed_files?: string[];
 }
 
 export function registerHealth(program: Command): void {
@@ -71,6 +72,12 @@ export function renderReport(r: HealthReport, chitinDir: string): string[] {
   add('orphaned chains', r.orphaned_chains, r.orphaned_chains === 0 ? 'pass' : 'warn');
   if (r.clock_skew_suspected) {
     add('clock skew', 'suspected', 'warn');
+  }
+  if (r.failed_files && r.failed_files.length > 0) {
+    add('failed files', r.failed_files.length, 'warn');
+    for (const entry of r.failed_files) {
+      lines.push(`        ${entry}`);
+    }
   }
   return lines;
 }

--- a/apps/cli/tests/health.test.ts
+++ b/apps/cli/tests/health.test.ts
@@ -98,4 +98,20 @@ describe('renderReport', () => {
     const lines = renderReport(mkReport({ clock_skew_suspected: false }), '/tmp/x');
     expect(lines.some((l) => l.includes('clock skew'))).toBe(false);
   });
+
+  it('renders a WARN row and per-entry lines when failed_files is non-empty', () => {
+    const lines = renderReport(
+      mkReport({ failed_files: ['/foo/events-bad.jsonl: permission denied'] }),
+      '/tmp/x',
+    );
+    expect(lines.some((l) => l.startsWith('[WARN]') && l.includes('failed files'))).toBe(true);
+    expect(lines.some((l) => l.includes('events-bad.jsonl: permission denied'))).toBe(true);
+  });
+
+  it('omits failed_files section when undefined or empty', () => {
+    const linesEmpty = renderReport(mkReport({ failed_files: [] }), '/tmp/x');
+    const linesUndef = renderReport(mkReport(), '/tmp/x');
+    expect(linesEmpty.some((l) => l.includes('failed files'))).toBe(false);
+    expect(linesUndef.some((l) => l.includes('failed files'))).toBe(false);
+  });
 });

--- a/docs/observations/runbooks/health.md
+++ b/docs/observations/runbooks/health.md
@@ -45,10 +45,12 @@ No events in the window. Either nothing has run through the hook in the last 24h
 
 Events that violate the v2 contract (parse fail, missing `schema_version`, `schema_version != "2"`, empty `surface`, unparseable `ts`).
 
+The kernel emits events to `.chitin/events-<run_id>.jsonl` (one file per run). `chitin health` scans every `*.jsonl` under the dir, so a drift count reflects events across all run files.
+
 **Do:**
 
-1. Most common cause: legacy events from a pre-v2 kernel still in `events.jsonl`. Confirm with `head -1 .chitin/events.jsonl | jq .`. If `schema_version` is null or `"1"`, archive the file (`mv .chitin/events.jsonl .chitin/events.jsonl.legacy-$(date +%s)`) and let the kernel start fresh.
-2. Less common: a corrupted line (truncated mid-write, partial UTF-8). Use `jq -c . .chitin/events.jsonl > /dev/null` to find the bad line.
+1. Most common cause: legacy events from a pre-v2 kernel. Find candidates with `ls -1 .chitin/events-*.jsonl` and check one: `head -1 .chitin/events-<run_id>.jsonl | jq .`. If `schema_version` is null or `"1"`, archive that run file: `mv .chitin/events-<run_id>.jsonl .chitin/events-<run_id>.jsonl.legacy-$(date +%s)` and let newer runs accumulate cleanly.
+2. Less common: a corrupted line (truncated mid-write, partial UTF-8). Walk the files: `for f in .chitin/events-*.jsonl; do jq -c . "$f" > /dev/null || echo "bad: $f"; done`.
 3. If the drift persists after archiving legacy data, the adapter is emitting malformed envelopes — file a ledger entry.
 
 ### `orphaned chains > 0` — [WARN]
@@ -67,5 +69,5 @@ An event has a `ts` > 1h in the future.
 
 ## Known limitations (tracked for Phase D ledger)
 
-- **Large JSONL scans are O(n) with no timeout.** A 1GB `events.jsonl` can take minutes; no progress indicator. Future: cap scan duration, return partial with `truncated: true`.
+- **Large JSONL scans are O(n) with no timeout.** A 1GB total across `events-*.jsonl` files can take minutes; no progress indicator. Future: cap scan duration, return partial with `truncated: true`.
 - **Silent `$HOME/.chitin` fallback.** If cwd has no `.chitin/`, the resolver quietly uses `$HOME/.chitin/`. The output header labels the resolved dir, but operators skim. Future: render a `[WARN]` when resolved dir ≠ cwd-local `.chitin/`.

--- a/docs/observations/runbooks/health.md
+++ b/docs/observations/runbooks/health.md
@@ -50,7 +50,7 @@ The kernel emits events to `.chitin/events-<run_id>.jsonl` (one file per run). `
 **Do:**
 
 1. Most common cause: legacy events from a pre-v2 kernel. Find candidates with `ls -1 .chitin/events-*.jsonl` and check one: `head -1 .chitin/events-<run_id>.jsonl | jq .`. If `schema_version` is null or `"1"`, archive that run file: `mv .chitin/events-<run_id>.jsonl .chitin/events-<run_id>.jsonl.legacy-$(date +%s)` and let newer runs accumulate cleanly.
-2. Less common: a corrupted line (truncated mid-write, partial UTF-8). Walk the files: `for f in .chitin/events-*.jsonl; do jq -c . "$f" > /dev/null || echo "bad: $f"; done`.
+2. Less common: a corrupted line (truncated mid-write, partial UTF-8). Walk the files: `for f in .chitin/events-*.jsonl; do [ -e "$f" ] || continue; jq -c . "$f" > /dev/null || echo "bad: $f"; done`. The `[ -e "$f" ]` guard handles the case where no run files exist yet (bash would otherwise iterate once with the literal glob pattern).
 3. If the drift persists after archiving legacy data, the adapter is emitting malformed envelopes — file a ledger entry.
 
 ### `orphaned chains > 0` — [WARN]

--- a/go/execution-kernel/internal/health/health.go
+++ b/go/execution-kernel/internal/health/health.go
@@ -50,6 +50,7 @@ func Gather(chitinDir string, window time.Duration) (Report, error) {
 	}
 	r.DirExists = true
 
+	skewThreshold := now.Add(clockSkewFutureTolerance)
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -58,7 +59,7 @@ func Gather(chitinDir string, window time.Duration) (Report, error) {
 		if !strings.HasSuffix(name, ".jsonl") {
 			continue
 		}
-		if err := scanJSONL(filepath.Join(chitinDir, name), &r); err != nil {
+		if err := scanJSONL(filepath.Join(chitinDir, name), &r, now, skewThreshold); err != nil {
 			return r, err
 		}
 	}
@@ -72,9 +73,15 @@ func Gather(chitinDir string, window time.Duration) (Report, error) {
 
 // Invariant: an event counts toward EventsTotal/EventsByWindow iff it parses,
 // has schema_version == "2", has a non-empty surface, and has ts inside the
-// window. Any other shape is schema drift (bumped exactly once per line) and
-// does not count as a real event.
-func scanJSONL(path string, r *Report) error {
+// window [WindowStart, now]. Any other shape is schema drift (bumped exactly
+// once per line) and does not count as a real event. Events past
+// skewThreshold (now + clockSkewFutureTolerance) set ClockSkewSuspected but
+// are not counted — future events would otherwise silently inflate the
+// window metrics across clock corrections.
+//
+// now and skewThreshold are pinned per Gather call so behavior is
+// deterministic within a single scan.
+func scanJSONL(path string, r *Report, now, skewThreshold time.Time) error {
 	f, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -111,16 +118,19 @@ func scanJSONL(path string, r *Report) error {
 		if t.After(r.LatestEventTs) {
 			r.LatestEventTs = t
 		}
-		if t.After(time.Now().UTC().Add(clockSkewFutureTolerance)) {
+		if t.After(skewThreshold) {
 			r.ClockSkewSuspected = true
 		}
-		if t.Before(r.WindowStart) {
+		if t.Before(r.WindowStart) || t.After(now) {
 			continue
 		}
 		r.EventsTotal++
 		r.EventsByWindow[ev.Surface]++
 	}
-	return sc.Err()
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("scan jsonl %q: %w", path, err)
+	}
+	return nil
 }
 
 func scanErrorLog(path string, r *Report) error {
@@ -129,7 +139,7 @@ func scanErrorLog(path string, r *Report) error {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
-		return fmt.Errorf("open error log: %w", err)
+		return fmt.Errorf("open error log %q: %w", path, err)
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
@@ -140,5 +150,8 @@ func scanErrorLog(path string, r *Report) error {
 		}
 		r.HookFailureCount++
 	}
-	return sc.Err()
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("scan error log %q: %w", path, err)
+	}
+	return nil
 }

--- a/go/execution-kernel/internal/health/health.go
+++ b/go/execution-kernel/internal/health/health.go
@@ -15,15 +15,20 @@ import (
 
 // Report is the shape `chitin health` presents.
 type Report struct {
-	WindowStart         time.Time      `json:"window_start"`
-	DirExists           bool           `json:"dir_exists"`
-	EventsByWindow      map[string]int `json:"events_by_window"`
-	EventsTotal         int            `json:"events_total"`
-	HookFailureCount    int            `json:"hook_failure_count"`
-	SchemaDriftCount    int            `json:"schema_drift_count"`
-	OrphanedChains      int            `json:"orphaned_chains"`
-	LatestEventTs       time.Time      `json:"latest_event_ts,omitempty"`
-	ClockSkewSuspected  bool           `json:"clock_skew_suspected"`
+	WindowStart        time.Time      `json:"window_start"`
+	DirExists          bool           `json:"dir_exists"`
+	EventsByWindow     map[string]int `json:"events_by_window"`
+	EventsTotal        int            `json:"events_total"`
+	HookFailureCount   int            `json:"hook_failure_count"`
+	SchemaDriftCount   int            `json:"schema_drift_count"`
+	OrphanedChains     int            `json:"orphaned_chains"`
+	LatestEventTs      time.Time      `json:"latest_event_ts,omitempty"`
+	ClockSkewSuspected bool           `json:"clock_skew_suspected"`
+	// FailedFiles records jsonl files whose scan failed with a non-ErrNotExist
+	// open error or a scanner error. Each entry is "<path>: <error message>".
+	// The remaining files are still scanned — one bad file must not black-box
+	// the health signal for the rest.
+	FailedFiles []string `json:"failed_files,omitempty"`
 }
 
 // clockSkewFutureTolerance bounds how far ahead of wall-clock an event ts may
@@ -59,14 +64,16 @@ func Gather(chitinDir string, window time.Duration) (Report, error) {
 		if !strings.HasSuffix(name, ".jsonl") {
 			continue
 		}
-		if err := scanJSONL(filepath.Join(chitinDir, name), &r, now, skewThreshold); err != nil {
-			return r, err
+		path := filepath.Join(chitinDir, name)
+		if err := scanJSONL(path, &r, now, skewThreshold); err != nil {
+			r.FailedFiles = append(r.FailedFiles, fmt.Sprintf("%s: %s", path, err))
+			continue
 		}
 	}
 
 	errLog := filepath.Join(chitinDir, "kernel-errors.log")
 	if err := scanErrorLog(errLog, &r); err != nil {
-		return r, err
+		r.FailedFiles = append(r.FailedFiles, fmt.Sprintf("%s: %s", errLog, err))
 	}
 	return r, nil
 }
@@ -74,10 +81,14 @@ func Gather(chitinDir string, window time.Duration) (Report, error) {
 // Invariant: an event counts toward EventsTotal/EventsByWindow iff it parses,
 // has schema_version == "2", has a non-empty surface, and has ts inside the
 // window [WindowStart, now]. Any other shape is schema drift (bumped exactly
-// once per line) and does not count as a real event. Events past
-// skewThreshold (now + clockSkewFutureTolerance) set ClockSkewSuspected but
-// are not counted — future events would otherwise silently inflate the
-// window metrics across clock corrections.
+// once per line) and does not count as a real event.
+//
+// Two separate rules govern future-stamped events:
+//   - Any event with t > now is excluded from EventsTotal / EventsByWindow
+//     (the window is half-open on the future side).
+//   - Only events with t > skewThreshold (now + clockSkewFutureTolerance)
+//     also set ClockSkewSuspected. Events between now and skewThreshold are
+//     silently excluded without flagging — they're within NTP jitter range.
 //
 // now and skewThreshold are pinned per Gather call so behavior is
 // deterministic within a single scan.

--- a/go/execution-kernel/internal/health/health_test.go
+++ b/go/execution-kernel/internal/health/health_test.go
@@ -94,22 +94,42 @@ func TestGather_SchemaDriftRules(t *testing.T) {
 	}
 }
 
-// Open-error propagation: a non-ErrNotExist error on a *.jsonl file must not
-// be silenced into a zero report. Simulate by making the file unreadable.
-func TestGather_PropagatesNonErrNotExistOnJSONL(t *testing.T) {
+// File-level errors accumulate in FailedFiles; scanning continues for other
+// files and the overall Gather call still returns nil error. One bad file
+// must not black-box the health signal for every other file.
+func TestGather_FailedFileDoesNotBlockOthers(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses file mode permission checks")
 	}
 	dir := t.TempDir()
-	jsonl := filepath.Join(dir, "events-testrun.jsonl")
-	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o000); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(jsonl, 0o644) })
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
 
-	_, err := Gather(dir, 24*time.Hour)
-	if err == nil {
-		t.Errorf("want permission error, got nil")
+	// File A: unreadable — should land in FailedFiles.
+	bad := filepath.Join(dir, "events-bad.jsonl")
+	if err := os.WriteFile(bad, []byte("{}\n"), 0o000); err != nil {
+		t.Fatalf("write bad fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) })
+
+	// File B: valid event — should still be counted.
+	good := filepath.Join(dir, "events-good.jsonl")
+	line := `{"schema_version":"2","ts":"` + recent + `","event_type":"session_start","surface":"claude-code"}`
+	if err := os.WriteFile(good, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatalf("write good fixture: %v", err)
+	}
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("want nil err (accumulated, not bailed), got %v", err)
+	}
+	if rep.EventsTotal != 1 {
+		t.Errorf("want 1 event from good file, got %d", rep.EventsTotal)
+	}
+	if len(rep.FailedFiles) != 1 {
+		t.Errorf("want 1 failed file, got %d (entries: %v)", len(rep.FailedFiles), rep.FailedFiles)
+	}
+	if len(rep.FailedFiles) == 1 && !strings.Contains(rep.FailedFiles[0], "events-bad.jsonl") {
+		t.Errorf("failed file entry should name the bad path, got: %q", rep.FailedFiles[0])
 	}
 }
 
@@ -184,10 +204,12 @@ func TestGather_NoClockSkewOnRecentEvents(t *testing.T) {
 	}
 }
 
-// Window is [WindowStart, now]. Events stamped AFTER now must not count
-// toward EventsByWindow — they flag ClockSkewSuspected but are excluded
-// from metrics. Otherwise a future-stamped event silently inflates the
-// window count across clock corrections.
+// Window is [WindowStart, now]. Events stamped AFTER now are excluded from
+// EventsByWindow regardless of magnitude. The ClockSkewSuspected flag is
+// separate — only events past now + 1h (clockSkewFutureTolerance) set it.
+// Events in the narrow band (now, now+1h] are silently excluded without
+// flagging, treated as NTP jitter. This test uses a 48h future event, which
+// satisfies both rules: excluded from counts AND flagged as skew.
 func TestGather_ExcludesFutureEventsFromCounts(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()

--- a/go/execution-kernel/internal/health/health_test.go
+++ b/go/execution-kernel/internal/health/health_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGather_CountsEventsInLastWindow(t *testing.T) {
 	dir := t.TempDir()
-	jsonl := filepath.Join(dir, "events.jsonl")
+	jsonl := filepath.Join(dir, "events-testrun.jsonl")
 	now := time.Now().UTC()
 	old := now.Add(-48 * time.Hour).Format(time.RFC3339)
 	recent := now.Add(-1 * time.Hour).Format(time.RFC3339)
@@ -77,7 +77,7 @@ func TestGather_SchemaDriftRules(t *testing.T) {
 		// Drift: unparseable ts
 		`{"schema_version":"2","ts":"not-a-date","surface":"claude-code"}`,
 	}
-	jsonl := filepath.Join(dir, "events.jsonl")
+	jsonl := filepath.Join(dir, "events-testrun.jsonl")
 	if err := os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestGather_PropagatesNonErrNotExistOnJSONL(t *testing.T) {
 		t.Skip("root bypasses file mode permission checks")
 	}
 	dir := t.TempDir()
-	jsonl := filepath.Join(dir, "events.jsonl")
+	jsonl := filepath.Join(dir, "events-testrun.jsonl")
 	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o000); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestGather_AbsentDirSetsDirExistsFalse(t *testing.T) {
 func TestGather_DetectsClockSkewFromFutureTs(t *testing.T) {
 	dir := t.TempDir()
 	future := time.Now().UTC().Add(48 * time.Hour).Format(time.RFC3339)
-	jsonl := filepath.Join(dir, "events.jsonl")
+	jsonl := filepath.Join(dir, "events-testrun.jsonl")
 	line := `{"schema_version":"2","ts":"` + future + `","event_type":"session_start","surface":"claude-code"}`
 	if err := os.WriteFile(jsonl, []byte(line+"\n"), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -169,7 +169,7 @@ func TestGather_DetectsClockSkewFromFutureTs(t *testing.T) {
 func TestGather_NoClockSkewOnRecentEvents(t *testing.T) {
 	dir := t.TempDir()
 	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
-	jsonl := filepath.Join(dir, "events.jsonl")
+	jsonl := filepath.Join(dir, "events-testrun.jsonl")
 	line := `{"schema_version":"2","ts":"` + recent + `","event_type":"session_start","surface":"claude-code"}`
 	if err := os.WriteFile(jsonl, []byte(line+"\n"), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -181,5 +181,38 @@ func TestGather_NoClockSkewOnRecentEvents(t *testing.T) {
 	}
 	if rep.ClockSkewSuspected {
 		t.Errorf("want ClockSkewSuspected=false for recent event")
+	}
+}
+
+// Window is [WindowStart, now]. Events stamped AFTER now must not count
+// toward EventsByWindow — they flag ClockSkewSuspected but are excluded
+// from metrics. Otherwise a future-stamped event silently inflates the
+// window count across clock corrections.
+func TestGather_ExcludesFutureEventsFromCounts(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	past := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	future := now.Add(48 * time.Hour).Format(time.RFC3339)
+	lines := []string{
+		`{"schema_version":"2","ts":"` + past + `","event_type":"session_start","surface":"claude-code"}`,
+		`{"schema_version":"2","ts":"` + future + `","event_type":"session_start","surface":"claude-code"}`,
+	}
+	jsonl := filepath.Join(dir, "events-testrun.jsonl")
+	if err := os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rep, err := Gather(dir, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.EventsTotal != 1 {
+		t.Errorf("want 1 in-window event, got %d (future event must not count)", rep.EventsTotal)
+	}
+	if rep.EventsByWindow["claude-code"] != 1 {
+		t.Errorf("want 1 claude-code event in window, got %d", rep.EventsByWindow["claude-code"])
+	}
+	if !rep.ClockSkewSuspected {
+		t.Errorf("want ClockSkewSuspected=true when a future event is present")
 	}
 }

--- a/souls/elo.md
+++ b/souls/elo.md
@@ -30,15 +30,33 @@ trainer's note, not a benchmark.
 | Sun Tzu | 1500 | canonical | — |
 | Turing | 1500 | canonical | — |
 | da Vinci | 1499 | canonical | −1 |
+| Hamilton | 1499 | canonical | −1 |
 | Dijkstra | 1500 | experimental | — |
 | Feynman | 1500 | experimental | — |
-| Hamilton | 1500 | experimental | — |
 | Hopper | 1500 | experimental | — |
 | Jared Pleva | 1500 | experimental | — |
 | Jobs | 1500 | experimental | — |
 | Jokić | 1500 | experimental | — |
 
 ## Event log
+
+### 2026-04-20
+
+- **Hamilton: promoted to canonical** (not an elo delta — tier change).
+  First operational trial of `/ship-review` skill used Hamilton as the
+  adversarial lens on PR #26. Promotion recorded in
+  `souls/canonical/hamilton.md` (previously `experimental/`).
+
+- **Hamilton −1 → 1499.** Strike 1. First operational use of
+  `/ship-review` skill: merged PR #26 at 16:00:18 UTC, 14 seconds after
+  Copilot submitted a third review with 7 real findings (including a
+  documented runbook path that doesn't exist — `.chitin/events.jsonl`
+  when the kernel actually emits `events-<run_id>.jsonl`). Hamilton's
+  own heuristics 1 ("the system will fail in ways you didn't design
+  for") and 3 ("'trained users won't make that mistake' is the bug
+  report") applied to the polling loop I'd written and trusted. PR #28
+  filed to remediate; skill patched with pre-merge freshness check.
+  See `souls/strikes/hamilton.md` for full record.
 
 ### 2026-04-19
 

--- a/souls/strikes/hamilton.md
+++ b/souls/strikes/hamilton.md
@@ -1,0 +1,83 @@
+# Strike log — Hamilton
+
+Operational feedback against the Hamilton soul. Each entry records a case
+where the lens (or the agent operating under it) produced work that failed
+to meet its own stated heuristics. Kept separately from
+`souls/canonical/hamilton.md` so the soul_hash remains stable for forensic
+event chains.
+
+Format per strike:
+- ID, date, session context
+- What the lens was supposed to catch
+- What actually happened
+- Which heuristic was violated
+- Remediation / learning
+
+---
+
+## Strike 1 — 2026-04-20 — Merged PR #26 14 seconds before Copilot's third review landed
+
+**Context.** First operational trial of the `/ship-review` skill (written
+earlier the same session). Hamilton was the active adversarial lens and
+stayed loaded through Phase 4's failure-mode batch. The cycle on
+chitinhq/chitin PR #26 went: Copilot review (11 findings) → Hamilton
+adversarial review (6 findings) → Knuth + Hamilton patch commits → push at
+15:49 UTC → poll for Copilot re-review → merge at 16:00:18 UTC.
+
+**What the lens was supposed to catch.**
+Heuristic 3 — *"Trained users won't make that mistake" is the bug report.*
+The polling loop that decided "silence = approval" after 10 minutes was
+the operator's own homemade defense, trusting the operator to pick the
+right interval. Hamilton's own rule: if the defense depends on a human
+being careful at 3am, it's not a defense.
+
+Heuristic 1 — *The system will fail in ways you didn't design for.* I
+wrote the `/ship-review` skill with a poll loop, then trusted the poll
+loop. The failure mode "Copilot reviews BETWEEN your last poll and your
+merge call" was not in my model. Hamilton's whole job is to name that
+class.
+
+**What actually happened.**
+Copilot submitted a third review at 16:00:04 UTC with 7 new findings (2
+real bugs, 1 real documentation bug, 2 ergonomic nits — notably that the
+kernel emits `events-<run_id>.jsonl` while my runbook referenced the
+non-existent `events.jsonl` path). I merged at 16:00:18 UTC — 14 seconds
+later — because my last poll (several minutes prior) had shown no new
+reviews and I interpreted the silence as approval. The findings were
+real and material; they had to be addressed in a follow-up PR (#28).
+
+The merge wasn't a hard failure — the code shipped was still better than
+main before the PR — but a documented operator runbook shipped with a
+wrong filename that would mislead on-call response. That exactly fits the
+class of regression Hamilton is supposed to flag.
+
+**Heuristic violated.**
+Primary: heuristic 3 ("trained users won't make that mistake" is the bug
+report). The polling loop was the footgun; trusting it as a defense was
+the fire.
+
+Secondary: heuristic 1 (design for the mistake). No guard in the merge
+step that re-checked Copilot state immediately before `gh pr merge`. The
+skill's Phase 6 checklist said "CI is green" and "no blocking comments"
+— both were true at poll time, neither was re-verified at merge time.
+
+**Remediation.**
+- PR #28 filed the same session with fixes for the 7 missed findings.
+- `/ship-review` skill patched: Phase 1 documents correct Copilot
+  re-review trigger (`gh pr edit --add-reviewer @copilot`, per GitHub
+  docs — NOT `@copilot` mentions or `/copilot review` slash-style
+  comments which have no documented effect). Phase 6 gains a pre-merge
+  freshness check: fetch `gh pr view --json reviews` immediately before
+  `gh pr merge`, and if the latest Copilot review is newer than the last
+  poll, loop back to Phase 3 instead of merging.
+- ELO: Hamilton −1 → 1499. Event logged in `souls/elo.md`.
+
+**Learning for the lens.**
+Hamilton's heuristic 3 must bind specifically to operator procedures I
+*myself* write in the same session. When I author a workflow AND run it,
+the review of the workflow and the review of the work must be separate
+passes under different eyes. A lens cannot adversarially review its own
+instrument.
+
+The skill-author and the skill-user should not be the same lens on the
+same day.


### PR DESCRIPTION
## Summary

Remediation for 5 real findings Copilot posted in a 3rd review on PR #26 that I merged 14 seconds later without re-checking. Also records the Hamilton strike + elo deduction for the miss.

### Code (Knuth lens)
- **Window upper bound.** `scanJSONL` now excludes events with \`ts > now\` from \`EventsByWindow\` — they still set \`ClockSkewSuspected\` but no longer inflate metrics across clock corrections. New test \`TestGather_ExcludesFutureEventsFromCounts\`.
- **Deterministic timestamps.** \`time.Now().UTC()\` hoisted once per \`Gather\` call and threaded into \`scanJSONL(path, r, now, skewThreshold)\`. No per-line calls.
- **Filename context on scanner errors.** Both \`scanJSONL\` and \`scanErrorLog\` wrap \`sc.Err()\` with the path.

### Docs
- Runbook schema-drift section corrected: kernel emits \`.chitin/events-<run_id>.jsonl\` (one file per run), not \`.chitin/events.jsonl\`. Walk-the-files snippet uses the glob.
- Test fixture renamed from \`events.jsonl\` to \`events-testrun.jsonl\` for semantic accuracy against real emit convention.

### Ops
- \`souls/strikes/hamilton.md\`: Strike 1 recorded. Hamilton was the adversarial lens for PR #26's cycle; heuristic 3 (\"'trained users won't make that mistake' is the bug report\") applied to the polling loop I authored and trusted.
- \`souls/elo.md\`: **Hamilton −1 → 1499**, promoted to canonical tier.
- \`/ship-review\` skill patched in workspace repo (separate commit): correct Copilot trigger documented (\`gh pr edit --add-reviewer @copilot\` — not \`@copilot\` mentions or \`/copilot review\` comments); Phase 6 gains a pre-merge freshness check.

## Test Plan

- [x] \`go test ./internal/health/... -v\` — 9 pass (was 8 in #26, +1 for window upper bound)
- [x] \`go test ./...\` — all kernel packages pass
- [x] \`nx build execution-kernel\` — clean
- [x] \`nx run cli:test\` — 23 pass
- [x] Smoke: \`chitin-kernel health --dir /tmp/chk2/.chitin\` against \`events-abc123.jsonl\` returns \`events_total:1\`
- [ ] Copilot review (this time using the CORRECT trigger)
- [ ] Hamilton adversarial review with pre-merge freshness check enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)