### PR TITLE
feat(gov): cost-governance milestone E — envelope operator surface

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/envelope.go
+++ b/go/execution-kernel/cmd/chitin-kernel/envelope.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// cmdEnvelope dispatches `envelope <op> [flags]`. Operator-facing surface
+// for managing BudgetEnvelopes (Milestone E of cost-governance kernel v3).
+//
+// Subcommands:
+//   create   --calls=N --bytes=N [--usd=N]   → emits ULID
+//   use      <id>                            → atomic write of ~/.chitin/current-envelope
+//   inspect  <id>                            → JSON snapshot
+//   list     [--limit=N]                     → JSON array (most recent first)
+//   grant    <id> [--calls=N] [--bytes=N] [--usd=N] [--reason=...]
+//                                            → raise caps + reopen + audit row
+//   close    <id>                            → idempotent close
+//
+// All subcommands share the same gov.db at ~/.chitin/gov.db; CHITIN_HOME
+// override exists for tests.
+func cmdEnvelope(args []string) {
+	if len(args) < 1 {
+		exitErr("envelope_no_subcommand", "usage: chitin-kernel envelope {create|use|inspect|list|grant|close} [flags]")
+	}
+	op := args[0]
+	rest := args[1:]
+	switch op {
+	case "create":
+		cmdEnvelopeCreate(rest)
+	case "use":
+		cmdEnvelopeUse(rest)
+	case "inspect":
+		cmdEnvelopeInspect(rest)
+	case "list":
+		cmdEnvelopeList(rest)
+	case "grant":
+		cmdEnvelopeGrant(rest)
+	case "close":
+		cmdEnvelopeClose(rest)
+	case "tail":
+		cmdEnvelopeTail(rest)
+	default:
+		exitErr("envelope_unknown_subcommand", op)
+	}
+}
+
+// openBudgetStore opens ~/.chitin/gov.db, creating the parent dir if
+// needed. Mirrors openStateCounter; both touch the same db file under WAL.
+func openBudgetStore() (*gov.BudgetStore, string, error) {
+	dir := chitinDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, dir, fmt.Errorf("mkdir state dir: %w", err)
+	}
+	store, err := gov.OpenBudgetStore(filepath.Join(dir, "gov.db"))
+	if err != nil {
+		return nil, dir, err
+	}
+	return store, dir, nil
+}
+
+// splitPositionalID returns the leading positional id (first arg if it
+// doesn't start with "-") plus the remaining flag args. Returns "" id
+// when no positional is present, signaling the caller to surface a
+// usage error.
+func splitPositionalID(args []string) (string, []string) {
+	if len(args) == 0 {
+		return "", args
+	}
+	if strings.HasPrefix(args[0], "-") {
+		return "", args
+	}
+	return args[0], args[1:]
+}
+
+func cmdEnvelopeCreate(args []string) {
+	fs := flag.NewFlagSet("envelope create", flag.ExitOnError)
+	calls := fs.Int64("calls", 0, "MaxToolCalls cap (0 = uncapped)")
+	bytes := fs.Int64("bytes", 0, "MaxInputBytes cap (0 = uncapped)")
+	usd := fs.Float64("usd", 0, "BudgetUSD informational cap")
+	fs.Parse(args)
+	if *calls < 0 || *bytes < 0 || *usd < 0 {
+		exitErr("envelope_create_negative", "--calls, --bytes, --usd must be non-negative")
+	}
+	store, _, err := openBudgetStore()
+	if err != nil {
+		exitErr("envelope_create_open", err.Error())
+	}
+	defer store.Close()
+	env, err := store.Create(gov.BudgetLimits{
+		MaxToolCalls:  *calls,
+		MaxInputBytes: *bytes,
+		BudgetUSD:     *usd,
+	})
+	if err != nil {
+		exitErr("envelope_create", err.Error())
+	}
+	// One ULID per line on stdout — scripting-friendly. The newline lets
+	// `envelope use $(envelope create ...)` work without a chomp.
+	fmt.Println(env.ID)
+}
+
+func cmdEnvelopeUse(args []string) {
+	fs := flag.NewFlagSet("envelope use", flag.ExitOnError)
+	fs.Parse(args)
+	if fs.NArg() != 1 {
+		exitErr("envelope_use_args", "usage: chitin-kernel envelope use <id>")
+	}
+	id := fs.Arg(0)
+	store, dir, err := openBudgetStore()
+	if err != nil {
+		exitErr("envelope_use_open", err.Error())
+	}
+	defer store.Close()
+	if _, err := store.Load(id); err != nil {
+		if errors.Is(err, gov.ErrEnvelopeNotFound) {
+			exitErr("envelope_not_found", id)
+		}
+		exitErr("envelope_use_load", err.Error())
+	}
+	if err := writeCurrentEnvelope(dir, id); err != nil {
+		exitErr("envelope_use_write", err.Error())
+	}
+}
+
+// writeCurrentEnvelope writes id+'\n' to <dir>/current-envelope atomically:
+// write to a tmp file in the same directory, fsync, rename over the target.
+//
+// Invariant: a concurrent reader of <dir>/current-envelope sees either the
+// previous content or the new content in full — never a partial/empty
+// interim. rename(2) is atomic on POSIX when src and dst are on the same
+// filesystem; placing tmp in the same directory guarantees that.
+//
+// On concurrent writers: every writer rename()s its own tmp file. The
+// final visible content is whichever rename happened last. Each writer's
+// content is internally consistent.
+func writeCurrentEnvelope(dir, id string) error {
+	target := filepath.Join(dir, "current-envelope")
+	tmp, err := os.CreateTemp(dir, "current-envelope.tmp.*")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.WriteString(id + "\n"); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("fsync tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+func cmdEnvelopeInspect(args []string) {
+	fs := flag.NewFlagSet("envelope inspect", flag.ExitOnError)
+	fs.Parse(args)
+	if fs.NArg() != 1 {
+		exitErr("envelope_inspect_args", "usage: chitin-kernel envelope inspect <id>")
+	}
+	id := fs.Arg(0)
+	store, _, err := openBudgetStore()
+	if err != nil {
+		exitErr("envelope_inspect_open", err.Error())
+	}
+	defer store.Close()
+	env, err := store.Load(id)
+	if err != nil {
+		if errors.Is(err, gov.ErrEnvelopeNotFound) {
+			exitErr("envelope_not_found", id)
+		}
+		exitErr("envelope_inspect_load", err.Error())
+	}
+	st, err := env.Inspect()
+	if err != nil {
+		exitErr("envelope_inspect", err.Error())
+	}
+	b, err := json.Marshal(st)
+	if err != nil {
+		exitErr("envelope_inspect_marshal", err.Error())
+	}
+	fmt.Println(string(b))
+}
+
+func cmdEnvelopeList(args []string) {
+	fs := flag.NewFlagSet("envelope list", flag.ExitOnError)
+	limit := fs.Int("limit", 20, "max envelopes to return (0 = no limit)")
+	fs.Parse(args)
+	if *limit < 0 {
+		exitErr("envelope_list_limit", "--limit must be non-negative")
+	}
+	store, _, err := openBudgetStore()
+	if err != nil {
+		exitErr("envelope_list_open", err.Error())
+	}
+	defer store.Close()
+	envs, err := store.List(*limit)
+	if err != nil {
+		exitErr("envelope_list", err.Error())
+	}
+	// Always emit a JSON array, never null — empty result = "[]".
+	if envs == nil {
+		envs = []gov.EnvelopeState{}
+	}
+	b, err := json.Marshal(envs)
+	if err != nil {
+		exitErr("envelope_list_marshal", err.Error())
+	}
+	fmt.Println(string(b))
+}
+
+func cmdEnvelopeGrant(args []string) {
+	// Stdlib `flag` stops parsing at the first non-flag arg, so we peel
+	// the positional <id> off the front before parsing flags. This lets
+	// operators write `envelope grant <id> --calls=10` (id-first feels
+	// natural) without forcing flags-before-positional ordering.
+	id, rest := splitPositionalID(args)
+	if id == "" {
+		exitErr("envelope_grant_args", "usage: chitin-kernel envelope grant <id> [--calls=N] [--bytes=N] [--usd=N] [--reason=...]")
+	}
+	fs := flag.NewFlagSet("envelope grant", flag.ExitOnError)
+	calls := fs.Int64("calls", 0, "delta to add to MaxToolCalls")
+	bytes := fs.Int64("bytes", 0, "delta to add to MaxInputBytes")
+	usd := fs.Float64("usd", 0, "delta to add to BudgetUSD (informational)")
+	reason := fs.String("reason", "", "operator-supplied reason recorded in envelope_grants and audit log")
+	fs.Parse(rest)
+	store, dir, err := openBudgetStore()
+	if err != nil {
+		exitErr("envelope_grant_open", err.Error())
+	}
+	defer store.Close()
+	env, err := store.Load(id)
+	if err != nil {
+		if errors.Is(err, gov.ErrEnvelopeNotFound) {
+			exitErr("envelope_not_found", id)
+		}
+		exitErr("envelope_grant_load", err.Error())
+	}
+	if err := env.Grant(*calls, *bytes, *usd, *reason); err != nil {
+		exitErr("envelope_grant", err.Error())
+	}
+	// Append an operator-grant row to the daily audit log so a later
+	// `envelope tail` can surface it alongside agent decisions. Action
+	// shape: type "operator.grant", target = envelope id. The closed
+	// ActionType enum is for agent-proposed actions; operator-grant is
+	// out-of-band, so it lands as a string here without expanding the
+	// enum (audit readers treat action_type as opaque).
+	audit := gov.Decision{
+		Allowed:    true,
+		Mode:       "enforce",
+		RuleID:     "operator-grant",
+		Reason:     fmtGrantDelta(*calls, *bytes, *usd, *reason),
+		Action:     gov.Action{Type: gov.ActionType("operator.grant"), Target: id},
+		Agent:      "operator",
+		Ts:         time.Now().UTC().Format(time.RFC3339),
+		EnvelopeID: id,
+		ToolCalls:  *calls,
+		InputBytes: *bytes,
+		CostUSD:    *usd,
+	}
+	if err := gov.WriteLog(audit, dir); err != nil {
+		// Audit-write failure isn't fatal — the grant landed in sqlite.
+		// Surface on stderr so operators see it but exit 0.
+		fmt.Fprintf(os.Stderr, `{"warning":"audit_write_failed","error":%q}`+"\n", err.Error())
+	}
+}
+
+func fmtGrantDelta(calls, bytes int64, usd float64, reason string) string {
+	parts := []string{}
+	if calls != 0 {
+		parts = append(parts, fmt.Sprintf("calls=%+d", calls))
+	}
+	if bytes != 0 {
+		parts = append(parts, fmt.Sprintf("bytes=%+d", bytes))
+	}
+	if usd != 0 {
+		parts = append(parts, fmt.Sprintf("usd=%+f", usd))
+	}
+	out := "grant"
+	if len(parts) > 0 {
+		out += " " + strings.Join(parts, " ")
+	}
+	if reason != "" {
+		out += " (" + reason + ")"
+	}
+	return out
+}
+
+func cmdEnvelopeClose(args []string) {
+	fs := flag.NewFlagSet("envelope close", flag.ExitOnError)
+	fs.Parse(args)
+	if fs.NArg() != 1 {
+		exitErr("envelope_close_args", "usage: chitin-kernel envelope close <id>")
+	}
+	id := fs.Arg(0)
+	store, _, err := openBudgetStore()
+	if err != nil {
+		exitErr("envelope_close_open", err.Error())
+	}
+	defer store.Close()
+	env, err := store.Load(id)
+	if err != nil {
+		if errors.Is(err, gov.ErrEnvelopeNotFound) {
+			exitErr("envelope_not_found", id)
+		}
+		exitErr("envelope_close_load", err.Error())
+	}
+	if err := env.CloseEnvelope(); err != nil {
+		exitErr("envelope_close", err.Error())
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/envelope_tail.go
+++ b/go/execution-kernel/cmd/chitin-kernel/envelope_tail.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// cmdEnvelopeTail streams ~/.chitin/gov-decisions-<date>.jsonl through a
+// per-line formatter. Optional <id> arg filters to one envelope; --stats
+// adds periodic envelope summary lines (queried from sqlite).
+//
+// Polling fallback only in v1: 250ms tick. inotify (fsnotify) can be
+// added in Milestone D when audit-log rotation lands and exact-time
+// readers matter more.
+//
+// Day rollover: opens today's file at start. If the date changes
+// mid-tail, the tail keeps following the original file. Documented
+// limitation; long-running operator tails should restart at midnight.
+func cmdEnvelopeTail(args []string) {
+	fs := flag.NewFlagSet("envelope tail", flag.ExitOnError)
+	stats := fs.Bool("stats", false, "emit periodic envelope summary lines")
+	statsEvery := fs.Duration("stats-every", 30*time.Second, "cadence for --stats summary lines")
+	pollInterval := fs.Duration("poll", 250*time.Millisecond, "poll interval for new log lines")
+	fromStart := fs.Bool("from-start", false, "replay all lines from today's log start before following")
+	fs.Parse(args)
+	if *pollInterval <= 0 {
+		exitErr("envelope_tail_poll", "--poll must be > 0")
+	}
+	filter := ""
+	if fs.NArg() == 1 {
+		filter = fs.Arg(0)
+	} else if fs.NArg() > 1 {
+		exitErr("envelope_tail_args", "usage: chitin-kernel envelope tail [<id>] [--stats] [--from-start]")
+	}
+
+	dir := chitinDir()
+	date := time.Now().UTC().Format("2006-01-02")
+	path := filepath.Join(dir, "gov-decisions-"+date+".jsonl")
+
+	state := &tailState{
+		denials: map[string]int64{},
+	}
+
+	var statsTicker <-chan time.Time
+	if *stats {
+		// Print one stats line up-front so operators see envelope state
+		// even before any decisions have flowed.
+		printStats(filter, state)
+		t := time.NewTicker(*statsEvery)
+		defer t.Stop()
+		statsTicker = t.C
+	}
+
+	var f *os.File
+	var reader *bufio.Reader
+	var offset int64
+
+	openOrWait := func() {
+		for {
+			var err error
+			f, err = os.Open(path)
+			if err == nil {
+				break
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				exitErr("envelope_tail_open", err.Error())
+			}
+			select {
+			case <-statsTicker:
+				printStats(filter, state)
+			case <-time.After(*pollInterval):
+			}
+		}
+		if !*fromStart {
+			fi, err := f.Stat()
+			if err != nil {
+				exitErr("envelope_tail_stat", err.Error())
+			}
+			offset = fi.Size()
+			if _, err := f.Seek(offset, io.SeekStart); err != nil {
+				exitErr("envelope_tail_seek", err.Error())
+			}
+		}
+		// 1 MiB scanner buffer covers the practical Decision row max
+		// (Reason + Suggestion + CorrectedCommand fields are each
+		// bounded; nothing in the v1 schema produces multi-MB rows).
+		reader = bufio.NewReaderSize(f, 1<<20)
+	}
+
+	openOrWait()
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+	}()
+
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			processLine(strings.TrimRight(line, "\n"), filter, state, os.Stdout)
+		}
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, io.EOF) {
+			exitErr("envelope_tail_read", err.Error())
+		}
+		// EOF: wait for new bytes (or a stats tick).
+		select {
+		case <-statsTicker:
+			printStats(filter, state)
+		case <-time.After(*pollInterval):
+		}
+	}
+}
+
+type tailState struct {
+	denials map[string]int64 // envelope_id → denials seen since tail start
+}
+
+// processLine decodes one JSONL line, applies the optional envelope-id
+// filter, and emits one formatted line. Unparseable lines are emitted
+// verbatim with a [parse-error] prefix on stderr — they shouldn't exist
+// in a well-formed audit log, but the operator-watch surface mustn't
+// silently drop signal.
+func processLine(line, filter string, state *tailState, out io.Writer) {
+	if line == "" {
+		return
+	}
+	var rec auditRow
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
+		fmt.Fprintf(os.Stderr, "[parse-error] %s\n", line)
+		return
+	}
+	if filter != "" && rec.EnvelopeID != filter {
+		return
+	}
+	if !rec.Allowed {
+		state.denials[rec.EnvelopeID]++
+	}
+	fmt.Fprintln(out, formatRow(rec))
+}
+
+// auditRow mirrors the shape WriteLog emits. Fields not relevant to the
+// formatter are still decoded so unknown keys don't surface as errors.
+type auditRow struct {
+	Allowed      bool     `json:"allowed"`
+	Mode         string   `json:"mode"`
+	RuleID       string   `json:"rule_id"`
+	Reason       string   `json:"reason,omitempty"`
+	Agent        string   `json:"agent,omitempty"`
+	ActionType   string   `json:"action_type"`
+	ActionTarget string   `json:"action_target"`
+	Ts           string   `json:"ts"`
+	EnvelopeID   string   `json:"envelope_id,omitempty"`
+	Tier         gov.Tier `json:"tier,omitempty"`
+	CostUSD      float64  `json:"cost_usd,omitempty"`
+	InputBytes   int64    `json:"input_bytes,omitempty"`
+	OutputBytes  int64    `json:"output_bytes,omitempty"`
+	ToolCalls    int64    `json:"tool_calls,omitempty"`
+}
+
+// formatRow renders one audit-log line per the plan §"envelope_tail.go":
+//
+//	2026-04-29T15:01:02Z  claude-code  T0  $0.000   file.read /path/...     ALLOW
+//
+// Tab-separated columns; widths chosen for terminal scan-readability.
+// The trailing verdict (ALLOW/DENY) on the right edge means a deny
+// stands out visually even when the line is long.
+func formatRow(r auditRow) string {
+	verdict := "ALLOW"
+	if !r.Allowed {
+		verdict = "DENY"
+	}
+	agent := r.Agent
+	if agent == "" {
+		agent = "-"
+	}
+	tier := string(r.Tier)
+	if tier == "" {
+		tier = "-"
+	}
+	target := r.ActionTarget
+	if len(target) > 60 {
+		target = target[:57] + "..."
+	}
+	return fmt.Sprintf("%-20s  %-12s  %-3s  $%-7.4f  %-22s  %-60s  %s",
+		r.Ts, agent, tier, r.CostUSD, r.ActionType, target, verdict)
+}
+
+// printStats reads the current envelope state from sqlite and prints
+// one line per envelope (or just the filtered one). Uses humanBytes for
+// MB/GB formatting and tallies in-memory denials seen since tail start.
+//
+// Empty-state behavior:
+//   - filter="" + no envelopes in sqlite → prints nothing.
+//   - filter set + envelope-not-found → prints a [stats] line noting it.
+func printStats(filter string, state *tailState) {
+	store, _, err := openBudgetStore()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[stats] open: %v\n", err)
+		return
+	}
+	defer store.Close()
+	if filter != "" {
+		env, err := store.Load(filter)
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "[stats] envelope %s: not found (%v)\n", filter, err)
+			return
+		}
+		st, err := env.Inspect()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[stats] inspect %s: %v\n", filter, err)
+			return
+		}
+		fmt.Fprintln(os.Stdout, formatStats(st, state.denials[filter]))
+		return
+	}
+	envs, err := store.List(0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[stats] list: %v\n", err)
+		return
+	}
+	for _, st := range envs {
+		fmt.Fprintln(os.Stdout, formatStats(st, state.denials[st.ID]))
+	}
+}
+
+func formatStats(st gov.EnvelopeState, denials int64) string {
+	closed := ""
+	if st.ClosedAt != "" {
+		closed = " [CLOSED]"
+	}
+	return fmt.Sprintf("[stats] envelope %s: calls %s, bytes %s, $%.2f (informational), denials %d%s",
+		st.ID,
+		formatCapStatusInt(st.SpentCalls, st.Limits.MaxToolCalls),
+		formatCapStatusBytes(st.SpentBytes, st.Limits.MaxInputBytes),
+		st.SpentUSD,
+		denials,
+		closed,
+	)
+}
+
+func formatCapStatusInt(spent, max int64) string {
+	if max <= 0 {
+		return fmt.Sprintf("%d/uncapped", spent)
+	}
+	return fmt.Sprintf("%d/%d", spent, max)
+}
+
+func formatCapStatusBytes(spent, max int64) string {
+	if max <= 0 {
+		return fmt.Sprintf("%s/uncapped", humanBytes(spent))
+	}
+	return fmt.Sprintf("%s/%s", humanBytes(spent), humanBytes(max))
+}
+
+// humanBytes renders bytes as B / KB / MB / GB. Decimal (1000-base) so
+// the displayed numbers match what operators see on cloud bills and
+// `du -h --si` defaults; binary 1024-base would be marginally more
+// accurate but inconsistent with the rest of the operator surface.
+func humanBytes(n int64) string {
+	if n < 1000 {
+		return fmt.Sprintf("%dB", n)
+	}
+	f := float64(n)
+	switch {
+	case n < 1000*1000:
+		return fmt.Sprintf("%.1fKB", f/1000)
+	case n < 1000*1000*1000:
+		return fmt.Sprintf("%.1fMB", f/(1000*1000))
+	default:
+		return fmt.Sprintf("%.1fGB", f/(1000*1000*1000))
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/envelope_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/envelope_test.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// runCLIWithHome runs the built chitin-kernel binary with CHITIN_HOME
+// set to the given directory. Mirrors runCLI but extends env so envelope
+// subcommands hit the test's sqlite db, not the operator's real one.
+func runCLIWithHome(t *testing.T, home string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), testBinary, args...)
+	cmd.Dir = home
+	cmd.Env = append(os.Environ(), "CHITIN_HOME="+home)
+	stdout, err := cmd.Output()
+	var stderr []byte
+	if ee, ok := err.(*exec.ExitError); ok {
+		stderr = ee.Stderr
+	}
+	return string(stdout), string(stderr), cmd.ProcessState.ExitCode()
+}
+
+func envelopeCreate(t *testing.T, home string, calls, bytes int64) string {
+	t.Helper()
+	out, errOut, code := runCLIWithHome(t, home,
+		"envelope", "create",
+		"--calls", strconv.FormatInt(calls, 10),
+		"--bytes", strconv.FormatInt(bytes, 10),
+	)
+	if code != 0 {
+		t.Fatalf("envelope create exit=%d stderr=%s", code, errOut)
+	}
+	id := strings.TrimSpace(out)
+	if len(id) != 26 {
+		t.Fatalf("expected 26-char ULID, got %q (len=%d)", id, len(id))
+	}
+	return id
+}
+
+func TestEnvelope_CreateInspectListClose(t *testing.T) {
+	home := t.TempDir()
+
+	id := envelopeCreate(t, home, 100, 1024)
+
+	// Inspect
+	out, errOut, code := runCLIWithHome(t, home, "envelope", "inspect", id)
+	if code != 0 {
+		t.Fatalf("inspect exit=%d stderr=%s", code, errOut)
+	}
+	var st map[string]any
+	if err := json.Unmarshal([]byte(out), &st); err != nil {
+		t.Fatalf("parse inspect json: %v (out=%s)", err, out)
+	}
+	if st["id"] != id {
+		t.Fatalf("inspect id mismatch: want %q got %v", id, st["id"])
+	}
+	limits := st["limits"].(map[string]any)
+	if int64(limits["max_tool_calls"].(float64)) != 100 {
+		t.Fatalf("max_tool_calls: want 100 got %v", limits["max_tool_calls"])
+	}
+	if st["closed_at"] != nil {
+		t.Fatalf("closed_at should be empty/missing pre-close: %v", st["closed_at"])
+	}
+
+	// List should include the new envelope
+	out, _, code = runCLIWithHome(t, home, "envelope", "list")
+	if code != 0 {
+		t.Fatalf("list exit=%d", code)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(out), &arr); err != nil {
+		t.Fatalf("parse list json: %v", err)
+	}
+	if len(arr) != 1 || arr[0]["id"] != id {
+		t.Fatalf("list mismatch: %v", arr)
+	}
+
+	// Close (idempotent)
+	if _, errOut, code := runCLIWithHome(t, home, "envelope", "close", id); code != 0 {
+		t.Fatalf("close exit=%d stderr=%s", code, errOut)
+	}
+	if _, errOut, code := runCLIWithHome(t, home, "envelope", "close", id); code != 0 {
+		t.Fatalf("close (idempotent re-call) exit=%d stderr=%s", code, errOut)
+	}
+
+	// Inspect after close: closed_at must be set
+	out, _, _ = runCLIWithHome(t, home, "envelope", "inspect", id)
+	_ = json.Unmarshal([]byte(out), &st)
+	if st["closed_at"] == nil || st["closed_at"] == "" {
+		t.Fatalf("closed_at should be set after close: %v", st["closed_at"])
+	}
+}
+
+func TestEnvelope_NotFound(t *testing.T) {
+	home := t.TempDir()
+	cases := [][]string{
+		{"envelope", "inspect", "FAKE-ID"},
+		{"envelope", "grant", "FAKE-ID", "--calls=10"},
+		{"envelope", "close", "FAKE-ID"},
+		{"envelope", "use", "FAKE-ID"},
+	}
+	for _, args := range cases {
+		_, errOut, code := runCLIWithHome(t, home, args...)
+		if code == 0 {
+			t.Fatalf("%v: expected non-zero exit, got 0", args)
+		}
+		if !strings.Contains(errOut, "envelope_not_found") {
+			t.Fatalf("%v: expected envelope_not_found in stderr, got %s", args, errOut)
+		}
+	}
+}
+
+func TestEnvelope_CreateNegativeLimitsRejected(t *testing.T) {
+	home := t.TempDir()
+	cases := [][]string{
+		{"envelope", "create", "--calls=-1"},
+		{"envelope", "create", "--bytes=-1"},
+		{"envelope", "create", "--usd=-0.1"},
+	}
+	for _, args := range cases {
+		_, errOut, code := runCLIWithHome(t, home, args...)
+		if code == 0 {
+			t.Fatalf("%v: expected non-zero exit", args)
+		}
+		if !strings.Contains(errOut, "envelope_create_negative") {
+			t.Fatalf("%v: expected envelope_create_negative in stderr, got %s", args, errOut)
+		}
+	}
+}
+
+func TestEnvelope_GrantReopensAndAudits(t *testing.T) {
+	home := t.TempDir()
+	id := envelopeCreate(t, home, 5, 0)
+
+	// Close first
+	if _, _, code := runCLIWithHome(t, home, "envelope", "close", id); code != 0 {
+		t.Fatalf("close failed")
+	}
+
+	// Grant +calls — should reopen and bump cap
+	if _, errOut, code := runCLIWithHome(t, home, "envelope", "grant", id, "--calls=10", "--reason=test-reopen"); code != 0 {
+		t.Fatalf("grant exit=%d stderr=%s", code, errOut)
+	}
+
+	// Verify reopen + cap bump
+	out, _, _ := runCLIWithHome(t, home, "envelope", "inspect", id)
+	var st map[string]any
+	_ = json.Unmarshal([]byte(out), &st)
+	if v := st["closed_at"]; v != nil && v != "" {
+		t.Fatalf("grant should have cleared closed_at, got %v", v)
+	}
+	limits := st["limits"].(map[string]any)
+	if int64(limits["max_tool_calls"].(float64)) != 15 {
+		t.Fatalf("max_tool_calls after grant: want 15 (5+10) got %v", limits["max_tool_calls"])
+	}
+
+	// Verify audit row was written
+	date := time.Now().UTC().Format("2006-01-02")
+	logPath := filepath.Join(home, "gov-decisions-"+date+".jsonl")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if !strings.Contains(string(data), `"rule_id":"operator-grant"`) {
+		t.Fatalf("audit log missing operator-grant row:\n%s", data)
+	}
+	if !strings.Contains(string(data), `"envelope_id":"`+id+`"`) {
+		t.Fatalf("audit log missing envelope_id=%s:\n%s", id, data)
+	}
+	if !strings.Contains(string(data), "test-reopen") {
+		t.Fatalf("audit log missing reason text 'test-reopen':\n%s", data)
+	}
+}
+
+// TestEnvelope_AtomicUseRace asserts the spec invariant: under concurrent
+// `envelope use <id>` calls, the final ~/.chitin/current-envelope content
+// equals exactly one of the input IDs and is internally well-formed.
+//
+// rename(2) on POSIX is atomic for src+dst on the same filesystem, which
+// is what writeCurrentEnvelope relies on. Verifying that here means: kick
+// off N concurrent subprocess writers and one or more concurrent readers,
+// then assert (a) final state ∈ {ids[0]..ids[N-1]}, (b) every observed
+// read mid-race was either empty (file not yet existing) or one of the
+// valid IDs — never a partial/torn line.
+func TestEnvelope_AtomicUseRace(t *testing.T) {
+	home := t.TempDir()
+	const N = 8
+
+	// Pre-create N envelopes so each `use` resolves a real id.
+	ids := make([]string, N)
+	for i := 0; i < N; i++ {
+		ids[i] = envelopeCreate(t, home, 1, 1)
+	}
+	validIDs := map[string]struct{}{}
+	for _, id := range ids {
+		validIDs[id] = struct{}{}
+	}
+
+	// Concurrent reader: spin reading current-envelope until done. Records
+	// every distinct value observed.
+	target := filepath.Join(home, "current-envelope")
+	stop := make(chan struct{})
+	var observedMu sync.Mutex
+	observed := map[string]struct{}{}
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b, err := os.ReadFile(target)
+			if err != nil {
+				continue
+			}
+			s := strings.TrimSpace(string(b))
+			observedMu.Lock()
+			observed[s] = struct{}{}
+			observedMu.Unlock()
+		}
+	}()
+
+	// Launch N writers in parallel.
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errOut, code := runCLIWithHome(t, home, "envelope", "use", ids[i])
+			if code != 0 {
+				t.Errorf("use %s: exit=%d stderr=%s", ids[i], code, errOut)
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+
+	// Final state must be one of the IDs, never partial/empty.
+	b, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read final current-envelope: %v", err)
+	}
+	final := strings.TrimSpace(string(b))
+	if _, ok := validIDs[final]; !ok {
+		t.Fatalf("final content %q is not one of the valid IDs %v", final, ids)
+	}
+
+	// Every observed mid-race state must be a valid ID (or empty if the
+	// reader saw EOF before any writer landed). Anything else means a
+	// torn/partial read leaked through.
+	observedMu.Lock()
+	defer observedMu.Unlock()
+	for s := range observed {
+		if s == "" {
+			continue
+		}
+		if _, ok := validIDs[s]; !ok {
+			t.Fatalf("observed torn/partial read: %q not in valid-id set", s)
+		}
+	}
+}
+
+func TestEnvelopeTail_FormatRow(t *testing.T) {
+	// Allow row with full payload — verify column layout is stable and
+	// the ALLOW verdict lands on the right.
+	got := formatRow(auditRow{
+		Allowed:      true,
+		Mode:         "enforce",
+		RuleID:       "allow-read",
+		Agent:        "claude-code",
+		ActionType:   "file.read",
+		ActionTarget: "/some/path/that/is/short.go",
+		Ts:           "2026-04-29T15:01:02Z",
+		Tier:         "T0",
+		CostUSD:      0.0001,
+	})
+	for _, want := range []string{
+		"2026-04-29T15:01:02Z", "claude-code", "T0", "$0.0001",
+		"file.read", "/some/path/that/is/short.go", "ALLOW",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatRow row missing %q in: %q", want, got)
+		}
+	}
+
+	// Deny row with no envelope/agent — verify empty-field placeholders
+	// render and DENY appears.
+	got = formatRow(auditRow{
+		Allowed:      false,
+		ActionType:   "git.push",
+		ActionTarget: "main",
+		Ts:           "2026-04-29T15:01:02Z",
+	})
+	if !strings.Contains(got, "DENY") {
+		t.Fatalf("expected DENY in formatRow output, got %q", got)
+	}
+	if !strings.Contains(got, "  -  ") {
+		t.Fatalf("expected dash placeholder for missing tier/agent, got %q", got)
+	}
+
+	// Long target should be truncated with an ellipsis so the column
+	// layout stays scannable.
+	long := strings.Repeat("a", 200)
+	got = formatRow(auditRow{Allowed: true, ActionType: "file.read", ActionTarget: long, Ts: "t"})
+	if !strings.Contains(got, "...") {
+		t.Fatalf("expected long target to be truncated with '...', got %q", got)
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0B"},
+		{999, "999B"},
+		{1000, "1.0KB"},
+		{2_300_000, "2.3MB"},
+		{1_500_000_000, "1.5GB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Fatalf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEnvelope_UseSetsResolverFile(t *testing.T) {
+	home := t.TempDir()
+	id := envelopeCreate(t, home, 5, 0)
+	if _, errOut, code := runCLIWithHome(t, home, "envelope", "use", id); code != 0 {
+		t.Fatalf("use exit=%d stderr=%s", code, errOut)
+	}
+	// gate_hook resolveEnvelope reads <chitinDir>/current-envelope.
+	// Verify exact content + trailing newline (kubectl-style convention).
+	b, err := os.ReadFile(filepath.Join(home, "current-envelope"))
+	if err != nil {
+		t.Fatalf("read current-envelope: %v", err)
+	}
+	if string(b) != id+"\n" {
+		t.Fatalf("current-envelope content: want %q got %q", id+"\n", string(b))
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -54,6 +54,8 @@ func main() {
 		cmdHealth(args)
 	case "gate":
 		cmdGate(args)
+	case "envelope":
+		cmdEnvelope(args)
 	case "drive":
 		if len(args) < 1 {
 			exitErr("drive_no_driver", "usage: chitin-kernel drive <driver> [flags]")

--- a/go/execution-kernel/internal/gov/budget.go
+++ b/go/execution-kernel/internal/gov/budget.go
@@ -27,21 +27,21 @@ type CostDelta struct {
 // BudgetUSD is informational only — it is recorded and surfaced by
 // `envelope inspect`/`envelope tail --stats` but never causes denial.
 type BudgetLimits struct {
-	MaxToolCalls  int64
-	MaxInputBytes int64
-	BudgetUSD     float64
+	MaxToolCalls  int64   `json:"max_tool_calls"`
+	MaxInputBytes int64   `json:"max_input_bytes"`
+	BudgetUSD     float64 `json:"budget_usd"`
 }
 
 // EnvelopeState is a read-only snapshot of an envelope row.
 type EnvelopeState struct {
-	ID           string
-	CreatedAt    string
-	ClosedAt     string
-	Limits       BudgetLimits
-	SpentCalls   int64
-	SpentBytes   int64
-	SpentUSD     float64
-	LastSpendAt  string
+	ID          string       `json:"id"`
+	CreatedAt   string       `json:"created_at"`
+	ClosedAt    string       `json:"closed_at,omitempty"`
+	Limits      BudgetLimits `json:"limits"`
+	SpentCalls  int64        `json:"spent_calls"`
+	SpentBytes  int64        `json:"spent_bytes"`
+	SpentUSD    float64      `json:"spent_usd"`
+	LastSpendAt string       `json:"last_spend_at,omitempty"`
 }
 
 // BudgetStore wraps a *sql.DB (typically against ~/.chitin/gov.db) with
@@ -86,11 +86,17 @@ func OpenBudgetStore(dbPath string) (_ *BudgetStore, err error) {
 			_ = db.Close()
 		}
 	}()
-	if _, err = db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
-		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
+	// busy_timeout BEFORE journal_mode=WAL: the WAL transition needs an
+	// exclusive lock on the db file. If another process is mid-open with
+	// the same db, the WAL pragma returns SQLITE_BUSY (261) immediately
+	// unless the connection has a busy_timeout configured. Setting timeout
+	// first lets the WAL pragma wait the full 5s rather than failing the
+	// open under N-process race (`envelope use` race test, Milestone E).
 	if _, err = db.Exec(`PRAGMA busy_timeout=5000`); err != nil {
 		return nil, fmt.Errorf("set busy_timeout: %w", err)
+	}
+	if _, err = db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
+		return nil, fmt.Errorf("enable WAL: %w", err)
 	}
 	// foreign_keys is OFF by default in sqlite. Without this PRAGMA the
 	// envelope_grants → envelopes REFERENCES clause would be decorative


### PR DESCRIPTION
## Summary

Adds the operator surface from cost-governance kernel v3 plan §Milestone E:
- `envelope create / use / inspect / list / grant / close` subcommand group
- `envelope tail [<id>] [--stats]` per-line audit-log formatter (poll-based; inotify deferred to Milestone D)
- Atomic `~/.chitin/current-envelope` write (tmp + rename + fsync) so the gate hook's resolver file flips atomically under concurrent `envelope use` calls
- Audit log row from `grant` with `rule_id=operator-grant`

Also fixes a milestone-A concurrency bug surfaced by the race test: `OpenBudgetStore` set `journal_mode=WAL` before `busy_timeout`, so the WAL transition failed immediately under N-process opens with `enable WAL: database is locked (261)`. Reordered so busy_timeout is in effect before WAL is requested.

## Plan

`docs/superpowers/plans/2026-04-29-cost-governance-kernel.md` §Milestone E

## Test plan

- [x] `go test ./...` — all 587 prior tests pass + 8 new envelope tests
- [x] Atomic `envelope use` race test (8-process concurrent writers + sibling reader; final state ∈ valid IDs, no torn reads observed)
- [x] Manual e2e: create → use → inspect → list → grant → tail --stats; resolver file has `<id>\n`; audit log has operator-grant row
- [ ] Live integration with milestone-C Claude Code hook (deferred to operator-side acceptance, not blocking review)
- [ ] Day-rollover behavior in tail (known limitation; documented; deferred to Milestone D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)