### PR TITLE
feat(driver/claudecode): cost-governance milestone C — Claude Code hook driver

### DIFF
--- a/docs/observations/2026-04-29-claude-code-hook-coldstart.md
+++ b/docs/observations/2026-04-29-claude-code-hook-coldstart.md
@@ -1,0 +1,49 @@
+# Claude Code Hook — Cold-Start Latency Verdict
+
+**Date:** 2026-04-29
+**Spec:** `docs/superpowers/specs/2026-04-29-cost-governance-kernel-design.md` §"Path A — Claude Code session"
+**Plan:** `docs/superpowers/plans/2026-04-29-cost-governance-kernel.md` Milestone C
+**Bench:** `go/execution-kernel/cmd/chitin-kernel/bench_coldstart_test.go`
+
+## Decision gate
+
+The plan's acceptance gate for the Claude Code hook driver:
+
+- **p95 ≤ 100ms** → ship cold-start. No daemon mode.
+- **p95 > 100ms** → design and build daemon mode (`gate daemon` listener on `~/.chitin/gate.sock`) before shipping.
+
+## Result (operator's box)
+
+100 cold-start invocations of `chitin-kernel gate evaluate --hook-stdin --agent=claude-code` against a fixture `Read /etc/hosts` PreToolUse payload, after 3 warm-up runs:
+
+| metric | latency |
+|---|---|
+| min | 3 ms |
+| p50 | 3 ms |
+| p95 | 3 ms |
+| p99 | 4 ms |
+| max | 4 ms |
+
+**Verdict: ship cold-start. Daemon mode is not needed for this slice.**
+
+Each invocation includes: subprocess spawn, sqlite open + WAL setup, policy load + parse from chitin.yaml, action normalize, gate evaluate, decision append to JSONL audit log, response write, exit. The headroom (3ms vs 100ms) is large enough to absorb 30x degradation on slower hardware before the gate flips.
+
+## Reproduce
+
+```bash
+cd go/execution-kernel
+COLDSTART=1 go test ./cmd/chitin-kernel/... -run ColdStart -v -count=1
+```
+
+The test is gated on `COLDSTART=1` so unit-test runs aren't slowed by full subprocess invocations. Set `COLDSTART_ITERS=N` to change the sample size (default 100).
+
+## Caveats
+
+- Box: Linux 6.17, Ryzen + NVMe (operator's RTX 3090 dev box per `memory/project_machine_topology.md`).
+- macOS and slower-disk hardware are likely to be different. Operators should re-run on their own box once before relying on the verdict for production hooks.
+- Test fixture is a deterministic-allow `Read /etc/hosts`. Deny paths and envelope-spend paths weren't measured separately — they share most of the cold-start cost (subprocess + sqlite + policy), so the difference is sub-ms.
+- Policy used is a 1-rule allow. Larger rule sets (~50+ rules, regex-heavy) might shift p95 — re-bench when the operator's policy stabilizes.
+
+## Future work
+
+If `BUILD DAEMON MODE` is ever the verdict on a box, the daemon spec lives at `gate daemon` in the plan: long-running listener on `~/.chitin/gate.sock`, hook command becomes `chitin-kernel gate evaluate --hook-stdin --via=sock`. Out of scope for this milestone since the gate didn't trip.

--- a/go/execution-kernel/cmd/chitin-kernel/bench_coldstart_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/bench_coldstart_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+// TestColdStart_HookStdinLatency is the spec acceptance gate: build the
+// chitin-kernel binary, exec it 100 times against a fixture PreToolUse
+// payload via `gate evaluate --hook-stdin`, measure wall-clock latency,
+// report p50/p95/p99 to stderr, and decide:
+//
+//	p95 ≤ 100ms  → ship cold-start; daemon mode not needed.
+//	p95 >  100ms → daemon mode is required for the hook driver to be
+//	               usable in interactive sessions; design that next.
+//
+// This test runs full subprocess cold-starts — sqlite open, policy
+// load, action normalize, gate evaluate, decision log write — exactly
+// what Claude Code triggers on each tool call. It is intentionally
+// gated behind COLDSTART=1 so unit-test runs aren't slow; CI and the
+// operator's "did we earn the cold-start ship decision" check enable it.
+//
+// 100 iterations is enough to get stable p95/p99 on the operator's box
+// without making test runs interminable. Adjust COLDSTART_ITERS if more
+// precision is needed for the daemon-mode call.
+func TestColdStart_HookStdinLatency(t *testing.T) {
+	if os.Getenv("COLDSTART") != "1" {
+		t.Skip("COLDSTART=1 not set; skipping cold-start benchmark")
+	}
+	iters := 100
+	if v := os.Getenv("COLDSTART_ITERS"); v != "" {
+		fmt.Sscanf(v, "%d", &iters)
+	}
+
+	binary := buildKernelBinary(t)
+	cwd := stagePolicyDir(t)
+	chitinHome := t.TempDir()
+
+	payload := map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/etc/hosts"},
+		"cwd":        cwd,
+	}
+	body, _ := json.Marshal(payload)
+
+	// Warm-up: 3 ignored runs so OS file cache + sqlite WAL setup don't
+	// inflate the first measurements. The acceptance gate is steady-
+	// state cold-start, not first-run cold-start.
+	for i := 0; i < 3; i++ {
+		_ = runOnce(t, binary, chitinHome, body)
+	}
+
+	durations := make([]time.Duration, iters)
+	for i := 0; i < iters; i++ {
+		durations[i] = runOnce(t, binary, chitinHome, body)
+	}
+
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	p50 := durations[iters*50/100]
+	p95 := durations[iters*95/100]
+	p99 := durations[iters*99/100]
+
+	verdict := "ship cold-start (p95 ≤ 100ms)"
+	if p95 > 100*time.Millisecond {
+		verdict = "BUILD DAEMON MODE (p95 > 100ms)"
+	}
+
+	report := map[string]any{
+		"iters":   iters,
+		"p50_ms":  p50.Milliseconds(),
+		"p95_ms":  p95.Milliseconds(),
+		"p99_ms":  p99.Milliseconds(),
+		"min_ms":  durations[0].Milliseconds(),
+		"max_ms":  durations[iters-1].Milliseconds(),
+		"verdict": verdict,
+	}
+	rb, _ := json.MarshalIndent(report, "", "  ")
+	t.Logf("cold-start latency report:\n%s", rb)
+
+	if p95 > 100*time.Millisecond {
+		t.Logf("DECISION: cold-start p95=%v exceeds 100ms gate; design daemon mode (gate.sock listener) before shipping the hook driver.", p95)
+	}
+}
+
+func runOnce(t *testing.T, binary, chitinHome string, payload []byte) time.Duration {
+	t.Helper()
+	cmd := exec.Command(binary, "gate", "evaluate", "--hook-stdin", "--agent=claude-code")
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.Env = append(os.Environ(), "CHITIN_HOME="+chitinHome)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	d := time.Since(start)
+	if err != nil {
+		// Exit 2 (block) is "successful failure" for some scenarios but
+		// the fixture is deliberately Read on /etc/hosts under an
+		// allow-read policy — the run should always be exit 0.
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok || exitErr.ExitCode() != 0 {
+			t.Fatalf("hook run failed: %v\noutput=%s", err, out)
+		}
+	}
+	return d
+}
+
+func buildKernelBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "chitin-kernel")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/chitin-kernel")
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build chitin-kernel: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func stagePolicyDir(t *testing.T) string {
+	t.Helper()
+	cwd := t.TempDir()
+	policy := `id: bench
+mode: enforce
+rules:
+  - id: allow-read
+    action: file.read
+    effect: allow
+    reason: read ok
+`
+	if err := os.WriteFile(filepath.Join(cwd, "chitin.yaml"), []byte(policy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	return cwd
+}
+
+// repoRoot finds the go-module root by walking up from cwd until a
+// go.mod is seen. Lets the test build the binary regardless of where
+// `go test` is invoked from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
+			return cwd
+		}
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			t.Fatalf("no go.mod up from %s", cwd)
+		}
+		cwd = parent
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -19,8 +19,8 @@ import (
 // PreToolUse hook. It wires real stdin/stdout/os.Exit around the pure
 // evalHookStdin core. The split keeps evalHookStdin testable in-process
 // while production gets the full os-level behavior.
-func runHookStdin(agent, envelopeFlag string) {
-	code := evalHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag)
+func runHookStdin(agent, envelopeFlag string, requirePolicy bool) {
+	code := evalHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag, requirePolicy)
 	os.Exit(code)
 }
 
@@ -32,10 +32,23 @@ func runHookStdin(agent, envelopeFlag string) {
 //	2 — block (out is `{"decision":"block","reason":"..."}`)
 //	1 — non-blocking error (out empty; errOut has the diagnostic)
 //
+// requirePolicy controls the no-chitin.yaml-in-cwd behavior:
+//   - false (default): fail open with a stderr warning. Convenient but
+//     means an operator running `claude` in any directory without a
+//     policy gets ungoverned tool calls.
+//   - true: fail closed (exit 2 block) so chitin governance is never
+//     silently absent. Operators who want the strict guarantee
+//     install with --require-policy.
+//
 // Latency-sensitive: every Claude Code tool call cold-starts this code.
 // The acceptance gate is p95 ≤ 100ms cold-start; if not met, daemon
 // mode (gate.sock) is the next step.
-func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag string) int {
+//
+// PERF NOTE: this opens two sqlite handles against ~/.chitin/gov.db
+// (Counter + BudgetStore). Sharing one *sql.DB would halve cold-start
+// open cost. Deferred until Milestone D's 8-shim stress test surfaces
+// real contention numbers — at 3ms p95 today the headroom is ample.
+func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag string, requirePolicy bool) int {
 	if agent == "" {
 		agent = "claude-code"
 	}
@@ -57,6 +70,12 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 	}
 	absCwd, _ := filepath.Abs(cwd)
 
+	// Route normalize warnings (wrong-type fields, etc.) to the same
+	// stderr stream so operators see malformed payloads explicitly
+	// rather than via a silent default-deny.
+	claudecode.SetWarnSink(errOut)
+	defer claudecode.SetWarnSink(nil)
+
 	action, err := claudecode.Normalize(payload)
 	if err != nil {
 		writeJSONLine(errOut, map[string]string{"error": "hook_normalize", "message": err.Error()})
@@ -70,18 +89,25 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 			writeBlockReason(out, "policy_invalid: "+errMsg)
 			return claudecode.ExitBlock
 		}
-		// No policy in cwd: cannot govern, fail open with a warning.
-		// The model proceeds; the operator sees the diagnostic.
+		// No policy in cwd. Default behavior is fail-open with a stderr
+		// warning so operators running `claude` in arbitrary dirs aren't
+		// blocked on every tool. With --require-policy, fail closed —
+		// the operator chose strict-mode and must scaffold a chitin.yaml
+		// (or run from a policy-covered cwd) before claude works.
+		if requirePolicy {
+			writeBlockReason(out, "chitin: no chitin.yaml found from cwd up; --require-policy refuses to allow ungoverned tool calls")
+			return claudecode.ExitBlock
+		}
 		writeJSONLine(errOut, map[string]string{
 			"warning": "no_policy_found",
-			"note":    "chitin governance hook fired in cwd without chitin.yaml; allowing",
+			"note":    "chitin governance hook fired in cwd without chitin.yaml; allowing (install with --require-policy to fail closed)",
 		})
 		return claudecode.ExitAllow
 	}
 
-	chitinDir := chitinDirFor(envelopeFlag)
-	_ = os.MkdirAll(chitinDir, 0o755)
-	dbPath := filepath.Join(chitinDir, "gov.db")
+	cdir := chitinDir()
+	_ = os.MkdirAll(cdir, 0o755)
+	dbPath := filepath.Join(cdir, "gov.db")
 
 	counter, err := gov.OpenCounter(dbPath)
 	if err != nil {
@@ -90,7 +116,7 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 	}
 	defer counter.Close()
 
-	envelope, store, err := resolveEnvelope(chitinDir, dbPath, envelopeFlag)
+	envelope, store, err := resolveEnvelope(cdir, dbPath, envelopeFlag)
 	if err != nil {
 		writeBlockReason(out, "chitin: "+err.Error())
 		return claudecode.ExitBlock
@@ -103,7 +129,7 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 
 	gate := &gov.Gate{
 		Policy: policy, Counter: counter,
-		LogDir: chitinDir, Cwd: absCwd,
+		LogDir: cdir, Cwd: absCwd,
 		ClassifyTier: tier.Route,
 		EstimateCost: func(a gov.Action, _ string) gov.CostDelta {
 			return cost.Estimate(a, agent, rates)
@@ -119,10 +145,10 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 	return code
 }
 
-// chitinDirFor returns the chitin state dir. The CHITIN_HOME env var
+// chitinDir returns the chitin state dir. The CHITIN_HOME env var
 // override exists primarily for tests to redirect ~/.chitin to a temp
 // dir without root-touching real state.
-func chitinDirFor(_ string) string {
+func chitinDir() string {
 	if v := os.Getenv("CHITIN_HOME"); v != "" {
 		return v
 	}

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/cost"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/tier"
+)
+
+// runHookStdin is the production entry point for the Claude Code
+// PreToolUse hook. It wires real stdin/stdout/os.Exit around the pure
+// evalHookStdin core. The split keeps evalHookStdin testable in-process
+// while production gets the full os-level behavior.
+func runHookStdin(agent, envelopeFlag string) {
+	code := evalHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag)
+	os.Exit(code)
+}
+
+// evalHookStdin is the pure hook-driver core. Reads one PreToolUse
+// payload from r, runs governance + envelope spend, writes the hook
+// response to out (or warning JSON to errOut), and returns the exit code:
+//
+//	0 — allow (out empty)
+//	2 — block (out is `{"decision":"block","reason":"..."}`)
+//	1 — non-blocking error (out empty; errOut has the diagnostic)
+//
+// Latency-sensitive: every Claude Code tool call cold-starts this code.
+// The acceptance gate is p95 ≤ 100ms cold-start; if not met, daemon
+// mode (gate.sock) is the next step.
+func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag string) int {
+	if agent == "" {
+		agent = "claude-code"
+	}
+
+	in, err := io.ReadAll(r)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{"error": "hook_read_stdin", "message": err.Error()})
+		return claudecode.ExitNonBlockError
+	}
+	var payload claudecode.HookInput
+	if err := json.Unmarshal(in, &payload); err != nil {
+		writeJSONLine(errOut, map[string]string{"error": "hook_parse_stdin", "message": err.Error()})
+		return claudecode.ExitNonBlockError
+	}
+
+	cwd := payload.Cwd
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	absCwd, _ := filepath.Abs(cwd)
+
+	action, err := claudecode.Normalize(payload)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{"error": "hook_normalize", "message": err.Error()})
+		return claudecode.ExitNonBlockError
+	}
+
+	policy, _, err := gov.LoadWithInheritance(absCwd)
+	if err != nil {
+		errMsg := err.Error()
+		if !strings.HasPrefix(errMsg, "no_policy_found") {
+			writeBlockReason(out, "policy_invalid: "+errMsg)
+			return claudecode.ExitBlock
+		}
+		// No policy in cwd: cannot govern, fail open with a warning.
+		// The model proceeds; the operator sees the diagnostic.
+		writeJSONLine(errOut, map[string]string{
+			"warning": "no_policy_found",
+			"note":    "chitin governance hook fired in cwd without chitin.yaml; allowing",
+		})
+		return claudecode.ExitAllow
+	}
+
+	chitinDir := chitinDirFor(envelopeFlag)
+	_ = os.MkdirAll(chitinDir, 0o755)
+	dbPath := filepath.Join(chitinDir, "gov.db")
+
+	counter, err := gov.OpenCounter(dbPath)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{"error": "hook_counter_open", "message": err.Error()})
+		return claudecode.ExitNonBlockError
+	}
+	defer counter.Close()
+
+	envelope, store, err := resolveEnvelope(chitinDir, dbPath, envelopeFlag)
+	if err != nil {
+		writeBlockReason(out, "chitin: "+err.Error())
+		return claudecode.ExitBlock
+	}
+	if store != nil {
+		defer store.Close()
+	}
+
+	rates := loadRates(absCwd, errOut)
+
+	gate := &gov.Gate{
+		Policy: policy, Counter: counter,
+		LogDir: chitinDir, Cwd: absCwd,
+		ClassifyTier: tier.Route,
+		EstimateCost: func(a gov.Action, _ string) gov.CostDelta {
+			return cost.Estimate(a, agent, rates)
+		},
+	}
+	d := gate.Evaluate(action, agent, envelope)
+
+	body, code := claudecode.Format(d)
+	if len(body) > 0 {
+		_, _ = out.Write(body)
+		_, _ = out.Write([]byte{'\n'})
+	}
+	return code
+}
+
+// chitinDirFor returns the chitin state dir. The CHITIN_HOME env var
+// override exists primarily for tests to redirect ~/.chitin to a temp
+// dir without root-touching real state.
+func chitinDirFor(_ string) string {
+	if v := os.Getenv("CHITIN_HOME"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".chitin")
+}
+
+// resolveEnvelope walks the precedence chain:
+//  1. envelopeFlag (--envelope=<id>)
+//  2. CHITIN_BUDGET_ENVELOPE env var
+//  3. <chitinDir>/current-envelope file
+//  4. None — returns (nil, nil, nil): gate + audit only, no spend.
+func resolveEnvelope(chitinDir, dbPath, envelopeFlag string) (*gov.BudgetEnvelope, *gov.BudgetStore, error) {
+	id := envelopeFlag
+	if id == "" {
+		id = os.Getenv("CHITIN_BUDGET_ENVELOPE")
+	}
+	if id == "" {
+		path := filepath.Join(chitinDir, "current-envelope")
+		if b, err := os.ReadFile(path); err == nil {
+			id = strings.TrimSpace(string(b))
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("read current-envelope: %w", err)
+		}
+	}
+	if id == "" {
+		return nil, nil, nil
+	}
+	store, err := gov.OpenBudgetStore(dbPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open budget store: %w", err)
+	}
+	env, err := store.Load(id)
+	if err != nil {
+		store.Close()
+		return nil, nil, fmt.Errorf("load envelope %s: %w", id, err)
+	}
+	return env, store, nil
+}
+
+// loadRates loads cost.RateTable from the cwd's chitin.yaml if present,
+// falling back to defaults. Errors are non-fatal: log and use defaults.
+// Hook latency is more important than perfectly-current rates.
+func loadRates(cwd string, errOut io.Writer) cost.RateTable {
+	path := filepath.Join(cwd, "chitin.yaml")
+	r, err := cost.LoadRates(path)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{"warning": "rates_load", "note": err.Error()})
+		return cost.DefaultRates()
+	}
+	return r
+}
+
+func writeBlockReason(out io.Writer, reason string) {
+	body, _ := json.Marshal(map[string]string{"decision": "block", "reason": reason})
+	_, _ = out.Write(body)
+	_, _ = out.Write([]byte{'\n'})
+}
+
+func writeJSONLine(out io.Writer, v map[string]string) {
+	b, _ := json.Marshal(v)
+	_, _ = out.Write(b)
+	_, _ = out.Write([]byte{'\n'})
+}

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -41,7 +41,7 @@ func runHookCall(t *testing.T, env *hookTestEnv, payload map[string]any, envelop
 	}
 	in := bytes.NewReader(body)
 	var out, errOut bytes.Buffer
-	exitCode = evalHookStdin(in, &out, &errOut, "claude-code", envelopeFlag)
+	exitCode = evalHookStdin(in, &out, &errOut, "claude-code", envelopeFlag, false)
 	return out.String(), errOut.String(), exitCode
 }
 
@@ -121,8 +121,15 @@ func TestEvalHookStdin_NoPolicyInCwdAllowsWithWarning(t *testing.T) {
 	// chitin.yaml absent — fail-open with stderr warning.
 	cwd := t.TempDir()
 	chitin := t.TempDir()
+	prev, hadPrev := os.LookupEnv("CHITIN_HOME")
 	_ = os.Setenv("CHITIN_HOME", chitin)
-	t.Cleanup(func() { _ = os.Unsetenv("CHITIN_HOME") })
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.Setenv("CHITIN_HOME", prev)
+		} else {
+			_ = os.Unsetenv("CHITIN_HOME")
+		}
+	})
 
 	body, _ := json.Marshal(map[string]any{
 		"tool_name":  "Read",
@@ -130,7 +137,7 @@ func TestEvalHookStdin_NoPolicyInCwdAllowsWithWarning(t *testing.T) {
 		"cwd":        cwd,
 	})
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "")
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", false)
 	if code != 0 {
 		t.Fatalf("exit=%d want 0 (fail-open)", code)
 	}
@@ -142,11 +149,65 @@ func TestEvalHookStdin_NoPolicyInCwdAllowsWithWarning(t *testing.T) {
 	}
 }
 
+func TestEvalHookStdin_NoPolicyInCwd_RequirePolicy_Blocks(t *testing.T) {
+	// Same setup as the fail-open case, but with requirePolicy=true.
+	// Expectation: exit 2 block + a chitin: reason in stdout.
+	cwd := t.TempDir()
+	chitin := t.TempDir()
+	prev, hadPrev := os.LookupEnv("CHITIN_HOME")
+	_ = os.Setenv("CHITIN_HOME", chitin)
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.Setenv("CHITIN_HOME", prev)
+		} else {
+			_ = os.Unsetenv("CHITIN_HOME")
+		}
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/x"},
+		"cwd":        cwd,
+	})
+	var out, errOut bytes.Buffer
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", true)
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (--require-policy → block)", code)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, out.String())
+	}
+	if parsed["decision"] != "block" {
+		t.Fatalf("decision=%q want block", parsed["decision"])
+	}
+	if !strings.Contains(parsed["reason"], "require-policy") {
+		t.Fatalf("reason missing require-policy mention: %q", parsed["reason"])
+	}
+}
+
+func TestEvalHookStdin_WrongTypeField_WarnsAndProceeds(t *testing.T) {
+	// file_path: 42 instead of a string. Normalize emits empty Target;
+	// stderr gets a tool_input_wrong_type warning so an operator
+	// debugging a malformed payload sees it.
+	env := setupHookEnv(t, baselinePolicy)
+	body, _ := json.Marshal(map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": 42},
+		"cwd":        env.cwd,
+	})
+	var out, errOut bytes.Buffer
+	_ = evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", false)
+	if !strings.Contains(errOut.String(), "tool_input_wrong_type") {
+		t.Fatalf("stderr missing wrong-type warning: %q", errOut.String())
+	}
+}
+
 func TestEvalHookStdin_MalformedJSONIsExit1(t *testing.T) {
 	env := setupHookEnv(t, baselinePolicy)
 	in := bytes.NewReader([]byte("not json"))
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(in, &out, &errOut, "claude-code", "")
+	code := evalHookStdin(in, &out, &errOut, "claude-code", "", false)
 	_ = env
 	if code != 1 {
 		t.Fatalf("exit=%d want 1 (non-blocking error)", code)
@@ -268,7 +329,17 @@ func TestEvalHookStdin_BadEnvelopeIDBlocks(t *testing.T) {
 	if code != 2 {
 		t.Fatalf("exit=%d want 2 (block on bad envelope)", code)
 	}
-	if !strings.Contains(stdout, "load envelope") {
-		t.Fatalf("missing envelope-load error: %q", stdout)
+	// Assert structurally on the parsed JSON shape rather than a brittle
+	// substring of the human-readable error text — the message can be
+	// reworded without needing to update tests.
+	var parsed map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace([]byte(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	if parsed["decision"] != "block" {
+		t.Fatalf("decision=%q want block", parsed["decision"])
+	}
+	if !strings.HasPrefix(parsed["reason"], "chitin: ") {
+		t.Fatalf("reason missing chitin: prefix: %q", parsed["reason"])
 	}
 }

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hookTestEnv stages a CHITIN_HOME + chitin.yaml in cwd so evalHookStdin
+// can run end-to-end against a real policy + sqlite gov.db.
+type hookTestEnv struct {
+	cwd     string
+	chitin  string
+	cleanup func()
+}
+
+func setupHookEnv(t *testing.T, policyYAML string) *hookTestEnv {
+	t.Helper()
+	cwd := t.TempDir()
+	chitin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "chitin.yaml"), []byte(policyYAML), 0o644); err != nil {
+		t.Fatalf("write chitin.yaml: %v", err)
+	}
+	prev := os.Getenv("CHITIN_HOME")
+	_ = os.Setenv("CHITIN_HOME", chitin)
+	t.Cleanup(func() { _ = os.Setenv("CHITIN_HOME", prev) })
+	return &hookTestEnv{cwd: cwd, chitin: chitin}
+}
+
+func runHookCall(t *testing.T, env *hookTestEnv, payload map[string]any, envelopeFlag string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	if _, ok := payload["cwd"]; !ok {
+		payload["cwd"] = env.cwd
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	in := bytes.NewReader(body)
+	var out, errOut bytes.Buffer
+	exitCode = evalHookStdin(in, &out, &errOut, "claude-code", envelopeFlag)
+	return out.String(), errOut.String(), exitCode
+}
+
+const baselinePolicy = `
+id: hook-test
+mode: enforce
+rules:
+  - id: allow-read
+    action: file.read
+    effect: allow
+    reason: read ok
+  - id: allow-write
+    action: file.write
+    effect: allow
+    reason: write ok
+  - id: no-rm
+    action: shell.exec
+    effect: deny
+    target: "rm -rf"
+    reason: "no rm -rf"
+    suggestion: "use git rm"
+    correctedCommand: "git rm <files>"
+  - id: allow-shell
+    action: shell.exec
+    effect: allow
+    reason: shell ok
+  - id: allow-http
+    action: http.request
+    effect: allow
+    reason: http ok
+  - id: allow-task
+    action: delegate.task
+    effect: allow
+    reason: task ok
+`
+
+func TestEvalHookStdin_AllowReadIsExit0EmptyStdout(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/etc/hosts"},
+	}, "")
+	if code != 0 {
+		t.Fatalf("exit=%d want 0 (allow), stdout=%q", code, stdout)
+	}
+	if stdout != "" {
+		t.Fatalf("allow stdout must be empty, got %q", stdout)
+	}
+}
+
+func TestEvalHookStdin_DenyRmRfIsExit2BlockJSON(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "rm -rf go/"},
+	}, "")
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (block)", code)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	if parsed["decision"] != "block" {
+		t.Fatalf("decision=%q", parsed["decision"])
+	}
+	if !strings.Contains(parsed["reason"], "no rm -rf") {
+		t.Fatalf("reason missing policy text: %q", parsed["reason"])
+	}
+	// Suggestion + corrected propagate to the model.
+	if !strings.Contains(parsed["reason"], "git rm") {
+		t.Fatalf("reason missing suggestion/corrected: %q", parsed["reason"])
+	}
+}
+
+func TestEvalHookStdin_NoPolicyInCwdAllowsWithWarning(t *testing.T) {
+	// chitin.yaml absent — fail-open with stderr warning.
+	cwd := t.TempDir()
+	chitin := t.TempDir()
+	_ = os.Setenv("CHITIN_HOME", chitin)
+	t.Cleanup(func() { _ = os.Unsetenv("CHITIN_HOME") })
+
+	body, _ := json.Marshal(map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/x"},
+		"cwd":        cwd,
+	})
+	var out, errOut bytes.Buffer
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "")
+	if code != 0 {
+		t.Fatalf("exit=%d want 0 (fail-open)", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout must be empty, got %q", out.String())
+	}
+	if !strings.Contains(errOut.String(), "no_policy_found") {
+		t.Fatalf("stderr missing no_policy_found warning: %q", errOut.String())
+	}
+}
+
+func TestEvalHookStdin_MalformedJSONIsExit1(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	in := bytes.NewReader([]byte("not json"))
+	var out, errOut bytes.Buffer
+	code := evalHookStdin(in, &out, &errOut, "claude-code", "")
+	_ = env
+	if code != 1 {
+		t.Fatalf("exit=%d want 1 (non-blocking error)", code)
+	}
+	if !strings.Contains(errOut.String(), "hook_parse_stdin") {
+		t.Fatalf("missing parse-stdin error: %q", errOut.String())
+	}
+}
+
+func TestEvalHookStdin_WithEnvelopeFlag_DebitsEnvelope(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, err := openBudgetStoreForTest(t, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	envelope, err := store.Create(budgetLimits(t, 10, 1024))
+	if err != nil {
+		t.Fatalf("create envelope: %v", err)
+	}
+	store.Close()
+
+	_, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/etc/hosts"},
+	}, envelope.ID)
+	if code != 0 {
+		t.Fatalf("exit=%d want 0", code)
+	}
+
+	// Reopen and check spend.
+	store2, _ := openBudgetStoreForTest(t, dbPath)
+	defer store2.Close()
+	env2, _ := store2.Load(envelope.ID)
+	st, _ := env2.Inspect()
+	if st.SpentCalls != 1 {
+		t.Fatalf("SpentCalls=%d want 1 — envelope flag not honored", st.SpentCalls)
+	}
+}
+
+func TestEvalHookStdin_EnvelopeExhausted_BlocksWithReason(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 1, 0))
+	store.Close()
+
+	// Burn the cap.
+	_, _, code1 := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/a"},
+	}, envelope.ID)
+	if code1 != 0 {
+		t.Fatalf("first call exit=%d want 0", code1)
+	}
+	// Next call: envelope-exhausted → block exit 2.
+	stdout, _, code2 := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/b"},
+	}, envelope.ID)
+	if code2 != 2 {
+		t.Fatalf("second call exit=%d want 2 (envelope-exhausted)", code2)
+	}
+	if !strings.Contains(stdout, "envelope") || !strings.Contains(stdout, "exhausted") {
+		t.Fatalf("block reason missing envelope-exhausted: %q", stdout)
+	}
+}
+
+func TestEvalHookStdin_EnvelopePrecedence_FlagBeatsEnvAndFile(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	flagEnv, _ := store.Create(budgetLimits(t, 10, 0))
+	envEnv, _ := store.Create(budgetLimits(t, 10, 0))
+	fileEnv, _ := store.Create(budgetLimits(t, 10, 0))
+	store.Close()
+
+	// Stage env var + current-envelope file pointing at the wrong envelopes.
+	_ = os.Setenv("CHITIN_BUDGET_ENVELOPE", envEnv.ID)
+	t.Cleanup(func() { _ = os.Unsetenv("CHITIN_BUDGET_ENVELOPE") })
+	if err := os.WriteFile(filepath.Join(env.chitin, "current-envelope"), []byte(fileEnv.ID), 0o600); err != nil {
+		t.Fatalf("stage current-envelope: %v", err)
+	}
+
+	// Pass flag — flag wins.
+	_, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/x"},
+	}, flagEnv.ID)
+	if code != 0 {
+		t.Fatalf("exit=%d want 0", code)
+	}
+
+	store2, _ := openBudgetStoreForTest(t, dbPath)
+	defer store2.Close()
+	for _, c := range []struct {
+		name string
+		id   string
+		want int64
+	}{
+		{"flag", flagEnv.ID, 1},
+		{"env", envEnv.ID, 0},
+		{"file", fileEnv.ID, 0},
+	} {
+		e, _ := store2.Load(c.id)
+		st, _ := e.Inspect()
+		if st.SpentCalls != c.want {
+			t.Errorf("%s envelope: SpentCalls=%d want %d", c.name, st.SpentCalls, c.want)
+		}
+	}
+}
+
+func TestEvalHookStdin_BadEnvelopeIDBlocks(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/x"},
+	}, "01-NONEXISTENT-ENVELOPE-ID-A")
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (block on bad envelope)", code)
+	}
+	if !strings.Contains(stdout, "load envelope") {
+		t.Fatalf("missing envelope-load error: %q", stdout)
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test_helpers_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test_helpers_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// openBudgetStoreForTest is a tiny shim so the hook test file doesn't
+// import gov for the test-helper-only call. Lives in a separate _test.go
+// file to keep gate_hook_test.go focused on hook-specific assertions.
+func openBudgetStoreForTest(t *testing.T, dbPath string) (*gov.BudgetStore, error) {
+	t.Helper()
+	return gov.OpenBudgetStore(dbPath)
+}
+
+func budgetLimits(_ *testing.T, calls, bytes int64) gov.BudgetLimits {
+	return gov.BudgetLimits{MaxToolCalls: calls, MaxInputBytes: bytes}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/install_claude_code.go
+++ b/go/execution-kernel/cmd/chitin-kernel/install_claude_code.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/govhookinstall"
+)
+
+// cmdInstallClaudeCodeHook handles `install claude-code-hook [--global|
+// --project] [--dry-run] [--envelope=<id>]`.
+//
+// Emits the canonical hook command into ~/.claude/settings.json (global)
+// or .claude/settings.json (project). Writes a one-time pre-chitin
+// backup the first time it touches the file. Idempotent on re-run.
+func cmdInstallClaudeCodeHook(args []string) {
+	fs := flag.NewFlagSet("install claude-code-hook", flag.ExitOnError)
+	global := fs.Bool("global", false, "install to ~/.claude/settings.json")
+	project := fs.Bool("project", false, "install to ./.claude/settings.json (cwd)")
+	dryRun := fs.Bool("dry-run", false, "report what would change without writing")
+	envelope := fs.String("envelope", "", "envelope ID to embed in the hook command (optional)")
+	fs.Parse(args)
+
+	if *global == *project {
+		exitErr("install_scope", "exactly one of --global or --project required")
+	}
+
+	scope := govhookinstall.ScopeGlobal
+	if *project {
+		scope = govhookinstall.ScopeProject
+	}
+
+	command := govhookinstall.HookCommand
+	if *envelope != "" {
+		command += " --envelope=" + *envelope
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		exitErr("install_cwd", err.Error())
+	}
+
+	if *dryRun {
+		plan, err := govhookinstall.DryRun(scope, cwd, command)
+		if err != nil {
+			exitErr("install_dry_run", err.Error())
+		}
+		emitJSON(map[string]any{
+			"ok":              true,
+			"dry_run":         true,
+			"path":            plan.Path,
+			"backup":          plan.Backup,
+			"backup_exists":   plan.BackupExists,
+			"would_write":     plan.WouldWrite,
+			"preserved_count": plan.PreservedCount,
+			"command":         plan.WrapperCommand,
+		})
+		return
+	}
+
+	path, backup, err := govhookinstall.Install(scope, cwd, command)
+	if err != nil {
+		exitErr("install_failed", err.Error())
+	}
+	emitJSON(map[string]any{
+		"ok":      true,
+		"path":    path,
+		"backup":  backup,
+		"command": command,
+	})
+}
+
+// cmdUninstallClaudeCodeHook handles `uninstall claude-code-hook
+// [--global|--project]`.
+func cmdUninstallClaudeCodeHook(args []string) {
+	fs := flag.NewFlagSet("uninstall claude-code-hook", flag.ExitOnError)
+	global := fs.Bool("global", false, "uninstall from ~/.claude/settings.json")
+	project := fs.Bool("project", false, "uninstall from ./.claude/settings.json (cwd)")
+	fs.Parse(args)
+
+	if *global == *project {
+		exitErr("uninstall_scope", "exactly one of --global or --project required")
+	}
+
+	scope := govhookinstall.ScopeGlobal
+	if *project {
+		scope = govhookinstall.ScopeProject
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		exitErr("uninstall_cwd", err.Error())
+	}
+	path, err := govhookinstall.Uninstall(scope, cwd)
+	if err != nil {
+		exitErr("uninstall_failed", err.Error())
+	}
+	emitJSON(map[string]any{"ok": true, "path": path})
+}
+
+func emitJSON(v map[string]any) {
+	b, _ := json.Marshal(v)
+	fmt.Println(string(b))
+}

--- a/go/execution-kernel/cmd/chitin-kernel/install_claude_code.go
+++ b/go/execution-kernel/cmd/chitin-kernel/install_claude_code.go
@@ -10,17 +10,29 @@ import (
 )
 
 // cmdInstallClaudeCodeHook handles `install claude-code-hook [--global|
-// --project] [--dry-run] [--envelope=<id>]`.
+// --project] [--dry-run] [--envelope=<id>] [--require-policy]`.
 //
 // Emits the canonical hook command into ~/.claude/settings.json (global)
 // or .claude/settings.json (project). Writes a one-time pre-chitin
 // backup the first time it touches the file. Idempotent on re-run.
+//
+// Flags worth knowing:
+//
+//	--envelope=<id>     embeds the envelope into the hook command line.
+//	                    Pins until reinstall; for switchable scope use
+//	                    `chitin-kernel envelope use <id>` and the
+//	                    ~/.chitin/current-envelope file pattern.
+//	--require-policy    embeds --require-policy into the hook command,
+//	                    flipping no-policy-in-cwd from fail-open to
+//	                    fail-closed (block). Default off so operators
+//	                    can run `claude` in arbitrary dirs.
 func cmdInstallClaudeCodeHook(args []string) {
 	fs := flag.NewFlagSet("install claude-code-hook", flag.ExitOnError)
 	global := fs.Bool("global", false, "install to ~/.claude/settings.json")
 	project := fs.Bool("project", false, "install to ./.claude/settings.json (cwd)")
 	dryRun := fs.Bool("dry-run", false, "report what would change without writing")
-	envelope := fs.String("envelope", "", "envelope ID to embed in the hook command (optional)")
+	envelope := fs.String("envelope", "", "envelope ID to embed in the hook command (pins until reinstall)")
+	requirePolicy := fs.Bool("require-policy", false, "embed --require-policy in the hook command (no-policy cwd → block, not allow)")
 	fs.Parse(args)
 
 	if *global == *project {
@@ -35,6 +47,9 @@ func cmdInstallClaudeCodeHook(args []string) {
 	command := govhookinstall.HookCommand
 	if *envelope != "" {
 		command += " --envelope=" + *envelope
+	}
+	if *requirePolicy {
+		command += " --require-policy"
 	}
 
 	cwd, err := os.Getwd()
@@ -56,6 +71,7 @@ func cmdInstallClaudeCodeHook(args []string) {
 			"would_write":     plan.WouldWrite,
 			"preserved_count": plan.PreservedCount,
 			"command":         plan.WrapperCommand,
+			"notes":           installNotes(*envelope, *requirePolicy),
 		})
 		return
 	}
@@ -69,7 +85,26 @@ func cmdInstallClaudeCodeHook(args []string) {
 		"path":    path,
 		"backup":  backup,
 		"command": command,
+		"notes":   installNotes(*envelope, *requirePolicy),
 	})
+}
+
+// installNotes is the loud-message channel: surfaced on stdout JSON
+// alongside the install result so the operator sees the consequences
+// of their flag choices (or non-choices) without having to read the
+// docs first. Reviewer-driven (PR #65 review #1, #4, #7).
+func installNotes(envelope string, requirePolicy bool) []string {
+	var notes []string
+	if !requirePolicy {
+		notes = append(notes, "no-policy fallback: tool calls in directories without chitin.yaml will be ALLOWED with a stderr warning. Reinstall with --require-policy to fail closed.")
+	} else {
+		notes = append(notes, "strict mode: tool calls in directories without chitin.yaml will be BLOCKED. Scaffold a chitin.yaml in any cwd you run `claude` from.")
+	}
+	if envelope != "" {
+		notes = append(notes, "envelope pinned in hook command: this envelope is in effect for every claude session until you reinstall the hook. For switchable contexts, drop --envelope and use `chitin-kernel envelope use <id>` instead.")
+	}
+	notes = append(notes, "coexistence: this hook does NOT replace the chain-recording adapter installed via `chitin-kernel install --surface=claude-code`. Both can coexist; both will fire on each tool call.")
+	return notes
 }
 
 // cmdUninstallClaudeCodeHook handles `uninstall claude-code-hook

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -573,6 +573,10 @@ func cmdUninstallHook(args []string) {
 }
 
 func cmdInstall(args []string) {
+	if len(args) > 0 && args[0] == "claude-code-hook" {
+		cmdInstallClaudeCodeHook(args[1:])
+		return
+	}
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
 	surface := fs.String("surface", "", "surface to install (claude-code)")
 	global := fs.Bool("global", false, "install into user-level settings (always-on)")
@@ -610,6 +614,10 @@ func cmdInstall(args []string) {
 }
 
 func cmdUninstall(args []string) {
+	if len(args) > 0 && args[0] == "claude-code-hook" {
+		cmdUninstallClaudeCodeHook(args[1:])
+		return
+	}
 	fs := flag.NewFlagSet("uninstall", flag.ExitOnError)
 	surface := fs.String("surface", "", "surface to uninstall (claude-code)")
 	global := fs.Bool("global", false, "uninstall from user-level settings")
@@ -694,7 +702,17 @@ func cmdGateEvaluate(args []string) {
 	argsJSON := fs.String("args-json", "{}", "tool args as JSON")
 	agent := fs.String("agent", "", "agent identifier (e.g. hermes)")
 	cwd := fs.String("cwd", ".", "cwd the action would execute against")
+	hookStdin := fs.Bool("hook-stdin", false, "read Claude Code PreToolUse JSON from stdin (hook driver mode)")
+	envelopeID := fs.String("envelope", "", "envelope ID (overrides CHITIN_BUDGET_ENVELOPE and ~/.chitin/current-envelope)")
 	fs.Parse(args)
+
+	if *hookStdin {
+		if *agent == "" {
+			*agent = "claude-code"
+		}
+		runHookStdin(*agent, *envelopeID)
+		return
+	}
 
 	if *tool == "" || *agent == "" {
 		exitErr("gate_missing_args", "--tool and --agent required")

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -704,13 +704,14 @@ func cmdGateEvaluate(args []string) {
 	cwd := fs.String("cwd", ".", "cwd the action would execute against")
 	hookStdin := fs.Bool("hook-stdin", false, "read Claude Code PreToolUse JSON from stdin (hook driver mode)")
 	envelopeID := fs.String("envelope", "", "envelope ID (overrides CHITIN_BUDGET_ENVELOPE and ~/.chitin/current-envelope)")
+	requirePolicy := fs.Bool("require-policy", false, "fail closed when no chitin.yaml is found from cwd (default: fail open with stderr warning)")
 	fs.Parse(args)
 
 	if *hookStdin {
 		if *agent == "" {
 			*agent = "claude-code"
 		}
-		runHookStdin(*agent, *envelopeID)
+		runHookStdin(*agent, *envelopeID, *requirePolicy)
 		return
 	}
 

--- a/go/execution-kernel/internal/driver/claudecode/format.go
+++ b/go/execution-kernel/internal/driver/claudecode/format.go
@@ -1,0 +1,65 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// Hook response exit codes per Claude Code's documented protocol.
+//
+//	0 — allow (empty stdout)
+//	2 — block (JSON {"decision":"block","reason":"..."} on stdout;
+//	    Claude Code feeds the reason back to the model as a tool error)
+//	1 — non-blocking error (Claude Code surfaces to user, does not
+//	    feed back to model). Used for chitin-internal failures like
+//	    malformed input, not for governance denials.
+const (
+	ExitAllow         = 0
+	ExitNonBlockError = 1
+	ExitBlock         = 2
+)
+
+// Format turns a gov.Decision into the hook response: stdout JSON (or
+// empty) + exit code. The Reason carries the model-visible block
+// message and includes Suggestion + CorrectedCommand if present so the
+// model can self-correct without operator intervention.
+func Format(d gov.Decision) ([]byte, int) {
+	if d.Allowed {
+		return nil, ExitAllow
+	}
+
+	out := map[string]string{
+		"decision": "block",
+		"reason":   formatReason(d),
+	}
+	body, err := json.Marshal(out)
+	if err != nil {
+		// json.Marshal of map[string]string can't realistically fail,
+		// but if it ever does, fall back to a fixed string so the model
+		// still sees a denial it can react to.
+		return []byte(`{"decision":"block","reason":"chitin: governance denied (marshal error)"}`), ExitBlock
+	}
+	return body, ExitBlock
+}
+
+// formatReason composes the model-visible message:
+//
+//	"chitin: <Reason> [| suggest: <Suggestion>] [| try: <CorrectedCommand>]"
+//
+// Empty fields are omitted. The "chitin:" prefix is always present so
+// the model can recognize chitin-origin denials in transcript review.
+//
+// Identical shape to the v1 SDK driver's formatGuideError so audit-log
+// analytics across both drivers can pattern-match the same way.
+func formatReason(d gov.Decision) string {
+	parts := []string{"chitin: " + d.Reason}
+	if d.Suggestion != "" {
+		parts = append(parts, "suggest: "+d.Suggestion)
+	}
+	if d.CorrectedCommand != "" {
+		parts = append(parts, "try: "+d.CorrectedCommand)
+	}
+	return strings.Join(parts, " | ")
+}

--- a/go/execution-kernel/internal/driver/claudecode/format_test.go
+++ b/go/execution-kernel/internal/driver/claudecode/format_test.go
@@ -1,0 +1,94 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+func TestFormat_AllowIsEmptyExit0(t *testing.T) {
+	body, code := Format(gov.Decision{Allowed: true, RuleID: "default-allow-shell"})
+	if code != ExitAllow {
+		t.Fatalf("code=%d want 0 (allow)", code)
+	}
+	if len(body) != 0 {
+		t.Fatalf("allow stdout must be empty, got %q", body)
+	}
+}
+
+func TestFormat_DenyIsBlockExit2WithReason(t *testing.T) {
+	d := gov.Decision{
+		Allowed: false,
+		RuleID:  "no-rm",
+		Reason:  "no rm",
+	}
+	body, code := Format(d)
+	if code != ExitBlock {
+		t.Fatalf("code=%d want 2 (block)", code)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("body not valid JSON: %v\nbody=%s", err, body)
+	}
+	if parsed["decision"] != "block" {
+		t.Fatalf("decision=%q want block", parsed["decision"])
+	}
+	if !strings.Contains(parsed["reason"], "chitin:") {
+		t.Fatalf("reason missing chitin: prefix: %q", parsed["reason"])
+	}
+	if !strings.Contains(parsed["reason"], "no rm") {
+		t.Fatalf("reason missing the policy reason: %q", parsed["reason"])
+	}
+}
+
+func TestFormat_DenyIncludesSuggestionAndCorrected(t *testing.T) {
+	d := gov.Decision{
+		Allowed:          false,
+		RuleID:           "no-rm",
+		Reason:           "no rm",
+		Suggestion:       "use git rm",
+		CorrectedCommand: "git rm <files>",
+	}
+	body, _ := Format(d)
+	var parsed map[string]string
+	_ = json.Unmarshal(body, &parsed)
+	if !strings.Contains(parsed["reason"], "suggest: use git rm") {
+		t.Fatalf("missing suggest segment: %q", parsed["reason"])
+	}
+	if !strings.Contains(parsed["reason"], "try: git rm <files>") {
+		t.Fatalf("missing try segment: %q", parsed["reason"])
+	}
+}
+
+func TestFormat_DenyOmitsBlankSegments(t *testing.T) {
+	d := gov.Decision{Allowed: false, Reason: "no rm"}
+	body, _ := Format(d)
+	var parsed map[string]string
+	_ = json.Unmarshal(body, &parsed)
+	if strings.Contains(parsed["reason"], "suggest:") {
+		t.Fatalf("blank Suggestion should not produce 'suggest:': %q", parsed["reason"])
+	}
+	if strings.Contains(parsed["reason"], "try:") {
+		t.Fatalf("blank CorrectedCommand should not produce 'try:': %q", parsed["reason"])
+	}
+}
+
+func TestFormat_EnvelopeExhaustedIsBlock(t *testing.T) {
+	// Envelope-exhausted decisions go through the same block path as
+	// policy denials — model sees a coherent reason and can ask the
+	// operator to grant more budget.
+	d := gov.Decision{
+		Allowed: false,
+		RuleID:  "envelope-exhausted",
+		Reason:  "envelope 01J...: envelope exhausted: id=01J... calls=10/10",
+	}
+	body, code := Format(d)
+	if code != ExitBlock {
+		t.Fatalf("code=%d want 2", code)
+	}
+	if !strings.Contains(string(body), "envelope") {
+		t.Fatalf("body missing envelope mention: %s", body)
+	}
+}

--- a/go/execution-kernel/internal/driver/claudecode/normalize.go
+++ b/go/execution-kernel/internal/driver/claudecode/normalize.go
@@ -1,0 +1,140 @@
+package claudecode
+
+import (
+	"fmt"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// Normalize maps a Claude Code PreToolUse payload to a canonical gov.Action.
+//
+// Tool-name mapping per the spec:
+//
+//	Bash                                → terminal (gov.Normalize re-tags
+//	                                      shell commands; rm/git/gh patterns
+//	                                      get re-classified to specific types)
+//	Edit, Write, NotebookEdit           → file.write
+//	Read                                → file.read
+//	WebFetch, WebSearch                 → http.request
+//	Task                                → delegate.task
+//	Glob, Grep, LS                      → file.read (browse-shaped, default-allow)
+//	TodoWrite                           → file.write target="todo"
+//	                                      (matches existing gov.Normalize convention)
+//	<unknown>                           → ActUnknown (fail-closed at policy)
+//
+// The Glob/Grep/LS/TodoWrite resolution follows the plan's leaning
+// recommendation: read-shaped browse tools default-allow rather than
+// fail-closed. TodoWrite uses ActFileWrite target="todo" to match the
+// pre-existing v2 normalize convention so policy rules need only one
+// "allow if target=todo" entry.
+func Normalize(in HookInput) (gov.Action, error) {
+	switch in.ToolName {
+	case "Bash":
+		// gov.Normalize handles terminal → re-classification (rm, git push,
+		// gh pr create, etc.). Pass the raw command string through under
+		// the "command" key, matching the existing gov.normalizeShell shape.
+		cmd := stringField(in.ToolInput, "command")
+		a, err := gov.Normalize("terminal", map[string]any{"command": cmd})
+		if err != nil {
+			return gov.Action{}, fmt.Errorf("normalize Bash: %w", err)
+		}
+		a.Path = in.Cwd
+		return a, nil
+
+	case "Read":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "file_path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "Edit", "Write", "NotebookEdit":
+		path := stringField(in.ToolInput, "file_path")
+		if path == "" {
+			path = stringField(in.ToolInput, "notebook_path")
+		}
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: path,
+			Path:   in.Cwd,
+		}, nil
+
+	case "WebFetch":
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: stringField(in.ToolInput, "url"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "WebSearch":
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: stringField(in.ToolInput, "query"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "Task":
+		// Task = subagent delegation. Use the description (human-readable
+		// goal) as the Target since policy rules and audit-log readers
+		// want the intent, not the verbose subagent_type or prompt.
+		target := stringField(in.ToolInput, "description")
+		if target == "" {
+			target = stringField(in.ToolInput, "subagent_type")
+		}
+		return gov.Action{
+			Type:   gov.ActDelegateTask,
+			Target: target,
+			Path:   in.Cwd,
+		}, nil
+
+	case "Glob":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "pattern"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "Grep":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "pattern"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "LS":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "TodoWrite":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "todo",
+			Path:   in.Cwd,
+		}, nil
+	}
+
+	// Forward-compat: future Claude Code tools we haven't seen go through
+	// as ActUnknown. Policy default-deny will reject them unless the
+	// operator adds a rule — fail-closed behavior.
+	return gov.Action{
+		Type:   gov.ActUnknown,
+		Target: in.ToolName,
+		Path:   in.Cwd,
+		Params: in.ToolInput,
+	}, nil
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/go/execution-kernel/internal/driver/claudecode/normalize.go
+++ b/go/execution-kernel/internal/driver/claudecode/normalize.go
@@ -2,9 +2,24 @@ package claudecode
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
 )
+
+// warnSink is the destination for non-fatal warnings emitted during
+// Normalize (e.g., wrong-type fields). nil → silent. Set by tests and
+// by the cmd-layer to capture warnings on stderr.
+//
+// Package-global because Normalize's signature is committed by the
+// hook protocol, but the additional channel is operator-facing
+// telemetry the tests want to verify. A field on a future struct-form
+// Normalizer would be cleaner; defer until we have multiple call sites.
+var warnSink io.Writer
+
+// SetWarnSink directs Normalize's non-fatal warnings (wrong-type
+// fields, etc.) to w. Call from cmd-layer wiring. Pass nil to silence.
+func SetWarnSink(w io.Writer) { warnSink = w }
 
 // Normalize maps a Claude Code PreToolUse payload to a canonical gov.Action.
 //
@@ -127,14 +142,27 @@ func Normalize(in HookInput) (gov.Action, error) {
 	}, nil
 }
 
+// stringField extracts a string field from a tool_input map. Three
+// paths:
+//
+//	missing key             → "", silent (caller decides if it's required)
+//	present + string        → the value, silent
+//	present + non-string    → "", warning to warnSink (operator telemetry
+//	                          for malformed payloads — silent empty
+//	                          would let policy default-deny mask the bug)
 func stringField(m map[string]any, key string) string {
 	if m == nil {
 		return ""
 	}
-	if v, ok := m[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if warnSink != nil {
+		fmt.Fprintf(warnSink, `{"warning":"tool_input_wrong_type","key":%q,"actual":%q}`+"\n", key, fmt.Sprintf("%T", v))
 	}
 	return ""
 }

--- a/go/execution-kernel/internal/driver/claudecode/normalize_test.go
+++ b/go/execution-kernel/internal/driver/claudecode/normalize_test.go
@@ -1,0 +1,202 @@
+package claudecode
+
+import (
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// TestNormalize_AllDocumentedToolsProduceNonEmptyType is the spec
+// invariant: every documented Claude Code tool name maps to a known
+// non-empty Action.Type. New Claude Code tools we haven't modeled fall
+// through to ActUnknown — also non-empty, but flagged so the policy
+// default-deny path catches them.
+func TestNormalize_AllDocumentedToolsProduceNonEmptyType(t *testing.T) {
+	tools := []string{
+		"Bash", "Edit", "Write", "NotebookEdit",
+		"Read", "WebFetch", "WebSearch", "Task",
+		"Glob", "Grep", "LS", "TodoWrite",
+	}
+	for _, name := range tools {
+		in := HookInput{
+			ToolName:  name,
+			ToolInput: map[string]any{"command": "x", "file_path": "/x", "url": "https://x", "query": "x", "pattern": "*", "path": "/x", "description": "x", "notebook_path": "/x.ipynb"},
+			Cwd:       "/cwd",
+		}
+		a, err := Normalize(in)
+		if err != nil {
+			t.Errorf("%s: err=%v", name, err)
+			continue
+		}
+		if a.Type == "" {
+			t.Errorf("%s: empty Action.Type", name)
+		}
+		if a.Type == gov.ActUnknown {
+			t.Errorf("%s: must not produce ActUnknown (documented tool)", name)
+		}
+	}
+}
+
+func TestNormalize_BashReclassifiesShellCommands(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want gov.ActionType
+	}{
+		{"git status", gov.ActGitStatus},
+		{"git push origin main", gov.ActGitPush},
+		{"gh pr create --title x", gov.ActGithubPRCreate},
+		{"rm -rf go/", gov.ActShellExec}, // re-tagged via Target match in policy, type stays shell.exec
+		{"terraform destroy", gov.ActInfraDestroy},
+		{"ls -la", gov.ActShellExec},
+	}
+	for _, tc := range cases {
+		a, err := Normalize(HookInput{
+			ToolName:  "Bash",
+			ToolInput: map[string]any{"command": tc.cmd},
+			Cwd:       "/tmp",
+		})
+		if err != nil {
+			t.Errorf("Bash %q: err=%v", tc.cmd, err)
+			continue
+		}
+		if a.Type != tc.want {
+			t.Errorf("Bash %q: type=%s want %s", tc.cmd, a.Type, tc.want)
+		}
+		if a.Path != "/tmp" {
+			t.Errorf("Bash %q: Path=%q want /tmp", tc.cmd, a.Path)
+		}
+	}
+}
+
+func TestNormalize_FileReadFromRead(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName:  "Read",
+		ToolInput: map[string]any{"file_path": "/etc/hosts"},
+		Cwd:       "/cwd",
+	})
+	if a.Type != gov.ActFileRead {
+		t.Fatalf("Type=%s want file.read", a.Type)
+	}
+	if a.Target != "/etc/hosts" {
+		t.Fatalf("Target=%q want /etc/hosts", a.Target)
+	}
+}
+
+func TestNormalize_FileWriteFromEditWriteNotebook(t *testing.T) {
+	for _, tool := range []string{"Edit", "Write"} {
+		a, _ := Normalize(HookInput{
+			ToolName:  tool,
+			ToolInput: map[string]any{"file_path": "/tmp/x"},
+		})
+		if a.Type != gov.ActFileWrite {
+			t.Errorf("%s: Type=%s want file.write", tool, a.Type)
+		}
+		if a.Target != "/tmp/x" {
+			t.Errorf("%s: Target=%q want /tmp/x", tool, a.Target)
+		}
+	}
+	// NotebookEdit uses notebook_path, not file_path.
+	a, _ := Normalize(HookInput{
+		ToolName:  "NotebookEdit",
+		ToolInput: map[string]any{"notebook_path": "/tmp/x.ipynb"},
+	})
+	if a.Type != gov.ActFileWrite || a.Target != "/tmp/x.ipynb" {
+		t.Fatalf("NotebookEdit: %+v", a)
+	}
+}
+
+func TestNormalize_HTTPFromWebFetchAndSearch(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName:  "WebFetch",
+		ToolInput: map[string]any{"url": "https://example.com"},
+	})
+	if a.Type != gov.ActHTTPRequest || a.Target != "https://example.com" {
+		t.Fatalf("WebFetch: %+v", a)
+	}
+	b, _ := Normalize(HookInput{
+		ToolName:  "WebSearch",
+		ToolInput: map[string]any{"query": "go sqlite wal"},
+	})
+	if b.Type != gov.ActHTTPRequest || b.Target != "go sqlite wal" {
+		t.Fatalf("WebSearch: %+v", b)
+	}
+}
+
+func TestNormalize_DelegateFromTask(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName: "Task",
+		ToolInput: map[string]any{
+			"description":   "review PR #64",
+			"subagent_type": "general-purpose",
+		},
+	})
+	if a.Type != gov.ActDelegateTask {
+		t.Fatalf("Type=%s want delegate.task", a.Type)
+	}
+	if a.Target != "review PR #64" {
+		t.Fatalf("Target=%q want description", a.Target)
+	}
+}
+
+func TestNormalize_DelegateTaskFallsBackToSubagentType(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName:  "Task",
+		ToolInput: map[string]any{"subagent_type": "Explore"},
+	})
+	if a.Target != "Explore" {
+		t.Fatalf("Target=%q want Explore", a.Target)
+	}
+}
+
+func TestNormalize_BrowseToolsAreFileRead(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     map[string]any
+		wantTarget string
+	}{
+		{"Glob", map[string]any{"pattern": "**/*.go"}, "**/*.go"},
+		{"Grep", map[string]any{"pattern": "TODO"}, "TODO"},
+		{"LS", map[string]any{"path": "/etc"}, "/etc"},
+	}
+	for _, tc := range cases {
+		a, _ := Normalize(HookInput{ToolName: tc.name, ToolInput: tc.input})
+		if a.Type != gov.ActFileRead {
+			t.Errorf("%s: type=%s want file.read", tc.name, a.Type)
+		}
+		if a.Target != tc.wantTarget {
+			t.Errorf("%s: Target=%q want %q", tc.name, a.Target, tc.wantTarget)
+		}
+	}
+}
+
+func TestNormalize_TodoWriteIsFileWriteWithTodoTarget(t *testing.T) {
+	a, _ := Normalize(HookInput{ToolName: "TodoWrite", ToolInput: map[string]any{"todos": []any{}}})
+	if a.Type != gov.ActFileWrite {
+		t.Fatalf("Type=%s want file.write", a.Type)
+	}
+	if a.Target != "todo" {
+		t.Fatalf("Target=%q want todo (existing v2 normalize convention)", a.Target)
+	}
+}
+
+func TestNormalize_UnknownToolFailsClosed(t *testing.T) {
+	a, _ := Normalize(HookInput{ToolName: "FutureUnreleasedTool", ToolInput: map[string]any{"x": 1}})
+	if a.Type != gov.ActUnknown {
+		t.Fatalf("Type=%s want ActUnknown", a.Type)
+	}
+	// Params preserved so audit log captures what we couldn't classify.
+	if a.Params == nil {
+		t.Fatalf("Params should preserve raw input for audit")
+	}
+}
+
+func TestNormalize_MissingFieldYieldsEmptyTarget(t *testing.T) {
+	// No file_path → empty Target. Don't crash, don't substitute.
+	a, _ := Normalize(HookInput{ToolName: "Read", ToolInput: map[string]any{}})
+	if a.Type != gov.ActFileRead {
+		t.Fatalf("Type=%s want file.read", a.Type)
+	}
+	if a.Target != "" {
+		t.Fatalf("Target=%q want empty", a.Target)
+	}
+}

--- a/go/execution-kernel/internal/driver/claudecode/types.go
+++ b/go/execution-kernel/internal/driver/claudecode/types.go
@@ -1,0 +1,28 @@
+// Package claudecode normalizes Claude Code's PreToolUse hook payloads
+// into gov.Actions and formats gov.Decisions back into the hook
+// response shape Claude Code expects.
+//
+// The hook is registered globally (~/.claude/settings.json) or per-project
+// (.claude/settings.json) by `chitin-kernel install claude-code-hook`,
+// pointing at `chitin-kernel gate evaluate --hook-stdin --agent=claude-code`.
+//
+// Hook protocol (Claude Code → chitin):
+//   - stdin: JSON with tool_name, tool_input, cwd, session_id, transcript_path
+//   - stdout (allow): empty; exit 0
+//   - stdout (deny):  {"decision":"block","reason":"..."}; exit 2
+//
+// See spec docs/superpowers/specs/2026-04-29-cost-governance-kernel-design.md
+// §"Path A — Claude Code session" for the full data flow.
+package claudecode
+
+// HookInput is the shape of Claude Code's PreToolUse JSON payload.
+// Fields beyond these are ignored — the hook protocol is forward-
+// compatible by design (Claude Code adds fields without removing).
+type HookInput struct {
+	SessionID      string         `json:"session_id"`
+	TranscriptPath string         `json:"transcript_path"`
+	Cwd            string         `json:"cwd"`
+	HookEventName  string         `json:"hook_event_name"`
+	ToolName       string         `json:"tool_name"`
+	ToolInput      map[string]any `json:"tool_input"`
+}

--- a/go/execution-kernel/internal/govhookinstall/install.go
+++ b/go/execution-kernel/internal/govhookinstall/install.go
@@ -1,0 +1,335 @@
+// Package govhookinstall installs the chitin governance hook into
+// Claude Code's settings.json. Distinct from internal/hookinstall, which
+// installs the chain-recording adapter — the two coexist as separate
+// PreToolUse entries with different tags so install/uninstall don't
+// step on each other.
+//
+// The governance hook fires `chitin-kernel gate evaluate --hook-stdin
+// --agent=claude-code` on every Bash/Edit/Write/NotebookEdit/Read/
+// WebFetch/WebSearch/Task. Allow → exit 0; deny → exit 2 with a JSON
+// reason that Claude Code surfaces back to the model.
+//
+// Both global (~/.claude/settings.json) and project (.claude/settings.json)
+// scopes are supported. Each install creates a one-time backup of the
+// settings file at <path>.chitin-backup-<utc-ts> the first time chitin
+// touches it, so an operator always has a pre-chitin restore point.
+package govhookinstall
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// chitinTag identifies governance-hook entries owned by chitin. Distinct
+// from internal/hookinstall's "chitin" tag so the two installs don't
+// remove each other on uninstall.
+const chitinTag = "chitin-governance"
+
+// matcher restricts the governance hook to tool names chitin knows how
+// to normalize. Future Claude Code tools we haven't modeled fall through
+// (no matcher = no chitin governance for them) so we don't gate on
+// unknowns. The audit log sees only matched tools.
+const matcher = "Bash|Edit|Write|NotebookEdit|Read|WebFetch|WebSearch|Task|Glob|Grep|LS|TodoWrite"
+
+// HookCommand is the literal command Claude Code spawns on PreToolUse.
+// Exposed for the cmd-layer install to override (e.g. with --envelope).
+const HookCommand = "chitin-kernel gate evaluate --hook-stdin --agent=claude-code"
+
+// Scope is global (~/.claude/settings.json) or project (.claude/settings.json
+// from cwd). Operators choose at install time.
+type Scope int
+
+const (
+	ScopeGlobal Scope = iota
+	ScopeProject
+)
+
+// Install merges the chitin governance hook into the settings file at
+// the given scope, idempotently. Pre-existing chitin-governance entries
+// are replaced so reinstall picks up command-string changes (e.g. when
+// the operator passes a new --envelope flag). Other entries are
+// preserved verbatim.
+//
+// command is the full hook command line. cwd is only used for ScopeProject;
+// global ignores it.
+//
+// Returns the absolute path of the settings file that was written, plus
+// the backup path (empty if no backup was taken — only the first chitin
+// touch creates a backup).
+func Install(scope Scope, cwd, command string) (path, backup string, err error) {
+	path, err = settingsPath(scope, cwd)
+	if err != nil {
+		return "", "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", "", fmt.Errorf("mkdir settings dir: %w", err)
+	}
+	settings, existed, err := loadSettings(path)
+	if err != nil {
+		return "", "", err
+	}
+	if existed {
+		backup, err = ensureBackup(path)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	hooks := ensureHooksMap(settings)
+	preToolUse := toAnySlice(hooks["PreToolUse"])
+	preToolUse = filterOutChitinGovernance(preToolUse)
+	preToolUse = append(preToolUse, govWrapper(command))
+	hooks["PreToolUse"] = preToolUse
+	settings["hooks"] = hooks
+
+	if err := writeSettingsAtomic(path, settings); err != nil {
+		return path, backup, err
+	}
+	return path, backup, nil
+}
+
+// Uninstall removes chitin's governance hook entries (identified by
+// _tag == chitin-governance) from PreToolUse. Other entries are
+// preserved. If PreToolUse becomes empty it is removed; if hooks
+// becomes empty it is removed. Missing settings file is a no-op.
+func Uninstall(scope Scope, cwd string) (path string, err error) {
+	path, err = settingsPath(scope, cwd)
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+		return path, nil
+	}
+	settings, _, err := loadSettings(path)
+	if err != nil {
+		return path, err
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return path, nil
+	}
+	preToolUse := toAnySlice(hooks["PreToolUse"])
+	filtered := filterOutChitinGovernance(preToolUse)
+	if len(filtered) == 0 {
+		delete(hooks, "PreToolUse")
+	} else {
+		hooks["PreToolUse"] = filtered
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	} else {
+		settings["hooks"] = hooks
+	}
+	if err := writeSettingsAtomic(path, settings); err != nil {
+		return path, err
+	}
+	return path, nil
+}
+
+// DryRunPlan reports what Install would do without writing. Returns the
+// settings path, the would-be backup path (empty if file doesn't exist
+// or backup already present), the planned PreToolUse entry, and the
+// number of non-chitin entries that would be preserved.
+type Plan struct {
+	Path           string
+	Backup         string
+	BackupExists   bool
+	WouldWrite     bool
+	PreservedCount int
+	WrapperCommand string
+}
+
+// DryRun returns a Plan describing the install without performing it.
+// Useful for `install claude-code-hook --dry-run`.
+func DryRun(scope Scope, cwd, command string) (Plan, error) {
+	path, err := settingsPath(scope, cwd)
+	if err != nil {
+		return Plan{}, err
+	}
+	plan := Plan{Path: path, WrapperCommand: command, WouldWrite: true}
+	if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+		return plan, nil
+	}
+	settings, _, err := loadSettings(path)
+	if err != nil {
+		return plan, err
+	}
+	if backupPath, exists := existingBackup(path); exists {
+		plan.Backup = backupPath
+		plan.BackupExists = true
+	} else {
+		plan.Backup = backupNameFor(path)
+	}
+	if hooks, ok := settings["hooks"].(map[string]any); ok {
+		preToolUse := toAnySlice(hooks["PreToolUse"])
+		preserved := filterOutChitinGovernance(preToolUse)
+		plan.PreservedCount = len(preserved)
+	}
+	return plan, nil
+}
+
+func govWrapper(command string) map[string]any {
+	return map[string]any{
+		"_tag":    chitinTag,
+		"matcher": matcher,
+		"hooks": []any{
+			map[string]any{"type": "command", "command": command},
+		},
+	}
+}
+
+func filterOutChitinGovernance(list []any) []any {
+	out := make([]any, 0, len(list))
+	for _, e := range list {
+		m, ok := e.(map[string]any)
+		if ok && m["_tag"] == chitinTag {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func settingsPath(scope Scope, cwd string) (string, error) {
+	switch scope {
+	case ScopeGlobal:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("home dir: %w", err)
+		}
+		return filepath.Join(home, ".claude", "settings.json"), nil
+	case ScopeProject:
+		abs, err := filepath.Abs(cwd)
+		if err != nil {
+			return "", fmt.Errorf("abs cwd: %w", err)
+		}
+		return filepath.Join(abs, ".claude", "settings.json"), nil
+	}
+	return "", fmt.Errorf("unknown scope: %d", scope)
+}
+
+// ensureBackup writes <path>.chitin-backup-<utc-ts> if no chitin backup
+// of this path exists yet. Returns the backup path (empty if a backup
+// already existed and we didn't overwrite). The backup is the operator's
+// pre-chitin restore point and must NOT be overwritten by reinstalls —
+// that would erase the original state on second touch.
+func ensureBackup(path string) (string, error) {
+	if _, exists := existingBackup(path); exists {
+		return "", nil
+	}
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read for backup: %w", err)
+	}
+	backup := backupNameFor(path)
+	if err := os.WriteFile(backup, src, 0o600); err != nil {
+		return "", fmt.Errorf("write backup: %w", err)
+	}
+	return backup, nil
+}
+
+func backupNameFor(path string) string {
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	return path + ".chitin-backup-" + ts
+}
+
+// existingBackup looks for any sibling file whose name starts with
+// <basename>.chitin-backup-. Returns the first match.
+func existingBackup(path string) (string, bool) {
+	dir := filepath.Dir(path)
+	prefix := filepath.Base(path) + ".chitin-backup-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && len(e.Name()) > len(prefix) && e.Name()[:len(prefix)] == prefix {
+			return filepath.Join(dir, e.Name()), true
+		}
+	}
+	return "", false
+}
+
+func loadSettings(path string) (map[string]any, bool, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{}, false, nil
+		}
+		return nil, false, err
+	}
+	if len(b) == 0 {
+		return map[string]any{}, true, nil
+	}
+	var s map[string]any
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil, true, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if s == nil {
+		s = map[string]any{}
+	}
+	return s, true, nil
+}
+
+func writeSettingsAtomic(path string, s map[string]any) error {
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", path, statErr)
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".settings.json.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp to %s: %w", path, err)
+	}
+	cleanup = false
+	return nil
+}
+
+func ensureHooksMap(settings map[string]any) map[string]any {
+	h, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return h
+}
+
+func toAnySlice(v any) []any {
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.([]any); ok {
+		return s
+	}
+	return nil
+}

--- a/go/execution-kernel/internal/govhookinstall/install.go
+++ b/go/execution-kernel/internal/govhookinstall/install.go
@@ -217,6 +217,10 @@ func settingsPath(scope Scope, cwd string) (string, error) {
 // already existed and we didn't overwrite). The backup is the operator's
 // pre-chitin restore point and must NOT be overwritten by reinstalls —
 // that would erase the original state on second touch.
+//
+// File mode is preserved from the original — a 0o644 settings.json
+// stays 0o644 in the backup. Defaults to 0o600 if the original is
+// missing (shouldn't happen since we only call after stat succeeds).
 func ensureBackup(path string) (string, error) {
 	if _, exists := existingBackup(path); exists {
 		return "", nil
@@ -225,8 +229,12 @@ func ensureBackup(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read for backup: %w", err)
 	}
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
 	backup := backupNameFor(path)
-	if err := os.WriteFile(backup, src, 0o600); err != nil {
+	if err := os.WriteFile(backup, src, mode); err != nil {
 		return "", fmt.Errorf("write backup: %w", err)
 	}
 	return backup, nil

--- a/go/execution-kernel/internal/govhookinstall/install_test.go
+++ b/go/execution-kernel/internal/govhookinstall/install_test.go
@@ -1,0 +1,236 @@
+package govhookinstall
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// projectInTempDir installs/uninstalls against a fresh temp dir using
+// ScopeProject — sidesteps the global $HOME path so the test can't
+// touch the user's real ~/.claude/settings.json.
+func projectInTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return dir
+}
+
+func readSettings(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings %s: %v", path, err)
+	}
+	var s map[string]any
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("parse settings: %v\nbody=%s", err, b)
+	}
+	return s
+}
+
+func TestInstall_FreshSettings_AddsGovernanceHook(t *testing.T) {
+	cwd := projectInTempDir(t)
+	path, backup, err := Install(ScopeProject, cwd, "chitin-kernel gate evaluate --hook-stdin --agent=claude-code")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if backup != "" {
+		t.Fatalf("fresh settings should not produce a backup, got %q", backup)
+	}
+	if !strings.HasSuffix(path, "/.claude/settings.json") {
+		t.Fatalf("path=%q should end with /.claude/settings.json", path)
+	}
+	s := readSettings(t, path)
+	hooks, ok := s["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing hooks: %+v", s)
+	}
+	pre, ok := hooks["PreToolUse"].([]any)
+	if !ok || len(pre) != 1 {
+		t.Fatalf("PreToolUse: %+v", hooks["PreToolUse"])
+	}
+	entry := pre[0].(map[string]any)
+	if entry["_tag"] != chitinTag {
+		t.Fatalf("_tag=%v want %s", entry["_tag"], chitinTag)
+	}
+	if entry["matcher"] == nil || !strings.Contains(entry["matcher"].(string), "Bash") {
+		t.Fatalf("matcher missing Bash: %v", entry["matcher"])
+	}
+}
+
+func TestInstall_PreservesNonChitinEntries(t *testing.T) {
+	cwd := projectInTempDir(t)
+	settingsDir := filepath.Join(cwd, ".claude")
+	_ = os.MkdirAll(settingsDir, 0o755)
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	original := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Read",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "user-script.sh"},
+					},
+				},
+			},
+		},
+	}
+	b, _ := json.MarshalIndent(original, "", "  ")
+	_ = os.WriteFile(settingsPath, b, 0o600)
+
+	_, _, err := Install(ScopeProject, cwd, "chitin-kernel gate evaluate --hook-stdin")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	s := readSettings(t, settingsPath)
+	pre := s["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(pre) != 2 {
+		t.Fatalf("PreToolUse count=%d want 2 (user + chitin)", len(pre))
+	}
+	// User entry first (preserved verbatim), chitin appended.
+	user := pre[0].(map[string]any)
+	if user["matcher"] != "Read" {
+		t.Fatalf("user entry mutated: %+v", user)
+	}
+	chitin := pre[1].(map[string]any)
+	if chitin["_tag"] != chitinTag {
+		t.Fatalf("chitin entry not appended last: %+v", pre)
+	}
+}
+
+func TestInstall_Idempotent_SecondInstallReplacesNotDuplicates(t *testing.T) {
+	cwd := projectInTempDir(t)
+	_, _, err := Install(ScopeProject, cwd, "old-command")
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	_, _, err = Install(ScopeProject, cwd, "new-command")
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	settingsPath := filepath.Join(cwd, ".claude", "settings.json")
+	s := readSettings(t, settingsPath)
+	pre := s["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(pre) != 1 {
+		t.Fatalf("expected 1 chitin entry after reinstall, got %d", len(pre))
+	}
+	cmd := pre[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"]
+	if cmd != "new-command" {
+		t.Fatalf("reinstall did not pick up new command: %v", cmd)
+	}
+}
+
+func TestInstall_FirstTouch_BacksUpExistingFile(t *testing.T) {
+	cwd := projectInTempDir(t)
+	settingsDir := filepath.Join(cwd, ".claude")
+	_ = os.MkdirAll(settingsDir, 0o755)
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	originalBytes := []byte(`{"unrelated":"value"}`)
+	_ = os.WriteFile(settingsPath, originalBytes, 0o600)
+
+	_, backup, err := Install(ScopeProject, cwd, "x")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if backup == "" {
+		t.Fatalf("expected backup to be created on first touch")
+	}
+	got, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(got) != string(originalBytes) {
+		t.Fatalf("backup contents do not match original")
+	}
+}
+
+func TestInstall_SecondTouch_DoesNotOverwriteBackup(t *testing.T) {
+	cwd := projectInTempDir(t)
+	settingsDir := filepath.Join(cwd, ".claude")
+	_ = os.MkdirAll(settingsDir, 0o755)
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	originalBytes := []byte(`{"unrelated":"value"}`)
+	_ = os.WriteFile(settingsPath, originalBytes, 0o600)
+
+	_, backup1, _ := Install(ScopeProject, cwd, "x")
+	if backup1 == "" {
+		t.Fatalf("first install should produce backup")
+	}
+	// Second install: the backup must be preserved (no overwrite).
+	_, backup2, _ := Install(ScopeProject, cwd, "y")
+	if backup2 != "" {
+		t.Fatalf("second install must NOT create another backup, got %q", backup2)
+	}
+	got, _ := os.ReadFile(backup1)
+	if string(got) != string(originalBytes) {
+		t.Fatalf("original backup was modified on second install")
+	}
+}
+
+func TestUninstall_RemovesGovernanceEntries_PreservesOthers(t *testing.T) {
+	cwd := projectInTempDir(t)
+	settingsDir := filepath.Join(cwd, ".claude")
+	_ = os.MkdirAll(settingsDir, 0o755)
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	original := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Read",
+					"hooks":   []any{map[string]any{"type": "command", "command": "user.sh"}},
+				},
+			},
+		},
+	}
+	b, _ := json.MarshalIndent(original, "", "  ")
+	_ = os.WriteFile(settingsPath, b, 0o600)
+
+	_, _, _ = Install(ScopeProject, cwd, "x")
+	if _, err := Uninstall(ScopeProject, cwd); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	s := readSettings(t, settingsPath)
+	pre := s["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(pre) != 1 {
+		t.Fatalf("expected user entry preserved, got %d", len(pre))
+	}
+	if pre[0].(map[string]any)["matcher"] != "Read" {
+		t.Fatalf("wrong entry preserved: %+v", pre[0])
+	}
+}
+
+func TestUninstall_EmptyAfterRemoval_PrunesKeys(t *testing.T) {
+	cwd := projectInTempDir(t)
+	_, _, _ = Install(ScopeProject, cwd, "x") // no other hooks present
+	if _, err := Uninstall(ScopeProject, cwd); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	settingsPath := filepath.Join(cwd, ".claude", "settings.json")
+	s := readSettings(t, settingsPath)
+	if _, has := s["hooks"]; has {
+		t.Fatalf("hooks key should be removed when empty")
+	}
+}
+
+func TestUninstall_MissingFileIsNoOp(t *testing.T) {
+	cwd := projectInTempDir(t)
+	if _, err := Uninstall(ScopeProject, cwd); err != nil {
+		t.Fatalf("Uninstall on missing file should be no-op, got %v", err)
+	}
+}
+
+func TestDryRun_DoesNotWriteFile(t *testing.T) {
+	cwd := projectInTempDir(t)
+	plan, err := DryRun(ScopeProject, cwd, "x")
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if !plan.WouldWrite {
+		t.Fatalf("WouldWrite=false; want true")
+	}
+	if _, err := os.Stat(plan.Path); !os.IsNotExist(err) {
+		t.Fatalf("DryRun must not create %s; stat err=%v", plan.Path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Milestone C: Claude Code PreToolUse hook driver. Operator runs `chitin-kernel install claude-code-hook --global`; from then on every tool call routes through `gate evaluate --hook-stdin` for governance + envelope spend, with audit-log entries tagged `agent=claude-code`.

**Stacked on #64 (milestone A).** Diff is C-only because base is set to A's branch. When #64 merges, I'll retarget to main and rebase.

## Cold-start verdict (decision gate)

100 cold-start invocations on this box:

| metric | latency |
|---|---|
| p50 | 3 ms |
| p95 | 3 ms |
| p99 | 4 ms |

**Decision: ship cold-start.** Daemon mode (gate.sock listener) deferred unless a future operator's box trips the 100ms gate. Recorded at `docs/observations/2026-04-29-claude-code-hook-coldstart.md`.

## What's in

- **`internal/driver/claudecode/{types,normalize,format}.go`** — `HookInput` payload shape; tool-name → `gov.Action` mapping per spec (Bash inherits shell re-tagging via `gov.Normalize`; Edit/Write/NotebookEdit→file.write; Read→file.read; WebFetch/WebSearch→http.request; Task→delegate.task; Glob/Grep/LS→file.read default-allow; TodoWrite→file.write target=todo per the v2 normalize convention; unknowns→`ActUnknown` so policy default-deny catches them); `Format()` emits the canonical `{\"decision\":\"block\",\"reason\":\"...\"}` shape with `chitin:` prefix + `suggest:`/`try:` segments mirroring the v1 SDK driver.
- **`internal/govhookinstall`** — separate package from `internal/hookinstall` so the governance hook coexists with the existing chain-recording adapter (different `_tag`, distinct install/uninstall paths). Idempotent reinstall replaces only the chitin-governance entry, preserving user entries verbatim. First-touch backup at `<path>.chitin-backup-<ts>`; subsequent installs do NOT overwrite the backup. `--global` and `--project` scopes; `--dry-run` reports the plan without writing.
- **`cmd/chitin-kernel/gate_hook.go`** — `--hook-stdin` mode factored into pure `evalHookStdin(reader, out, errOut, agent, envelopeFlag) (exitCode int)` plus `runHookStdin` that wires `os.Stdin/Stdout/Exit`. Envelope precedence: `--envelope` flag → `CHITIN_BUDGET_ENVELOPE` env → `~/.chitin/current-envelope` file → none. Bad envelope ID → block with a `chitin:` reason. No policy in cwd → fail open with stderr warning. Cost/tier callbacks wired to `internal/cost.Estimate` + `internal/tier.Route`.
- **`cmd/chitin-kernel/install_claude_code.go`** — `install claude-code-hook [--global|--project] [--dry-run] [--envelope=<id>]` and matching uninstall. `--envelope` embeds an envelope ID into the hook command line for global pinning.
- **`cmd/chitin-kernel/bench_coldstart_test.go`** — gated on `COLDSTART=1` so unit-test runs aren't slowed; reports p50/p95/p99 + verdict.
- **`docs/observations/2026-04-29-claude-code-hook-coldstart.md`** — verdict recording.

## Tests

19 new tests:
- 9 in `internal/driver/claudecode` (every documented tool maps to non-empty Action.Type; Bash re-classifies shell commands; field plumbing for each tool kind; unknown-tool fail-closed; missing field yields empty Target; Format allow/deny shapes + suggest/try omission; envelope-exhausted reason)
- 8 in `internal/govhookinstall` (fresh-settings install; preserve non-chitin entries; idempotent reinstall replaces; first-touch backup; second-touch preserves backup; uninstall removes only chitin entries; uninstall prunes empty keys; missing-file no-op; dry-run doesn't write)
- 9 in `cmd/chitin-kernel` (allow/deny exit codes; no-policy fail-open warning; malformed JSON exit 1; envelope debit; envelope-exhausted blocks with reason; envelope precedence flag>env>file; bad envelope ID blocks)
- 1 cold-start benchmark (gated)

All `./...` green under `-race -count=1`.

## Test plan

- [x] `go test -race ./...` green
- [x] Cold-start bench run on operator's box; verdict ≤ 100ms
- [x] No-policy-in-cwd path fails open (operator can run \`claude\` in arbitrary dirs without blocking)
- [x] Envelope precedence chain works (flag wins over env wins over file)
- [ ] **Live integration**: install hook globally, run a real \`claude\` session that does Read + Bash + Edit, confirm decisions appear in \`gov-decisions-<today>.jsonl\` with \`agent: \"claude-code\"\` — defer to operator validation post-merge

## Out of scope

- Envelope CLI subcommands (`envelope create/use/list/inspect/grant/close`, `envelope tail`) — Milestone E
- Copilot ACP shim — Milestone B
- Multi-agent envelope stress test — Milestone D
- Daemon mode (`gate daemon`) — not needed at this latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)