### PR TITLE
fix(gov): exempt chitin-kernel admin commands from envelope spend

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/cost"
@@ -14,6 +15,33 @@ import (
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/tier"
 )
+
+// reChitinAdminCmd matches a shell command whose first executable token
+// is the bare `chitin-kernel` binary, optionally preceded by `env VAR=val`
+// or inline `VAR=val` env prefixes. Path-prefixed forms
+// (`/usr/local/bin/chitin-kernel`) intentionally don't match — install
+// puts chitin-kernel on PATH, and operators using literal paths have
+// explicit invocation control. See isChitinAdminCommand for rationale.
+var reChitinAdminCmd = regexp.MustCompile(
+	`^(?:\s*(?:env\s+|[A-Za-z_][A-Za-z0-9_]*=\S*\s+))*chitin-kernel(?:\s|$)`,
+)
+
+// isChitinAdminCommand returns true when action is a shell command
+// invoking chitin-kernel directly. Such commands bypass envelope spend
+// (so an exhausted/closed envelope can be recovered from inside the
+// gated session via `envelope grant`) but are still subject to policy
+// evaluation — an operator who wants to deny chitin-kernel invocations
+// from the agent can add a shell.exec policy rule.
+//
+// The matcher only fires on Type=ActShellExec, so a chitin-kernel
+// command re-classified to a more specific type (none today, but
+// future re-tagging is possible) won't match.
+func isChitinAdminCommand(a gov.Action) bool {
+	if a.Type != gov.ActShellExec {
+		return false
+	}
+	return reChitinAdminCmd.MatchString(strings.TrimSpace(a.Target))
+}
 
 // runHookStdin is the production entry point for the Claude Code
 // PreToolUse hook. It wires real stdin/stdout/os.Exit around the pure
@@ -135,7 +163,26 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 			return cost.Estimate(a, agent, rates)
 		},
 	}
-	d := gate.Evaluate(action, agent, envelope)
+	// Operator-recovery commands (chitin-kernel envelope grant, use, etc.)
+	// pass nil envelope so policy still evaluates but no spend is debited.
+	// Without this, an exhausted/closed envelope deadlocks the operator's
+	// own recovery surface — the agent's gate hook denies the very
+	// `envelope grant` call that would reopen the envelope. Decision is
+	// logged without envelope stamping (the call doesn't belong to any
+	// envelope's spend); a structured info line goes to errOut so
+	// operators auditing the hook see when an exemption fired.
+	spendEnvelope := envelope
+	if isChitinAdminCommand(action) {
+		spendEnvelope = nil
+		if envelope != nil {
+			writeJSONLine(errOut, map[string]string{
+				"info":    "chitin_admin_exempt",
+				"command": action.Target,
+				"note":    "envelope spend skipped; policy still evaluated",
+			})
+		}
+	}
+	d := gate.Evaluate(action, agent, spendEnvelope)
 
 	body, code := claudecode.Format(d)
 	if len(body) > 0 {

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -489,6 +489,55 @@ func TestEvalHookStdin_ChitinAdmin_NotMatchingNotExempt(t *testing.T) {
 	}
 }
 
+// TestEvalHookStdin_ChitinAdmin_ChainedRmRfStillBlocked verifies that
+// the exemption only bypasses envelope spend, not policy. A chained
+// command like `chitin-kernel ... && rm -rf X` matches the admin matcher
+// (so the envelope isn't debited), but the policy's rm-rf rule
+// evaluates against the full Target and still denies. Belt-and-suspenders
+// proof that exempting spend doesn't open a destructive-operation
+// bypass through the chitin-kernel prefix.
+func TestEvalHookStdin_ChitinAdmin_ChainedRmRfStillBlocked(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 10, 0))
+	store.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"tool_name": "Bash",
+		"tool_input": map[string]any{
+			"command": "chitin-kernel envelope list && rm -rf /",
+		},
+		"cwd": env.cwd,
+	})
+	var out, errOut bytes.Buffer
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", envelope.ID, false)
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (rm-rf rule should still apply); stdout=%q", code, out.String())
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(parsed["reason"], "rm -rf") {
+		t.Fatalf("reason missing rm-rf policy text: %q", parsed["reason"])
+	}
+	// Confirm the exemption did fire — otherwise this would only test
+	// that policy denies, not that the exemption preserves policy
+	// enforcement on the chained command.
+	if !strings.Contains(errOut.String(), "chitin_admin_exempt") {
+		t.Fatalf("stderr missing chitin_admin_exempt info; exemption may not have fired: %q", errOut.String())
+	}
+	// Denial path should not have debited.
+	store2, _ := openBudgetStoreForTest(t, dbPath)
+	defer store2.Close()
+	e2, _ := store2.Load(envelope.ID)
+	st, _ := e2.Inspect()
+	if st.SpentCalls != 0 {
+		t.Fatalf("SpentCalls=%d want 0 — denial should not debit", st.SpentCalls)
+	}
+}
+
 // TestEvalHookStdin_ChitinAdmin_ExemptInfoLogged verifies the
 // structured info line on stderr — operators auditing the hook should
 // see when an exemption fired.

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -320,6 +320,200 @@ func TestEvalHookStdin_EnvelopePrecedence_FlagBeatsEnvAndFile(t *testing.T) {
 	}
 }
 
+// chitinAdminPolicy: like baselinePolicy but adds a deny rule targeting
+// `chitin-kernel envelope grant` so the policy-still-applies test can
+// fire a real deny.
+const chitinAdminPolicy = `
+id: hook-test-admin
+mode: enforce
+rules:
+  - id: deny-grant
+    action: shell.exec
+    effect: deny
+    target: "chitin-kernel envelope grant"
+    reason: "chitin-kernel envelope grant denied by operator policy"
+  - id: allow-shell
+    action: shell.exec
+    effect: allow
+    reason: shell ok
+  - id: allow-read
+    action: file.read
+    effect: allow
+    reason: read ok
+`
+
+// TestEvalHookStdin_ChitinAdmin_AllowedOnExhaustedEnvelope verifies the
+// recovery path: with a 1-call envelope already exhausted by a prior
+// Read, a chitin-kernel admin command still passes the gate. Without
+// the exemption, the hook would deny on envelope-closed and the
+// operator would have to leave the gated session to recover.
+func TestEvalHookStdin_ChitinAdmin_AllowedOnExhaustedEnvelope(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 1, 0))
+	store.Close()
+
+	// Burn the cap with a Read.
+	_, _, code1 := runHookCall(t, env, map[string]any{
+		"tool_name":  "Read",
+		"tool_input": map[string]any{"file_path": "/a"},
+	}, envelope.ID)
+	if code1 != 0 {
+		t.Fatalf("first call exit=%d want 0", code1)
+	}
+
+	// Confirm a non-admin Bash now denies (envelope-exhausted).
+	stdoutDeny, _, codeDeny := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "ls /"},
+	}, envelope.ID)
+	if codeDeny != 2 {
+		t.Fatalf("non-admin call exit=%d want 2 (envelope blocked); stdout=%q", codeDeny, stdoutDeny)
+	}
+
+	// chitin-kernel envelope grant should pass — exempt from spend.
+	stdoutAdmin, _, codeAdmin := runHookCall(t, env, map[string]any{
+		"tool_name": "Bash",
+		"tool_input": map[string]any{
+			"command": "chitin-kernel envelope grant " + envelope.ID + " --calls=+10",
+		},
+	}, envelope.ID)
+	if codeAdmin != 0 {
+		t.Fatalf("chitin-admin call exit=%d want 0 (exempt); stdout=%q", codeAdmin, stdoutAdmin)
+	}
+}
+
+// TestEvalHookStdin_ChitinAdmin_NoEnvelopeSpend verifies that a
+// chitin-kernel command does NOT debit the envelope even when one is
+// healthy. Otherwise the agent could rack up spend on admin calls
+// while believing it's at zero cost.
+func TestEvalHookStdin_ChitinAdmin_NoEnvelopeSpend(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 100, 0))
+	store.Close()
+
+	for _, cmd := range []string{
+		"chitin-kernel envelope inspect " + envelope.ID,
+		"chitin-kernel envelope list",
+		"env CHITIN_HOME=/tmp chitin-kernel envelope list",
+		"FOO=1 BAR=2 chitin-kernel envelope list",
+	} {
+		_, _, code := runHookCall(t, env, map[string]any{
+			"tool_name":  "Bash",
+			"tool_input": map[string]any{"command": cmd},
+		}, envelope.ID)
+		if code != 0 {
+			t.Fatalf("cmd %q: exit=%d want 0", cmd, code)
+		}
+	}
+
+	store2, _ := openBudgetStoreForTest(t, dbPath)
+	defer store2.Close()
+	e2, _ := store2.Load(envelope.ID)
+	st, _ := e2.Inspect()
+	if st.SpentCalls != 0 {
+		t.Fatalf("SpentCalls=%d want 0 — admin commands debited envelope", st.SpentCalls)
+	}
+}
+
+// TestEvalHookStdin_ChitinAdmin_PolicyStillApplies verifies the
+// exemption is spend-only: a policy rule denying
+// `chitin-kernel envelope grant` still produces a block, even though
+// the envelope is healthy. Operators retain control over which admin
+// commands the agent may run.
+func TestEvalHookStdin_ChitinAdmin_PolicyStillApplies(t *testing.T) {
+	env := setupHookEnv(t, chitinAdminPolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 10, 0))
+	store.Close()
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name": "Bash",
+		"tool_input": map[string]any{
+			"command": "chitin-kernel envelope grant " + envelope.ID + " --calls=+10",
+		},
+	}, envelope.ID)
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (policy denies admin grant); stdout=%q", code, stdout)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(parsed["reason"], "denied by operator policy") {
+		t.Fatalf("reason missing operator-deny text: %q", parsed["reason"])
+	}
+}
+
+// TestEvalHookStdin_ChitinAdmin_NotMatchingNotExempt verifies the
+// matcher's negative cases: lookalike commands don't get exempted.
+// Each of these should debit the envelope normally.
+func TestEvalHookStdin_ChitinAdmin_NotMatchingNotExempt(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"path-prefixed", "/usr/local/bin/chitin-kernel envelope list"},
+		{"echo prefix", "echo chitin-kernel envelope list"},
+		{"hyphen extension", "chitin-kernel-fake envelope list"},
+		{"compound", "chitin-kernelizer envelope list"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env := setupHookEnv(t, baselinePolicy)
+			dbPath := filepath.Join(env.chitin, "gov.db")
+			store, _ := openBudgetStoreForTest(t, dbPath)
+			envelope, _ := store.Create(budgetLimits(t, 10, 0))
+			store.Close()
+
+			_, _, code := runHookCall(t, env, map[string]any{
+				"tool_name":  "Bash",
+				"tool_input": map[string]any{"command": c.cmd},
+			}, envelope.ID)
+			if code != 0 {
+				t.Fatalf("exit=%d want 0", code)
+			}
+
+			store2, _ := openBudgetStoreForTest(t, dbPath)
+			defer store2.Close()
+			e2, _ := store2.Load(envelope.ID)
+			st, _ := e2.Inspect()
+			if st.SpentCalls != 1 {
+				t.Fatalf("SpentCalls=%d want 1 — lookalike was incorrectly exempted", st.SpentCalls)
+			}
+		})
+	}
+}
+
+// TestEvalHookStdin_ChitinAdmin_ExemptInfoLogged verifies the
+// structured info line on stderr — operators auditing the hook should
+// see when an exemption fired.
+func TestEvalHookStdin_ChitinAdmin_ExemptInfoLogged(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 10, 0))
+	store.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "chitin-kernel envelope list"},
+		"cwd":        env.cwd,
+	})
+	var out, errOut bytes.Buffer
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", envelope.ID, false)
+	if code != 0 {
+		t.Fatalf("exit=%d want 0", code)
+	}
+	if !strings.Contains(errOut.String(), "chitin_admin_exempt") {
+		t.Fatalf("stderr missing chitin_admin_exempt info: %q", errOut.String())
+	}
+}
+
 func TestEvalHookStdin_BadEnvelopeIDBlocks(t *testing.T) {
 	env := setupHookEnv(t, baselinePolicy)
 	stdout, _, code := runHookCall(t, env, map[string]any{


### PR DESCRIPTION
## Summary

Fixes a deadlock in the operator-recovery path: when an envelope exhausts mid-session, the documented recovery (\`chitin-kernel envelope grant\`) can't execute because the recovery command itself goes through the gate, hits the closed envelope, and gets denied.

## Root cause

Two-layer:

1. \`Spend\` auto-closes envelopes on exhaustion (\`budget.go:281-288\`). This is intentional and internally consistent — \`Grant\` clears \`closed_at\` (\`budget.go:349\`), so the design's recovery flow is \"exhaust → auto-close → grant reopens.\"
2. The Claude Code hook denies \`chitin-kernel envelope grant\` itself, because it runs as a \`Bash\` tool call → \`PreToolUse\` → envelope spend → \`envelope closed\` → exit 2. The recovery surface is unreachable from inside the gated session. Today's only escape is to open another shell that isn't under the hook.

Found while dogfooding milestone C/E in a live Claude Code session — the assistant ran out of envelope mid-task and couldn't recover without operator intervention from outside the session.

## Fix

\`evalHookStdin\` now detects bare \`chitin-kernel\` invocations (with optional \`env VAR=val\` or inline \`VAR=val\` prefixes) and passes \`nil\` to \`gate.Evaluate\` for those calls. Per the gate contract, nil envelope means \"policy gate, no spend, no envelope stamping on the Decision row.\"

Spend bypassed; everything else preserved:

- **Policy still applies.** An operator who wants to deny \`chitin-kernel envelope grant\` from agent context can add a \`shell.exec\` rule. Default policy can allow it.
- **Audit log unaffected on the policy/decision side.** The Decision row records the action, allow/deny, ruleID, reason — just without envelope-scoped fields (the call doesn't belong to any envelope's spend).
- **Operator visibility.** A structured info line goes to stderr (\`{\"info\":\"chitin_admin_exempt\", \"command\":...}\`) so anyone auditing the hook sees when an exemption fired.

Path-prefixed forms (\`/usr/local/bin/chitin-kernel\`) intentionally don't match — install puts \`chitin-kernel\` on PATH, and operators invoking by literal path have explicit invocation control.

## Why this is correct

The exemption is the narrowest fix that unblocks the deadlock without weakening the safety model:

- Without it: closed-envelope is a hard wall. Operator must leave the session.
- With it: \`grant\` works as documented. Adversarial prompt-injection budget escapes are still defeated by policy rules — operators decide what \`chitin-kernel\` subcommands the agent may run.

The alternative (relax \`Spend\` to not auto-close on exhaust) was considered and rejected: the auto-close behavior is internally consistent with the \"sticky closed_at + Grant clears it\" design, and removing it would change observable Decision shape (\`envelope-exhausted\` → no longer terminal). This patch leaves the budget semantics intact and only fixes the recovery-surface reachability.

## Test plan

- [x] \`go test ./...\` — 598 tests across 20 packages, all green
- [x] New tests in \`gate_hook_test.go\`:
  - [x] \`ChitinAdmin_AllowedOnExhaustedEnvelope\` — burns envelope cap with a Read, confirms a non-admin Bash now denies, then confirms \`chitin-kernel envelope grant\` passes
  - [x] \`ChitinAdmin_NoEnvelopeSpend\` — covers bare, \`env VAR=val\`, and inline \`VAR=val VAR=val\` forms; asserts \`SpentCalls == 0\` after multiple admin calls
  - [x] \`ChitinAdmin_PolicyStillApplies\` — operator policy denying \`chitin-kernel envelope grant\` produces exit 2 even with healthy envelope
  - [x] \`ChitinAdmin_NotMatchingNotExempt\` — table test: path-prefixed, echo prefix, hyphen extension (\`chitin-kernel-fake\`), compound (\`chitin-kernelizer\`) all debit normally
  - [x] \`ChitinAdmin_ExemptInfoLogged\` — stderr info line emitted on exemption
- [ ] Live verification: install hook, exhaust envelope from inside Claude Code, run \`chitin-kernel envelope grant\` from inside the same session, confirm it succeeds without operator leaving the session

## Open follow-ups (not in this PR)

- Plan §\"E (partial)\" already lists \`envelope start\` (one-shot create + use). Worth pairing with this once dogfooded — together they kill most of the per-session friction.
- Spec note: the v3 plan (\`docs/superpowers/plans/2026-04-29-cost-governance-kernel.md\`) doesn't currently mention admin-exemption. Could add a paragraph under \"Envelope discovery precedence\" in a follow-up doc patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)