### PR TITLE
fix(telemetry): add .js extension for ESM import in jsonl-tailer.ts

### DIFF
--- a/libs/telemetry/src/jsonl-tailer.ts
+++ b/libs/telemetry/src/jsonl-tailer.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
-import type { V2Event } from './sqlite-indexer';
+import type { V2Event } from './sqlite-indexer.js';
 
 export async function* tailJSONL(path: string): AsyncGenerator<V2Event> {
   const rl = createInterface({


### PR DESCRIPTION
Resolves #10

NodeNext module resolution requires `.js` extensions on relative imports. All other imports in the telemetry package already use `.js`; `jsonl-tailer.ts` was the only holdout.

**Change:** `'./sqlite-indexer'` → `'./sqlite-indexer.js'` on line 3 of `libs/telemetry/src/jsonl-tailer.ts`

Verified with `tsc --noEmit` — compiles cleanly.