### PR TITLE
gov: allow github.pr.merge in default-allow-github-write rule

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -97,7 +97,7 @@ rules:
     reason: "GitHub read-only operations allowed"
 
   - id: default-allow-github-write
-    action: [github.issue.create, github.issue.close, github.pr.create, github.pr.close]
+    action: [github.issue.create, github.issue.close, github.pr.create, github.pr.close, github.pr.merge]
     effect: allow
     reason: "GitHub state-changing operations allowed (bounds still apply to pr.create)"
 


### PR DESCRIPTION
Closes vocabulary gap so `gh pr merge` no longer falls through to default-deny. Implements `gov-policy-allow-pr-merge` from `docs/swarm-backlog.md`. First end-to-end run via the slice-5b claude-code-headless driver — chitin.yaml edit produced by `claude -p --dangerously-skip-permissions`, gated by the existing chitin PreToolUse hook (PR #66), branch pushed by the slice-5 apply pipeline.

---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-pr-merge-cch-1777684679`
Branch: `swarm/swarm-pr-merge-cch-1777684679`
Head: `25d0b3de`
Diff: `1 file changed, 1 insertion(+), 1 deletion(-)`
Commits: 1