### PR TITLE
Phase E: GH Actions composite — observe action + CI wire-up

### DIFF
--- a/.github/actions/observe/action.yml
+++ b/.github/actions/observe/action.yml
@@ -1,0 +1,46 @@
+name: chitin observe
+description: Wrap a workflow job with chitin session_start / session_end events.
+
+# Stub emission — raw JSONL, no hash linkage, no full v2 envelope. Events
+# written here will not parse through the kernel's sqlite indexer until
+# the composite is upgraded to invoke a chitin-kernel binary for emit.
+# Stamping session boundaries now so that future CI-aware tooling
+# (chitin review, ledger trace-refs) has something to point at.
+
+inputs:
+  run-id:
+    description: Unique run identifier (defaults to the GH run id)
+    required: false
+    default: ${{ github.run_id }}
+  workspace:
+    description: Workspace dir (defaults to GITHUB_WORKSPACE)
+    required: false
+    default: ${{ github.workspace }}
+
+runs:
+  using: composite
+  steps:
+    - name: chitin — session_start
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${{ inputs.workspace }}/.chitin"
+        SESSION_ID="gh-${{ inputs.run-id }}-${{ github.job }}"
+        TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        LOG="${{ inputs.workspace }}/.chitin/events-${{ inputs.run-id }}.jsonl"
+        cat >> "$LOG" <<EOF
+        {"schema_version":"2","ts":"$TS","event_type":"session_start","surface":"gh-actions","session_id":"$SESSION_ID","chain_id":"$SESSION_ID","chain_type":"session","seq":0,"prev_hash":null,"this_hash":"","payload":{"cwd":"${{ inputs.workspace }}","client_info":{"name":"gh-actions","version":"${{ github.action_ref || 'unknown' }}"}}}
+        EOF
+        echo "CHITIN_SESSION_ID=$SESSION_ID" >> "$GITHUB_ENV"
+        echo "CHITIN_RUN_ID=${{ inputs.run-id }}" >> "$GITHUB_ENV"
+
+    - name: chitin — session_end (always)
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+        TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        LOG="${{ inputs.workspace }}/.chitin/events-${CHITIN_RUN_ID:-${{ inputs.run-id }}}.jsonl"
+        cat >> "$LOG" <<EOF
+        {"schema_version":"2","ts":"$TS","event_type":"session_end","surface":"gh-actions","session_id":"${CHITIN_SESSION_ID:-unknown}","chain_id":"${CHITIN_SESSION_ID:-unknown}","chain_type":"session","seq":0,"prev_hash":null,"this_hash":"","payload":{"reason":"gh-actions workflow end","job_status":"${{ job.status }}"}}
+        EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/observe
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10


### PR DESCRIPTION
## Summary

Phase E of the dogfood-debt-ledger plan. Ships the GH Actions composite action and wires chitin's own CI through it, so CI runs stamp session boundaries on the same surface/schema family as Claude Code and openclaw.

- **E1** (`c056c9a`) — `.github/actions/observe/action.yml`. Writes minimal `session_start` and always-on `session_end` events to `.chitin/events-<run_id>.jsonl` (matches kernel's per-run convention). Persists `CHITIN_SESSION_ID` and `CHITIN_RUN_ID` to `$GITHUB_ENV` so the end step pairs with the start even if `inputs.run-id` evaluates differently at the two steps.
- **E2** (`b9419e5`) — wires `./.github/actions/observe` into `.github/workflows/ci.yml` as the first step after `actions/checkout@v4`.

## Known stubs (intentional)

The emission is raw JSONL without hash-chain linkage and missing several v2 envelope fields (`driver_identity`, `agent_instance_id`, `agent_fingerprint`, `labels`). Events written by this action will not parse through the sqlite indexer until the composite is upgraded to invoke a chitin-kernel binary for the emit path. This is the minimal-stub path the plan calls out at §2186 — stamping the boundaries now so later CI-aware tooling (`chitin review` from CI, ledger cross-refs against CI runs) has something to point at.

Nothing in CI consumes the emitted events yet, so malformed-event parse failures are not a risk on this PR.

## Verification

- Both YAML files parse via `yaml.safe_load`.
- CI on this PR will itself run the composite (via the E2 wire-up) — first live exercise of the action.

## Test Plan

- [ ] CI green on this branch (proves the composite is syntactically valid and runs end-to-end)
- [ ] Copilot review
- [ ] Adversarial pass (Hamilton lens)
- [ ] Merge