### PR TITLE
feat(normalize): map openclaw pi-runtime tool names to canonical actions

### DIFF
--- a/go/execution-kernel/internal/gov/normalize.go
+++ b/go/execution-kernel/internal/gov/normalize.go
@@ -24,12 +24,31 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 	switch toolName {
 	case "terminal", "bash", "shell":
 		return normalizeShell(args), nil
+	// openclaw pi-runtime core tools — same shape as terminal/bash/shell.
+	// `exec` runs a shell command via the gateway; `process` is the same
+	// surface for backgrounded/long-running commands. Both carry `cmd` (or
+	// `command`) so normalizeShell handles them uniformly.
+	case "exec", "process":
+		return normalizeShell(args), nil
 	case "execute_code":
 		return normalizeExecuteCode(args), nil
 	case "write_file", "patch":
 		return normalizeWriteFile(args), nil
+	// openclaw pi-runtime file tools. `write` creates/overwrites; `edit`
+	// modifies in-place. Both end at file.write because both are mutations
+	// from the policy's perspective — the existing `write_file` mapping
+	// already encodes that policy.
+	case "write", "edit":
+		return normalizeWriteFile(args), nil
 	case "read_file":
 		return Action{Type: ActFileRead, Target: stringArg(args, "path")}, nil
+	case "read":
+		// openclaw pi-runtime read tool — path-based file read.
+		path := stringArg(args, "path")
+		if path == "" {
+			path = stringArg(args, "file_path")
+		}
+		return Action{Type: ActFileRead, Target: path}, nil
 	case "delegate_task":
 		return Action{Type: ActDelegateTask, Target: stringArg(args, "goal")}, nil
 	case "search_files":

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -310,3 +310,96 @@ func TestNormalize_TerminalReadOnly(t *testing.T) {
 		}
 	}
 }
+
+// openclaw pi-runtime tool names — closes the "exec/process/read/write/edit
+// fall through to ActUnknown" gap that left the openclaw plugin gating with
+// default-deny-unknown instead of policy-meaningful action types.
+//
+// Invariant: an exec/process call with the same command as a terminal call
+// produces the same Action — one rule catches all routes (bypass closure).
+
+func TestNormalize_OpenclawExec(t *testing.T) {
+	// Same shape as terminal: passes cmd, lands on shell.exec.
+	a, _ := Normalize("exec", map[string]any{"cmd": "echo gate-fired"})
+	if a.Type != ActShellExec {
+		t.Errorf("Type: got %q want shell.exec", a.Type)
+	}
+	if a.Target != "echo gate-fired" {
+		t.Errorf("Target: got %q want %q", a.Target, "echo gate-fired")
+	}
+}
+
+func TestNormalize_OpenclawExec_RmRfIsDangerous(t *testing.T) {
+	// Bypass closure: openclaw `exec` and `terminal` must produce the same
+	// Action for the same command. If a future rule denies `rm -rf` via
+	// terminal, it must also deny it via exec — same fingerprint.
+	terminalA, _ := Normalize("terminal", map[string]any{"command": "rm -rf go/"})
+	execA, _ := Normalize("exec", map[string]any{"cmd": "rm -rf go/"})
+	if terminalA.Type != execA.Type {
+		t.Errorf("terminal/exec divergence: terminal=%q exec=%q", terminalA.Type, execA.Type)
+	}
+	if terminalA.Fingerprint() != execA.Fingerprint() {
+		t.Errorf("fingerprint divergence: terminal=%s exec=%s",
+			terminalA.Fingerprint(), execA.Fingerprint())
+	}
+}
+
+func TestNormalize_OpenclawProcess(t *testing.T) {
+	// `process` is openclaw's long-running/backgrounded shell tool —
+	// same command shape, same gate decision.
+	a, _ := Normalize("process", map[string]any{"cmd": "tail -f /var/log/syslog"})
+	if a.Type != ActShellExec {
+		t.Errorf("Type: got %q want shell.exec", a.Type)
+	}
+}
+
+func TestNormalize_OpenclawWrite(t *testing.T) {
+	a, _ := Normalize("write", map[string]any{"path": "/tmp/foo.txt", "content": "hi"})
+	if a.Type != ActFileWrite {
+		t.Errorf("Type: got %q want file.write", a.Type)
+	}
+	if a.Target != "/tmp/foo.txt" {
+		t.Errorf("Target: got %q", a.Target)
+	}
+}
+
+func TestNormalize_OpenclawEdit(t *testing.T) {
+	// `edit` is in-place mutation; same policy class as `write`.
+	a, _ := Normalize("edit", map[string]any{"path": "/etc/hosts"})
+	if a.Type != ActFileWrite {
+		t.Errorf("Type: got %q want file.write (edit is mutation)", a.Type)
+	}
+	if a.Target != "/etc/hosts" {
+		t.Errorf("Target: got %q", a.Target)
+	}
+}
+
+func TestNormalize_OpenclawRead(t *testing.T) {
+	a, _ := Normalize("read", map[string]any{"path": "/etc/passwd"})
+	if a.Type != ActFileRead {
+		t.Errorf("Type: got %q want file.read", a.Type)
+	}
+	if a.Target != "/etc/passwd" {
+		t.Errorf("Target: got %q", a.Target)
+	}
+}
+
+func TestNormalize_OpenclawRead_FilePathAlias(t *testing.T) {
+	// Some openclaw schemas use file_path; both should be accepted.
+	a, _ := Normalize("read", map[string]any{"file_path": "/etc/hostname"})
+	if a.Target != "/etc/hostname" {
+		t.Errorf("file_path alias not honored: got %q", a.Target)
+	}
+}
+
+func TestNormalize_OpenclawTools_NoLongerUnknown(t *testing.T) {
+	// Regression: each of these used to fall into ActUnknown and trip
+	// default-deny-unknown. After the openclaw mappings, none should be
+	// ActUnknown — they get policy-meaningful types.
+	for _, tool := range []string{"exec", "process", "read", "write", "edit"} {
+		a, _ := Normalize(tool, map[string]any{"cmd": "noop", "path": "/tmp/x"})
+		if a.Type == ActUnknown {
+			t.Errorf("%s still maps to ActUnknown — normalizer mapping missing", tool)
+		}
+	}
+}

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -329,10 +329,12 @@ func TestNormalize_OpenclawExec(t *testing.T) {
 	}
 }
 
-func TestNormalize_OpenclawExec_RmRfIsDangerous(t *testing.T) {
+func TestNormalize_OpenclawExec_BypassClosure(t *testing.T) {
 	// Bypass closure: openclaw `exec` and `terminal` must produce the same
-	// Action for the same command. If a future rule denies `rm -rf` via
-	// terminal, it must also deny it via exec — same fingerprint.
+	// Action (Type + Fingerprint) for the same command, so one policy rule
+	// catches both surfaces. This test does NOT assert the resulting type
+	// is "dangerous" — `rm -rf` is just a representative command. The
+	// invariant under test is parity, not classification.
 	terminalA, _ := Normalize("terminal", map[string]any{"command": "rm -rf go/"})
 	execA, _ := Normalize("exec", map[string]any{"cmd": "rm -rf go/"})
 	if terminalA.Type != execA.Type {


### PR DESCRIPTION
## Summary

Closes the gap that left the openclaw governance plugin (PR #81) gating with `default-deny-unknown` instead of policy-meaningful action types. The slice 2 plugin hooks pi-runtime's `before_tool_call` event correctly, but openclaw's pi-runtime exposes its core tools under names chitin's normalizer didn't recognize (`exec`, `process`, `read`, `write`, `edit`). All of these fell through to `ActUnknown` so no rule could match the underlying intent.

## Mappings added

| openclaw tool | maps to | rationale |
|---|---|---|
| `exec`, `process` | `normalizeShell` (→ `shell.exec` etc.) | same shape as `terminal/bash/shell` — carries `cmd`/`command` |
| `write`, `edit` | `normalizeWriteFile` (→ `file.write`) | both are mutations from the policy's perspective |
| `read` | `ActFileRead` (with `path` / `file_path` alias) | path-based file read |

Bypass closure verified: same command via `terminal` and `exec` produces identical `Action` and `Fingerprint`, so any rule that catches one catches the other. This is the same invariant as `terminal`/`execute_code` — one rule covers all routes.

## End-to-end verified post-rebuild

Temporal workflow `smoke-exec-mapped-1777669056` dispatched local LLM via openclaw → `exec` tool → `before_tool_call` hook → kernel.

**Before this change:** `agent=main, type=unknown, target=exec, rule=default-deny-unknown`
**After this change:**  `agent=main, type=shell.exec, target="echo gated-via-openclaw", rule=default-allow-shell, allowed=true`

Recorded at `2026-05-01T20:59:22Z` in `~/.chitin/gov-decisions-2026-05-01.jsonl`.

## Test plan

- [x] 8 new tests in `gov/normalize_test.go`:
  - per-tool mapping (`exec`, `process`, `write`, `edit`, `read`)
  - `file_path` alias for `read`
  - fingerprint parity between `terminal` and `exec` (bypass closure)
  - regression: none of `exec/process/read/write/edit` map to `ActUnknown` anymore
- [x] All `internal/gov/...` tests pass locally
- [x] kernel rebuilt and tested live: `chitin-kernel gate evaluate -agent openclaw-plugin -tool exec -args-json '{"cmd":"echo ..."}' ` returns `action_type=shell.exec, allowed=true, rule_id=default-allow-shell`
- [x] Temporal workflow → openclaw → local LLM → exec → gate fire confirmed in chain
- [ ] CI green
- [ ] Copilot review
- [ ] Adversarial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)