### PR TITLE
chore(docs): replace mechanical substitutions with context-aware prose

### DIFF
--- a/docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md
+++ b/docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make chitin always-on observability on this RTX 3090 Linux box, add the CLI tooling needed for a weekly governance-debt-ledger review, ship a GH Actions composite stub, and complete the openclaw-adapter investigation up to a design-addendum spec (implementation deferred to a follow-up plan per Socrates/Knuth gates).
 
-**Architecture:** Generic `install --surface <name>` subcommand in the Go kernel (claude-code surface implemented; pattern documented for future surfaces). User-level install writes into `~/.claude/settings.json` pointing at a stable binary path (`~/.local/bin/chitin-kernel`). Orphan sessions (no enclosing `.chitin/`) land in `~/.chitin/`. Ledger lives at `chitin/docs/observations/governance-debt-ledger.md`; tooling (`chitin health`, `chitin review`, `chitin ledger new|lint`) supports the weekly review protocol. the work repo repo gets `.chitin/` gitignored on first clone.
+**Architecture:** Generic `install --surface <name>` subcommand in the Go kernel (claude-code surface implemented; pattern documented for future surfaces). User-level install writes into `~/.claude/settings.json` pointing at a stable binary path (`~/.local/bin/chitin-kernel`). Orphan sessions (no enclosing `.chitin/`) land in `~/.chitin/`. Ledger lives at `chitin/docs/observations/governance-debt-ledger.md`; tooling (`chitin health`, `chitin review`, `chitin ledger new|lint`) supports the weekly review protocol. Private work repos that the user clones onto the same box add `.chitin/` to their gitignore on first session (onboarding note for any specific private target is tracked in a private workspace, not in this OSS repo).
 
 **Tech Stack:** Go 1.25 (kernel), TypeScript + Node (CLI and adapter), pnpm + Nx workspace, Vitest (TS tests), `go test` (Go tests), `commander` (CLI), `better-sqlite3` (ledger lint trace resolution).
 
@@ -41,7 +41,6 @@
 **Docs and meta:**
 - `docs/observations/governance-debt-ledger.md` — seeded ledger (empty table of entries)
 - `docs/observations/retrospectives/.gitkeep`
-- `docs/observations/private-work-repo-onboarding.md` — one-page note about `.chitin/` gitignore rule
 - `.github/actions/observe/action.yml` — composite action stub
 - `scripts/install-kernel-symlink.sh` — symlink `dist/.../chitin-kernel` to `~/.local/bin/chitin-kernel`
 
@@ -119,7 +118,7 @@ Verify: `ls -l ~/.local/bin/chitin-kernel` shows the symlink; `chitin-kernel` on
 
 ```bash
 git add scripts/install-kernel-symlink.sh package.json
-git -c user.email=user@example.com -c user.name=Jared commit -m "build: install-kernel symlink to ~/.local/bin for stable path"
+git commit -m "build: install-kernel symlink to ~/.local/bin for stable path"
 ```
 
 ---
@@ -290,7 +289,7 @@ Expected: `--- PASS: TestResolve_FindsExistingChitinDirInParent`, `--- PASS: Tes
 
 ```bash
 git add go/execution-kernel/internal/chitindir/
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): chitindir resolver with walk-up and orphan fallback"
+git commit -m "feat(kernel): chitindir resolver with walk-up and orphan fallback"
 ```
 
 ---
@@ -420,7 +419,7 @@ Expected: 3 tests pass.
 
 ```bash
 git add libs/contracts/src/chitindir-resolve.ts libs/contracts/src/chitindir-resolve.test.ts libs/contracts/src/index.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(contracts): resolveChitinDir TS helper mirrors Go resolver"
+git commit -m "feat(contracts): resolveChitinDir TS helper mirrors Go resolver"
 ```
 
 ---
@@ -476,7 +475,7 @@ Expected: existing 2 tests still pass.
 
 ```bash
 git add go/execution-kernel/internal/hookinstall/install.go
-git -c user.email=user@example.com -c user.name=Jared commit -m "refactor(kernel): export SubscribedHooks for reuse by global install"
+git commit -m "refactor(kernel): export SubscribedHooks for reuse by global install"
 ```
 
 ---
@@ -772,7 +771,7 @@ Expected: all 5 tests pass (2 original + 3 new).
 
 ```bash
 git add go/execution-kernel/internal/hookinstall/global.go go/execution-kernel/internal/hookinstall/global_test.go
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): InstallGlobal / UninstallGlobal with merge semantics"
+git commit -m "feat(kernel): InstallGlobal / UninstallGlobal with merge semantics"
 ```
 
 ---
@@ -868,7 +867,7 @@ Verify: `cat "$HOME/.claude/settings.json"` shows hooks wired for `/usr/local/bi
 
 ```bash
 git add go/execution-kernel/cmd/chitin-kernel/main.go
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): install / uninstall subcommands with --surface dispatch"
+git commit -m "feat(kernel): install / uninstall subcommands with --surface dispatch"
 ```
 
 ---
@@ -1031,7 +1030,7 @@ Expected: the smoke test passes (status 0, `.chitin/` exists).
 
 ```bash
 git add libs/adapters/claude-code/bin/ libs/adapters/claude-code/package.json libs/adapters/claude-code/src/adapter-context.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(adapter-cc): stdin-based CLI entry for user-level hook install"
+git commit -m "feat(adapter-cc): stdin-based CLI entry for user-level hook install"
 ```
 
 ---
@@ -1169,7 +1168,7 @@ Expected: `{"ok":true}` from kernel, then `verify: OK — chitin adapter wired f
 
 ```bash
 git add apps/cli/src/commands/install.ts apps/cli/src/main.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chitin install / uninstall --surface commands"
+git commit -m "feat(cli): chitin install / uninstall --surface commands"
 ```
 
 ---
@@ -1248,7 +1247,7 @@ Expected: test passes.
 
 ```bash
 git add apps/cli/tests/install-e2e.test.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "test(cli): e2e install/uninstall against throwaway HOME"
+git commit -m "test(cli): e2e install/uninstall against throwaway HOME"
 ```
 
 ---
@@ -1444,7 +1443,7 @@ Expected: both tests pass.
 
 ```bash
 git add go/execution-kernel/internal/health/
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): health.Gather — events, hook failures, schema drift"
+git commit -m "feat(kernel): health.Gather — events, hook failures, schema drift"
 ```
 
 ---
@@ -1510,7 +1509,7 @@ Expected: JSON line containing `"events_total":1`, `"events_by_window":{"claude-
 
 ```bash
 git add go/execution-kernel/cmd/chitin-kernel/main.go
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): health subcommand over .chitin JSONL + error log"
+git commit -m "feat(kernel): health subcommand over .chitin JSONL + error log"
 ```
 
 ---
@@ -1607,7 +1606,7 @@ Expected: a `[PASS]` / `[WARN]` / `[FAIL]` table; exit code 0 or 1 depending on 
 
 ```bash
 git add apps/cli/src/commands/health.ts apps/cli/src/main.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chitin health with pass/warn/fail output"
+git commit -m "feat(cli): chitin health with pass/warn/fail output"
 ```
 
 ---
@@ -1619,7 +1618,6 @@ git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chit
 **Files:**
 - Create: `docs/observations/governance-debt-ledger.md`
 - Create: `docs/observations/retrospectives/.gitkeep`
-- Create: `docs/observations/private-work-repo-onboarding.md`
 
 - [ ] **Step 1: Create the ledger stub**
 
@@ -1653,32 +1651,21 @@ mkdir -p docs/observations/retrospectives
 touch docs/observations/retrospectives/.gitkeep
 ```
 
-- [ ] **Step 3: Write the the work repo onboarding note**
+- [ ] **Step 3: Write an onboarding note for any private integration target — in a private workspace, not in this repo**
 
-Create `docs/observations/private-work-repo-onboarding.md`:
+The originally-planned repo-specific onboarding note was removed from this repo per the chitin-is-OSS boundary rule (no private-company-specific content on any branch). For each private repo the user clones onto this box that will capture chitin events, an onboarding note belongs in the user's own private workspace (not in `chitinhq/chitin`). The note should cover:
 
-```markdown
-# private-work-repo Onboarding (chitin side)
+1. Add `.chitin/` to the private repo's `.gitignore` before the first session.
+2. Verify after first session: `git status -s .chitin` should report nothing staged.
+3. Ledger entries referencing private sessions use stable refs (`chain_id:seq` or `this_hash`); do not paste verbatim trace content that could identify internal logic. Paraphrase.
 
-When cloning `github.com/REDACTED/REDACTED` onto this box:
-
-1. **Add `.chitin/` to its `.gitignore`** before the first session there.
-   Chitin captures locally; events never commit to the work repo's repo.
-2. **Verify** after first session: `git status -s .chitin` should report
-   nothing staged.
-3. **Ledger entries** referencing the work repo sessions use stable refs
-   (`chain_id:seq` or `this_hash`); do not paste verbatim trace content
-   that could identify internal logic. Paraphrase.
-
-No chitin-side install is needed in the private-work-repo repo — the
-Claude Code hook is user-level, so capture happens automatically.
-```
+No chitin-side install is needed in the private repo — the Claude Code hook is user-level, so capture happens automatically.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add docs/observations/
-git -c user.email=user@example.com -c user.name=Jared commit -m "docs(observations): seed ledger file and the work repo onboarding note"
+git commit -m "docs(observations): seed ledger file"
 ```
 
 ---
@@ -1804,7 +1791,7 @@ git checkout docs/observations/governance-debt-ledger.md
 
 ```bash
 git add apps/cli/src/commands/ledger-new.ts apps/cli/src/main.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chitin ledger new — stub entry scaffolder"
+git commit -m "feat(cli): chitin ledger new — stub entry scaffolder"
 ```
 
 ---
@@ -2041,7 +2028,7 @@ Expected: lint reports structural warnings for the stub (placeholder values), ex
 ```bash
 git add apps/cli/src/commands/ledger.ts apps/cli/src/main.ts
 git rm apps/cli/src/commands/ledger-new.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chitin ledger lint — uniqueness, field presence, trace resolution, gh graduation check"
+git commit -m "feat(cli): chitin ledger lint — uniqueness, field presence, trace resolution, gh graduation check"
 ```
 
 ---
@@ -2143,7 +2130,7 @@ Expected: markdown-style report with Health section and Recent sessions section.
 
 ```bash
 git add apps/cli/src/commands/review.ts apps/cli/src/main.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chitin review — weekly skim aggregator"
+git commit -m "feat(cli): chitin review — weekly skim aggregator"
 ```
 
 ---
@@ -2202,7 +2189,7 @@ This is intentionally minimal: it emits raw JSONL without the Go kernel's hash-c
 
 ```bash
 git add .github/actions/observe/action.yml
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(ci): gh-actions composite stub emits session_start/end to .chitin"
+git commit -m "feat(ci): gh-actions composite stub emits session_start/end to .chitin"
 ```
 
 ---
@@ -2239,7 +2226,7 @@ Expected: test job runs, `.chitin/events.jsonl` appears in the workflow workspac
 
 ```bash
 git add .github/workflows/ci.yml
-git -c user.email=user@example.com -c user.name=Jared commit -m "ci: wire chitin's own CI through observe composite action"
+git commit -m "ci: wire chitin's own CI through observe composite action"
 ```
 
 ---
@@ -2273,7 +2260,7 @@ Run: `openclaw --help` (or equivalent). Capture stdout for the README.
 
 ```bash
 git add libs/adapters/openclaw/README.md libs/adapters/openclaw/SPIKE.md
-git -c user.email=user@example.com -c user.name=Jared commit -m "docs(openclaw): install path documented; smoke-verified locally"
+git commit -m "docs(openclaw): install path documented; smoke-verified locally"
 ```
 
 ---
@@ -2321,7 +2308,7 @@ Document in README under "Tool-call surface".
 
 ```bash
 git add libs/adapters/openclaw/README.md
-git -c user.email=user@example.com -c user.name=Jared commit -m "docs(openclaw): answer the 4 SPIKE questions from observation"
+git commit -m "docs(openclaw): answer the 4 SPIKE questions from observation"
 ```
 
 ---
@@ -2380,7 +2367,7 @@ event at entry and one session_end event at exit, linked by chain_id.">
 
 ```bash
 git add docs/superpowers/specs/YYYY-MM-DD-openclaw-adapter-implementation-design.md
-git -c user.email=user@example.com -c user.name=Jared commit -m "spec: openclaw adapter implementation design addendum"
+git commit -m "spec: openclaw adapter implementation design addendum"
 ```
 
 ---
@@ -2464,7 +2451,7 @@ Expected: exits 0 with no errors (warnings OK for soul_hash placeholder).
 
 ```bash
 git add docs/observations/governance-debt-ledger.md
-git -c user.email=user@example.com -c user.name=Jared commit -m "observations: GDL-001 — first live ledger entry (dogfooding proof-of-life)"
+git commit -m "observations: GDL-001 — first live ledger entry (dogfooding proof-of-life)"
 ```
 
 ---
@@ -2477,7 +2464,7 @@ git -c user.email=user@example.com -c user.name=Jared commit -m "observations: G
 |---|---|
 | Capture architecture: install mechanism (claude-code) | Phase B |
 | Capture architecture: events landing (walk-up + orphan) | Phase A2, A3 |
-| Capture architecture: privacy (defer redaction, `.chitin/` gitignore in private-work-repo) | Phase D1 (onboarding note), no code needed |
+| Capture architecture: privacy (defer redaction, `.chitin/` gitignore in any private work repo) | Phase D1 (onboarding note tracked in a private workspace, not in this repo), no code needed |
 | Capture architecture: openclaw workstream | Phase F |
 | Capture architecture: Copilot CLI | Out of scope (documented extension path; no tasks) |
 | Capture architecture: GH Actions composite | Phase E |

--- a/docs/superpowers/plans/2026-04-19-phase-1.5-observability-chain-contract.md
+++ b/docs/superpowers/plans/2026-04-19-phase-1.5-observability-chain-contract.md
@@ -162,7 +162,7 @@ Expected: PASS (6/6).
 
 ```bash
 git add libs/contracts/src/envelope.schema.ts libs/contracts/tests/envelope.schema.test.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(contracts): v2 envelope zod schema"
+git commit -m "feat(contracts): v2 envelope zod schema"
 ```
 
 ---
@@ -480,7 +480,7 @@ Expected: PASS (all cases).
 
 ```bash
 git add libs/contracts/src/payloads.schema.ts libs/contracts/tests/payloads.schema.test.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(contracts): v2 per-event payload schemas"
+git commit -m "feat(contracts): v2 per-event payload schemas"
 ```
 
 ---
@@ -663,7 +663,7 @@ Expected: all PASS.
 
 ```bash
 git add libs/contracts/src libs/contracts/tests
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(contracts)!: v2 Event = Envelope + discriminated payload, break v1"
+git commit -m "feat(contracts)!: v2 Event = Envelope + discriminated payload, break v1"
 ```
 
 ---
@@ -798,7 +798,7 @@ export * from './hash';
 
 ```bash
 git add libs/contracts/src/hash.ts libs/contracts/src/index.ts libs/contracts/tests/hash.test.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(contracts): canonical JSON + SHA-256 hash helpers"
+git commit -m "feat(contracts): canonical JSON + SHA-256 hash helpers"
 ```
 
 ---
@@ -1055,7 +1055,7 @@ Expected: PASS.
 
 ```bash
 git add go/execution-kernel/internal/hash/
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): canonical JSON + SHA-256 hash helpers (Go parity with TS)"
+git commit -m "feat(kernel): canonical JSON + SHA-256 hash helpers (Go parity with TS)"
 ```
 
 ---
@@ -1343,7 +1343,7 @@ Expected: PASS for chain. Existing event/emit/hook tests may break because `Even
 
 ```bash
 git add go/execution-kernel/internal/event go/execution-kernel/internal/chain go/execution-kernel/go.mod go/execution-kernel/go.sum
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): v2 Event struct + chain index (sqlite-backed)"
+git commit -m "feat(kernel): v2 Event struct + chain index (sqlite-backed)"
 ```
 
 ---
@@ -1630,7 +1630,7 @@ Expected: `canon`, `normalize`, `event`, `hash`, `chain`, `emit` PASS. `hook` ha
 
 ```bash
 git add go/execution-kernel/internal go/execution-kernel/cmd
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): v2 emit — seq + hash linkage + JSONL append"
+git commit -m "feat(kernel): v2 emit — seq + hash linkage + JSONL append"
 ```
 
 ---
@@ -1827,7 +1827,7 @@ Expected: `sessions/` and `transcript_checkpoint.json` present.
 
 ```bash
 git add go/execution-kernel
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): init subcommand (idempotent + --force wipe)"
+git commit -m "feat(kernel): init subcommand (idempotent + --force wipe)"
 ```
 
 ---
@@ -2085,7 +2085,7 @@ Expected: JSONL contains one line with filled `seq=0`, `prev_hash=null`, `this_h
 
 ```bash
 git add go/execution-kernel
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): emit + chain-info subcommands + hook dispatcher"
+git commit -m "feat(kernel): emit + chain-info subcommands + hook dispatcher"
 ```
 
 ---
@@ -2405,7 +2405,7 @@ Expected: PASS for all packages.
 
 ```bash
 git add go/execution-kernel
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): ingest-transcript subcommand + checkpoint; sweep-transcripts stub"
+git commit -m "feat(kernel): ingest-transcript subcommand + checkpoint; sweep-transcripts stub"
 ```
 
 ---
@@ -2678,7 +2678,7 @@ Expected: PASS (dispatch tests; runner is tested via smoke in T17).
 
 ```bash
 git add libs/adapters/claude-code
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(adapter/claude-code): v2 hook runner — 7 hooks → kernel emit"
+git commit -m "feat(adapter/claude-code): v2 hook runner — 7 hooks → kernel emit"
 ```
 
 ---
@@ -2933,7 +2933,7 @@ Expected: PASS.
 
 ```bash
 git add apps/cli
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): chitin run <surface> orchestration + adapter context"
+git commit -m "feat(cli): chitin run <surface> orchestration + adapter context"
 ```
 
 ---
@@ -3133,7 +3133,7 @@ Expected: PASS.
 
 ```bash
 git add go/execution-kernel
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(kernel): install-hook / uninstall-hook subcommands"
+git commit -m "feat(kernel): install-hook / uninstall-hook subcommands"
 ```
 
 ---
@@ -3373,7 +3373,7 @@ Expected: PASS.
 
 ```bash
 git add libs/adapters/ollama-local apps/cli pnpm-lock.yaml pnpm-workspace.yaml 2>/dev/null || git add libs/adapters/ollama-local apps/cli
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(adapter/ollama-local): session-chain wrapper mode"
+git commit -m "feat(adapter/ollama-local): session-chain wrapper mode"
 ```
 
 ---
@@ -3495,7 +3495,7 @@ Expected: PASS.
 
 ```bash
 git add libs/adapters/openclaw apps/cli
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(adapter/openclaw): spike + minimal session-chain wrapper"
+git commit -m "feat(adapter/openclaw): spike + minimal session-chain wrapper"
 ```
 
 ---
@@ -3693,7 +3693,7 @@ registerEventsTree(program);
 
 ```bash
 git add apps/cli libs/telemetry
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(cli): events:tree renderer + telemetry session query helper"
+git commit -m "feat(cli): events:tree renderer + telemetry session query helper"
 ```
 
 ---
@@ -4037,7 +4037,7 @@ Expected: PASS. (Any remaining v1-shaped assertions should be rewritten to v2; d
 
 ```bash
 git add libs/telemetry
-git -c user.email=user@example.com -c user.name=Jared commit -m "feat(telemetry)!: v2 SQLite schema + JSONL tailer + replay tree walker"
+git commit -m "feat(telemetry)!: v2 SQLite schema + JSONL tailer + replay tree walker"
 ```
 
 ---
@@ -4141,7 +4141,7 @@ Expected: PASS.
 
 ```bash
 git add apps/cli/tests/e2e.smoke.test.ts
-git -c user.email=user@example.com -c user.name=Jared commit -m "test(cli): e2e smoke — chain seq + hash linkage"
+git commit -m "test(cli): e2e smoke — chain seq + hash linkage"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md
+++ b/docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md
@@ -32,7 +32,7 @@ Dogfooding quantifies the debt as it accumulates. Phase 2 pays it down.
 ## Scope
 
 **In scope:**
-- User-level Claude Code capture on this box (`chitinhq/chitin` + the work repo work + orphan sessions).
+- User-level Claude Code capture on this box (`chitinhq/chitin` + private work repos + orphan sessions).
 - Debt ledger artifact + entry format + three-lane triage model.
 - Weekly review cadence and protocol.
 - Trip-wires and soul-handoff mechanics.
@@ -113,8 +113,8 @@ removes the symlink.
 ### 2. Events landing
 
 - **Repo-local default:** walk up from cwd looking for existing `.chitin/`;
-  use it if found. Covers chitin repo, private-work-repo once cloned, any
-  future chitin-aware repo.
+  use it if found. Covers chitin repo, any private work repo once cloned,
+  any future chitin-aware repo.
 - **Orphan fallback:** `~/.chitin/events.jsonl` when cwd has no enclosing
   `.chitin/` inside a workspace boundary.
 - **Chain integrity:** same `chain_id` / `prev_hash` / `seq` contract as
@@ -123,16 +123,16 @@ removes the symlink.
 
 ### 3. Privacy / redaction
 
-- No client secrets on this box. the work repo repo is user's own; chitin is
-  open-source. Defer redaction.
+- No client secrets on this box. Private work repos stay in their own
+  remotes; chitin is open-source. Defer redaction.
 - Flag: if/when a repo with real third-party secrets lands here, redesign
   redaction before the first session in that repo.
 - Never-commit list for chitin's `.gitignore`: no additions. Chitin's own
   `.chitin/events.jsonl` stays committed (dogfood-eating-itself is the
   demo).
-- Never-commit list for private-work-repo's `.gitignore`: `.chitin/`
+- Never-commit list for any private work repo's `.gitignore`: `.chitin/`
   added on first session. Events capture locally, ledger entries flow to
-  chitin's repo, zero artifacts in the work repo's git history.
+  chitin's repo, zero artifacts in the private repo's git history.
 
 ### 4. openclaw workstream (parallel to Claude Code install)
 
@@ -172,8 +172,8 @@ re-fighting the vote):**
 ### Location
 
 `chitin/docs/observations/governance-debt-ledger.md` — chitin repo only.
-the work repo never sees it, even when entries reference traces from work
-done inside private-work-repo.
+The private work repo never sees it, even when entries reference traces
+from work done inside it.
 
 ### Entry shape
 
@@ -181,7 +181,7 @@ done inside private-work-repo.
 ### GDL-NNN — <one-line what the platform should have caught>
 
 - **Observed:** YYYY-MM-DD, chain `<chain_id>`, seq `<n>`, hash `<this_hash[:12]>`
-- **Surface / repo:** claude-code / chitin  |  claude-code / private-work-repo  |  openclaw / chitin  |  ...
+- **Surface / repo:** claude-code / chitin  |  claude-code / <private-work-repo>  |  openclaw / chitin  |  ...
 - **Finding:** what happened, one paragraph.
 - **Lane:** ① FIX | ② DETERMINISM | ③ SOUL ROUTING
 - **Severity:** low / medium / high (impact if this recurs at scale)
@@ -192,11 +192,11 @@ done inside private-work-repo.
 ### Cross-repo trace refs
 
 - Prefer stable refs: `chain_id:seq` or content-addressed `this_hash`.
-- File-path refs (`private-work-repo/.chitin/events.jsonl#L42`) are
+- File-path refs (`<private-work-repo>/.chitin/events.jsonl#L42`) are
   fallback only — machine-local.
 - Quoting trace content: paraphrase if content could identify internal
-  the work repo logic. Most entries will be chitin-on-chitin; cross-repo
-  entries are the minority.
+  logic in any private codebase. Most entries will be chitin-on-chitin;
+  cross-repo entries are the minority.
 
 ### Invariants
 
@@ -224,7 +224,7 @@ minutes; if it bloats, the tooling needs work.
    - Chain-depth distribution
    - Orphaned chains (`session_start` with no `session_end`)
 2. **Narrative replay** (10–15 min) — pick 2–3 recent sessions across
-   available repos (chitin always available; private-work-repo once
+   available repos (chitin always available; private work repos once
    cloned here; orphan sessions from `~/.chitin/` are valid picks too).
    Run `chitin replay <session_id>`. Ask:
    - Did the trace tell the session's story accurately?
@@ -236,7 +236,7 @@ minutes; if it bloats, the tooling needs work.
 ### Trigger events (interrupt cadence)
 
 - Hook silently dropped an event → immediate Knuth session.
-- the work repo session had a near-miss (almost committed a secret, ran
+- A private work session had a near-miss (almost committed a secret, ran
   something destructive) → immediate write-up.
 - A lane crosses its saturation threshold → graduate that lane.
 

--- a/docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md
+++ b/docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md
@@ -115,8 +115,8 @@ removes the symlink.
 - **Repo-local default:** walk up from cwd looking for existing `.chitin/`;
   use it if found. Covers chitin repo, any private work repo once cloned,
   any future chitin-aware repo.
-- **Orphan fallback:** `~/.chitin/events.jsonl` when cwd has no enclosing
-  `.chitin/` inside a workspace boundary.
+- **Orphan fallback:** `~/.chitin/events-*.jsonl` (per-run) when cwd has
+  no enclosing `.chitin/` inside a workspace boundary.
 - **Chain integrity:** same `chain_id` / `prev_hash` / `seq` contract as
   Phase 1.5. No special-casing for orphan events — they're just a different
   storage root.
@@ -128,8 +128,8 @@ removes the symlink.
 - Flag: if/when a repo with real third-party secrets lands here, redesign
   redaction before the first session in that repo.
 - Never-commit list for chitin's `.gitignore`: no additions. Chitin's own
-  `.chitin/events.jsonl` stays committed (dogfood-eating-itself is the
-  demo).
+  `.chitin/events-*.jsonl` files stay committed (dogfood-eating-itself is
+  the demo).
 - Never-commit list for any private work repo's `.gitignore`: `.chitin/`
   added on first session. Events capture locally, ledger entries flow to
   chitin's repo, zero artifacts in the private repo's git history.
@@ -192,8 +192,8 @@ from work done inside it.
 ### Cross-repo trace refs
 
 - Prefer stable refs: `chain_id:seq` or content-addressed `this_hash`.
-- File-path refs (`<private-work-repo>/.chitin/events.jsonl#L42`) are
-  fallback only — machine-local.
+- File-path refs (`<private-work-repo>/.chitin/events-<run_id>.jsonl#L42`)
+  are fallback only — machine-local.
 - Quoting trace content: paraphrase if content could identify internal
   logic in any private codebase. Most entries will be chitin-on-chitin;
   cross-repo entries are the minority.

--- a/souls/elo.md
+++ b/souls/elo.md
@@ -42,10 +42,10 @@ trainer's note, not a benchmark.
 
 ### 2026-04-20
 
-- **Knuth −1 → 1499.** Strike 1. Used `user@example.com` (work email)
-  for every direct commit in the Phase C session, copying the plan
-  file's example verbatim without verifying. the work repo is the WORK
-  repo; chitin is personal and should attribute to `jpleva91@gmail.com`.
+- **Knuth −1 → 1499.** Strike 1. Used a work-project email for every
+  direct commit in the Phase C session, copying the plan file's
+  example verbatim without verifying. chitin is personal OSS and
+  should attribute to `jpleva91@gmail.com`, not any work identity.
   Squash-merges on main were correctly attributed via GitHub's PR-author
   logic, but three direct-to-main scope-note commits carry the wrong
   identity. Knuth's heuristic 1 ("prove it or it's not proven")

--- a/souls/strikes/knuth.md
+++ b/souls/strikes/knuth.md
@@ -26,11 +26,14 @@ commits for Knuth scope updates.
 **What the lens was supposed to catch.**
 Heuristic 1 — *Prove it or it's not proven.* A commit's author identity is
 a small invariant: "this commit is attributed to the entity who authored
-it." The plan file at `docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md`
-contains example commands with a hard-coded work-project email.
-Those examples were wrong — that was a work identity;
-chitin is a personal OSS repo that should attribute to `jpleva91@gmail.com`.
-I used the plan's example verbatim without verifying the invariant.
+it." At the time of this strike, the plan file at
+`docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md` contained
+example commands with a hard-coded work-project email. Those examples
+were wrong — that was a work identity; chitin is a personal OSS repo
+that should attribute to `jpleva91@gmail.com`. I used the plan's example
+verbatim without verifying the invariant. (The plan examples have since
+been fixed to use plain `git commit` with no hard-coded identity, so
+new readers won't be led astray by the same trap.)
 
 Secondarily, heuristic 2 — *Naming is half the algorithm.* An author name
 IS a name. Copying it from an example without reading what it represented

--- a/souls/strikes/knuth.md
+++ b/souls/strikes/knuth.md
@@ -27,8 +27,8 @@ commits for Knuth scope updates.
 Heuristic 1 — *Prove it or it's not proven.* A commit's author identity is
 a small invariant: "this commit is attributed to the entity who authored
 it." The plan file at `docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md`
-contains example commands with `-c user.email=user@example.com` hard-coded.
-Those examples were wrong — the the work repo email is the WORK identity;
+contains example commands with a hard-coded work-project email.
+Those examples were wrong — that was a work identity;
 chitin is a personal OSS repo that should attribute to `jpleva91@gmail.com`.
 I used the plan's example verbatim without verifying the invariant.
 
@@ -38,8 +38,8 @@ is exactly the "vague noun hiding logic" pattern Knuth's heuristic 2
 warns against.
 
 **What actually happened.**
-Every direct commit I authored in the session used
-`user@example.com`. The PR squash-merges on `main` attributed correctly
+Every direct commit I authored in the session used the work
+identity. The PR squash-merges on `main` attributed correctly
 to `jpleva91@gmail.com` because GitHub uses the PR author for squash
 commits — but three direct-to-main scope-note commits bypass that and
 carry the wrong identity (`6afc3de`, `bf5295b`, and earlier Phase B notes).
@@ -59,12 +59,12 @@ Secondary: heuristic 2 (naming is half the algorithm). An email is a
 name; copying one without reading what it represents is unnamed logic.
 
 **Remediation.**
-- `.mailmap` added at repo root translating `user@example.com` →
+- `.mailmap` added at repo root translating the work email →
   `jpleva91@gmail.com` for historical commits. Non-destructive;
   `git log --use-mailmap` and GitHub's UI will now show the correct
   attribution without rewriting main's history.
 - Memory saved: `project_git_identity.md` — explicit rule that chitin
-  commits use `jpleva91@gmail.com`; the work repo email is work-only.
+  commits use `jpleva91@gmail.com`; the work email stays on work repos only.
 - ELO: Knuth −1 → 1499. Event logged in `souls/elo.md`.
 - Plan file will be corrected in a future commit (examples should show
   the right email), but not in this remediation PR — it's a separate


### PR DESCRIPTION
Re-opens PR #30 (auto-closed when main's history was rewritten). Purpose has narrowed — post-rewrite, main already has private-identifier strings scrubbed by mechanical `--replace-text` substitution, so the commit-metadata and file-history leaks are gone. But some of those mechanical substitutions read awkwardly (`the work repo work`, `the work repo repo is user's own`, lowercase `the` at sentence starts). This PR replaces them with context-aware prose.

## What's in this PR

Context-aware prose replacements in: `docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md`, `docs/superpowers/plans/2026-04-19-dogfood-debt-ledger.md`, `docs/superpowers/plans/2026-04-19-phase-1.5-observability-chain-contract.md`, `souls/elo.md`, `souls/strikes/knuth.md`.

Example of what changes:

- Before (mechanical): `Readybench repo is user's own; chitin is` → `the work repo repo is user's own; chitin is`
- After (prose): `Private work repos stay in their own remotes; chitin is`

And the D1 Step 3 section in the dogfood plan gets a real rewrite acknowledging the OSS-boundary rule, rather than just replacing proper nouns.

## Test Plan

- [ ] CI green
- [ ] Read-through for remaining awkward phrasing
- [ ] Merge