### PR TITLE
fix(hermes-tick): mutex + timeouts + diff validation after first live tick

### DIFF
--- a/scripts/hermes/tests/stubs/git
+++ b/scripts/hermes/tests/stubs/git
@@ -4,6 +4,12 @@ echo "git $*" >> "${STUB_LOG:?}"
 # Pass-through mode for sub-commands tick.sh cares about (apply --check
 # must succeed for happy paths; commit/push are no-ops).
 case "$*" in
-  "apply --check"*) exit 0 ;;
-  *)                exit 0 ;;
+  "apply --check"*)
+    if [[ -n "${STUB_GIT_APPLY_CHECK_FAIL:-}" ]]; then
+      echo "error: patch does not apply" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *) exit 0 ;;
 esac

--- a/scripts/hermes/tests/tick.bats
+++ b/scripts/hermes/tests/tick.bats
@@ -10,7 +10,12 @@ setup() {
   export CHITIN_SINK_ROOT="$TEST_TMPDIR/chitin-sink"
   export HERMES_TICK_TS="20260422T000000Z"         # deterministic tick dir name
   export HERMES_TICK_DATE="2026-04-22"
-  mkdir -p "$CHITIN_SINK_ROOT/ticks"
+  # Isolate tick-level state that now has env overrides (lock file,
+  # worktree base). Keeps tests from touching the real /tmp lock or
+  # ~/workspace.
+  export HERMES_TICK_LOCK_FILE="$TEST_TMPDIR/hermes-tick.lock"
+  export HERMES_TICK_WORKTREE_BASE="$TEST_TMPDIR/worktrees"
+  mkdir -p "$CHITIN_SINK_ROOT/ticks" "$HERMES_TICK_WORKTREE_BASE"
   : > "$STUB_LOG"
 
   STUBS="$BATS_TEST_DIRNAME/stubs"
@@ -142,4 +147,84 @@ teardown() {
   tick_dir="$CHITIN_SINK_ROOT/ticks/$HERMES_TICK_DATE/$HERMES_TICK_TS"
   [ -f "$tick_dir/act-log.txt" ]
   grep -q 'HERMES_TICK_DRY_RUN=1' "$STUB_LOG"
+}
+
+@test "concurrency guard: second tick exits cleanly when lock is held" {
+  # Hold the lock in an inherited fd from a subshell that blocks until we
+  # let it go. If tick.sh sees the lock busy, it must exit 0 without
+  # running any stages.
+  ( flock -x 200; sleep 5 ) 200>"$HERMES_TICK_LOCK_FILE" &
+  lock_holder=$!
+  # Give the subshell a moment to acquire the flock.
+  sleep 0.2
+
+  run "$BATS_TEST_DIRNAME/../tick.sh"
+  [ "$status" -eq 0 ]
+
+  # No stage 1 invocation, no tick dir contents — the run short-circuited
+  # before queue fetch.
+  ! grep -q '^hermes chat' "$STUB_LOG"
+  tick_dir="$CHITIN_SINK_ROOT/ticks/$HERMES_TICK_DATE/$HERMES_TICK_TS"
+  [ ! -f "$tick_dir/plan.json" ]
+
+  # The skip message goes to stderr so cron-tick.log captures it.
+  echo "$output" | grep -q 'lock held by another run'
+
+  kill "$lock_holder" 2>/dev/null || true
+  wait "$lock_holder" 2>/dev/null || true
+}
+
+@test "fence strip: stage 2 output wrapped in code fences is stripped before git apply --check" {
+  export STUB_HERMES_PLAN_OUTPUT='{"action":"code","issue_number":10,"reason":"fix ESM","diff_request":{"files":["x.ts"],"intent":"append .js"}}'
+  # qwen3-coder:30b emits its diff inside a fenced block despite prompt
+  # instructions. The fence lines must be stripped before stage 3.
+  export STUB_HERMES_CODE_OUTPUT='```diff
+--- a/x.ts
++++ b/x.ts
+@@ -1 +1 @@
+-import { foo } from "./bar";
++import { foo } from "./bar.js";
+```'
+
+  run "$BATS_TEST_DIRNAME/../tick.sh"
+  [ "$status" -eq 0 ]
+
+  tick_dir="$CHITIN_SINK_ROOT/ticks/$HERMES_TICK_DATE/$HERMES_TICK_TS"
+  # Fences gone, diff body preserved.
+  ! grep -q '^```' "$tick_dir/diff.patch"
+  grep -q '^--- a/x.ts' "$tick_dir/diff.patch"
+  grep -q '^+++ b/x.ts' "$tick_dir/diff.patch"
+  # Stage 2 logged as done (validation passed via git stub apply --check).
+  grep -q 'stage 2 done' "$tick_dir/tick.log"
+}
+
+@test "invalid diff: git apply --check failure short-circuits before stage 3" {
+  export STUB_HERMES_PLAN_OUTPUT='{"action":"code","issue_number":10,"reason":"fix","diff_request":{"files":["x.ts"],"intent":"fix"}}'
+  export STUB_HERMES_CODE_OUTPUT='not a valid diff at all'
+  export STUB_GIT_APPLY_CHECK_FAIL=1
+
+  run "$BATS_TEST_DIRNAME/../tick.sh"
+  [ "$status" -eq 0 ]
+
+  tick_dir="$CHITIN_SINK_ROOT/ticks/$HERMES_TICK_DATE/$HERMES_TICK_TS"
+  grep -q 'stage 2 invalid diff' "$tick_dir/tick.log"
+  # Stage 3 never ran — no act-log.
+  [ ! -f "$tick_dir/act-log.txt" ]
+  ! grep -q 'Stage 3 (ACT)' "$STUB_LOG"
+}
+
+@test "in-flight worktree: pre-existing chitin-N dir causes code action to skip" {
+  export STUB_HERMES_PLAN_OUTPUT='{"action":"code","issue_number":10,"reason":"fix","diff_request":{"files":["x.ts"],"intent":"fix"}}'
+  # A worktree already exists for issue #10 — likely from an earlier tick
+  # still finishing. Skip rather than duplicate the attempt.
+  mkdir -p "$HERMES_TICK_WORKTREE_BASE/chitin-10"
+
+  run "$BATS_TEST_DIRNAME/../tick.sh"
+  [ "$status" -eq 0 ]
+
+  tick_dir="$CHITIN_SINK_ROOT/ticks/$HERMES_TICK_DATE/$HERMES_TICK_TS"
+  grep -q 'in_flight_local' "$tick_dir/tick.log"
+  # Stage 2 never ran.
+  [ ! -f "$tick_dir/diff.patch" ]
+  ! grep -q 'qwen3-coder' "$STUB_LOG"
 }

--- a/scripts/hermes/tests/tick.bats
+++ b/scripts/hermes/tests/tick.bats
@@ -11,11 +11,13 @@ setup() {
   export HERMES_TICK_TS="20260422T000000Z"         # deterministic tick dir name
   export HERMES_TICK_DATE="2026-04-22"
   # Isolate tick-level state that now has env overrides (lock file,
-  # worktree base). Keeps tests from touching the real /tmp lock or
-  # ~/workspace.
+  # worktree base, repo root). Keeps tests from touching the real /tmp
+  # lock or ~/workspace. The repo root is where stage 2 runs
+  # `git apply --check` — bare dir is enough since `git` is stubbed.
   export HERMES_TICK_LOCK_FILE="$TEST_TMPDIR/hermes-tick.lock"
   export HERMES_TICK_WORKTREE_BASE="$TEST_TMPDIR/worktrees"
-  mkdir -p "$CHITIN_SINK_ROOT/ticks" "$HERMES_TICK_WORKTREE_BASE"
+  export HERMES_TICK_REPO_ROOT="$TEST_TMPDIR/repo"
+  mkdir -p "$CHITIN_SINK_ROOT/ticks" "$HERMES_TICK_WORKTREE_BASE" "$HERMES_TICK_REPO_ROOT"
   : > "$STUB_LOG"
 
   STUBS="$BATS_TEST_DIRNAME/stubs"

--- a/scripts/hermes/tests/tick.bats
+++ b/scripts/hermes/tests/tick.bats
@@ -153,10 +153,15 @@ teardown() {
   # Hold the lock in an inherited fd from a subshell that blocks until we
   # let it go. If tick.sh sees the lock busy, it must exit 0 without
   # running any stages.
-  ( flock -x 200; sleep 5 ) 200>"$HERMES_TICK_LOCK_FILE" &
+  ready_file="$TEST_TMPDIR/lock-holder.ready"
+  ( flock -x 200; touch "$ready_file"; sleep 5 ) 200>"$HERMES_TICK_LOCK_FILE" &
   lock_holder=$!
-  # Give the subshell a moment to acquire the flock.
-  sleep 0.2
+  # Wait (up to ~2.5s) for the holder to signal it has the lock.
+  for _ in $(seq 1 50); do
+    [[ -f "$ready_file" ]] && break
+    sleep 0.05
+  done
+  [[ -f "$ready_file" ]]
 
   run "$BATS_TEST_DIRNAME/../tick.sh"
   [ "$status" -eq 0 ]

--- a/scripts/hermes/tick.sh
+++ b/scripts/hermes/tick.sh
@@ -36,9 +36,30 @@ MODEL_PLAN="${HERMES_TICK_MODEL_PLAN:-glm-5.1:cloud}"
 MODEL_CODE="${HERMES_TICK_MODEL_CODE:-qwen3-coder:30b}"
 MODEL_ACT="${HERMES_TICK_MODEL_ACT:-glm-5.1:cloud}"
 
+# Per-stage timeouts. Stage 2 budget covers cold local-model load (~7 min
+# observed for qwen3-coder:30b after 38h idle). Stage 3 budget covers
+# multi-tool execution (git apply → commit → push → gh pr create).
+TIMEOUT_PLAN="${HERMES_TICK_TIMEOUT_PLAN:-120}"
+TIMEOUT_CODE="${HERMES_TICK_TIMEOUT_CODE:-900}"
+TIMEOUT_ACT="${HERMES_TICK_TIMEOUT_ACT:-600}"
+
+# Worktree base for in-flight detection (see code-action branch).
+WORKTREE_BASE="${HERMES_TICK_WORKTREE_BASE:-$HOME/workspace}"
+
 # Deterministic timestamps for tests; real runs compute fresh.
 ts="${HERMES_TICK_TS:-$(date -u +%Y%m%dT%H%M%SZ)}"
 date_str="${HERMES_TICK_DATE:-$(date -u +%Y-%m-%d)}"
+
+# ---- Concurrency guard ----------------------------------------------------
+# Prevent stacked ticks when a previous run is still in flight (eg. stage 2
+# took longer than the cron cadence). A second cron fire exits cleanly
+# rather than racing for the same queue item.
+LOCK_FILE="${HERMES_TICK_LOCK_FILE:-/tmp/hermes-tick.lock}"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "[$(date -u +%H:%M:%SZ)] tick skipped — lock held by another run ($LOCK_FILE)" >&2
+  exit 0
+fi
 
 TICK_DIR="$CHITIN_SINK_ROOT/ticks/$date_str/$ts"
 mkdir -p "$TICK_DIR"
@@ -86,14 +107,35 @@ run_stage_code() {
 plan=$plan_body
 
 files=$file_dump"
-  if ! hermes chat -Q --model "$MODEL_CODE" -q "$stage2_prompt" \
-         > "$TICK_DIR/diff.patch" 2> "$TICK_DIR/code-stderr.txt"; then
-    log "stage 2 failed (hermes non-zero)"
+  local rc=0
+  timeout "${TIMEOUT_CODE}s" hermes chat -Q --model "$MODEL_CODE" -q "$stage2_prompt" \
+      > "$TICK_DIR/diff.patch" 2> "$TICK_DIR/code-stderr.txt" || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    if [[ $rc -eq 124 ]]; then
+      log "stage 2 timeout (${TIMEOUT_CODE}s)"
+    else
+      log "stage 2 failed (rc=$rc)"
+    fi
     return 1
   fi
 
   if [[ ! -s "$TICK_DIR/diff.patch" ]]; then
     log "code_empty_output: stage 2 emitted empty diff"
+    return 1
+  fi
+
+  # Strip leading/trailing triple-backtick fences. qwen3-coder:30b emits
+  # fenced diffs despite prompt instructions, and `git apply -` chokes on
+  # the opening backticks — observed 2026-04-23 during first live tick.
+  sed -i -E '1{/^```[a-zA-Z]*[[:space:]]*$/d;};${/^```[[:space:]]*$/d;}' \
+    "$TICK_DIR/diff.patch"
+
+  # Validate the diff applies cleanly before handing to stage 3. This
+  # catches malformed hunks early (partial failures in ACT leave the
+  # worktree half-modified with no PR — hard to diagnose after the fact).
+  if ! (cd "$REPO_ROOT" && git apply --check "$TICK_DIR/diff.patch") \
+       2> "$TICK_DIR/diff-check.err"; then
+    log "stage 2 invalid diff (git apply --check failed)"
     return 1
   fi
   log "stage 2 done"
@@ -113,9 +155,15 @@ run_stage_act() {
 plan=$plan_body
 
 diff=$diff_body"
-  if ! hermes chat -Q --model "$MODEL_ACT" -q "$stage3_prompt" \
-         > "$TICK_DIR/act-log.txt" 2> "$TICK_DIR/act-stderr.txt"; then
-    log "stage 3 failed (hermes non-zero)"
+  local rc=0
+  timeout "${TIMEOUT_ACT}s" hermes chat -Q --model "$MODEL_ACT" -q "$stage3_prompt" \
+      > "$TICK_DIR/act-log.txt" 2> "$TICK_DIR/act-stderr.txt" || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    if [[ $rc -eq 124 ]]; then
+      log "stage 3 timeout (${TIMEOUT_ACT}s)"
+    else
+      log "stage 3 failed (rc=$rc)"
+    fi
     return 0
   fi
   log "stage 3 done"
@@ -150,9 +198,15 @@ stage1_prompt="$(cat "$PROMPT_PLAN")
 
 --- CONTEXT ---
 $(cat "$TICK_DIR/queue.json")"
-if ! hermes chat -Q --model "$MODEL_PLAN" -q "$stage1_prompt" \
-       > "$TICK_DIR/plan.json" 2> "$TICK_DIR/plan-stderr.txt"; then
-  log "stage 1 failed (hermes non-zero)"
+rc=0
+timeout "${TIMEOUT_PLAN}s" hermes chat -Q --model "$MODEL_PLAN" -q "$stage1_prompt" \
+    > "$TICK_DIR/plan.json" 2> "$TICK_DIR/plan-stderr.txt" || rc=$?
+if [[ $rc -ne 0 ]]; then
+  if [[ $rc -eq 124 ]]; then
+    log "stage 1 timeout (${TIMEOUT_PLAN}s)"
+  else
+    log "stage 1 failed (rc=$rc)"
+  fi
   exit 0
 fi
 
@@ -182,6 +236,14 @@ case "$action" in
     exit 0
     ;;
   code)
+    # In-flight guard: if a worktree for this issue already exists, a
+    # previous tick is (or was) working it. Stage 1 doesn't see local
+    # state; without this check, two ticks duplicate the same PR attempt.
+    issue_num="$(jq -r '.issue_number' "$TICK_DIR/plan.json")"
+    if [[ -n "$issue_num" && "$issue_num" != "0" && -d "$WORKTREE_BASE/chitin-$issue_num" ]]; then
+      log "in_flight_local: worktree $WORKTREE_BASE/chitin-$issue_num exists for #$issue_num; skip"
+      exit 0
+    fi
     if ! probe_ollama; then
       log "ollama_unreachable: skip stages 2 and 3"
       exit 0

--- a/scripts/hermes/tick.sh
+++ b/scripts/hermes/tick.sh
@@ -240,7 +240,7 @@ case "$action" in
     # previous tick is (or was) working it. Stage 1 doesn't see local
     # state; without this check, two ticks duplicate the same PR attempt.
     issue_num="$(jq -r '.issue_number' "$TICK_DIR/plan.json")"
-    if [[ -n "$issue_num" && "$issue_num" != "0" && -d "$WORKTREE_BASE/chitin-$issue_num" ]]; then
+    if [[ -n "$issue_num" && "$issue_num" != "0" && "$issue_num" != "null" && -d "$WORKTREE_BASE/chitin-$issue_num" ]]; then
       log "in_flight_local: worktree $WORKTREE_BASE/chitin-$issue_num exists for #$issue_num; skip"
       exit 0
     fi

--- a/scripts/hermes/tick.sh
+++ b/scripts/hermes/tick.sh
@@ -46,6 +46,17 @@ TIMEOUT_ACT="${HERMES_TICK_TIMEOUT_ACT:-600}"
 # Worktree base for in-flight detection (see code-action branch).
 WORKTREE_BASE="${HERMES_TICK_WORKTREE_BASE:-$HOME/workspace}"
 
+# Precondition: flock + timeout are required. Without them, the guards
+# and per-stage budgets below would fail under `set -e` mid-run. Exit 0
+# with an explicit stderr message to preserve the script contract
+# ("Always exits 0 except on shell crash") on minimal boxes.
+for bin in flock timeout; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "[$(date -u +%H:%M:%SZ)] tick aborted — required binary not found: $bin" >&2
+    exit 0
+  fi
+done
+
 # Deterministic timestamps for tests; real runs compute fresh.
 ts="${HERMES_TICK_TS:-$(date -u +%Y%m%dT%H%M%SZ)}"
 date_str="${HERMES_TICK_DATE:-$(date -u +%Y-%m-%d)}"
@@ -127,8 +138,13 @@ files=$file_dump"
   # Strip leading/trailing triple-backtick fences. qwen3-coder:30b emits
   # fenced diffs despite prompt instructions, and `git apply -` chokes on
   # the opening backticks — observed 2026-04-23 during first live tick.
-  sed -i -E '1{/^```[a-zA-Z]*[[:space:]]*$/d;};${/^```[[:space:]]*$/d;}' \
-    "$TICK_DIR/diff.patch"
+  # Temp-file + mv pattern avoids `sed -i` which is non-portable across
+  # GNU and BSD (BSD treats `-E` as the required -i backup extension).
+  local tmp_diff="$TICK_DIR/diff.patch.tmp"
+  sed -E -e '1{/^```[a-zA-Z]*[[:space:]]*$/d;}' \
+         -e '${/^```[[:space:]]*$/d;}' \
+         "$TICK_DIR/diff.patch" > "$tmp_diff"
+  mv "$tmp_diff" "$TICK_DIR/diff.patch"
 
   # Validate the diff applies cleanly before handing to stage 3. This
   # catches malformed hunks early (partial failures in ACT leave the


### PR DESCRIPTION
## Summary

First live staged tick (2026-04-23, issue #8) surfaced four orchestration gaps. Policy v1 was correctly a non-participant — these are all tick.sh orchestration, not governance.

- **Concurrency guard.** Stage 2 on cold `qwen3-coder:30b` (18 GB, 38h idle) took 7 min. The next `:40` cron fired mid-ACT and re-planned the same issue. Added `flock -n` at script top with `HERMES_TICK_LOCK_FILE` override for tests.
- **Per-stage timeouts.** A hung `hermes chat` blocked indefinitely. Each stage now wrapped in `timeout`: `plan=120s`, `code=900s` (covers cold load), `act=600s`. Exit 124 logged as timeout, else `rc=N`.
- **Diff format defensive strip + validate.** qwen emits diffs inside ``` fences despite the prompt; `git apply -` chokes on the opening backticks and silently stops mid-patch (today: 1 of 4 files applied, no PR, half-dirty worktree). `sed` strips leading/trailing fence lines and `git apply --check` in `REPO_ROOT` rejects malformed diffs before they reach ACT.
- **In-flight local detection.** Stage 1 can't see local worktrees, so two ticks in the same `:10` window both pick the same issue. Skip `code` action if `$WORKTREE_BASE/chitin-<issue_number>` already exists.

## Test plan

- [x] Existing bats: `bats scripts/hermes/tests/tick.bats` — 6 passing
- [x] New bats: `bats scripts/hermes/tests/tick.bats` — 10 passing total
    - concurrency guard: second tick exits cleanly when lock is held
    - fence strip: code fences stripped before `git apply --check`
    - invalid diff: `git apply --check` failure short-circuits stage 3
    - in-flight worktree: pre-existing `chitin-N` dir skips code action
- [x] `bash -n scripts/hermes/tick.sh` — syntax clean
- [ ] Live smoke: re-label issue #8 once PR merges, observe one full tick end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)