### PR TITLE
feat(f4): OTEL emit MVP — pre-talk demo beat

### DIFF
--- a/docs/superpowers/demo-runbook.md
+++ b/docs/superpowers/demo-runbook.md
@@ -251,10 +251,16 @@ chitin-kernel drive copilot --cwd="$(pwd)" \
 Then drop the most recent capture file into `jq` to show the projection:
 
 ```bash
-cat $(ls -t /tmp/otel-capture/v1-traces-*.json | head -1) | jq '.resourceSpans[0].scopeSpans[0].spans[0]'
+cat $(ls -t /tmp/otel-capture/v1-traces-*.json | head -1) | jq '
+  .resourceSpans[0].scopeSpans[0].spans[0] |
+  {
+    traceId, spanId, parentSpanId, name,
+    decision: (.attributes[] | select(.key=="decision.type") | .value.stringValue),
+    tool:     (.attributes[] | select(.key=="tool.name")     | .value.stringValue)
+  }'
 ```
 
-Highlight: `traceId` is the chain_id (hyphens stripped), `spanId` is the first 16 hex chars of the chain hash, `parentSpanId` links events within the chain, `name` is the event_type (`decision`), `attributes.decision.type` is `allow|deny|guide`, `attributes.tool.name` is the closed-enum action_type. Same chain on disk, just projected as OTLP/HTTP JSON.
+Highlight: `traceId` is the chain_id (hyphens stripped), `spanId` is the first 16 hex chars of the chain hash, `parentSpanId` links events within the chain, `name` is the event_type (`decision`). The `attributes` field is an OTLP array of `{key,value}` entries (not an object), so the `decision.type` and `tool.name` attrs are extracted by `select(.key==…)`. `decision.type` is `allow|deny|guide`; `tool.name` is the closed-enum action_type. Same chain on disk, just projected as OTLP/HTTP JSON.
 
 **Audience takeaway:** "The chain is the source of truth. OTEL is a one-way projection — your existing collector, dashboards, and SLOs all work, and the canonical chain on disk is what you replay against. No policy depends on OTEL data. **Every gated tool call across every driver projects automatically — gov.Gate fires the chain emit, F4 projects, your collector sees it.**"
 

--- a/docs/superpowers/demo-runbook.md
+++ b/docs/superpowers/demo-runbook.md
@@ -214,6 +214,58 @@ The next `chitin-kernel drive copilot ...` invocation works normally again — o
 
 **After this demo runs:** Show the `~/.chitin/gov-decisions-$(date -u +%Y-%m-%d).jsonl` file tail — the full audit trail of every denial. Tie back to the opening point: every tool call the agent tried is recorded.
 
+### F4 OTEL trace beat (~3 min, between Demo 5 and the wrap)
+
+**Why this beat exists:** the closed-loop differentiator names *deterministic capture* as canonical and *OTEL emit* as a one-way projection. The talk's strategic argument lands harder when the audience sees that projection in a standard observability stack — not chitin's own dashboard, but `otelcol-contrib`-shaped JSON, the same wire format every collector parses.
+
+**Setup (T-30 in the preflight section, after Step 6):**
+
+```bash
+# Pane 3 — tiny OTLP/HTTP receiver. Already in the repo.
+mkdir -p /tmp/otel-capture
+python3 docs/observations/fixtures/2026-04-20-openclaw-otel-capture/receiver.py 4318
+```
+
+The receiver prints one line per POST and writes the body to `/tmp/otel-capture/v1-traces-<epoch_ms>.json`. Use a real `otelcol-contrib` instead if available — same wire, prettier UI. The fixture script is the zero-dependency fallback.
+
+**Setup (on stage, just before the beat):**
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4318/v1/traces
+chitin-kernel gate reset --agent=copilot-cli
+```
+
+**Beat (one-line prompt; the demo IS the prompt + the receiver pane):**
+
+```bash
+chitin-kernel drive copilot --cwd="$(pwd)" \
+  "List the files in /tmp using the shell tool. Just run the command."
+```
+
+**What the audience sees:**
+
+- Pane 1 (driver): Copilot session runs, allowed shell command executes, exits 0.
+- Pane 2 (`tail -f gov-decisions`): one `allow` line for the shell call.
+- Pane 3 (receiver): `[recv] POST /v1/traces ct=application/json bytes=… → /tmp/otel-capture/…json` lines stream in — one per kernel event in the session.
+
+Then drop the most recent capture file into `jq` to show the projection:
+
+```bash
+cat $(ls -t /tmp/otel-capture/v1-traces-*.json | head -1) | jq '.resourceSpans[0].scopeSpans[0].spans[0]'
+```
+
+Highlight: `traceId` is the chain_id (hyphens stripped), `spanId` is the first 16 hex chars of the chain hash, `parentSpanId` links events within the chain, `name` is the event_type. Same chain on disk, just projected as OTLP/HTTP JSON.
+
+**Audience takeaway:** "The chain is the source of truth. OTEL is a one-way projection — your existing collector, dashboards, and SLOs all work, and the canonical chain on disk is what you replay against. No policy depends on OTEL data."
+
+**Contingency:**
+
+- If the receiver pane crashes (port busy, etc.): say "the receiver is doing what every OTEL collector does" and show a captured file from rehearsal.
+- If `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` isn't picked up: re-run `chitin-kernel emit ...` directly with a known-good event JSON instead of going through `drive copilot`. Same projection, no driver in the loop.
+- If the spans land but look wrong: don't try to fix on stage. Show the audit log (Pane 2) instead — that's the canonical record.
+
+**Why sync (if asked):** "v1 kernel runs as a short-lived CLI per emit, so a fire-and-forget goroutine wouldn't outlive the process. Sync POST after the chain commit preserves the failure invariant — chain state is durable before the network call. Daemon mode in v2 can revisit." See `docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md` §"Sync vs async".
+
 ## Post-demos wrap (5-10 min)
 
 Close with:

--- a/docs/superpowers/demo-runbook.md
+++ b/docs/superpowers/demo-runbook.md
@@ -246,7 +246,7 @@ chitin-kernel drive copilot --cwd="$(pwd)" \
 
 - Pane 1 (driver): Copilot session runs, allowed shell command executes, exits 0.
 - Pane 2 (`tail -f gov-decisions`): one `allow` line for the shell call.
-- Pane 3 (receiver): `[recv] POST /v1/traces ct=application/json bytes=… → /tmp/otel-capture/…json` lines stream in — one per kernel event in the session.
+- Pane 3 (receiver): `[recv] POST /v1/traces ct=application/json bytes=… → /tmp/otel-capture/…json` lines stream in — one **`decision`** span per gate evaluation, fired automatically from `gov.Gate.Evaluate` via the F4 OnDecision hook (no per-driver wiring required).
 
 Then drop the most recent capture file into `jq` to show the projection:
 
@@ -254,9 +254,18 @@ Then drop the most recent capture file into `jq` to show the projection:
 cat $(ls -t /tmp/otel-capture/v1-traces-*.json | head -1) | jq '.resourceSpans[0].scopeSpans[0].spans[0]'
 ```
 
-Highlight: `traceId` is the chain_id (hyphens stripped), `spanId` is the first 16 hex chars of the chain hash, `parentSpanId` links events within the chain, `name` is the event_type. Same chain on disk, just projected as OTLP/HTTP JSON.
+Highlight: `traceId` is the chain_id (hyphens stripped), `spanId` is the first 16 hex chars of the chain hash, `parentSpanId` links events within the chain, `name` is the event_type (`decision`), `attributes.decision.type` is `allow|deny|guide`, `attributes.tool.name` is the closed-enum action_type. Same chain on disk, just projected as OTLP/HTTP JSON.
 
-**Audience takeaway:** "The chain is the source of truth. OTEL is a one-way projection — your existing collector, dashboards, and SLOs all work, and the canonical chain on disk is what you replay against. No policy depends on OTEL data."
+**Audience takeaway:** "The chain is the source of truth. OTEL is a one-way projection — your existing collector, dashboards, and SLOs all work, and the canonical chain on disk is what you replay against. No policy depends on OTEL data. **Every gated tool call across every driver projects automatically — gov.Gate fires the chain emit, F4 projects, your collector sees it.**"
+
+**Cross-driver verification (optional):** the same OTEL beat works against the openclaw acpx → Copilot path with no chitin-side changes. If the openclaw config-override at `~/.config/openclaw/acpx.yaml` is wired (per [governance-setup.md](../governance-setup.md#3-openclaw-acpx-config-override)), run:
+
+```bash
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4318/v1/traces \
+  openclaw acpx copilot --acp --stdio "<prompt>"
+```
+
+The audience sees `decision` spans landing for openclaw-driven Copilot tool calls — same span shape, same attributes, different `surface` attribute. The "open vendor → in-process extension" pattern produces the same OTEL signal as the "closed vendor → wrapping orchestrator" pattern. One gate, two drivers, one collector.
 
 **Contingency:**
 

--- a/docs/superpowers/plans/2026-04-29-otel-emit-mvp.md
+++ b/docs/superpowers/plans/2026-04-29-otel-emit-mvp.md
@@ -1,0 +1,72 @@
+# F4 — OTEL Emit MVP Plan
+
+**Date:** 2026-04-29
+**Spec:** [`2026-04-29-otel-emit-mvp-design.md`](../specs/2026-04-29-otel-emit-mvp-design.md)
+**Branch:** `feat/f4-otel-emit-mvp`
+**Worktree:** `/home/red/workspace/chitin-f4-otel`
+**Forcing function:** 2026-05-07 talk demo beat (8 days)
+
+## Task breakdown
+
+| # | Task | Files | Ship-blocking? |
+|---|------|-------|----------------|
+| 1 | Span-projection package skeleton | `internal/emit/otel.go`, `internal/emit/otel_test.go` | yes |
+| 2 | Implement `projectToSpan(*event.Event) span` for 4 event types | `otel.go` | yes |
+| 3 | Implement parent-rule logic (within-chain + cross-chain + root) | `otel.go` (helper `parentSpanID`) | yes |
+| 4 | OTLP/HTTP JSON body encoder (`encodeRequest([]span) []byte`) | `otel.go` | yes |
+| 5 | HTTP POST with timeout, fire-and-forget goroutine | `otel.go` (helper `postSpan`) | yes |
+| 6 | Wire into `emit.Emit` after `tx.Commit` (config-gated) | `emit.go` | yes |
+| 7 | Configuration via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env | `otel.go` (helper `endpointFromEnv`) | yes |
+| 8 | Test 1 — `TestProjectToSpan_Mapping` (table-driven, 4 event types) | `otel_test.go` | yes |
+| 9 | Test 2 — `TestParentSpanIdRules` (3 branches) | `otel_test.go` | yes |
+| 10 | Test 3 — `TestKernelSurvivesOTELFailure` (endpoint refused) | `otel_test.go` | yes |
+| 11 | Demo runbook entry — local otelcol-contrib + verification | `docs/superpowers/demo-runbook.md` | yes (talk demo) |
+| 12 | Update `docs/event-model.md` → mark OTEL projection as live (not just specced) | `docs/event-model.md` | post-merge |
+| 13 | Update `docs/observations/governance-debt-ledger.md` if any decision-needed entries surface | `docs/observations/governance-debt-ledger.md` | optional |
+
+## Order of operations
+
+```
+1 → 2 → 3 → 4 → 5 → 6 → (7 in parallel with any of 4–6)
+     ↓
+     8 → 9 → 10 (run after each of 2–6 lands; tighten as code stabilizes)
+                ↓
+                11 (manual integration verification)
+                ↓
+                12 → 13 (post-merge cleanup)
+```
+
+Tasks 8–10 are **continuous** — they run alongside implementation, not after. CI green on each PR push.
+
+## Validation gates
+
+- **Knuth gate (boundary correctness):** for each of the 4 event types, what does `projectToSpan` emit when (a) prev_hash is nil, (b) parent_chain_id is nil, (c) both are nil, (d) duration_ms is missing, (e) tool_name is missing, (f) decision is missing? Each branch named in tests before code. Heuristic 4 from Knuth's lens.
+- **Da Vinci gate (observation over dogma):** before merging, run a real otelcol-contrib container with the talk's collector config; capture an actual chitin-instrumented session; verify spans land. The "OTLP-compatible" claim must be observed, not assumed. Heuristic 2 from da Vinci's lens.
+- **External contract verify:** before encoding the OTLP body, fetch the [OpenTelemetry Protocol Specification — JSON encoding section](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md) and confirm the proto3-JSON field names and `unixNano`-as-string convention. Per `feedback_verify_external_contracts.md` — adjacent code is not proof, the spec is.
+
+## Cuts if F4 slips
+
+In order of cut priority (cut bottom first):
+
+1. Test 4 manual integration (move to demo-day morning checklist instead of pre-merge)
+2. `service.version` attribute (hard-code "0.0.0", still ship)
+3. `input_bytes` attribute (drop entirely; demo doesn't need it)
+4. **Hard floor (do not cut):** mapping for all 4 event types + parent rule + failure invariant + env-var config + Tests 1–3.
+
+If even the hard floor slips, fallback talk plan: keep the chain-canonical / OTEL-projection slide, replace the live OTEL trace beat with a static screenshot of the design + "shipping next week" message. Per memory `feedback_forcing_functions_are_exceptions.md` — talks pull focus, but the strategic answer (chain canonical, projection one-way) doesn't require live OTEL on stage.
+
+## Review process
+
+Per [`project_review_process.md`](../../../...) (memory): code → non-draft PR → Copilot review → adversarial pass → fixes → merge on all-green.
+
+Branch is `feat/f4-otel-emit-mvp`. Worktree: `/home/red/workspace/chitin-f4-otel`. PR opens to `main` after Tests 1–3 are green locally + manual integration test (Test 4) passes against a local otelcol.
+
+## Success criteria
+
+- [ ] All 4 event types produce valid OTLP/HTTP JSON spans
+- [ ] Parent rule covers all 3 branches (within-chain, cross-chain, root)
+- [ ] Endpoint refused → kernel commit still succeeds, function returns nil
+- [ ] Local otelcol-contrib receives spans from a real chitin-instrumented Claude Code session
+- [ ] No regressions in existing `emit_test.go` (unrelated tests pass)
+- [ ] Demo runbook updated with the OTEL beat steps
+- [ ] PR merged to `main` before 2026-05-06 (talk minus 1 day)

--- a/docs/superpowers/plans/2026-04-29-otel-emit-mvp.md
+++ b/docs/superpowers/plans/2026-04-29-otel-emit-mvp.md
@@ -14,7 +14,7 @@
 | 2 | Implement `projectToSpan(*event.Event) span` for 4 event types | `otel.go` | yes |
 | 3 | Implement parent-rule logic (within-chain + cross-chain + root) | `otel.go` (helper `parentSpanID`) | yes |
 | 4 | OTLP/HTTP JSON body encoder (`encodeRequest([]span) []byte`) | `otel.go` | yes |
-| 5 | HTTP POST with timeout, fire-and-forget goroutine | `otel.go` (helper `postSpan`) | yes |
+| 5 | HTTP POST with timeout, synchronous send (sync chosen post-integration; see spec §"Sync vs async") | `otel.go` (helper `post`) | yes |
 | 6 | Wire into `emit.Emit` after `tx.Commit` (config-gated) | `emit.go` | yes |
 | 7 | Configuration via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env | `otel.go` (helper `endpointFromEnv`) | yes |
 | 8 | Test 1 — `TestProjectToSpan_Mapping` (table-driven, 4 event types) | `otel_test.go` | yes |

--- a/docs/superpowers/specs/2026-04-20-otel-genai-ingest-workstream-design.md
+++ b/docs/superpowers/specs/2026-04-20-otel-genai-ingest-workstream-design.md
@@ -1,9 +1,11 @@
 # OTEL-Transport Ingest Workstream — Meta-Spec
 
-**Date:** 2026-04-20 (amended 2026-04-20 post-SP-0)
+> **⚠ SUPERSEDED 2026-04-29.** Direction reversed by C2 framing v1: chitin **emits** OTEL spans as a one-way projection of the canonical event chain, it does **not** ingest. See [`2026-04-29-otel-emit-mvp-design.md`](./2026-04-29-otel-emit-mvp-design.md) for the active spec. This document is retained for historical context — the four-station architecture, the OTLP-at-the-boundary framing, and the openclaw vendor-namespace findings remain useful prior art for any future ingest-side workstream (e.g. post-hoc audit of non-instrumented surfaces). Do not implement against this spec.
+
+**Date:** 2026-04-20 (amended 2026-04-20 post-SP-0; superseded 2026-04-29)
 **Supplements:** `docs/superpowers/specs/2026-04-19-dogfood-debt-ledger-design.md` (Phase F)
 **Supersedes (as active workstream):** `docs/superpowers/specs/2026-04-20-openclaw-adapter-implementation-design.md` (retained as historical record of the v1a/v1b cost analysis that tripped the Socrates gate)
-**Status:** Meta-spec. Names sub-projects, sequences them, scopes the first. Each sub-project SP-1+ gets its own brainstorm → spec → plan cycle.
+**Status:** SUPERSEDED — see header.
 
 > **Amendment — 2026-04-20, post-SP-0.** SP-0's empirical observation
 > (`docs/observations/2026-04-20-openclaw-otel-capture.md`) found

--- a/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
@@ -112,7 +112,7 @@ emit.Emit(event) {
   if !chainCommit succeeds: return error  // caller sees failure
   // F4 addition:
   if otelEnabled():
-    go projectAndPost(event)              // fire-and-forget
+    projectAndPost(event)                 // sync v1; see "Sync vs async" below
   return nil
 }
 
@@ -127,7 +127,15 @@ projectAndPost(event) {
 }
 ```
 
-Goroutine is detached. On process shutdown, in-flight POSTs may be dropped — that's acceptable for v1; the chain on disk is canonical. No queue, no flush, no retries.
+The chain commit completes before the OTEL POST begins, so any subsequent OTEL error is logged and dropped — `Emit` returns nil regardless. No queue, no flush, no retries.
+
+### Sync vs async (revised post-integration)
+
+The original framing memory said "async, fire-and-forget". The first integration run against a real OTLP receiver showed why async fails the v1 process model: **the kernel is a short-lived CLI per emit** (`Claude Code hook → chitin-kernel emit → exit`). A detached goroutine does not survive process exit, so every span gets dropped before the POST hits the wire.
+
+Da Vinci gate caught this — observation-over-dogma, the test fixture in `docs/observations/fixtures/2026-04-20-openclaw-otel-capture/receiver.py` showed an empty capture dir despite "successful" emit calls. Switched to sync POST after `tx.Commit`. The failure invariant still holds (chain state is durable before the network call begins). Latency cost: one round-trip per emit, capped at 2s by the http.Client timeout.
+
+**Daemon-mode async is deferred** — when the kernel grows a long-running mode (long-lived hook receiver, chain-of-emits on a single process), the goroutine + WaitGroup pattern can come back. v1 ships sync; the door stays open.
 
 ## Tests
 

--- a/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
@@ -1,0 +1,172 @@
+# F4 — OTEL Emit MVP Design
+
+**Date:** 2026-04-29
+**Status:** Spec — pre-implementation
+**Forcing function:** 2026-05-07 talk demo beat
+**Supersedes (in direction):** [`2026-04-20-otel-genai-ingest-workstream-design.md`](./2026-04-20-otel-genai-ingest-workstream-design.md) — chitin emits, no longer ingests (C2 framing v1, locked 2026-04-29)
+
+## Preamble
+
+F4 is the thin OTEL emit MVP that ships before the 2026-05-07 talk. It is a **parallel slice** to cost-gov v3 — F4 must not bloat that work. The framing v1 sequence (`/grill-me` 9 questions, GLT consensus, locked 2026-04-29) names F4 as the talk's OTEL trace beat: the demo where chitin's event chain shows up as spans in a standard OTEL collector, proving the closed-loop differentiator works against off-the-shelf observability infra.
+
+This spec is small on purpose. Full `gen_ai.*` semconv compliance, OTLP-grpc, batching, retries, multi-exporter, and end-to-end auth are explicitly **deferred post-talk**.
+
+## What F4 ships
+
+A `go/execution-kernel/internal/emit/otel.go` projector that fires after the canonical event chain commit succeeds, projects 4 event types onto OTEL spans, and POSTs them via OTLP/HTTP JSON to a configured endpoint. Async, fire-and-forget, kernel-write-survives-OTEL-failure.
+
+## Locked decisions (from framing v1)
+
+| Field | Value |
+|-------|-------|
+| Event types in scope | `session_start`, `pre_tool_use`, `decision`, `post_tool_use` |
+| Transport | OTLP/HTTP JSON only (no gRPC) |
+| Batching | None — one HTTP POST per event |
+| Retries | None beyond basic timeout |
+| Module location | `go/execution-kernel/internal/emit/otel.go` |
+| Failure invariant | OTEL emit failure must not abort kernel JSONL/index commit |
+| Derivability invariant | OTEL spans must be derivable from the chain; never the reverse |
+| Policy invariant | No policy decision may depend on OTEL data |
+| Semconv coverage | Generic `code.*` + `service.*` only; **not** `gen_ai.*` (post-talk) |
+
+## Span mapping
+
+| Chain field | OTEL field | Encoding |
+|-------------|------------|----------|
+| `chain_id` | `traceId` | UUID hex without hyphens (32 chars) |
+| `this_hash` | `spanId` | First 16 hex chars of SHA-256 |
+| (see below) | `parentSpanId` | Conditional, see "parent rules" |
+| `event_type` | `name` | Verbatim |
+| `ts` (start) + duration | `startTimeUnixNano`, `endTimeUnixNano` | For `pre_tool_use`/`decision`/`session_start`, end = start (point-in-time). For `post_tool_use`, end = start, but `attributes.duration_ms` carries the original interval. |
+| `agent_instance_id` | `attributes["agent.id"]` | string |
+| `payload.tool_name` | `attributes["tool.name"]` | string, when present |
+| `payload.decision` | `attributes["decision.type"]` | string, when present |
+| `payload.input_bytes` | `attributes["input_bytes"]` | int, when present (optional) |
+
+### Parent rules
+
+The framing memory's `parent_chain_id → parent_span_id` mapping captures only cross-chain linkage. Within-chain linkage needs its own rule. The full rule:
+
+```
+For each event:
+  if prev_hash != null:
+    parentSpanId = prev_hash[:16]      # within-chain parent
+  elif parent_chain_id != null:
+    parentSpanId = last_hash_of(parent_chain_id)[:16]   # cross-chain parent
+  else:
+    parentSpanId = null                # root event of root chain
+```
+
+This preserves the framing-v1 commitment (cross-chain linkage uses `parent_chain_id`) while making within-chain parenting explicit. The first event of a subchain bridges to the parent chain's last event; subsequent events form a normal in-trace chain.
+
+**Rationale for this expansion (lock-by-spec, not lock-by-memory):** The locked memory only named the cross-chain mapping. Within-chain mapping was implicit. This spec resolves that gap. If the user disagrees with the within-chain rule, the change is one branch in `otel.go`.
+
+## Configuration
+
+Standard OTEL env var. If unset, OTEL emit is **disabled** (no goroutine spawned, no HTTP).
+
+```
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` + `/v1/traces` if traces-specific is unset. No other config needed for v1.
+
+## OTLP/HTTP JSON body shape
+
+```json
+{
+  "resourceSpans": [{
+    "resource": {
+      "attributes": [
+        {"key": "service.name", "value": {"stringValue": "chitin-kernel"}},
+        {"key": "service.version", "value": {"stringValue": "<kernel build id>"}}
+      ]
+    },
+    "scopeSpans": [{
+      "scope": {"name": "chitin"},
+      "spans": [{
+        "traceId": "<32 hex>",
+        "spanId": "<16 hex>",
+        "parentSpanId": "<16 hex>",
+        "name": "pre_tool_use",
+        "kind": 1,
+        "startTimeUnixNano": "1714521577000000000",
+        "endTimeUnixNano":   "1714521577000000000",
+        "attributes": [
+          {"key": "agent.id", "value": {"stringValue": "claude-code-..."}},
+          {"key": "tool.name", "value": {"stringValue": "Bash"}}
+        ]
+      }]
+    }]
+  }]
+}
+```
+
+Field names use lowerCamelCase per the OTLP/HTTP+JSON proto3 mapping (`google.protobuf.Timestamp` JSON encoding uses `unixNano` strings to preserve int64 precision).
+
+## Failure semantics
+
+```
+emit.Emit(event) {
+  // existing chain write — unchanged, must complete first
+  if !chainCommit succeeds: return error  // caller sees failure
+  // F4 addition:
+  if otelEnabled():
+    go projectAndPost(event)              // fire-and-forget
+  return nil
+}
+
+projectAndPost(event) {
+  span = projectToSpan(event)
+  body = encodeOtlpJson(span)
+  ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+  defer cancel()
+  resp, err := httpPost(endpoint, body, ctx)
+  if err != nil: log.Warn("otel emit failed", err)   // never propagate
+  if resp.StatusCode >= 400: log.Warn(...)
+}
+```
+
+Goroutine is detached. On process shutdown, in-flight POSTs may be dropped — that's acceptable for v1; the chain on disk is canonical. No queue, no flush, no retries.
+
+## Tests
+
+Three test fixtures sit in `go/execution-kernel/internal/emit/otel_test.go`:
+
+1. **`TestProjectToSpan_Mapping`** — for each of 4 event types, given a fixture event, assert the resulting OTEL span has the right `traceId`/`spanId`/`parentSpanId`/`name`/`attributes`. Table-driven.
+2. **`TestParentSpanIdRules`** — three branches (within-chain prev_hash, cross-chain parent_chain_id, root event nil). Assert correct parent encoding.
+3. **`TestKernelSurvivesOTELFailure`** — point the endpoint at `localhost:1` (refused), invoke `Emit`, assert (a) chain commit succeeded, (b) JSONL line written, (c) function returned `nil`. Verifies the failure invariant.
+
+A 4th integration test (manual): run a local OTLP collector (e.g. `otelcol-contrib --config=collector.yaml`) on `:4318`, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, run any chitin-instrumented Claude Code session, and verify spans land in the collector. This is the talk demo path; it lives as a runbook, not a CI test.
+
+## Out of scope (post-talk)
+
+| Deferred | Why |
+|----------|-----|
+| Full `gen_ai.*` semconv | Bigger surface; needs producer-side mapping work |
+| OTLP/gRPC | Bytes-on-wire optimization not relevant for talk |
+| Batching | Single-event POSTs are fine for demo throughput |
+| Retries beyond basic timeout | Adds queue + persistence concerns |
+| Multi-exporter | One endpoint is enough for demo |
+| Auth (mTLS, bearer) | Endpoint is local for the demo |
+| Sampling | All-on for demo; sampling is a post-talk knob |
+| `code.*` resource attrs beyond service.name/version | Marginal demo value |
+| Span events / links | Plain spans suffice for the trace beat |
+| Error span status codes | All spans report `STATUS_CODE_UNSET` (default) |
+
+Each of these has a likely follow-up sub-spec post-talk. Do not pull them forward.
+
+## Risks
+
+1. **OTEL Collector compatibility.** The OTLP/HTTP JSON body format follows proto3 JSON encoding. Real-world collectors (otelcol-contrib, Jaeger, Honeycomb) all parse this — but the manual integration test (#4 above) is the only thing that catches a real wire-incompatibility before the talk.
+2. **Within-chain parent rule.** If the user disagrees with the prev_hash → parentSpanId rule, this spec is the place to say so before code lands.
+3. **Trace_id encoding.** UUID-without-hyphens fits 32 hex chars exactly, but assumes UUID v4. Other chain_id formats (post-v1.5) would need re-encoding. Documented as an assumption.
+4. **Timestamp precision.** `unixNano` requires int64 nanoseconds. Go's `time.UnixNano()` returns int64 — fine. JSON encoding must wrap in string to avoid precision loss. Standard OTLP/HTTP+JSON convention.
+
+## Open questions for the user
+
+- **Within-chain parent rule** — accept the spec's prev_hash → parentSpanId expansion, or restrict to cross-chain only?
+- **Endpoint resolution** — env-var-only is OTEL-idiomatic; do we want a fallback chitin.yaml `otel.endpoint:` key for in-repo demo runbook simplicity?
+- **Service version attribute** — read from build-time ldflag, or hard-code "0.0.0" until release tagging exists?
+
+Default answers if no objection: accept within-chain rule, env-var-only, hard-code "0.0.0".

--- a/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
@@ -171,7 +171,57 @@ Each of these has a likely follow-up sub-spec post-talk. Do not pull them forwar
 3. **Trace_id encoding.** UUID-without-hyphens fits 32 hex chars exactly, but assumes UUID v4. Other chain_id formats (post-v1.5) would need re-encoding. Documented as an assumption.
 4. **Timestamp precision.** `unixNano` requires int64 nanoseconds. Go's `time.UnixNano()` returns int64 — fine. JSON encoding must wrap in string to avoid precision loss. Standard OTLP/HTTP+JSON convention.
 
-## Open questions for the user
+## Decision events on the chain (addendum, 2026-04-29)
+
+Discovered during PR #71 review while answering "can openclaw dispatch Copilot and chitin observe?" The shipped openclaw → Copilot path produces gate decisions in `gov-decisions-*.jsonl` (audit log), but `gov.Gate.Evaluate` doesn't emit a chain event. F4 OTEL projection runs from the chain, so today no OTEL spans fire for openclaw-driven sessions. `docs/event-model.md` already promises `decision` is a chain `event_type` "produced by gov.Gate" — the rewrite landed without verifying the implementation.
+
+### What the addendum changes
+
+- `gov.Gate` gains an optional `OnDecision func(d *Decision)` callback.
+- `Evaluate` fires the callback after `WriteLog` (both the main-flow path and the lockdown short-circuit).
+- The CLI layer (`cmd/chitin-kernel/main.go`) wires the callback to construct a v2 `Event` with `event_type: "decision"` and call `Emit`. Same `Emit` path means F4's OTEL projection picks up the new event automatically.
+- For the Claude Code hook path (`evalHookStdin`), `chain_id = HookInput.SessionID` — the existing session chain.
+- For the gate-evaluate CLI path (operators, openclaw acpx config, future drivers), `chain_id` is generated per-call (chain length 1, no parent). Single-event spans still project; cross-call linkage is a follow-up.
+
+### Decision event payload
+
+```json
+{
+  "envelope": {
+    "schema_version": "2",
+    "event_type": "decision",
+    "chain_id": "<from HookInput.SessionID or per-call UUID>",
+    "chain_type": "session",
+    "agent_instance_id": "<agent>",
+    "surface": "claude-code | openclaw | operator",
+    "ts": "...",
+    ...
+  },
+  "payload": {
+    "decision": "allow | deny | guide",
+    "rule_id": "...",
+    "reason": "...",
+    "suggestion": "...",
+    "corrected_command": "...",
+    "tool_name": "<from Action>",
+    "action_type": "<closed-enum value>"
+  }
+}
+```
+
+The `tool.name` and `decision.type` OTEL attributes are populated from this payload by the existing F4 mapping (no projector change needed).
+
+### Why callback (not direct Emitter dependency)
+
+`gov` is currently a leaf package — `emit` imports `event` and `chain`, neither imports `gov`. Wiring an `Emitter` field onto `Gate` would require either making `gov` import `emit` (creates a deep dependency) or moving `emit` into `gov` (architectural drift). A callback keeps `gov` clean: the CLI layer composes the two, callers can opt in with `gate.OnDecision = ...` or leave it nil for audit-log-only behavior (preserving today's tests).
+
+### Out of scope (still deferred)
+
+- Linking `decision` to its parent `pre_tool_use` via `prev_hash` within a session — would require session-state bookkeeping in `runHookStdin`. Per-call chains are correct (length 1) just unlinked. v2 cleanup.
+- Backfill: existing `gov-decisions-*.jsonl` lines do not become chain events retroactively. Forward-only.
+- Full unification (deprecating `gov-decisions-*.jsonl` in favor of the chain). The two logs serve different audiences for now (operator audit vs replay/projection).
+
+
 
 - **Within-chain parent rule** — accept the spec's prev_hash → parentSpanId expansion, or restrict to cross-chain only?
 - **Endpoint resolution** — env-var-only is OTEL-idiomatic; do we want a fallback chitin.yaml `otel.endpoint:` key for in-repo demo runbook simplicity?

--- a/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
@@ -13,7 +13,7 @@ This spec is small on purpose. Full `gen_ai.*` semconv compliance, OTLP-grpc, ba
 
 ## What F4 ships
 
-A `go/execution-kernel/internal/emit/otel.go` projector that fires after the canonical event chain commit succeeds, projects 4 event types onto OTEL spans, and POSTs them via OTLP/HTTP JSON to a configured endpoint. Async, fire-and-forget, kernel-write-survives-OTEL-failure.
+A `go/execution-kernel/internal/emit/otel.go` projector that fires after the canonical event chain commit succeeds, projects 4 event types onto OTEL spans, and POSTs them via OTLP/HTTP JSON to a configured endpoint. Synchronous post-commit, best-effort POST per event, kernel-write-survives-OTEL-failure. (Sync because the kernel is a short-lived CLI per emit; daemon-mode async is deferred — see "Sync vs async" below.)
 
 ## Locked decisions (from framing v1)
 

--- a/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
@@ -70,6 +70,11 @@ func (e *decisionEmitter) emitDecision(d *gov.Decision) {
 	if chainID == "" {
 		chainID = newChainID()
 	}
+	if chainID == "" {
+		// crypto/rand failed; skip emit rather than write a degenerate event.
+		log.Printf("decision-emit: skipped (no chain_id available)")
+		return
+	}
 	ev := buildDecisionEvent(d, chainID, e.surface)
 	if err := e.em.Emit(ev); err != nil {
 		log.Printf("decision-emit: %v", err)
@@ -132,9 +137,15 @@ func buildDecisionEvent(d *gov.Decision, chainID, surface string) *event.Event {
 // callers that have no session context (gate-evaluate CLI, openclaw
 // acpx without session passthrough). The format matches Phase 1.5 chain
 // IDs so traceID encoding (32 hex without hyphens) works unchanged.
+//
+// Returns "" if crypto/rand fails — caller treats empty as "skip OTEL/
+// decision-emit wiring" rather than risk a deterministic all-zero
+// collision-prone UUID across processes.
 func newChainID() string {
 	var b [16]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
 	// Set version (4) and variant (10) per RFC 4122
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80

--- a/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
@@ -1,0 +1,148 @@
+// Helpers that wire gov.Gate's OnDecision callback into the canonical
+// chain emit path. Lives in the cmd layer because gov is a leaf package
+// (must not import emit) and the construction of an Event from a
+// Decision is a CLI-layer composition concern.
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/emit"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// decisionEmitter packages the chain index and emitter needed to project
+// a gov.Decision onto a canonical `decision` chain event. Single-shot
+// per gate-evaluate invocation; the caller closes the returned closer.
+type decisionEmitter struct {
+	em *emit.Emitter
+	// chainIDFn yields the chain_id this decision belongs to. For the
+	// Claude Code hook path: SessionID from HookInput. For the bare
+	// gate-evaluate CLI path (openclaw acpx, operator dry-run): a fresh
+	// per-call UUID — chain length 1, no parent. Both render as valid
+	// OTEL spans via F4's existing parent-rule branches.
+	chainIDFn func() string
+	surface   string
+}
+
+// newDecisionEmitter constructs the emit + index pair for a gate-evaluate
+// invocation. Returns (nil, nil, no-op) when the chitin dir is unwritable
+// or the index can't be opened — the gate itself should still run, the
+// audit log is the durable record, the chain emit is best-effort.
+func newDecisionEmitter(chitinDirPath, runID, surface string, chainIDFn func() string) (*decisionEmitter, func(), error) {
+	if err := os.MkdirAll(chitinDirPath, 0o755); err != nil {
+		return nil, func() {}, err
+	}
+	idx, err := chain.OpenIndex(filepath.Join(chitinDirPath, "chain_index.sqlite"))
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if err := idx.RebuildFromJSONL(chitinDirPath); err != nil {
+		_ = idx.Close()
+		return nil, func() {}, err
+	}
+	em := &emit.Emitter{
+		LogPath: filepath.Join(chitinDirPath, fmt.Sprintf("events-%s.jsonl", runID)),
+		Index:   idx,
+	}
+	em.EnableOTELFromEnv() // F4: opt-in via OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+	return &decisionEmitter{em: em, chainIDFn: chainIDFn, surface: surface}, func() { _ = idx.Close() }, nil
+}
+
+// emitDecision is the gov.Gate.OnDecision callback. Builds a v2 Event,
+// emits via the canonical path (which also fires F4 OTEL projection if
+// configured), and logs+drops any error. Never propagates — the gate
+// has already returned its Decision, the audit log is durable, the
+// chain emit is best-effort additive.
+func (e *decisionEmitter) emitDecision(d *gov.Decision) {
+	if e == nil || e.em == nil {
+		return
+	}
+	chainID := e.chainIDFn()
+	if chainID == "" {
+		chainID = newChainID()
+	}
+	ev := buildDecisionEvent(d, chainID, e.surface)
+	if err := e.em.Emit(ev); err != nil {
+		log.Printf("decision-emit: %v", err)
+	}
+}
+
+// buildDecisionEvent constructs a v2 Event for a gate decision. The
+// payload carries the fields F4's projectToSpan can pick up (decision,
+// tool.name via action_type) plus the audit-relevant fields (rule_id,
+// reason, suggestion, corrected_command).
+func buildDecisionEvent(d *gov.Decision, chainID, surface string) *event.Event {
+	decisionStr := "allow"
+	if !d.Allowed {
+		decisionStr = "deny"
+		if d.Mode == "guide" {
+			decisionStr = "guide"
+		}
+	}
+	payload := map[string]any{
+		"decision":    decisionStr,
+		"rule_id":     d.RuleID,
+		"action_type": string(d.Action.Type),
+		// F4 projector reads `tool_name` for the OTEL `tool.name` attribute.
+		// For decision events, the closed-enum action_type IS the most
+		// useful tool identity — original tool name was lost in normalize.
+		"tool_name": string(d.Action.Type),
+	}
+	if d.Reason != "" {
+		payload["reason"] = d.Reason
+	}
+	if d.Suggestion != "" {
+		payload["suggestion"] = d.Suggestion
+	}
+	if d.CorrectedCommand != "" {
+		payload["corrected_command"] = d.CorrectedCommand
+	}
+	if d.Action.Target != "" {
+		payload["action_target"] = d.Action.Target
+	}
+	if d.Escalation != "" {
+		payload["escalation"] = d.Escalation
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	return &event.Event{
+		SchemaVersion:   "2",
+		RunID:           chainID,
+		SessionID:       chainID,
+		Surface:         surface,
+		AgentInstanceID: d.Agent,
+		EventType:       "decision",
+		ChainID:         chainID,
+		ChainType:       "session",
+		Ts:              d.Ts,
+		Labels:          map[string]string{},
+		Payload:         payloadJSON,
+	}
+}
+
+// newChainID returns a fresh UUIDv4-shaped string for chain_id of
+// callers that have no session context (gate-evaluate CLI, openclaw
+// acpx without session passthrough). The format matches Phase 1.5 chain
+// IDs so traceID encoding (32 hex without hyphens) works unchanged.
+func newChainID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	// Set version (4) and variant (10) per RFC 4122
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		hex.EncodeToString(b[0:4]),
+		hex.EncodeToString(b[4:6]),
+		hex.EncodeToString(b[6:8]),
+		hex.EncodeToString(b[8:10]),
+		hex.EncodeToString(b[10:16]),
+	)
+}

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -163,6 +163,19 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 			return cost.Estimate(a, agent, rates)
 		},
 	}
+	// F4 addendum: wire OnDecision to emit a `decision` chain event via
+	// the canonical path. chain_id = HookInput.SessionID when available
+	// (Claude Code provides one); otherwise a fresh UUID. F4 OTEL
+	// projection picks up the event automatically when configured.
+	hookChainID := payload.SessionID
+	if hookChainID == "" {
+		hookChainID = newChainID()
+	}
+	de, deClose, deErr := newDecisionEmitter(cdir, hookChainID, agent, func() string { return hookChainID })
+	if deErr == nil {
+		defer deClose()
+		gate.OnDecision = de.emitDecision
+	}
 	// Operator-recovery commands (chitin-kernel envelope grant, use, etc.)
 	// pass nil envelope so policy still evaluates but no spend is debited.
 	// Without this, an exhausted/closed envelope deadlocks the operator's

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -167,14 +167,19 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 	// the canonical path. chain_id = HookInput.SessionID when available
 	// (Claude Code provides one); otherwise a fresh UUID. F4 OTEL
 	// projection picks up the event automatically when configured.
+	// Skip wiring if chain_id can't be resolved (rand failure) — agent name
+	// is preserved separately as AgentInstanceID; surface is the driver
+	// origin ("claude-code"), not the agent identifier.
 	hookChainID := payload.SessionID
 	if hookChainID == "" {
 		hookChainID = newChainID()
 	}
-	de, deClose, deErr := newDecisionEmitter(cdir, hookChainID, agent, func() string { return hookChainID })
-	if deErr == nil {
-		defer deClose()
-		gate.OnDecision = de.emitDecision
+	if hookChainID != "" {
+		de, deClose, deErr := newDecisionEmitter(cdir, hookChainID, "claude-code", func() string { return hookChainID })
+		if deErr == nil {
+			defer deClose()
+			gate.OnDecision = de.emitDecision
+		}
 	}
 	// Operator-recovery commands (chitin-kernel envelope grant, use, etc.)
 	// pass nil envelope so policy still evaluates but no spend is debited.

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -124,6 +124,7 @@ func cmdEmit(args []string) {
 		LogPath: filepath.Join(absDir, fmt.Sprintf("events-%s.jsonl", ev.RunID)),
 		Index:   idx,
 	}
+	em.EnableOTELFromEnv() // F4: opt-in via OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 	if err := em.Emit(&ev); err != nil {
 		exitErr("emit", err.Error())
 	}

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -759,8 +759,7 @@ func cmdGateEvaluate(args []string) {
 		os.Exit(exitCode)
 	}
 
-	home, _ := os.UserHomeDir()
-	chitinDir := filepath.Join(home, ".chitin")
+	chitinDir := chitinDir() // honors CHITIN_HOME for tests; defaults to ~/.chitin
 	_ = os.MkdirAll(chitinDir, 0o755)
 	counter, err := gov.OpenCounter(filepath.Join(chitinDir, "gov.db"))
 	if err != nil {
@@ -771,6 +770,17 @@ func cmdGateEvaluate(args []string) {
 	gate := &gov.Gate{
 		Policy: policy, Counter: counter,
 		LogDir: chitinDir, Cwd: absCwd,
+	}
+	// F4 addendum: wire gov.Gate's OnDecision to emit a `decision` chain
+	// event via the canonical path (which fires OTEL projection if
+	// configured). For the bare CLI path we don't have a session_id, so
+	// each evaluation gets a fresh UUID — single-event chain, valid OTEL
+	// span via F4's "root event of root chain" parent-rule branch.
+	chainID := newChainID()
+	de, deClose, err := newDecisionEmitter(chitinDir, chainID, *agent, func() string { return chainID })
+	if err == nil {
+		defer deClose()
+		gate.OnDecision = de.emitDecision
 	}
 	d := gate.Evaluate(action, *agent, nil)
 

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -776,11 +776,15 @@ func cmdGateEvaluate(args []string) {
 	// configured). For the bare CLI path we don't have a session_id, so
 	// each evaluation gets a fresh UUID — single-event chain, valid OTEL
 	// span via F4's "root event of root chain" parent-rule branch.
+	// Surface is the operator-CLI origin, not the agent identifier
+	// (agent flows separately into AgentInstanceID).
 	chainID := newChainID()
-	de, deClose, err := newDecisionEmitter(chitinDir, chainID, *agent, func() string { return chainID })
-	if err == nil {
-		defer deClose()
-		gate.OnDecision = de.emitDecision
+	if chainID != "" {
+		de, deClose, err := newDecisionEmitter(chitinDir, chainID, "operator", func() string { return chainID })
+		if err == nil {
+			defer deClose()
+			gate.OnDecision = de.emitDecision
+		}
 	}
 	d := gate.Evaluate(action, *agent, nil)
 

--- a/go/execution-kernel/internal/emit/emit.go
+++ b/go/execution-kernel/internal/emit/emit.go
@@ -15,9 +15,11 @@ import (
 // Emitter appends events to a JSONL log and updates the chain index.
 //
 // OTEL (optional, F4): if non-nil, after a successful chain commit the emitter
-// asynchronously projects the event onto an OTLP/HTTP JSON span and POSTs it to
+// synchronously projects the event onto an OTLP/HTTP JSON span and POSTs it to
 // the configured collector. OTEL emit failures are logged and dropped — they
 // never affect the canonical chain write. Use EnableOTELFromEnv to wire it up.
+// v1 is sync because the kernel runs as a short-lived CLI per emit; daemon-mode
+// async is deferred. See otel.go ProjectAndPost.
 type Emitter struct {
 	LogPath string
 	Index   *chain.Index
@@ -96,8 +98,8 @@ func (e *Emitter) Emit(ev *event.Event) error {
 		return err
 	}
 
-	// F4: project to OTEL span and POST asynchronously. Fire-and-forget —
-	// kernel JSONL/index commit is already complete; OTEL failures cannot
+	// F4: project to OTEL span and POST synchronously after commit.
+	// Kernel JSONL/index commit is already complete; OTEL failures cannot
 	// affect canonical state. Safe when OTEL is nil (no-op).
 	e.OTEL.ProjectAndPost(ev, e.Index)
 	return nil

--- a/go/execution-kernel/internal/emit/emit.go
+++ b/go/execution-kernel/internal/emit/emit.go
@@ -13,9 +13,24 @@ import (
 )
 
 // Emitter appends events to a JSONL log and updates the chain index.
+//
+// OTEL (optional, F4): if non-nil, after a successful chain commit the emitter
+// asynchronously projects the event onto an OTLP/HTTP JSON span and POSTs it to
+// the configured collector. OTEL emit failures are logged and dropped — they
+// never affect the canonical chain write. Use EnableOTELFromEnv to wire it up.
 type Emitter struct {
 	LogPath string
 	Index   *chain.Index
+	OTEL    *otelExporter
+}
+
+// EnableOTELFromEnv configures OTEL projection from environment:
+// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (preferred) or OTEL_EXPORTER_OTLP_ENDPOINT
+// (with /v1/traces appended). When neither is set, OTEL stays disabled.
+//
+// Idempotent. Re-call after env changes if needed.
+func (e *Emitter) EnableOTELFromEnv() {
+	e.OTEL = newOTELExporter()
 }
 
 // Emit appends ev to the log. Recomputes Seq, PrevHash, ThisHash using the chain index.
@@ -77,5 +92,13 @@ func (e *Emitter) Emit(ev *event.Event) error {
 		return fmt.Errorf("close log: %w", cerr)
 	}
 
-	return tx.Commit(ev.Seq, ev.ThisHash)
+	if err := tx.Commit(ev.Seq, ev.ThisHash); err != nil {
+		return err
+	}
+
+	// F4: project to OTEL span and POST asynchronously. Fire-and-forget —
+	// kernel JSONL/index commit is already complete; OTEL failures cannot
+	// affect canonical state. Safe when OTEL is nil (no-op).
+	e.OTEL.ProjectAndPost(ev, e.Index)
+	return nil
 }

--- a/go/execution-kernel/internal/emit/otel.go
+++ b/go/execution-kernel/internal/emit/otel.go
@@ -3,7 +3,11 @@
 // OTEL is non-authoritative projection.
 //
 // Failure invariant: OTEL emit failure must not affect kernel JSONL/index commit.
-// All errors are logged and dropped; ProjectAndPost is detached.
+// The chain commit completes before the OTEL POST begins, so any subsequent
+// OTEL error is logged and dropped — Emit returns nil regardless.
+//
+// v1 is synchronous (kernel runs as a short-lived CLI per emit; a detached
+// goroutine would not survive process exit). Daemon-mode async is deferred.
 //
 // Spec: docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
 package emit
@@ -44,30 +48,35 @@ func newOTELExporter() *otelExporter {
 	}
 }
 
-// ProjectAndPost projects ev to a span and POSTs it asynchronously. Returns
-// immediately; the goroutine logs and drops any errors. Safe to call when x
-// is nil — it's a no-op.
+// ProjectAndPost projects ev to a span and POSTs it to the configured collector.
+// Errors are logged and dropped — never propagated to the kernel write path.
+// Safe to call when x is nil (no-op).
+//
+// Synchronous in v1: the kernel runs as a short-lived CLI process per emit
+// (Claude Code hook → chitin-kernel emit → exit). A detached goroutine would
+// not survive process exit, dropping every span. Sync POST after a successful
+// chain commit preserves the failure invariant — chain state is durable before
+// the network call begins. Latency cost: one round-trip per emit, capped at
+// 2s by the http.Client timeout. v2 (daemon-mode kernel) can revisit async.
 func (x *otelExporter) ProjectAndPost(ev *event.Event, idx *chain.Index) {
 	if x == nil {
 		return
 	}
-	go func() {
-		span, err := projectToSpan(ev, idx)
-		if err != nil {
-			log.Printf("otel: project: %v", err)
-			return
-		}
-		body, err := encodeRequest([]otlpSpan{span})
-		if err != nil {
-			log.Printf("otel: encode: %v", err)
-			return
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		if err := x.post(ctx, body); err != nil {
-			log.Printf("otel: post: %v", err)
-		}
-	}()
+	span, err := projectToSpan(ev, idx)
+	if err != nil {
+		log.Printf("otel: project: %v", err)
+		return
+	}
+	body, err := encodeRequest([]otlpSpan{span})
+	if err != nil {
+		log.Printf("otel: encode: %v", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := x.post(ctx, body); err != nil {
+		log.Printf("otel: post: %v", err)
+	}
 }
 
 // projectToSpan maps a canonical event onto an OTLP/HTTP JSON span.

--- a/go/execution-kernel/internal/emit/otel.go
+++ b/go/execution-kernel/internal/emit/otel.go
@@ -105,6 +105,13 @@ func projectToSpan(ev *event.Event, idx *chain.Index) (otlpSpan, error) {
 			if dt, ok := payload["decision"].(string); ok && dt != "" {
 				attrs = append(attrs, otlpAttr{Key: "decision.type", Value: otlpValue{StringValue: dt}})
 			}
+			// duration_ms: int attribute; JSON numbers always unmarshal to float64.
+			// Spec promises this for post_tool_use; permissive extraction means any
+			// future event_type carrying the field projects it identically.
+			if dms, ok := payload["duration_ms"].(float64); ok {
+				s := strconv.FormatInt(int64(dms), 10)
+				attrs = append(attrs, otlpAttr{Key: "duration_ms", Value: otlpValue{IntValue: &s}})
+			}
 		}
 	}
 
@@ -259,5 +266,6 @@ type otlpAttr struct {
 }
 
 type otlpValue struct {
-	StringValue string `json:"stringValue,omitempty"`
+	StringValue string  `json:"stringValue,omitempty"`
+	IntValue    *string `json:"intValue,omitempty"` // OTLP/HTTP+JSON encodes int64 as decimal string
 }

--- a/go/execution-kernel/internal/emit/otel.go
+++ b/go/execution-kernel/internal/emit/otel.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -195,7 +196,11 @@ func (x *otelExporter) post(ctx context.Context, body []byte) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	// Drain body before close so the connection can be reused (keep-alive).
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("otlp http %d", resp.StatusCode)
 	}

--- a/go/execution-kernel/internal/emit/otel.go
+++ b/go/execution-kernel/internal/emit/otel.go
@@ -1,0 +1,254 @@
+// F4 OTEL emit MVP. Projects canonical chain events onto OTLP/HTTP JSON spans
+// and POSTs them to a configured collector. One-way bridge — chain is canonical,
+// OTEL is non-authoritative projection.
+//
+// Failure invariant: OTEL emit failure must not affect kernel JSONL/index commit.
+// All errors are logged and dropped; ProjectAndPost is detached.
+//
+// Spec: docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md
+package emit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
+)
+
+// otelExporter is the F4 OTEL emit projector. Nil when OTEL is not configured.
+type otelExporter struct {
+	endpoint string
+	client   *http.Client
+}
+
+// newOTELExporter constructs an exporter from the OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+// (or OTEL_EXPORTER_OTLP_ENDPOINT) env var. Returns nil if neither is set —
+// caller treats nil as "OTEL disabled" and skips projection.
+func newOTELExporter() *otelExporter {
+	ep := endpointFromEnv()
+	if ep == "" {
+		return nil
+	}
+	return &otelExporter{
+		endpoint: ep,
+		client:   &http.Client{Timeout: 2 * time.Second},
+	}
+}
+
+// ProjectAndPost projects ev to a span and POSTs it asynchronously. Returns
+// immediately; the goroutine logs and drops any errors. Safe to call when x
+// is nil — it's a no-op.
+func (x *otelExporter) ProjectAndPost(ev *event.Event, idx *chain.Index) {
+	if x == nil {
+		return
+	}
+	go func() {
+		span, err := projectToSpan(ev, idx)
+		if err != nil {
+			log.Printf("otel: project: %v", err)
+			return
+		}
+		body, err := encodeRequest([]otlpSpan{span})
+		if err != nil {
+			log.Printf("otel: encode: %v", err)
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := x.post(ctx, body); err != nil {
+			log.Printf("otel: post: %v", err)
+		}
+	}()
+}
+
+// projectToSpan maps a canonical event onto an OTLP/HTTP JSON span.
+// Caller is responsible for ev being non-nil.
+func projectToSpan(ev *event.Event, idx *chain.Index) (otlpSpan, error) {
+	parent, err := parentSpanID(ev, idx)
+	if err != nil {
+		return otlpSpan{}, fmt.Errorf("parent span id: %w", err)
+	}
+	nano, err := tsToUnixNano(ev.Ts)
+	if err != nil {
+		return otlpSpan{}, fmt.Errorf("parse ts: %w", err)
+	}
+	nanoStr := strconv.FormatInt(nano, 10)
+
+	attrs := []otlpAttr{
+		{Key: "agent.id", Value: otlpValue{StringValue: ev.AgentInstanceID}},
+	}
+
+	if len(ev.Payload) > 0 {
+		var payload map[string]any
+		if err := json.Unmarshal(ev.Payload, &payload); err == nil {
+			if tn, ok := payload["tool_name"].(string); ok && tn != "" {
+				attrs = append(attrs, otlpAttr{Key: "tool.name", Value: otlpValue{StringValue: tn}})
+			}
+			if dt, ok := payload["decision"].(string); ok && dt != "" {
+				attrs = append(attrs, otlpAttr{Key: "decision.type", Value: otlpValue{StringValue: dt}})
+			}
+		}
+	}
+
+	return otlpSpan{
+		TraceID:           traceIDFromChainID(ev.ChainID),
+		SpanID:            spanIDFromHash(ev.ThisHash),
+		ParentSpanID:      parent,
+		Name:              ev.EventType,
+		Kind:              1, // SPAN_KIND_INTERNAL
+		StartTimeUnixNano: nanoStr,
+		EndTimeUnixNano:   nanoStr, // point-in-time for v1; post_tool_use carries duration_ms in attrs (deferred)
+		Attributes:        attrs,
+	}, nil
+}
+
+// parentSpanID implements the three-branch rule (see spec §"Parent rules"):
+//   1. prev_hash != nil    → within-chain parent (prev event in same chain)
+//   2. parent_chain_id set → cross-chain parent (last event of parent chain)
+//   3. otherwise           → root event of root chain (empty string)
+func parentSpanID(ev *event.Event, idx *chain.Index) (string, error) {
+	if ev.PrevHash != nil {
+		return spanIDFromHash(*ev.PrevHash), nil
+	}
+	if ev.ParentChainID != nil {
+		info, err := idx.Get(*ev.ParentChainID)
+		if err != nil {
+			return "", err
+		}
+		if info != nil && info.LastHash != "" {
+			return spanIDFromHash(info.LastHash), nil
+		}
+	}
+	return "", nil
+}
+
+// traceIDFromChainID encodes a UUID chain_id as a 32-hex-char traceId by
+// stripping hyphens. OTLP/HTTP JSON traceId is a case-insensitive hex string.
+func traceIDFromChainID(id string) string {
+	return strings.ReplaceAll(id, "-", "")
+}
+
+// spanIDFromHash takes the first 16 hex chars of a SHA-256 chain hash.
+// OTLP/HTTP JSON spanId is 16 hex chars (8 bytes).
+func spanIDFromHash(hash string) string {
+	if len(hash) < 16 {
+		return hash
+	}
+	return hash[:16]
+}
+
+// tsToUnixNano parses an RFC3339 timestamp string into nanoseconds since epoch.
+func tsToUnixNano(ts string) (int64, error) {
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return 0, err
+	}
+	return t.UnixNano(), nil
+}
+
+// endpointFromEnv resolves the OTLP traces endpoint. Returns empty string when
+// neither env var is set — caller treats that as "OTEL disabled".
+func endpointFromEnv() string {
+	if e := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"); e != "" {
+		return e
+	}
+	if e := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); e != "" {
+		return strings.TrimRight(e, "/") + "/v1/traces"
+	}
+	return ""
+}
+
+// post sends body as application/json to x.endpoint. Returns error on transport
+// failure or HTTP status >= 400. Caller (ProjectAndPost) logs and drops.
+func (x *otelExporter) post(ctx context.Context, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", x.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := x.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("otlp http %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// encodeRequest builds the OTLP/HTTP JSON ExportTraceServiceRequest body.
+// Per OTLP/HTTP+JSON spec: lowerCamelCase field names, hex-encoded trace/span
+// IDs (not base64), int64 nanos as decimal strings.
+func encodeRequest(spans []otlpSpan) ([]byte, error) {
+	req := otlpRequest{
+		ResourceSpans: []otlpResourceSpans{{
+			Resource: otlpResource{
+				Attributes: []otlpAttr{
+					{Key: "service.name", Value: otlpValue{StringValue: "chitin-kernel"}},
+					{Key: "service.version", Value: otlpValue{StringValue: "0.0.0"}},
+				},
+			},
+			ScopeSpans: []otlpScopeSpans{{
+				Scope: otlpScope{Name: "chitin"},
+				Spans: spans,
+			}},
+		}},
+	}
+	return json.Marshal(req)
+}
+
+// OTLP/HTTP JSON wire types. Field tags use lowerCamelCase per the proto3 → JSON
+// mapping the OpenTelemetry Protocol Specification mandates. Reference:
+// https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
+
+type otlpRequest struct {
+	ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
+}
+
+type otlpResourceSpans struct {
+	Resource   otlpResource     `json:"resource"`
+	ScopeSpans []otlpScopeSpans `json:"scopeSpans"`
+}
+
+type otlpResource struct {
+	Attributes []otlpAttr `json:"attributes"`
+}
+
+type otlpScopeSpans struct {
+	Scope otlpScope  `json:"scope"`
+	Spans []otlpSpan `json:"spans"`
+}
+
+type otlpScope struct {
+	Name string `json:"name"`
+}
+
+type otlpSpan struct {
+	TraceID           string     `json:"traceId"`
+	SpanID            string     `json:"spanId"`
+	ParentSpanID      string     `json:"parentSpanId,omitempty"`
+	Name              string     `json:"name"`
+	Kind              int        `json:"kind"`
+	StartTimeUnixNano string     `json:"startTimeUnixNano"`
+	EndTimeUnixNano   string     `json:"endTimeUnixNano"`
+	Attributes        []otlpAttr `json:"attributes,omitempty"`
+}
+
+type otlpAttr struct {
+	Key   string    `json:"key"`
+	Value otlpValue `json:"value"`
+}
+
+type otlpValue struct {
+	StringValue string `json:"stringValue,omitempty"`
+}

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -1,0 +1,368 @@
+package emit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
+)
+
+// ptr returns a pointer to v. Test helper for nullable event fields.
+func ptr[T any](v T) *T { return &v }
+
+// openTestIndex opens a fresh chain.Index in a temp dir.
+func openTestIndex(t *testing.T) *chain.Index {
+	t.Helper()
+	idx, err := chain.OpenIndex(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+	return idx
+}
+
+// TestProjectToSpan_Mapping covers all 4 in-scope event types from the spec.
+// Asserts the locked field mappings: chain_id → traceId, this_hash → spanId,
+// event_type → name, agent_instance_id → attributes["agent.id"], plus the
+// payload-derived attributes (tool.name on pre/post_tool_use, decision.type
+// on decision events).
+func TestProjectToSpan_Mapping(t *testing.T) {
+	idx := openTestIndex(t)
+	const (
+		chainID  = "550e8400-e29b-41d4-a716-446655440000"
+		thisHash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+		ts       = "2026-04-30T01:39:37.647Z"
+	)
+	wantTraceID := "550e8400e29b41d4a716446655440000"
+	wantSpanID := "abcdef0123456789"
+
+	cases := []struct {
+		name      string
+		ev        *event.Event
+		wantName  string
+		wantAttrs map[string]string
+	}{
+		{
+			name: "session_start",
+			ev: &event.Event{
+				EventType: "session_start", ChainID: chainID, ThisHash: thisHash,
+				AgentInstanceID: "claude-code-1", Ts: ts,
+				Payload: json.RawMessage(`{}`),
+			},
+			wantName:  "session_start",
+			wantAttrs: map[string]string{"agent.id": "claude-code-1"},
+		},
+		{
+			name: "pre_tool_use",
+			ev: &event.Event{
+				EventType: "pre_tool_use", ChainID: chainID, ThisHash: thisHash,
+				AgentInstanceID: "claude-code-1", Ts: ts,
+				Payload: json.RawMessage(`{"tool_name":"Bash"}`),
+			},
+			wantName: "pre_tool_use",
+			wantAttrs: map[string]string{
+				"agent.id":  "claude-code-1",
+				"tool.name": "Bash",
+			},
+		},
+		{
+			name: "decision",
+			ev: &event.Event{
+				EventType: "decision", ChainID: chainID, ThisHash: thisHash,
+				AgentInstanceID: "claude-code-1", Ts: ts,
+				Payload: json.RawMessage(`{"decision":"deny"}`),
+			},
+			wantName: "decision",
+			wantAttrs: map[string]string{
+				"agent.id":      "claude-code-1",
+				"decision.type": "deny",
+			},
+		},
+		{
+			name: "post_tool_use",
+			ev: &event.Event{
+				EventType: "post_tool_use", ChainID: chainID, ThisHash: thisHash,
+				AgentInstanceID: "claude-code-1", Ts: ts,
+				Payload: json.RawMessage(`{"tool_name":"Bash"}`),
+			},
+			wantName: "post_tool_use",
+			wantAttrs: map[string]string{
+				"agent.id":  "claude-code-1",
+				"tool.name": "Bash",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := projectToSpan(tc.ev, idx)
+			if err != nil {
+				t.Fatalf("projectToSpan: %v", err)
+			}
+			if span.TraceID != wantTraceID {
+				t.Errorf("TraceID: got %q, want %q", span.TraceID, wantTraceID)
+			}
+			if span.SpanID != wantSpanID {
+				t.Errorf("SpanID: got %q, want %q", span.SpanID, wantSpanID)
+			}
+			if span.Name != tc.wantName {
+				t.Errorf("Name: got %q, want %q", span.Name, tc.wantName)
+			}
+			if span.Kind != 1 {
+				t.Errorf("Kind: got %d, want 1 (SPAN_KIND_INTERNAL)", span.Kind)
+			}
+			// startTime == endTime for v1 (point-in-time)
+			if span.StartTimeUnixNano != span.EndTimeUnixNano {
+				t.Errorf("start != end (v1 expects point-in-time): %s vs %s",
+					span.StartTimeUnixNano, span.EndTimeUnixNano)
+			}
+			// nano string is decimal int per OTLP/HTTP+JSON
+			if span.StartTimeUnixNano == "" {
+				t.Errorf("StartTimeUnixNano empty")
+			}
+			gotAttrs := map[string]string{}
+			for _, a := range span.Attributes {
+				gotAttrs[a.Key] = a.Value.StringValue
+			}
+			for k, want := range tc.wantAttrs {
+				if got := gotAttrs[k]; got != want {
+					t.Errorf("attr %s: got %q, want %q", k, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestParentSpanIdRules covers the three parent branches from the spec:
+// within-chain (prev_hash), cross-chain (parent_chain_id), and root (neither).
+func TestParentSpanIdRules(t *testing.T) {
+	idx := openTestIndex(t)
+
+	const parentChainID = "11111111-1111-1111-1111-111111111111"
+	const parentLastHash = "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+	if err := idx.Upsert(parentChainID, 5, parentLastHash); err != nil {
+		t.Fatalf("seed parent chain: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		ev   *event.Event
+		want string
+	}{
+		{
+			name: "within-chain (prev_hash takes precedence)",
+			ev: &event.Event{
+				ChainID:  "child-a",
+				PrevHash: ptr("11112222333344445555666677778888aaaabbbbccccddddeeeeffff00001111"),
+				// parent_chain_id should be ignored in this branch
+				ParentChainID: ptr(parentChainID),
+			},
+			want: "1111222233334444",
+		},
+		{
+			name: "cross-chain (parent_chain_id, prev_hash nil)",
+			ev: &event.Event{
+				ChainID:       "child-b",
+				ParentChainID: ptr(parentChainID),
+			},
+			want: "deadbeef01234567",
+		},
+		{
+			name: "root event of root chain (neither set)",
+			ev:   &event.Event{ChainID: "root"},
+			want: "",
+		},
+		{
+			name: "cross-chain with unknown parent (parent_chain_id set but not in index)",
+			ev: &event.Event{
+				ChainID:       "orphan",
+				ParentChainID: ptr("99999999-9999-9999-9999-999999999999"),
+			},
+			want: "", // graceful: empty parent rather than error
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parentSpanID(tc.ev, idx)
+			if err != nil {
+				t.Fatalf("parentSpanID: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEncodeRequest_Shape sanity-checks the OTLP/HTTP JSON body shape against
+// the spec: lowerCamelCase field names, hex traceId/spanId not base64, decimal
+// nano string. We marshal a single span and parse the JSON back to assert keys.
+func TestEncodeRequest_Shape(t *testing.T) {
+	span := otlpSpan{
+		TraceID:           "550e8400e29b41d4a716446655440000",
+		SpanID:            "abcdef0123456789",
+		ParentSpanID:      "1111222233334444",
+		Name:              "pre_tool_use",
+		Kind:              1,
+		StartTimeUnixNano: "1714521577000000000",
+		EndTimeUnixNano:   "1714521577000000000",
+		Attributes: []otlpAttr{
+			{Key: "agent.id", Value: otlpValue{StringValue: "claude-code-1"}},
+			{Key: "tool.name", Value: otlpValue{StringValue: "Bash"}},
+		},
+	}
+	body, err := encodeRequest([]otlpSpan{span})
+	if err != nil {
+		t.Fatalf("encodeRequest: %v", err)
+	}
+
+	// Hex IDs MUST appear unmodified — base64 encoding would mangle them.
+	bodyStr := string(body)
+	for _, want := range []string{
+		`"traceId":"550e8400e29b41d4a716446655440000"`,
+		`"spanId":"abcdef0123456789"`,
+		`"parentSpanId":"1111222233334444"`,
+		`"startTimeUnixNano":"1714521577000000000"`,
+		`"resourceSpans":`,
+		`"scopeSpans":`,
+		`"service.name"`,
+	} {
+		if !strings.Contains(bodyStr, want) {
+			t.Errorf("body missing %q\nbody: %s", want, bodyStr)
+		}
+	}
+
+	// Forbidden: snake_case (proto field name) instead of lowerCamelCase
+	for _, forbidden := range []string{
+		`"trace_id"`,
+		`"span_id"`,
+		`"parent_span_id"`,
+		`"start_time_unix_nano"`,
+	} {
+		if strings.Contains(bodyStr, forbidden) {
+			t.Errorf("body contains forbidden snake_case key %q", forbidden)
+		}
+	}
+}
+
+// TestEndpointFromEnv covers all three branches: traces-specific env, generic
+// env (with /v1/traces appended), and unset (returns "" → OTEL disabled).
+func TestEndpointFromEnv(t *testing.T) {
+	t.Run("traces-specific env wins", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces.example/x/v1/traces")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic.example")
+		got := endpointFromEnv()
+		if got != "http://traces.example/x/v1/traces" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("generic env appends /v1/traces", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic.example")
+		got := endpointFromEnv()
+		if got != "http://generic.example/v1/traces" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("trims trailing slash on generic env", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic.example/")
+		got := endpointFromEnv()
+		if got != "http://generic.example/v1/traces" {
+			t.Errorf("got %q", got)
+		}
+	})
+	t.Run("unset returns empty (OTEL disabled)", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		if got := endpointFromEnv(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// TestProjectAndPost_RoundtripToTestServer verifies the happy path: spin up
+// an httptest server, point the exporter at it, fire a span, assert the server
+// received a body containing the expected hex traceId.
+func TestProjectAndPost_RoundtripToTestServer(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotBody string
+		gotPath string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		mu.Lock()
+		gotBody = string(buf)
+		gotPath = r.URL.Path
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", srv.URL+"/v1/traces")
+	x := newOTELExporter()
+	if x == nil {
+		t.Fatal("expected exporter, got nil")
+	}
+
+	idx := openTestIndex(t)
+	ev := &event.Event{
+		EventType:       "pre_tool_use",
+		ChainID:         "550e8400-e29b-41d4-a716-446655440000",
+		ThisHash:        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		AgentInstanceID: "claude-code-1",
+		Ts:              "2026-04-30T01:39:37.647Z",
+		Payload:         json.RawMessage(`{"tool_name":"Bash"}`),
+	}
+
+	x.ProjectAndPost(ev, idx)
+	// Wait for the detached goroutine to land. 500ms is plenty for localhost.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := gotBody != ""
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	body, path := gotBody, gotPath
+	mu.Unlock()
+
+	if path != "/v1/traces" {
+		t.Errorf("path: got %q, want /v1/traces", path)
+	}
+	if !strings.Contains(body, `"traceId":"550e8400e29b41d4a716446655440000"`) {
+		t.Errorf("body missing expected traceId\nbody: %s", body)
+	}
+	if !strings.Contains(body, `"tool.name"`) {
+		t.Errorf("body missing tool.name attr\nbody: %s", body)
+	}
+}
+
+// TestProjectAndPost_NilExporterIsNoOp ensures the nil-exporter path doesn't
+// panic. This is the "OTEL disabled" branch — newOTELExporter returns nil
+// when env is unset, and the kernel must continue to function.
+func TestProjectAndPost_NilExporterIsNoOp(t *testing.T) {
+	idx := openTestIndex(t)
+	ev := &event.Event{
+		EventType: "session_start", ChainID: "x", ThisHash: "y",
+		AgentInstanceID: "z", Ts: "2026-04-30T01:39:37Z",
+	}
+	var x *otelExporter // nil
+	x.ProjectAndPost(ev, idx)
+	// Pass = no panic
+}

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -43,10 +43,11 @@ func TestProjectToSpan_Mapping(t *testing.T) {
 	wantSpanID := "abcdef0123456789"
 
 	cases := []struct {
-		name      string
-		ev        *event.Event
-		wantName  string
-		wantAttrs map[string]string
+		name         string
+		ev           *event.Event
+		wantName     string
+		wantAttrs    map[string]string // stringValue attrs
+		wantIntAttrs map[string]string // intValue attrs (decimal string per OTLP)
 	}{
 		{
 			name: "session_start",
@@ -97,6 +98,22 @@ func TestProjectToSpan_Mapping(t *testing.T) {
 				"tool.name": "Bash",
 			},
 		},
+		{
+			name: "post_tool_use with duration_ms (spec attribute)",
+			ev: &event.Event{
+				EventType: "post_tool_use", ChainID: chainID, ThisHash: thisHash,
+				AgentInstanceID: "claude-code-1", Ts: ts,
+				Payload: json.RawMessage(`{"tool_name":"Bash","duration_ms":42}`),
+			},
+			wantName: "post_tool_use",
+			wantAttrs: map[string]string{
+				"agent.id":  "claude-code-1",
+				"tool.name": "Bash",
+			},
+			wantIntAttrs: map[string]string{
+				"duration_ms": "42",
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -126,13 +143,23 @@ func TestProjectToSpan_Mapping(t *testing.T) {
 			if span.StartTimeUnixNano == "" {
 				t.Errorf("StartTimeUnixNano empty")
 			}
-			gotAttrs := map[string]string{}
+			gotStrAttrs := map[string]string{}
+			gotIntAttrs := map[string]string{}
 			for _, a := range span.Attributes {
-				gotAttrs[a.Key] = a.Value.StringValue
+				if a.Value.IntValue != nil {
+					gotIntAttrs[a.Key] = *a.Value.IntValue
+				} else {
+					gotStrAttrs[a.Key] = a.Value.StringValue
+				}
 			}
 			for k, want := range tc.wantAttrs {
-				if got := gotAttrs[k]; got != want {
-					t.Errorf("attr %s: got %q, want %q", k, got, want)
+				if got := gotStrAttrs[k]; got != want {
+					t.Errorf("string attr %s: got %q, want %q", k, got, want)
+				}
+			}
+			for k, want := range tc.wantIntAttrs {
+				if got := gotIntAttrs[k]; got != want {
+					t.Errorf("int attr %s: got %q, want %q", k, got, want)
 				}
 			}
 		})
@@ -205,17 +232,19 @@ func TestParentSpanIdRules(t *testing.T) {
 // the spec: lowerCamelCase field names, hex traceId/spanId not base64, decimal
 // nano string. We marshal a single span and parse the JSON back to assert keys.
 func TestEncodeRequest_Shape(t *testing.T) {
+	durStr := "42"
 	span := otlpSpan{
 		TraceID:           "550e8400e29b41d4a716446655440000",
 		SpanID:            "abcdef0123456789",
 		ParentSpanID:      "1111222233334444",
-		Name:              "pre_tool_use",
+		Name:              "post_tool_use",
 		Kind:              1,
 		StartTimeUnixNano: "1714521577000000000",
 		EndTimeUnixNano:   "1714521577000000000",
 		Attributes: []otlpAttr{
 			{Key: "agent.id", Value: otlpValue{StringValue: "claude-code-1"}},
 			{Key: "tool.name", Value: otlpValue{StringValue: "Bash"}},
+			{Key: "duration_ms", Value: otlpValue{IntValue: &durStr}},
 		},
 	}
 	body, err := encodeRequest([]otlpSpan{span})
@@ -233,6 +262,10 @@ func TestEncodeRequest_Shape(t *testing.T) {
 		`"resourceSpans":`,
 		`"scopeSpans":`,
 		`"service.name"`,
+		// IntValue: per OTLP/HTTP+JSON, int64 attributes encode as decimal string
+		// inside an "intValue" key — distinct from "stringValue".
+		`"intValue":"42"`,
+		`"key":"duration_ms"`,
 	} {
 		if !strings.Contains(bodyStr, want) {
 			t.Errorf("body missing %q\nbody: %s", want, bodyStr)

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -366,3 +366,50 @@ func TestProjectAndPost_NilExporterIsNoOp(t *testing.T) {
 	x.ProjectAndPost(ev, idx)
 	// Pass = no panic
 }
+
+// TestKernelSurvivesOTELFailure verifies the F4 failure invariant: when the
+// configured OTEL endpoint is unreachable, Emit must still return nil, the
+// JSONL line must be written, and the chain index must be updated. The OTEL
+// goroutine fires-and-forgets, errors are logged and dropped.
+//
+// This is the "kernel-write-survives-OTEL-failure" invariant from the spec.
+func TestKernelSurvivesOTELFailure(t *testing.T) {
+	dir, idx := newEnv(t)
+
+	// Refused port (no listener at :1) — the goroutine will get connection refused.
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://127.0.0.1:1/v1/traces")
+
+	logPath := filepath.Join(dir, "events.jsonl")
+	em := Emitter{LogPath: logPath, Index: idx}
+	em.EnableOTELFromEnv()
+	if em.OTEL == nil {
+		t.Fatal("expected OTEL enabled from env, got nil exporter")
+	}
+
+	ev := minimalSessionStart("550e8400-e29b-41d4-a716-446655440000", 0)
+	if err := em.Emit(ev); err != nil {
+		t.Fatalf("Emit must return nil even when OTEL fails: got %v", err)
+	}
+
+	// JSONL line written?
+	lines := readLines(t, logPath)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 JSONL line, got %d", len(lines))
+	}
+	if got, _ := lines[0]["event_type"].(string); got != "session_start" {
+		t.Errorf("event_type: got %q, want session_start", got)
+	}
+
+	// Chain index updated?
+	info, err := idx.Get(ev.ChainID)
+	if err != nil {
+		t.Fatalf("idx.Get: %v", err)
+	}
+	if info == nil || info.LastSeq != 0 || info.LastHash != ev.ThisHash {
+		t.Errorf("chain index not updated: %+v want seq=0 hash=%q", info, ev.ThisHash)
+	}
+
+	// Wait briefly so the goroutine completes (and logs its failure) before
+	// the test exits and t.Setenv unwinds. Avoids noise on test stderr.
+	time.Sleep(100 * time.Millisecond)
+}

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -2,6 +2,7 @@ package emit
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -331,8 +332,10 @@ func TestProjectAndPost_RoundtripToTestServer(t *testing.T) {
 		gotPath string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(buf)
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("server read body: %v", err)
+		}
 		mu.Lock()
 		gotBody = string(buf)
 		gotPath = r.URL.Path
@@ -390,14 +393,15 @@ func TestProjectAndPost_NilExporterIsNoOp(t *testing.T) {
 
 // TestKernelSurvivesOTELFailure verifies the F4 failure invariant: when the
 // configured OTEL endpoint is unreachable, Emit must still return nil, the
-// JSONL line must be written, and the chain index must be updated. The OTEL
-// goroutine fires-and-forgets, errors are logged and dropped.
+// JSONL line must be written, and the chain index must be updated. OTEL
+// export happens synchronously after the durable JSONL/index commit; export
+// errors are logged and dropped.
 //
 // This is the "kernel-write-survives-OTEL-failure" invariant from the spec.
 func TestKernelSurvivesOTELFailure(t *testing.T) {
 	dir, idx := newEnv(t)
 
-	// Refused port (no listener at :1) — the goroutine will get connection refused.
+	// Refused port (no listener at :1) makes the synchronous OTEL POST fail fast.
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://127.0.0.1:1/v1/traces")
 
 	logPath := filepath.Join(dir, "events.jsonl")

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
@@ -325,18 +324,7 @@ func TestProjectAndPost_RoundtripToTestServer(t *testing.T) {
 		Payload:         json.RawMessage(`{"tool_name":"Bash"}`),
 	}
 
-	x.ProjectAndPost(ev, idx)
-	// Wait for the detached goroutine to land. 500ms is plenty for localhost.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		done := gotBody != ""
-		mu.Unlock()
-		if done {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	x.ProjectAndPost(ev, idx) // sync — returns after the POST completes
 
 	mu.Lock()
 	body, path := gotBody, gotPath
@@ -387,6 +375,9 @@ func TestKernelSurvivesOTELFailure(t *testing.T) {
 	}
 
 	ev := minimalSessionStart("550e8400-e29b-41d4-a716-446655440000", 0)
+	// Emit blocks for the OTEL POST (sync v1) — the http.Client timeout caps
+	// this at 2s. Connection refused is faster than that, so this returns
+	// quickly. The chain commit ran before the OTEL POST began.
 	if err := em.Emit(ev); err != nil {
 		t.Fatalf("Emit must return nil even when OTEL fails: got %v", err)
 	}
@@ -408,8 +399,4 @@ func TestKernelSurvivesOTELFailure(t *testing.T) {
 	if info == nil || info.LastSeq != 0 || info.LastHash != ev.ThisHash {
 		t.Errorf("chain index not updated: %+v want seq=0 hash=%q", info, ev.ThisHash)
 	}
-
-	// Wait briefly so the goroutine completes (and logs its failure) before
-	// the test exits and t.Setenv unwinds. Avoids noise on test stderr.
-	time.Sleep(100 * time.Millisecond)
 }

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -13,6 +13,12 @@ import (
 // gov package from internal/cost and internal/tier (which import gov for
 // Action). Wire them in at the cmd layer; nil means "default behavior":
 // tier=Unset, delta={ToolCalls:1}.
+//
+// OnDecision is the F4-addendum callback that fires after WriteLog with
+// the final Decision. The CLI layer wires it to emit a `decision` chain
+// event via the canonical emit path, so F4's OTEL projection picks up
+// every gated action across every driver. Optional; nil preserves the
+// pre-F4 audit-log-only behavior.
 type Gate struct {
 	Policy       Policy
 	Counter      *Counter
@@ -20,6 +26,7 @@ type Gate struct {
 	Cwd          string
 	EstimateCost func(a Action, agent string) CostDelta
 	ClassifyTier func(a Action) Tier
+	OnDecision   func(d *Decision)
 }
 
 // Evaluate is the single entry point: normalize-already-done Action →
@@ -59,6 +66,9 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decisi
 		}
 		stampEnvelope(&d, envelope, g, a, agent)
 		_ = WriteLog(d, g.LogDir)
+		if g.OnDecision != nil {
+			g.OnDecision(&d)
+		}
 		return d
 	}
 
@@ -148,6 +158,14 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decisi
 
 	// 8. Log.
 	_ = WriteLog(d, g.LogDir)
+
+	// 9. F4 addendum: emit a `decision` chain event via the wired callback,
+	// if any. Fires after WriteLog so the audit log is durable first; the
+	// callback's failure (if any) is the CLI layer's concern, never affects
+	// the Decision returned to the caller.
+	if g.OnDecision != nil {
+		g.OnDecision(&d)
+	}
 
 	return d
 }

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -67,7 +67,9 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decisi
 		stampEnvelope(&d, envelope, g, a, agent)
 		_ = WriteLog(d, g.LogDir)
 		if g.OnDecision != nil {
-			g.OnDecision(&d)
+			// Pass a copy so callbacks can't mutate the Decision the caller sees.
+			dCopy := d
+			g.OnDecision(&dCopy)
 		}
 		return d
 	}
@@ -162,9 +164,11 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decisi
 	// 9. F4 addendum: emit a `decision` chain event via the wired callback,
 	// if any. Fires after WriteLog so the audit log is durable first; the
 	// callback's failure (if any) is the CLI layer's concern, never affects
-	// the Decision returned to the caller.
+	// the Decision returned to the caller. Pass a copy so callbacks can't
+	// mutate the Decision the caller sees.
 	if g.OnDecision != nil {
-		g.OnDecision(&d)
+		dCopy := d
+		g.OnDecision(&dCopy)
 	}
 
 	return d

--- a/go/execution-kernel/internal/gov/gate_test.go
+++ b/go/execution-kernel/internal/gov/gate_test.go
@@ -105,3 +105,72 @@ func TestGate_MonitorModeAllowsButLogs(t *testing.T) {
 		t.Errorf("Mode: got %q want monitor", d.Mode)
 	}
 }
+
+// TestGate_OnDecisionFiresOnAllow / Deny / Lockdown verify the F4 addendum
+// callback is invoked exactly once per Evaluate call, with the final
+// Decision (post-bounds, post-monitor-override, post-stamp). Three cases
+// cover the three exit paths through Evaluate.
+func TestGate_OnDecisionFiresOnAllow(t *testing.T) {
+	g, _ := newTestGate(t)
+	var calls []Decision
+	g.OnDecision = func(d *Decision) { calls = append(calls, *d) }
+
+	g.Evaluate(Action{Type: ActFileRead, Target: "/tmp/x"}, "agent1", nil)
+
+	if len(calls) != 1 {
+		t.Fatalf("OnDecision: got %d calls, want 1", len(calls))
+	}
+	if !calls[0].Allowed {
+		t.Errorf("OnDecision callback received Decision.Allowed=false, want true")
+	}
+	if calls[0].Action.Type != ActFileRead {
+		t.Errorf("OnDecision Action.Type: got %q want %q", calls[0].Action.Type, ActFileRead)
+	}
+}
+
+func TestGate_OnDecisionFiresOnDeny(t *testing.T) {
+	g, _ := newTestGate(t)
+	var calls []Decision
+	g.OnDecision = func(d *Decision) { calls = append(calls, *d) }
+
+	g.Evaluate(Action{Type: ActShellExec, Target: "rm -rf go/"}, "agent1", nil)
+
+	if len(calls) != 1 {
+		t.Fatalf("OnDecision: got %d calls, want 1", len(calls))
+	}
+	if calls[0].Allowed {
+		t.Errorf("OnDecision callback received Allowed=true, want false")
+	}
+	if calls[0].RuleID != "no-rm" {
+		t.Errorf("OnDecision RuleID: got %q want no-rm", calls[0].RuleID)
+	}
+}
+
+func TestGate_OnDecisionFiresOnLockdown(t *testing.T) {
+	g, _ := newTestGate(t)
+	g.Counter.Lockdown("agent1")
+
+	var calls []Decision
+	g.OnDecision = func(d *Decision) { calls = append(calls, *d) }
+
+	g.Evaluate(Action{Type: ActFileRead, Target: "/tmp/x"}, "agent1", nil)
+
+	if len(calls) != 1 {
+		t.Fatalf("OnDecision (lockdown path): got %d calls, want 1", len(calls))
+	}
+	if calls[0].RuleID != "lockdown" {
+		t.Errorf("OnDecision lockdown RuleID: got %q want lockdown", calls[0].RuleID)
+	}
+}
+
+// TestGate_OnDecisionNilIsSafe ensures pre-F4 behavior is preserved when
+// the callback is not wired — Evaluate must not panic and the audit log
+// path must still run.
+func TestGate_OnDecisionNilIsSafe(t *testing.T) {
+	g, _ := newTestGate(t)
+	// g.OnDecision left nil
+	d := g.Evaluate(Action{Type: ActFileRead, Target: "/tmp/x"}, "agent1", nil)
+	if !d.Allowed {
+		t.Errorf("Evaluate with nil OnDecision must still produce a Decision: %+v", d)
+	}
+}


### PR DESCRIPTION
## Summary

Ships the F4 thin OTEL emit MVP — chitin's canonical event chain projected onto OTLP/HTTP JSON spans and POSTed to a configured collector. Talk demo beat for 2026-05-07 ("Copilot CLI Without Fear"). Parallel slice to cost-gov v3; does not bloat that work.

The chain is canonical; OTEL is a one-way projection. No policy depends on OTEL data. OTEL emit failure never affects kernel JSONL/index commit.

## What's in scope (locked by framing v1, 2026-04-29)

- **4 event types:** `session_start`, `pre_tool_use`, `decision`, `post_tool_use`
- **Transport:** OTLP/HTTP JSON only
- **Mapping:** `chain_id → traceId` (32 hex), `this_hash → spanId` (16 hex), parent rule covers within-chain (`prev_hash`) and cross-chain (`parent_chain_id`) branches plus root
- **Config:** `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var (with `OTEL_EXPORTER_OTLP_ENDPOINT` fallback). Unset → OTEL disabled.
- **Failure invariant:** chain commit completes before OTEL POST begins. OTEL errors logged and dropped.

## What's out of scope (deferred post-talk)

Full `gen_ai.*` semconv, OTLP-grpc, batching, retries beyond basic timeout, multi-exporter, mTLS/auth, sampling, span events/links, error span status codes, backfill paths (`cmdIngestTranscript`, `cmdIngestOTEL`, `cmdIngestHermes` intentionally not wired — past timestamps would confuse a live trace view).

## Da Vinci gate (observation reshaped the design)

Original spec said "async, fire-and-forget." First end-to-end run against the receiver fixture at `docs/observations/fixtures/2026-04-20-openclaw-otel-capture/receiver.py` showed an empty capture dir — the kernel is a short-lived CLI per emit, so a detached goroutine never delivers. Switched to sync POST after `tx.Commit`. The failure invariant still holds (chain state durable before the network call). Daemon-mode async is deferred to v2. Documented in spec §"Sync vs async (revised post-integration)".

End-to-end verification with two-event chain:
- Event 1 (session_start): `parentSpanId` absent (root branch ✓)
- Event 2 (pre_tool_use): `parentSpanId` = first 16 hex of event 1's `this_hash` (within-chain branch ✓)
- Both share `traceId` = chain_id with hyphens stripped ✓

## Tests

12 emit-package tests green (6 new for F4, 5 existing, 1 new survival test); full kernel suite (18 packages) green.

- `TestProjectToSpan_Mapping` — table-driven over the 4 event types
- `TestParentSpanIdRules` — within-chain, cross-chain, root, unknown-parent graceful path
- `TestEncodeRequest_Shape` — hex IDs not base64, lowerCamelCase not snake_case
- `TestEndpointFromEnv` — 4 branches of env resolution (specific / generic / trim / unset)
- `TestProjectAndPost_RoundtripToTestServer` — real `httptest` HTTP roundtrip
- `TestProjectAndPost_NilExporterIsNoOp` — disabled-OTEL safety branch
- `TestKernelSurvivesOTELFailure` — refused endpoint → Emit returns nil, JSONL written, chain index updated

External contract verified before coding (lowerCamelCase, hex trace/span IDs not base64, decimal nano strings, body shape `ExportTraceServiceRequest`) — citation in `otel.go`.

## Files

- `go/execution-kernel/internal/emit/otel.go` (new) — projector + OTLP/HTTP JSON encoder + post + env config
- `go/execution-kernel/internal/emit/otel_test.go` (new) — 7 tests
- `go/execution-kernel/internal/emit/emit.go` — Emitter gains `OTEL` field + `EnableOTELFromEnv` helper; `Emit` calls `e.OTEL.ProjectAndPost` after `tx.Commit`
- `go/execution-kernel/cmd/chitin-kernel/main.go` — `cmdEmit` calls `em.EnableOTELFromEnv()`
- `docs/superpowers/specs/2026-04-29-otel-emit-mvp-design.md` (new) — spec
- `docs/superpowers/plans/2026-04-29-otel-emit-mvp.md` (new) — plan
- `docs/superpowers/specs/2026-04-20-otel-genai-ingest-workstream-design.md` — SUPERSEDED header (G2 cleanup byproduct)
- `docs/superpowers/demo-runbook.md` — F4 OTEL trace beat section between Demo 5 and the wrap

## Test plan

- [ ] CI green
- [ ] Copilot review (heuristic scanner; signal mostly noise per memory)
- [ ] Adversarial review (the real signal — `/review` skill against the diff)
- [ ] Manual demo runbook walkthrough on demo-eve (T-30 from talk)
- [ ] Spec hard-floor: 4 event types projected, 3-branch parent rule, env-var config, kernel-survives-OTEL-failure invariant — all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)