### PR TITLE
feat(slice-5b): claude-code-headless as a worker driver — corrects 2026-04-30 ToS misread

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -40,6 +40,13 @@ function resolveAgent(driver: DriverId): string {
   return DRIVER_AGENT_MAP[driver] ?? 'main';
 }
 
+// Tools the headless Claude Code session is allowed to dispatch. Mirrors
+// the chat-domain coverage chitin's normalizer recognizes (read/edit/write/
+// bash) so every tool call still hits a policy-meaningful action_type.
+// Override per request via CHITIN_CLAUDE_ALLOWED_TOOLS env var if you need
+// a tighter scope (e.g., 'Read,Edit' only).
+const DEFAULT_CLAUDE_ALLOWED_TOOLS = 'Read,Edit,Write,Bash,Glob,Grep';
+
 function planInvocation(req: ExecutionRequest): DriverInvocation {
   const driver: DriverId = req.allowed_drivers[0];
   switch (driver) {
@@ -47,6 +54,26 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
       return {
         command: 'chitin-kernel',
         args: ['drive', 'copilot', req.prompt],
+      };
+    case 'claude-code-headless':
+      // Anthropic publishes this as the supported pattern for unattended
+      // runs (see code.claude.com/docs/en/headless). Spawned in the
+      // worktree (when base_ref is set on the request) so edits land on
+      // a real branch. The existing claude-code adapter PreToolUse hook
+      // (PR #66) gates every tool call — same enforcement plane as the
+      // interactive surface, just no human in the loop. The
+      // --dangerously-skip-permissions flag bypasses Claude Code's own
+      // interactive permission prompts; chitin's gate is the actual
+      // policy boundary.
+      return {
+        command: 'claude',
+        args: [
+          '-p', req.prompt,
+          '--dangerously-skip-permissions',
+          '--allowedTools', process.env.CHITIN_CLAUDE_ALLOWED_TOOLS ?? DEFAULT_CLAUDE_ALLOWED_TOOLS,
+          '--output-format', 'stream-json',
+          '--verbose',
+        ],
       };
     case 'local-qwen':
     case 'local-glm':

--- a/apps/temporal-worker/test/activity.test.ts
+++ b/apps/temporal-worker/test/activity.test.ts
@@ -58,6 +58,38 @@ describe('planInvocation', () => {
     const bad = { ...baseReq, allowed_drivers: ['gpt-5'] } as unknown as ExecutionRequest;
     expect(() => planInvocation(bad)).toThrow(/unknown driver/);
   });
+
+  // Slice 5b: claude-code-headless dispatch.
+  it('dispatches claude-code-headless via the `claude` CLI in headless mode', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'] });
+    expect(plan.command).toBe('claude');
+    expect(plan.args).toContain('-p');
+    expect(plan.args).toContain(baseReq.prompt);
+    expect(plan.args).toContain('--dangerously-skip-permissions');
+    expect(plan.args).toContain('--output-format');
+    expect(plan.args).toContain('stream-json');
+  });
+
+  it('claude-code-headless includes a default --allowedTools scope', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'] });
+    const idx = plan.args.indexOf('--allowedTools');
+    expect(idx).toBeGreaterThan(-1);
+    const value = plan.args[idx + 1];
+    expect(value).toMatch(/Read|Edit|Bash/);
+  });
+
+  it('honors CHITIN_CLAUDE_ALLOWED_TOOLS env override for tighter scope', () => {
+    const saved = process.env.CHITIN_CLAUDE_ALLOWED_TOOLS;
+    process.env.CHITIN_CLAUDE_ALLOWED_TOOLS = 'Read,Edit';
+    try {
+      const plan = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'] });
+      const idx = plan.args.indexOf('--allowedTools');
+      expect(plan.args[idx + 1]).toBe('Read,Edit');
+    } finally {
+      if (saved === undefined) delete process.env.CHITIN_CLAUDE_ALLOWED_TOOLS;
+      else process.env.CHITIN_CLAUDE_ALLOWED_TOOLS = saved;
+    }
+  });
 });
 
 describe('resolvePolicySrc', () => {

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -11,10 +11,20 @@ export const TaskClassSchema = z.enum([
 
 export const RiskLevelSchema = z.enum(['low', 'medium', 'high', 'irreversible']);
 
-// Anthropic ToS forbids Claude Code as a worker driver — interactive CLI / /schedule only.
-// Schema is the contract boundary; reject at parse, not at dispatch.
+// Driver tiers for the swarm. The 2026-04-30 framing that excluded
+// `claude-code` was based on a misread of Anthropic's terms — verified
+// 2026-05-02 against code.claude.com/docs/en/headless that headless mode
+// (`claude -p ... --dangerously-skip-permissions`) is officially supported
+// for unattended/CI/cron use. The interactive CLI surface is a separate
+// thing and not represented in this enum (you don't programmatically
+// dispatch interactive sessions; they're always Jared-driven).
+//
+// claude-code-headless joins as the strongest programmatic tier (T4 in
+// swarm-backlog.md), distinct from `copilot` (T1-T3 depending on Copilot
+// model) and the local-* drivers (T0/T2).
 export const DriverIdSchema = z.enum([
   'copilot',
+  'claude-code-headless',
   'local-qwen',
   'local-glm',
   'local-deepseek',

--- a/libs/contracts/tests/execution-request.schema.test.ts
+++ b/libs/contracts/tests/execution-request.schema.test.ts
@@ -41,9 +41,19 @@ describe('ExecutionRequestSchema', () => {
     expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
   });
 
-  it('rejects claude-code as a worker driver (Anthropic ToS — interactive only)', () => {
+  it('rejects bare claude-code as a worker driver (use claude-code-headless)', () => {
+    // The interactive Claude Code surface is not a programmatic driver —
+    // there's no spawn pattern for it. Headless mode is the supported
+    // unattended path (see project_anthropic_tos_constraints.md, corrected
+    // 2026-05-02). Reject the unqualified id to force callers to be
+    // explicit about which surface they mean.
     const bad = { ...validRequest, allowed_drivers: ['claude-code' as never] };
     expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('accepts claude-code-headless as a worker driver (slice 5b — Anthropic-supported headless mode)', () => {
+    const ok = { ...validRequest, allowed_drivers: ['claude-code-headless' as const] };
+    expect(() => ExecutionRequestSchema.parse(ok)).not.toThrow();
   });
 
   it('rejects malformed repo (missing owner)', () => {


### PR DESCRIPTION
## Summary

Reverses the 2026-04-30 framing that excluded Claude Code from the worker driver enum. Adds `claude-code-headless` as the strongest programmatic tier (T4) in the swarm.

**The misread:** memory `project_anthropic_tos_constraints.md` (locked 2026-04-30) claimed "Claude Code as a worker driver violates Anthropic ToS." That conclusion drove PR #81's removal of `claude-code` from `DriverIdSchema` plus the entire "openclaw is the worker substrate, Claude Code is interactive only" framing.

**The actual constraint** (verified 2026-05-02 against code.claude.com/docs/en/headless): headless mode is officially supported for unattended / CI/CD / cron use. The published flags are `-p`/`--print`, `--dangerously-skip-permissions`, `--allowedTools`, `--output-format stream-json`, `--max-turns`, `--max-budget-usd`. The AUP prohibits account/credential sharing, rate-limit evasion, scraping, and using the API to train competing models — none of which describe "Jared's machine runs `claude -p` against his own account on a Temporal cron." Usage just counts against normal plan limits.

## End-to-end verified live

The swarm produced **its own PR** for the slice 4 grooming-promoted T0 entry `gov-policy-allow-pr-merge`:

```
workflow:    swarm-pr-merge-cch-1777684679
driver:      claude-code-headless
base_ref:    main
worktree:    ~/.cache/chitin/swarm-worktrees/swarm-pr-merge-cch-1777684679
agent edit:  chitin.yaml (1 file changed, 1 insertion(+), 1 deletion(-))
agent commit: 25d0b3d
duration:    15s agent + ~3s apply
cost:        $0.20 (Claude Opus 4.7)
permission_denials: []
result:      PR #94 (opened by the swarm)
```

This is the first time the swarm closed the loop on **real engineering work** — agent decided the change, made it, committed, the apply pipeline pushed and PR'd. PR #94 stands on its own as the actual fix.

## Schema (`libs/contracts/src/execution-request.schema.ts`)

`DriverIdSchema` adds `'claude-code-headless'`. The bare `'claude-code'` id stays rejected — that's the interactive surface, no programmatic spawn pattern, callers must be explicit about which they mean.

## Activity dispatch (`apps/temporal-worker/src/activity.ts`)

```ts
case 'claude-code-headless':
  return {
    command: 'claude',
    args: [
      '-p', req.prompt,
      '--dangerously-skip-permissions',
      '--allowedTools', process.env.CHITIN_CLAUDE_ALLOWED_TOOLS ?? DEFAULT_CLAUDE_ALLOWED_TOOLS,
      '--output-format', 'stream-json',
      '--verbose',
    ],
  };
```

`DEFAULT_CLAUDE_ALLOWED_TOOLS = 'Read,Edit,Write,Bash,Glob,Grep'`. Override via `CHITIN_CLAUDE_ALLOWED_TOOLS` for tighter per-task scope.

The existing claude-code adapter PreToolUse hook (PR #66) gates every tool call — same enforcement plane as the interactive surface, just no human in the loop. `--dangerously-skip-permissions` bypasses **Claude Code's own** interactive prompts; **chitin's gate is the actual policy boundary** and still fires. Permission-denial = chitin policy says no, not "user didn't approve."

## Closes slice-5 demo gaps

PR #93 documented two "Known limitations" that blocked the slice-5 real-work demo:

1. **Copilot driver permission denial** — in-process Copilot SDK asked the user per-edit; worker has no user. Headless Claude Code has no equivalent gap because it explicitly supports `--dangerously-skip-permissions` for unattended runs.
2. **openclaw agent cwd ≠ process cwd** — qwen-agent's view of "current directory" was its own openclaw workspace, not the spawned cwd. Headless Claude Code respects the spawned process cwd as its working directory; the agent saw chitin.yaml in the worktree without any extra plumbing.

Both gaps are now bypassed by the new driver, not "fixed" — the underlying issues remain real for their respective drivers, but the swarm has a path that works today.

## Test plan

- [x] 2 new schema tests (accept `claude-code-headless`, reject bare `claude-code`)
- [x] 3 new activity-dispatch tests (CLI shape, default `--allowedTools` includes Read/Edit/Bash, env override honored)
- [x] 132/132 vitest tests pass
- [x] `pnpm exec tsc -p apps/temporal-worker/tsconfig.json --noEmit` clean
- [x] End-to-end live (PR #94 opened by the swarm)
- [ ] Copilot review
- [ ] Adversarial review

## Memory updated

`project_anthropic_tos_constraints.md` flipped from "BANNED" to "headless IS supported" with full audit trail of the misread + correction. Includes a meta-note: any future "X is banned by ToS" claim in this project's memory needs verification against authoritative sources before propagating — this exact mistake cost a slice's worth of architecture.

## Cost calibration data point

$0.20 per agent turn at Claude Opus 4.7 for a single-file YAML edit + commit. That's high for a T0; would be cheaper at Haiku or Sonnet via `--model`. Worth a follow-up issue (`claude-code-headless-model-routing`) to expose `--model` as a per-driver knob and route by tier (T4 = Opus, T3 = Sonnet, T2 = Haiku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)