### PR TITLE
Phase D: ledger tooling — governance-debt ledger + review aggregator

### DIFF
--- a/apps/cli/src/commands/events-list.ts
+++ b/apps/cli/src/commands/events-list.ts
@@ -1,4 +1,5 @@
 import BetterSqlite3 from 'better-sqlite3';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { ensureIndexed } from '@chitin/telemetry';
 
@@ -9,23 +10,41 @@ export interface ListOpts {
   limit?: number;
 }
 
+export interface ListFromDirOpts {
+  surface?: string;
+  run?: string;
+  limit?: number;
+  skipEnsureIndexed?: boolean;
+}
+
 export function eventsListCommand(opts: ListOpts): void {
   const workspace = opts.workspace ?? process.cwd();
   const chitinDir = join(workspace, '.chitin');
-  ensureIndexed(chitinDir);
+  listRecentEvents(chitinDir, opts);
+}
+
+export function listRecentEvents(chitinDir: string, opts: ListFromDirOpts): void {
+  if (!opts.skipEnsureIndexed) ensureIndexed(chitinDir);
   const dbPath = join(chitinDir, 'events.db');
-  const db = new BetterSqlite3(dbPath, { readonly: true });
-  const clauses: string[] = [];
-  const params: unknown[] = [];
-  if (opts.surface) { clauses.push('surface = ?'); params.push(opts.surface); }
-  if (opts.run) { clauses.push('run_id = ?'); params.push(opts.run); }
-  const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
-  const limit = opts.limit ?? 50;
-  const rows = db
-    .prepare(`SELECT ts, surface, event_type, chain_id, session_id FROM events ${where} ORDER BY ts DESC LIMIT ?`)
-    .all(...params, limit) as Array<{ ts: string; surface: string; event_type: string; chain_id: string; session_id: string }>;
-  for (const r of rows) {
-    process.stdout.write(`${r.ts}  ${r.surface.padEnd(14)} ${r.event_type.padEnd(16)} ${r.chain_id.slice(0, 12).padEnd(14)} ${r.session_id}\n`);
+  if (!existsSync(dbPath)) {
+    process.stdout.write('(no events captured yet)\n');
+    return;
   }
-  db.close();
+  const db = new BetterSqlite3(dbPath, { readonly: true });
+  try {
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+    if (opts.surface) { clauses.push('surface = ?'); params.push(opts.surface); }
+    if (opts.run) { clauses.push('run_id = ?'); params.push(opts.run); }
+    const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+    const limit = opts.limit ?? 50;
+    const rows = db
+      .prepare(`SELECT ts, surface, event_type, chain_id, session_id FROM events ${where} ORDER BY ts DESC LIMIT ?`)
+      .all(...params, limit) as Array<{ ts: string; surface: string; event_type: string; chain_id: string; session_id: string }>;
+    for (const r of rows) {
+      process.stdout.write(`${r.ts}  ${r.surface.padEnd(14)} ${r.event_type.padEnd(16)} ${r.chain_id.slice(0, 12).padEnd(14)} ${r.session_id}\n`);
+    }
+  } finally {
+    db.close();
+  }
 }

--- a/apps/cli/src/commands/ledger.ts
+++ b/apps/cli/src/commands/ledger.ts
@@ -224,9 +224,23 @@ export function lintTraceRefs(
 }
 
 export function lintGraduationMarkers(blocks: LedgerEntry[]): LintFinding[] {
+  const hasGraduated = blocks.some((b) => /\*\*Graduated:\*\*.*?#\d+/i.test(b.body));
+  if (!hasGraduated) return [];
+
+  const auth = spawnSync('gh', ['auth', 'status'], { encoding: 'utf8' });
+  if (auth.status !== 0) {
+    return [
+      {
+        level: 'warn',
+        gdl: '*',
+        msg: 'skipping graduation-marker resolution (gh not authenticated — run `gh auth login`)',
+      },
+    ];
+  }
+
   const findings: LintFinding[] = [];
   for (const b of blocks) {
-    const m = /\*\*Graduated:\*\*.*?(issue|PR|souls PR)\s*#(\d+)/i.exec(b.body);
+    const m = /\*\*Graduated:\*\*.*?(souls PR|issue|PR)\s*#(\d+)/i.exec(b.body);
     if (!m) continue;
     const num = m[2];
     const issue = spawnSync('gh', ['issue', 'view', num, '--json', 'number'], { encoding: 'utf8' });

--- a/apps/cli/src/commands/ledger.ts
+++ b/apps/cli/src/commands/ledger.ts
@@ -40,13 +40,13 @@ export function registerLedger(program: Command): void {
     .option('--surface <s>', 'surface (e.g. claude-code)', 'claude-code')
     .option('--repo <name>', 'repo name (e.g. chitin)', 'chitin')
     .option('--soul <id>', 'active soul id', 'davinci')
-    .option('--ledger <path>', 'ledger path (default: repo-root)', LEDGER_REL)
+    .option('--ledger <path>', 'ledger path — resolved relative to cwd unless absolute', LEDGER_REL)
     .action(handleNew);
 
   ledger
     .command('lint')
     .description('Validate ledger entry integrity')
-    .option('--ledger <path>', 'ledger path', LEDGER_REL)
+    .option('--ledger <path>', 'ledger path — resolved relative to cwd unless absolute', LEDGER_REL)
     .option('--db <path>', 'events.db path for trace_ref resolution')
     .option('--strict', 'fail on unresolved trace refs', false)
     .action(handleLint);
@@ -198,10 +198,10 @@ export function lintTraceRefs(
   try {
     let stmt: Database.Statement;
     try {
-      stmt = db.prepare('SELECT 1 FROM chain_index WHERE chain_id = ? LIMIT 1');
+      stmt = db.prepare('SELECT 1 FROM events WHERE chain_id = ? LIMIT 1');
     } catch (err) {
       return [
-        { level: 'warn', gdl: '*', msg: `events.db has no chain_index table: ${String(err)}` },
+        { level: 'warn', gdl: '*', msg: `events.db has no events table: ${String(err)}` },
       ];
     }
     for (const b of blocks) {

--- a/apps/cli/src/commands/ledger.ts
+++ b/apps/cli/src/commands/ledger.ts
@@ -1,0 +1,243 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import Database from 'better-sqlite3';
+import type { Command } from 'commander';
+
+const LEDGER_REL = 'docs/observations/governance-debt-ledger.md';
+
+export interface LintFinding {
+  level: 'error' | 'warn';
+  gdl: string;
+  msg: string;
+}
+
+export interface LedgerEntry {
+  id: string;
+  body: string;
+}
+
+export interface StubInput {
+  lane: string;
+  chain?: string;
+  seq?: string;
+  hash?: string;
+  surface: string;
+  repo: string;
+  soul: string;
+  today: string;
+}
+
+export function registerLedger(program: Command): void {
+  const ledger = program.command('ledger').description('Governance-debt ledger tools');
+
+  ledger
+    .command('new')
+    .description('Append a new stub entry to the ledger')
+    .argument('<lane>', 'lane: 1 | 2 | 3 (fix / determinism / soul-routing)')
+    .option('--chain <id>', 'chain_id reference (stable)')
+    .option('--seq <n>', 'seq number within chain')
+    .option('--hash <sha>', 'this_hash (first 12 chars are kept)')
+    .option('--surface <s>', 'surface (e.g. claude-code)', 'claude-code')
+    .option('--repo <name>', 'repo name (e.g. chitin)', 'chitin')
+    .option('--soul <id>', 'active soul id', 'davinci')
+    .option('--ledger <path>', 'ledger path (default: repo-root)', LEDGER_REL)
+    .action(handleNew);
+
+  ledger
+    .command('lint')
+    .description('Validate ledger entry integrity')
+    .option('--ledger <path>', 'ledger path', LEDGER_REL)
+    .option('--db <path>', 'events.db path for trace_ref resolution')
+    .option('--strict', 'fail on unresolved trace refs', false)
+    .action(handleLint);
+}
+
+function handleNew(
+  laneArg: string,
+  opts: {
+    chain?: string;
+    seq?: string;
+    hash?: string;
+    surface: string;
+    repo: string;
+    soul: string;
+    ledger: string;
+  },
+): void {
+  const body = readFileSync(opts.ledger, 'utf8');
+  const nextId = nextGDL(body);
+  const today = new Date().toISOString().slice(0, 10);
+  const entry = buildStubEntry(nextId, {
+    lane: laneArg,
+    chain: opts.chain,
+    seq: opts.seq,
+    hash: opts.hash,
+    surface: opts.surface,
+    repo: opts.repo,
+    soul: opts.soul,
+    today,
+  });
+  writeFileSync(opts.ledger, body.trimEnd() + '\n' + entry);
+  console.log(`appended GDL-${pad(nextId)} to ${opts.ledger}`);
+}
+
+function handleLint(opts: { ledger: string; db?: string; strict: boolean }): void {
+  const body = readFileSync(opts.ledger, 'utf8');
+  const blocks = splitEntries(body);
+
+  const findings: LintFinding[] = [
+    ...lintStructural(body, blocks),
+    ...lintTraceRefs(blocks, opts.db, opts.strict),
+    ...lintGraduationMarkers(blocks),
+  ];
+
+  for (const f of findings) {
+    const tag = f.level === 'error' ? 'ERROR' : 'WARN';
+    console.log(`[${tag}]  ${f.gdl.padEnd(10)} ${f.msg}`);
+  }
+  const errors = findings.filter((f) => f.level === 'error').length;
+  console.log(`\n${findings.length} findings (${errors} errors)`);
+  process.exit(errors > 0 ? 1 : 0);
+}
+
+export function buildStubEntry(id: number, inp: StubInput): string {
+  const laneLabel = laneLabelFor(inp.lane);
+  return [
+    '',
+    `### GDL-${pad(id)} — <one-line what the platform should have caught>`,
+    '',
+    `- **Observed:** ${inp.today}, chain \`${inp.chain ?? '<chain_id>'}\`, seq \`${inp.seq ?? '<n>'}\`, hash \`${(inp.hash ?? '<this_hash>').slice(0, 12)}\``,
+    `- **Surface / repo:** ${inp.surface} / ${inp.repo}`,
+    '- **Finding:** <what happened, one paragraph>',
+    `- **Lane:** ${laneLabel}`,
+    '- **Severity:** low / medium / high',
+    '- **Graduated:** <null>',
+    `- **Soul active:** ${inp.soul} @ <soul_hash[:8]>`,
+    '',
+  ].join('\n');
+}
+
+export function laneLabelFor(lane: string): string {
+  const l = lane.toLowerCase();
+  if (lane === '1' || l === 'fix') return '① FIX';
+  if (lane === '2' || l === 'determinism') return '② DETERMINISM';
+  if (lane === '3' || l === 'soul-routing' || l === 'soul') return '③ SOUL ROUTING';
+  throw new Error(`unknown lane: ${lane}`);
+}
+
+export function nextGDL(body: string): number {
+  const matches = body.matchAll(/^### GDL-(\d+)/gm);
+  let max = 0;
+  for (const m of matches) {
+    const n = parseInt(m[1], 10);
+    if (n > max) max = n;
+  }
+  return max + 1;
+}
+
+export function pad(n: number): string {
+  return n.toString().padStart(3, '0');
+}
+
+export function splitEntries(body: string): LedgerEntry[] {
+  const out: LedgerEntry[] = [];
+  let current: LedgerEntry | null = null;
+  for (const line of body.split('\n')) {
+    const m = /^### (GDL-\d+)\b/.exec(line);
+    if (m) {
+      if (current) out.push(current);
+      current = { id: m[1], body: '' };
+      continue;
+    }
+    if (current) current.body += line + '\n';
+  }
+  if (current) out.push(current);
+  return out;
+}
+
+export function lintStructural(body: string, blocks: LedgerEntry[]): LintFinding[] {
+  const findings: LintFinding[] = [];
+
+  const ids = new Set<string>();
+  for (const m of body.matchAll(/^### (GDL-\d+)\b.*$/gm)) {
+    const id = m[1];
+    if (ids.has(id)) {
+      findings.push({ level: 'error', gdl: id, msg: 'duplicate ID' });
+    }
+    ids.add(id);
+  }
+
+  for (const b of blocks) {
+    if (!/\*\*Observed:\*\*/.test(b.body)) {
+      findings.push({ level: 'error', gdl: b.id, msg: 'missing Observed field' });
+    }
+    if (!/\*\*Lane:\*\*\s+[①②③]/.test(b.body)) {
+      findings.push({ level: 'error', gdl: b.id, msg: 'missing or malformed Lane' });
+    }
+    if (!/\*\*Graduated:\*\*/.test(b.body)) {
+      findings.push({ level: 'warn', gdl: b.id, msg: 'missing Graduated field' });
+    }
+  }
+
+  return findings;
+}
+
+export function lintTraceRefs(
+  blocks: LedgerEntry[],
+  dbPath: string | undefined,
+  strict: boolean,
+): LintFinding[] {
+  if (!dbPath || !existsSync(dbPath)) return [];
+  const findings: LintFinding[] = [];
+  let db: Database.Database;
+  try {
+    db = new Database(dbPath, { readonly: true });
+  } catch (err) {
+    return [{ level: 'warn', gdl: '*', msg: `events.db open failed: ${String(err)}` }];
+  }
+  try {
+    let stmt: Database.Statement;
+    try {
+      stmt = db.prepare('SELECT 1 FROM chain_index WHERE chain_id = ? LIMIT 1');
+    } catch (err) {
+      return [
+        { level: 'warn', gdl: '*', msg: `events.db has no chain_index table: ${String(err)}` },
+      ];
+    }
+    for (const b of blocks) {
+      const m = /chain\s+`([^`]+)`/.exec(b.body);
+      if (!m) continue;
+      if (m[1].startsWith('<')) continue;
+      const row = stmt.get(m[1]);
+      if (!row) {
+        findings.push({
+          level: strict ? 'error' : 'warn',
+          gdl: b.id,
+          msg: `chain_id not in events.db: ${m[1]}`,
+        });
+      }
+    }
+  } finally {
+    db.close();
+  }
+  return findings;
+}
+
+export function lintGraduationMarkers(blocks: LedgerEntry[]): LintFinding[] {
+  const findings: LintFinding[] = [];
+  for (const b of blocks) {
+    const m = /\*\*Graduated:\*\*.*?(issue|PR|souls PR)\s*#(\d+)/i.exec(b.body);
+    if (!m) continue;
+    const num = m[2];
+    const issue = spawnSync('gh', ['issue', 'view', num, '--json', 'number'], { encoding: 'utf8' });
+    if (issue.status === 0) continue;
+    const pr = spawnSync('gh', ['pr', 'view', num, '--json', 'number'], { encoding: 'utf8' });
+    if (pr.status === 0) continue;
+    findings.push({
+      level: 'warn',
+      gdl: b.id,
+      msg: `graduated marker #${num} not resolvable via gh`,
+    });
+  }
+  return findings;
+}

--- a/apps/cli/src/commands/ledger.ts
+++ b/apps/cli/src/commands/ledger.ts
@@ -228,6 +228,15 @@ export function lintGraduationMarkers(blocks: LedgerEntry[]): LintFinding[] {
   if (!hasGraduated) return [];
 
   const auth = spawnSync('gh', ['auth', 'status'], { encoding: 'utf8' });
+  if (auth.error && (auth.error as NodeJS.ErrnoException).code === 'ENOENT') {
+    return [
+      {
+        level: 'warn',
+        gdl: '*',
+        msg: 'skipping graduation-marker resolution (`gh` CLI not installed)',
+      },
+    ];
+  }
   if (auth.status !== 0) {
     return [
       {

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -1,10 +1,8 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
 import { resolveChitinDir } from '@chitin/contracts';
 import { ensureIndexed } from '@chitin/telemetry';
 import type { Command } from 'commander';
-import { eventsListCommand } from './events-list.js';
+import { listRecentEvents } from './events-list.js';
 import type { HealthReport } from './health.js';
 
 export interface ReviewOpts {
@@ -46,12 +44,7 @@ export function registerReview(program: Command): void {
 
       console.log('## Recent sessions');
       ensureIndexed(chitinDir);
-      const dbPath = join(chitinDir, 'events.db');
-      if (!existsSync(dbPath)) {
-        console.log('(no events captured yet)');
-      } else {
-        eventsListCommand({ workspace: dirname(chitinDir), limit: 20 });
-      }
+      listRecentEvents(chitinDir, { limit: 20, skipEnsureIndexed: true });
     });
 }
 

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { resolveChitinDir } from '@chitin/contracts';
+import { ensureIndexed } from '@chitin/telemetry';
 import type { Command } from 'commander';
 import { eventsListCommand } from './events-list.js';
 import type { HealthReport } from './health.js';
@@ -44,6 +45,7 @@ export function registerReview(program: Command): void {
       console.log('');
 
       console.log('## Recent sessions');
+      ensureIndexed(chitinDir);
       const dbPath = join(chitinDir, 'events.db');
       if (!existsSync(dbPath)) {
         console.log('(no events captured yet)');

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -69,7 +69,7 @@ export function renderHealth(r: HealthReport, chitinDir: string): string[] {
     return lines;
   }
   lines.push(`- events total:      ${r.events_total}`);
-  for (const [s, c] of Object.entries(r.events_by_window)) {
+  for (const [s, c] of Object.entries(r.events_by_window ?? {})) {
     lines.push(`- events / ${s}:     ${c}`);
   }
   lines.push(`- hook failures:     ${r.hook_failure_count}`);

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { resolveChitinDir } from '@chitin/contracts';
+import type { Command } from 'commander';
+import { eventsListCommand } from './events-list.js';
+import type { HealthReport } from './health.js';
+
+export interface ReviewOpts {
+  last: string;
+  chitinDir?: string;
+}
+
+export function registerReview(program: Command): void {
+  program
+    .command('review')
+    .description('Weekly review skim: health + recent session list')
+    .option('--last <window>', 'window (e.g. 7d, 24h)', '7d')
+    .option('--chitin-dir <path>', 'override .chitin dir (default: resolve from cwd)')
+    .action((opts: ReviewOpts) => {
+      const hours = parseWindow(opts.last);
+      const chitinDir = opts.chitinDir ?? resolveChitinDir(process.cwd(), '');
+      const kernelBin = process.env.CHITIN_KERNEL_BINARY ?? 'chitin-kernel';
+
+      console.log(`# chitin review — window: ${opts.last} (${hours}h)\n`);
+
+      const h = spawnSync(
+        kernelBin,
+        ['health', '--dir', chitinDir, '--window-hours', String(hours)],
+        { encoding: 'utf8' },
+      );
+      if (h.error) {
+        console.error(`health: failed to start ${kernelBin}: ${h.error.message}`);
+      } else if (h.status !== 0) {
+        if (h.stderr) console.error(`health exited ${h.status}: ${h.stderr.trim()}`);
+      } else {
+        try {
+          const r = JSON.parse(h.stdout) as HealthReport;
+          for (const line of renderHealth(r, chitinDir)) console.log(line);
+        } catch (err) {
+          console.error(`health: could not parse kernel output: ${String(err)}`);
+        }
+      }
+      console.log('');
+
+      console.log('## Recent sessions');
+      const dbPath = join(chitinDir, 'events.db');
+      if (!existsSync(dbPath)) {
+        console.log('(no events captured yet)');
+      } else {
+        eventsListCommand({ workspace: dirname(chitinDir), limit: 20 });
+      }
+    });
+}
+
+export function parseWindow(w: string): number {
+  const m = /^(\d+)([hd])$/.exec(w);
+  if (!m) throw new Error(`bad window: ${w}`);
+  const n = parseInt(m[1], 10);
+  return m[2] === 'd' ? n * 24 : n;
+}
+
+export function renderHealth(r: HealthReport, chitinDir: string): string[] {
+  const lines: string[] = [`## Health (${chitinDir})`];
+  if (!r.dir_exists) {
+    lines.push('- chitin dir:        MISSING');
+    return lines;
+  }
+  lines.push(`- events total:      ${r.events_total}`);
+  for (const [s, c] of Object.entries(r.events_by_window)) {
+    lines.push(`- events / ${s}:     ${c}`);
+  }
+  lines.push(`- hook failures:     ${r.hook_failure_count}`);
+  lines.push(`- schema drift:      ${r.schema_drift_count}`);
+  lines.push(`- orphaned chains:   ${r.orphaned_chains}`);
+  return lines;
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -9,6 +9,7 @@ import { registerEventsTree } from './commands/events-tree.js';
 import { registerInstall } from './commands/install.js';
 import { registerHealth } from './commands/health.js';
 import { registerLedger } from './commands/ledger.js';
+import { registerReview } from './commands/review.js';
 
 const program = new Command();
 program.name('chitin').description('Observability-first substrate for AI coding agents');
@@ -41,6 +42,7 @@ registerEventsTree(events);
 registerInstall(program);
 registerHealth(program);
 registerLedger(program);
+registerReview(program);
 
 program.parseAsync(process.argv).catch((err) => {
   console.error(err);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -8,6 +8,7 @@ import { registerRun } from './commands/run.js';
 import { registerEventsTree } from './commands/events-tree.js';
 import { registerInstall } from './commands/install.js';
 import { registerHealth } from './commands/health.js';
+import { registerLedger } from './commands/ledger.js';
 
 const program = new Command();
 program.name('chitin').description('Observability-first substrate for AI coding agents');
@@ -39,6 +40,7 @@ registerRun(program);
 registerEventsTree(events);
 registerInstall(program);
 registerHealth(program);
+registerLedger(program);
 
 program.parseAsync(process.argv).catch((err) => {
   console.error(err);

--- a/apps/cli/tests/ledger.test.ts
+++ b/apps/cli/tests/ledger.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStubEntry,
+  laneLabelFor,
+  lintStructural,
+  nextGDL,
+  pad,
+  splitEntries,
+} from '../src/commands/ledger';
+
+describe('nextGDL', () => {
+  it('returns 1 for an empty ledger', () => {
+    expect(nextGDL('# Governance-Debt Ledger\n\n## Entries\n')).toBe(1);
+  });
+
+  it('returns 2 when GDL-001 exists', () => {
+    expect(nextGDL('### GDL-001 — foo\n\nbody\n')).toBe(2);
+  });
+
+  it('returns max + 1 across non-contiguous ids', () => {
+    const body = '### GDL-001 — a\n\n### GDL-003 — b\n\n### GDL-002 — c\n';
+    expect(nextGDL(body)).toBe(4);
+  });
+
+  it('ignores HTML comment references like GDL-000', () => {
+    const body = '<!-- GDL-000 reserved -->\n### GDL-001 — real\n';
+    expect(nextGDL(body)).toBe(2);
+  });
+});
+
+describe('laneLabelFor', () => {
+  it('maps 1/fix', () => {
+    expect(laneLabelFor('1')).toBe('① FIX');
+    expect(laneLabelFor('fix')).toBe('① FIX');
+    expect(laneLabelFor('FIX')).toBe('① FIX');
+  });
+
+  it('maps 2/determinism', () => {
+    expect(laneLabelFor('2')).toBe('② DETERMINISM');
+    expect(laneLabelFor('determinism')).toBe('② DETERMINISM');
+  });
+
+  it('maps 3/soul-routing/soul', () => {
+    expect(laneLabelFor('3')).toBe('③ SOUL ROUTING');
+    expect(laneLabelFor('soul-routing')).toBe('③ SOUL ROUTING');
+    expect(laneLabelFor('soul')).toBe('③ SOUL ROUTING');
+  });
+
+  it('throws on unknown lanes', () => {
+    expect(() => laneLabelFor('4')).toThrow(/unknown lane/);
+    expect(() => laneLabelFor('bogus')).toThrow(/unknown lane/);
+  });
+});
+
+describe('pad', () => {
+  it('zero-pads to 3 digits', () => {
+    expect(pad(1)).toBe('001');
+    expect(pad(42)).toBe('042');
+    expect(pad(999)).toBe('999');
+    expect(pad(1000)).toBe('1000');
+  });
+});
+
+describe('splitEntries', () => {
+  it('returns [] on empty body', () => {
+    expect(splitEntries('')).toEqual([]);
+  });
+
+  it('skips preamble before the first entry', () => {
+    const body = '# Header\n\nsome text\n\n### GDL-001 — a\n\nbody a\n';
+    const out = splitEntries(body);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('GDL-001');
+    expect(out[0].body).toContain('body a');
+    expect(out[0].body).not.toContain('some text');
+  });
+
+  it('splits multiple entries', () => {
+    const body = '### GDL-001 — a\n\nbody a\n\n### GDL-002 — b\n\nbody b\n';
+    const out = splitEntries(body);
+    expect(out.map((e) => e.id)).toEqual(['GDL-001', 'GDL-002']);
+    expect(out[0].body).toContain('body a');
+    expect(out[0].body).not.toContain('body b');
+    expect(out[1].body).toContain('body b');
+  });
+});
+
+describe('buildStubEntry', () => {
+  const baseInput = {
+    lane: '1',
+    surface: 'claude-code',
+    repo: 'chitin',
+    soul: 'davinci',
+    today: '2026-04-20',
+  };
+
+  it('includes header with padded id', () => {
+    const entry = buildStubEntry(7, baseInput);
+    expect(entry).toContain('### GDL-007 — <one-line');
+  });
+
+  it('emits lane label for the given lane', () => {
+    expect(buildStubEntry(1, { ...baseInput, lane: '2' })).toContain('② DETERMINISM');
+  });
+
+  it('substitutes provided chain / seq / hash', () => {
+    const entry = buildStubEntry(1, {
+      ...baseInput,
+      chain: 'abcdef',
+      seq: '5',
+      hash: '0123456789abcdef012345',
+    });
+    expect(entry).toContain('chain `abcdef`');
+    expect(entry).toContain('seq `5`');
+    expect(entry).toContain('hash `0123456789ab`'); // first 12 chars
+  });
+
+  it('inserts placeholder references when trace fields are omitted', () => {
+    const entry = buildStubEntry(1, baseInput);
+    expect(entry).toContain('chain `<chain_id>`');
+    expect(entry).toContain('seq `<n>`');
+    expect(entry).toContain('hash `<this_hash>`');
+  });
+
+  it('records surface, repo, soul, and today', () => {
+    const entry = buildStubEntry(1, { ...baseInput, surface: 'gh-actions', soul: 'knuth' });
+    expect(entry).toContain('gh-actions / chitin');
+    expect(entry).toContain('knuth @ <soul_hash[:8]>');
+    expect(entry).toContain('**Observed:** 2026-04-20');
+  });
+});
+
+describe('lintStructural', () => {
+  function bodyOf(block: string): { body: string; blocks: { id: string; body: string }[] } {
+    const blocks = splitEntries(block);
+    return { body: block, blocks };
+  }
+
+  it('reports nothing on a well-formed entry', () => {
+    const { body, blocks } = bodyOf(
+      '### GDL-001 — ok\n\n- **Observed:** x\n- **Lane:** ① FIX\n- **Graduated:** <null>\n',
+    );
+    expect(lintStructural(body, blocks)).toEqual([]);
+  });
+
+  it('reports duplicate ids as error', () => {
+    const body =
+      '### GDL-001 — a\n\n- **Observed:** x\n- **Lane:** ① FIX\n- **Graduated:** <null>\n' +
+      '### GDL-001 — b\n\n- **Observed:** y\n- **Lane:** ② DETERMINISM\n- **Graduated:** <null>\n';
+    const blocks = splitEntries(body);
+    const findings = lintStructural(body, blocks);
+    expect(findings.some((f) => f.level === 'error' && f.msg === 'duplicate ID')).toBe(true);
+  });
+
+  it('reports missing Observed as error', () => {
+    const { body, blocks } = bodyOf(
+      '### GDL-001 — ok\n\n- **Lane:** ① FIX\n- **Graduated:** <null>\n',
+    );
+    const findings = lintStructural(body, blocks);
+    expect(findings).toContainEqual({
+      level: 'error',
+      gdl: 'GDL-001',
+      msg: 'missing Observed field',
+    });
+  });
+
+  it('reports missing Lane as error', () => {
+    const { body, blocks } = bodyOf(
+      '### GDL-001 — ok\n\n- **Observed:** x\n- **Graduated:** <null>\n',
+    );
+    const findings = lintStructural(body, blocks);
+    expect(findings).toContainEqual({
+      level: 'error',
+      gdl: 'GDL-001',
+      msg: 'missing or malformed Lane',
+    });
+  });
+
+  it('reports malformed Lane (no circled digit) as error', () => {
+    const { body, blocks } = bodyOf(
+      '### GDL-001 — ok\n\n- **Observed:** x\n- **Lane:** FIX\n- **Graduated:** <null>\n',
+    );
+    const findings = lintStructural(body, blocks);
+    expect(findings).toContainEqual({
+      level: 'error',
+      gdl: 'GDL-001',
+      msg: 'missing or malformed Lane',
+    });
+  });
+
+  it('reports missing Graduated as warn (not error)', () => {
+    const { body, blocks } = bodyOf(
+      '### GDL-001 — ok\n\n- **Observed:** x\n- **Lane:** ① FIX\n',
+    );
+    const findings = lintStructural(body, blocks);
+    expect(findings).toContainEqual({
+      level: 'warn',
+      gdl: 'GDL-001',
+      msg: 'missing Graduated field',
+    });
+    expect(findings.filter((f) => f.level === 'error')).toEqual([]);
+  });
+});

--- a/apps/cli/tests/review.test.ts
+++ b/apps/cli/tests/review.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { parseWindow, renderHealth } from '../src/commands/review';
+import type { HealthReport } from '../src/commands/health';
+
+function mkReport(overrides: Partial<HealthReport> = {}): HealthReport {
+  return {
+    events_total: 0,
+    events_by_window: {},
+    hook_failure_count: 0,
+    schema_drift_count: 0,
+    orphaned_chains: 0,
+    dir_exists: true,
+    clock_skew_suspected: false,
+    ...overrides,
+  };
+}
+
+describe('parseWindow', () => {
+  it('parses hours', () => {
+    expect(parseWindow('24h')).toBe(24);
+    expect(parseWindow('1h')).toBe(1);
+  });
+
+  it('parses days to hours', () => {
+    expect(parseWindow('7d')).toBe(168);
+    expect(parseWindow('1d')).toBe(24);
+  });
+
+  it('throws on malformed input', () => {
+    expect(() => parseWindow('7')).toThrow(/bad window/);
+    expect(() => parseWindow('1w')).toThrow(/bad window/);
+    expect(() => parseWindow('')).toThrow(/bad window/);
+  });
+});
+
+describe('renderHealth', () => {
+  it('includes the chitin dir in the header', () => {
+    const lines = renderHealth(mkReport(), '/tmp/chit');
+    expect(lines[0]).toBe('## Health (/tmp/chit)');
+  });
+
+  it('renders MISSING when dir absent and skips metrics', () => {
+    const lines = renderHealth(mkReport({ dir_exists: false }), '/nope');
+    expect(lines).toEqual(['## Health (/nope)', '- chitin dir:        MISSING']);
+  });
+
+  it('renders one row per surface', () => {
+    const r = mkReport({
+      events_total: 4,
+      events_by_window: { 'claude-code': 3, 'gh-actions': 1 },
+    });
+    const lines = renderHealth(r, '/tmp/x');
+    expect(lines.some((l) => l.includes('events / claude-code'))).toBe(true);
+    expect(lines.some((l) => l.includes('events / gh-actions'))).toBe(true);
+  });
+
+  it('renders the four core metrics', () => {
+    const r = mkReport({
+      events_total: 9,
+      hook_failure_count: 2,
+      schema_drift_count: 1,
+      orphaned_chains: 3,
+    });
+    const lines = renderHealth(r, '/tmp/x');
+    expect(lines).toContain('- events total:      9');
+    expect(lines).toContain('- hook failures:     2');
+    expect(lines).toContain('- schema drift:      1');
+    expect(lines).toContain('- orphaned chains:   3');
+  });
+});

--- a/docs/observations/governance-debt-ledger.md
+++ b/docs/observations/governance-debt-ledger.md
@@ -1,0 +1,18 @@
+# Governance-Debt Ledger
+
+Living ledger of findings produced by the weekly dogfooding review
+(see `docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md`).
+
+Every entry cites a captured trace (`chain_id:seq` or content-addressed
+`this_hash`), classifies the finding into a triage lane, and tracks
+graduation. No speculative entries.
+
+---
+
+## Entries
+
+<!-- Append new entries here. IDs are stable; never renumber. -->
+
+<!-- GDL-000 reserved — do not use. -->
+
+<!-- First real entry starts at GDL-001. -->


### PR DESCRIPTION
Re-opens PR #29 (auto-closed when main's history was rewritten to scrub private-identifier leaks from commit metadata and file history). Same three commits, new SHAs after the rewrite.

## Summary

Phase D of the dogfood-debt-ledger plan. Ships the tooling that turns weekly dogfooding sessions into a living ledger.

- **D1** — seed `docs/observations/governance-debt-ledger.md` stub (GDL-NNN entry format, lane/severity/graduation scaffold) and `docs/observations/retrospectives/.gitkeep`.
- **D2+D3** — unified `apps/cli/src/commands/ledger.ts` with `ledger new <lane>` (stub appender) and `ledger lint` (id uniqueness, field presence, optional `events.db` trace-ref resolution, optional `gh` graduation-marker resolution). Pure helpers (`nextGDL`, `laneLabelFor`, `splitEntries`, `buildStubEntry`, `lintStructural`) are unit-tested without mocking fs/child_process/sqlite; effectful lint passes compose on top. Collapses the plan's D2+D3 into one commit since D3's original instruction was just "delete D2's file and make a unified one."
- **D4** — `chitin review --last <window>` aggregator. Prints kernel health metrics + 20 most recent sessions. Calls `chitin-kernel health` directly and invokes `eventsListCommand` in-process rather than re-shelling through `pnpm`. Gracefully reports `(no events captured yet)` when `events.db` does not exist.

## Verification

- 55 CLI tests passing (30 new: 23 ledger + 7 review); all Go kernel packages green.
- Smoke-run `chitin ledger new 1 --chain test-chain-abc --seq 5 --hash deadbeefcafebabe123` → well-formed GDL-001 entry.
- Smoke-run `chitin ledger lint` → `0 findings (0 errors)` on the stub.
- Smoke-run `chitin review --last 7d` → markdown report with Health + Recent sessions sections; exits 0.

## Test Plan

- [ ] CI green on this branch
- [ ] Copilot review
- [ ] Adversarial review pass
- [ ] Merge