### PR TITLE
docs: add autonomous canary note

### DIFF
--- a/docs/observations/README.md
+++ b/docs/observations/README.md
@@ -1,0 +1,2 @@
+Observations
+Autonomous canary succeeded on 2026-04-22


### PR DESCRIPTION
This PR adds a canary note to docs/observations/README.md as part of the autonomous worker test.