### PR TITLE
feat(slice-6): tier model routing + claude-code worktree gating + openclaw cwd alignment

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -1,8 +1,8 @@
 import { spawn, execFileSync } from 'node:child_process';
-import { mkdtempSync, copyFileSync, existsSync, rmSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, copyFileSync, existsSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import type { ExecutionRequest, DriverId } from '@chitin/contracts';
+import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
 import type { ActivityResult, WorktreeResult } from './activity-types.ts';
 
 // Bytes of stdout/stderr returned to Temporal in ActivityResult. Buffers
@@ -47,34 +47,82 @@ function resolveAgent(driver: DriverId): string {
 // a tighter scope (e.g., 'Read,Edit' only).
 const DEFAULT_CLAUDE_ALLOWED_TOOLS = 'Read,Edit,Write,Bash,Glob,Grep';
 
+// Slice 6c: tier → model maps per driver. T0/T1 use the cheap fast
+// models; T4 uses the strongest. Drivers that route via a per-agent
+// configured model (the local-* tier through openclaw) ignore the tier
+// — its model is set at agent-creation time, not per call. Override by
+// setting CHITIN_MODEL_<DRIVER>_<TIER> for tactical experimentation.
+const CLAUDE_TIER_MODEL: Record<Tier, string> = {
+  T0: 'claude-haiku-4-5',
+  T1: 'claude-haiku-4-5',
+  T2: 'claude-sonnet-4-6',
+  T3: 'claude-sonnet-4-6',
+  T4: 'claude-opus-4-7',
+};
+
+const COPILOT_TIER_MODEL: Record<Tier, string> = {
+  T0: 'gpt-4.1',
+  T1: 'gpt-4.1',
+  T2: 'claude-haiku-4.5',
+  T3: 'claude-sonnet-4.6',
+  T4: 'claude-opus-4.7',
+};
+
+function envOverride(driverEnvKey: string, tier: Tier): string | undefined {
+  const v = process.env[`CHITIN_MODEL_${driverEnvKey}_${tier}`];
+  return v && v.trim() ? v.trim() : undefined;
+}
+
+function resolveClaudeModel(tier: Tier | undefined): string | null {
+  if (!tier) return null;
+  return envOverride('CLAUDE_CODE_HEADLESS', tier) ?? CLAUDE_TIER_MODEL[tier];
+}
+
+function resolveCopilotModel(tier: Tier | undefined): string | null {
+  if (!tier) return null;
+  return envOverride('COPILOT', tier) ?? COPILOT_TIER_MODEL[tier];
+}
+
 function planInvocation(req: ExecutionRequest): DriverInvocation {
   const driver: DriverId = req.allowed_drivers[0];
   switch (driver) {
-    case 'copilot':
+    case 'copilot': {
+      // Slice 6c: append --model when tier is set, so chitin-kernel drive
+      // copilot threads it into the Copilot SDK SessionConfig.
+      const args = ['drive', 'copilot', req.prompt];
+      const model = resolveCopilotModel(req.tier);
+      if (model) args.push('--model', model);
       return {
         command: 'chitin-kernel',
-        args: ['drive', 'copilot', req.prompt],
+        args,
       };
-    case 'claude-code-headless':
+    }
+    case 'claude-code-headless': {
       // Anthropic publishes this as the supported pattern for unattended
       // runs (see code.claude.com/docs/en/headless). Spawned in the
       // worktree (when base_ref is set on the request) so edits land on
-      // a real branch. The existing claude-code adapter PreToolUse hook
-      // (PR #66) gates every tool call — same enforcement plane as the
-      // interactive surface, just no human in the loop. The
-      // --dangerously-skip-permissions flag bypasses Claude Code's own
-      // interactive permission prompts; chitin's gate is the actual
-      // policy boundary.
+      // a real branch. The chitin claude-code PreToolUse hook gates every
+      // tool call — but only fires when Claude Code's settings discovery
+      // picks up a hooks-bearing settings.json, which is project-relative.
+      // Slice 6a wires that via writeWorktreeSettings before this spawn.
+      // --dangerously-skip-permissions bypasses Claude Code's own
+      // interactive permission prompts; chitin's gate is the actual policy
+      // boundary, and it still fires via the worktree's project settings.
+      const args = [
+        '-p', req.prompt,
+        '--dangerously-skip-permissions',
+        '--allowedTools', process.env.CHITIN_CLAUDE_ALLOWED_TOOLS ?? DEFAULT_CLAUDE_ALLOWED_TOOLS,
+        '--output-format', 'stream-json',
+        '--verbose',
+      ];
+      // Slice 6c: tier-driven model. T0/T1 → haiku, T2/T3 → sonnet, T4 → opus.
+      const model = resolveClaudeModel(req.tier);
+      if (model) args.push('--model', model);
       return {
         command: 'claude',
-        args: [
-          '-p', req.prompt,
-          '--dangerously-skip-permissions',
-          '--allowedTools', process.env.CHITIN_CLAUDE_ALLOWED_TOOLS ?? DEFAULT_CLAUDE_ALLOWED_TOOLS,
-          '--output-format', 'stream-json',
-          '--verbose',
-        ],
+        args,
       };
+    }
     case 'local-qwen':
     case 'local-glm':
     case 'local-deepseek':
@@ -155,6 +203,91 @@ function provisionWorktree(req: ExecutionRequest, repoRoot: string): { path: str
   return { path, branch };
 }
 
+// Slice 6a: write a project-level .claude/settings.json into the worktree
+// before spawning claude -p. This wires the chitin PreToolUse hook for
+// claude-code-headless runs whose cwd is outside the user's primary
+// workspace dir — without this, slice 5b's headless runs bypassed the
+// chitin gate entirely (verified by zero claude-code chain entries on
+// 2026-05-02 despite 1123+ hook captures going to the no-op global hook).
+//
+// Claude Code merges hooks across scopes (managed > local > project >
+// user), so this project-level settings.json adds chitin gating ON TOP
+// OF whatever the user's global settings define — it does not replace
+// the global config.
+function writeWorktreeClaudeSettings(worktreePath: string): void {
+  const claudeDir = join(worktreePath, '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  const settingsPath = join(claudeDir, 'settings.json');
+  // The hook command must produce a JSON decision the Claude Code hook
+  // protocol recognizes. chitin-kernel's `gate evaluate --hook-stdin`
+  // mode reads the hook payload from stdin, normalizes the tool call,
+  // calls gov.Gate.Evaluate, and prints {decision} on stdout.
+  const settings = {
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command' as const,
+              command: 'chitin-kernel gate evaluate --hook-stdin --agent=claude-code',
+            },
+          ],
+        },
+      ],
+    },
+  };
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+}
+
+// Slice 6b: write a per-workflow openclaw config dir that points the
+// requested local-* agent's workspace at the worktree. Spawned openclaw
+// reads OPENCLAW_STATE_DIR for its config + state, so a transient
+// per-workflow STATE_DIR avoids mutating the user's `~/.openclaw/openclaw.json`
+// (which would race with concurrent workflows). Returns the env var to set
+// on the spawn, or null when no remap is needed.
+function provisionOpenclawState(
+  req: ExecutionRequest,
+  worktreePath: string,
+  agentId: string,
+): { stateDir: string; envOverride: Record<string, string> } | null {
+  const sourceConfig = resolve(homedir(), '.openclaw/openclaw.json');
+  if (!existsSync(sourceConfig)) return null;
+  const sourceState = resolve(homedir(), '.openclaw');
+  const stateDir = join(SWARM_WORKTREES_ROOT, `${req.workflow_id}-openclaw-state`);
+  mkdirSync(stateDir, { recursive: true });
+  // Symlink everything from the source state dir except openclaw.json,
+  // which we rewrite below to redirect the requested agent's workspace.
+  // This avoids copying gigabytes of session/transcript history while
+  // still letting openclaw find its providers, plugins, agent dirs.
+  for (const entry of execFileSync('ls', ['-1', sourceState], { encoding: 'utf8' }).trim().split('\n')) {
+    if (!entry || entry === 'openclaw.json' || entry === 'openclaw.json.bak') continue;
+    const target = join(stateDir, entry);
+    if (existsSync(target)) continue;
+    try {
+      execFileSync('ln', ['-s', join(sourceState, entry), target]);
+    } catch {
+      // skip — usually a dangling symlink in source we can't follow
+    }
+  }
+  // Read the user's openclaw.json, redirect the named agent's workspace
+  // to the worktree, write to the per-workflow state dir.
+  const cfg = JSON.parse(readFileSync(sourceConfig, 'utf8'));
+  const list = cfg?.agents?.list;
+  if (Array.isArray(list)) {
+    for (const a of list) {
+      if (a && typeof a === 'object' && a.id === agentId) {
+        a.workspace = worktreePath;
+      }
+    }
+  }
+  writeFileSync(join(stateDir, 'openclaw.json'), JSON.stringify(cfg, null, 2));
+  return {
+    stateDir,
+    envOverride: { OPENCLAW_STATE_DIR: stateDir },
+  };
+}
+
 // After agent exits, capture worktree state for the apply step. Does not
 // modify anything — purely observational.
 function captureWorktreeState(worktreePath: string, baseRef: string): WorktreeResult {
@@ -205,9 +338,26 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
   const repoRoot = resolveRepoRoot();
   let workDir: string;
   let worktreeInfo: { path: string; branch: string } | null = null;
+  let openclawState: { stateDir: string; envOverride: Record<string, string> } | null = null;
   if (useWorktree) {
     worktreeInfo = provisionWorktree(req, repoRoot);
     workDir = worktreeInfo.path;
+    // Slice 6a: claude-code-headless needs project-level chitin hook
+    // settings.json in the worktree so its tool calls actually gate.
+    if (req.allowed_drivers.includes('claude-code-headless')) {
+      writeWorktreeClaudeSettings(worktreeInfo.path);
+    }
+    // Slice 6b: openclaw-driven local-* drivers need the agent's workspace
+    // pointed at the worktree so the agent's read/edit tools see the right
+    // files. We provision a per-workflow OPENCLAW_STATE_DIR with a remapped
+    // openclaw.json instead of mutating the user's global config.
+    const localDriver = req.allowed_drivers.find((d) =>
+      d === 'local-qwen' || d === 'local-glm' || d === 'local-deepseek',
+    );
+    if (localDriver) {
+      const agentId = resolveAgent(localDriver as DriverId);
+      openclawState = provisionOpenclawState(req, worktreeInfo.path, agentId);
+    }
   } else {
     workDir = mkdtempSync(join(tmpdir(), `chitin-worker-${req.workflow_id}-`));
     const policySrc = resolvePolicySrc();
@@ -227,6 +377,7 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
         env: {
           ...process.env,
           ...(plan.env ?? {}),
+          ...(openclawState?.envOverride ?? {}),
           CHITIN_WORKFLOW_ID: req.workflow_id,
           CHITIN_RUN_ID: req.run_id,
         },
@@ -265,6 +416,13 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     if (!useWorktree) {
       rmSync(workDir, { recursive: true, force: true });
     }
+    // Slice 6b: per-workflow openclaw state dir is transient — clean it
+    // up unconditionally regardless of activity success/failure. The user's
+    // `~/.openclaw/openclaw.json` was never mutated, so there's nothing
+    // to restore there.
+    if (openclawState) {
+      rmSync(openclawState.stateDir, { recursive: true, force: true });
+    }
   }
 
   if (useWorktree && worktreeInfo) {
@@ -288,6 +446,12 @@ export const __test__ = {
   resolveRepoRoot,
   provisionWorktree,
   captureWorktreeState,
+  resolveClaudeModel,
+  resolveCopilotModel,
+  writeWorktreeClaudeSettings,
+  provisionOpenclawState,
   DRIVER_AGENT_MAP,
   SWARM_WORKTREES_ROOT,
+  CLAUDE_TIER_MODEL,
+  COPILOT_TIER_MODEL,
 };

--- a/apps/temporal-worker/test/slice6.test.ts
+++ b/apps/temporal-worker/test/slice6.test.ts
@@ -1,0 +1,253 @@
+// Slice 6 unit tests: tier-based model routing (6c), claude-code worktree
+// settings injection (6a), per-workflow openclaw state remap (6b).
+//
+// Integration tests (6 — three-driver smoke against the real swarm) live
+// in the slice 6 PR description as observation records, not vitest.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ExecutionRequest, Tier } from '@chitin/contracts';
+import { __test__ } from '../src/activity.ts';
+
+const {
+  planInvocation,
+  resolveClaudeModel,
+  resolveCopilotModel,
+  writeWorktreeClaudeSettings,
+  provisionOpenclawState,
+  CLAUDE_TIER_MODEL,
+  COPILOT_TIER_MODEL,
+} = __test__;
+
+const baseReq: ExecutionRequest = {
+  schema_version: '1',
+  workflow_id: 'wf-slice6-test',
+  run_id: 'wf-slice6-test-attempt-1',
+  repo: 'chitinhq/chitin',
+  task_class: 'refactor',
+  risk_level: 'low',
+  allowed_drivers: ['claude-code-headless'],
+  network_policy: 'allowlist',
+  write_policy: 'worktree',
+  bounds: { max_tool_calls: 50, max_cost_usd: 0, wall_timeout_s: 600 },
+  prompt: 'do the thing',
+};
+
+// ─── 6c: tier → model resolution ──────────────────────────────────────────
+
+describe('slice 6c — tier → model resolution', () => {
+  const envKeys = [
+    'CHITIN_MODEL_CLAUDE_CODE_HEADLESS_T0',
+    'CHITIN_MODEL_CLAUDE_CODE_HEADLESS_T4',
+    'CHITIN_MODEL_COPILOT_T0',
+    'CHITIN_MODEL_COPILOT_T4',
+  ];
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of envKeys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('resolveClaudeModel returns null when tier is undefined', () => {
+    expect(resolveClaudeModel(undefined)).toBeNull();
+  });
+
+  it('resolveClaudeModel maps T0/T1 to haiku and T4 to opus by default', () => {
+    expect(resolveClaudeModel('T0' as Tier)).toBe('claude-haiku-4-5');
+    expect(resolveClaudeModel('T1' as Tier)).toBe('claude-haiku-4-5');
+    expect(resolveClaudeModel('T2' as Tier)).toBe('claude-sonnet-4-6');
+    expect(resolveClaudeModel('T3' as Tier)).toBe('claude-sonnet-4-6');
+    expect(resolveClaudeModel('T4' as Tier)).toBe('claude-opus-4-7');
+  });
+
+  it('resolveClaudeModel honors per-tier env override', () => {
+    process.env.CHITIN_MODEL_CLAUDE_CODE_HEADLESS_T0 = 'claude-tiny-experimental';
+    expect(resolveClaudeModel('T0' as Tier)).toBe('claude-tiny-experimental');
+    expect(resolveClaudeModel('T4' as Tier)).toBe('claude-opus-4-7'); // unaffected
+  });
+
+  it('resolveCopilotModel maps T0/T1 to free GPT-4.1 and T4 to opus', () => {
+    expect(resolveCopilotModel('T0' as Tier)).toBe('gpt-4.1');
+    expect(resolveCopilotModel('T1' as Tier)).toBe('gpt-4.1');
+    expect(resolveCopilotModel('T4' as Tier)).toBe('claude-opus-4.7');
+  });
+
+  it('resolveCopilotModel honors per-tier env override', () => {
+    process.env.CHITIN_MODEL_COPILOT_T4 = 'gpt-5.4-experimental';
+    expect(resolveCopilotModel('T4' as Tier)).toBe('gpt-5.4-experimental');
+  });
+
+  it('CLAUDE/COPILOT_TIER_MODEL maps cover all 5 tiers', () => {
+    for (const t of ['T0', 'T1', 'T2', 'T3', 'T4'] as const) {
+      expect(CLAUDE_TIER_MODEL[t]).toBeTruthy();
+      expect(COPILOT_TIER_MODEL[t]).toBeTruthy();
+    }
+  });
+});
+
+// ─── 6c: planInvocation threads --model into the spawn args ───────────────
+
+describe('slice 6c — planInvocation tier wiring', () => {
+  it('claude-code-headless without tier omits --model (driver default)', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'] });
+    expect(plan.args).not.toContain('--model');
+  });
+
+  it('claude-code-headless with tier appends --model with the right id', () => {
+    const planT0 = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'], tier: 'T0' as Tier });
+    expect(planT0.args).toContain('--model');
+    expect(planT0.args[planT0.args.indexOf('--model') + 1]).toBe('claude-haiku-4-5');
+
+    const planT4 = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'], tier: 'T4' as Tier });
+    expect(planT4.args[planT4.args.indexOf('--model') + 1]).toBe('claude-opus-4-7');
+  });
+
+  it('copilot without tier omits --model (driver default = gpt-4.1)', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['copilot'] });
+    expect(plan.args).not.toContain('--model');
+  });
+
+  it('copilot with tier appends --model into the chitin-kernel shim args', () => {
+    const planT2 = planInvocation({ ...baseReq, allowed_drivers: ['copilot'], tier: 'T2' as Tier });
+    expect(planT2.args).toContain('--model');
+    expect(planT2.args[planT2.args.indexOf('--model') + 1]).toBe('claude-haiku-4.5');
+  });
+});
+
+// ─── 6a: claude-code worktree settings.json ───────────────────────────────
+
+describe('slice 6a — writeWorktreeClaudeSettings', () => {
+  let scratch: string;
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'chitin-6a-test-'));
+  });
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('creates .claude/settings.json with a PreToolUse chitin-kernel hook', () => {
+    writeWorktreeClaudeSettings(scratch);
+    const settingsPath = join(scratch, '.claude/settings.json');
+    expect(existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    const hooks = settings.hooks?.PreToolUse;
+    expect(Array.isArray(hooks)).toBe(true);
+    expect(hooks.length).toBeGreaterThan(0);
+    const cmd = hooks[0]?.hooks?.[0]?.command;
+    expect(cmd).toContain('chitin-kernel');
+    expect(cmd).toContain('gate evaluate');
+    expect(cmd).toContain('--hook-stdin');
+    expect(cmd).toContain('--agent=claude-code');
+  });
+
+  it('uses matcher: "" so the hook applies to all tool calls', () => {
+    writeWorktreeClaudeSettings(scratch);
+    const settings = JSON.parse(readFileSync(join(scratch, '.claude/settings.json'), 'utf8'));
+    expect(settings.hooks.PreToolUse[0].matcher).toBe('');
+  });
+
+  it('overwrites an existing settings.json (idempotent for re-runs)', () => {
+    mkdirSync(join(scratch, '.claude'), { recursive: true });
+    writeFileSync(join(scratch, '.claude/settings.json'), '{"stale": true}');
+    writeWorktreeClaudeSettings(scratch);
+    const settings = JSON.parse(readFileSync(join(scratch, '.claude/settings.json'), 'utf8'));
+    expect(settings.stale).toBeUndefined();
+    expect(settings.hooks).toBeDefined();
+  });
+});
+
+// ─── 6b: provisionOpenclawState (per-workflow STATE_DIR with workspace remap) ─
+
+describe('slice 6b — provisionOpenclawState', () => {
+  let scratch: string;
+  let savedHome: string | undefined;
+  let fakeHome: string;
+  let fakeOpenclaw: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'chitin-6b-test-'));
+    fakeHome = mkdtempSync(join(tmpdir(), 'chitin-6b-home-'));
+    fakeOpenclaw = join(fakeHome, '.openclaw');
+    mkdirSync(fakeOpenclaw, { recursive: true });
+    // Source openclaw config with a couple of agents.
+    writeFileSync(
+      join(fakeOpenclaw, 'openclaw.json'),
+      JSON.stringify(
+        {
+          agents: {
+            list: [
+              { id: 'main' },
+              { id: 'qwen-agent', workspace: '/some/old/qwen-workspace' },
+              { id: 'glm-agent', workspace: '/some/old/glm-workspace' },
+            ],
+          },
+          plugins: { allow: ['chitin-governance'] },
+        },
+        null,
+        2,
+      ),
+    );
+    // Other state-dir entries that should get symlinked.
+    mkdirSync(join(fakeOpenclaw, 'agents'));
+    writeFileSync(join(fakeOpenclaw, 'extensions'), 'placeholder file\n');
+    savedHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(scratch, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it('returns null when no openclaw.json exists in $HOME/.openclaw', () => {
+    rmSync(join(fakeOpenclaw, 'openclaw.json'));
+    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const result = provisionOpenclawState(req, scratch, 'qwen-agent');
+    expect(result).toBeNull();
+  });
+
+  it('writes a state dir with openclaw.json that remaps the named agent workspace', () => {
+    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const result = provisionOpenclawState(req, scratch, 'qwen-agent');
+    expect(result).not.toBeNull();
+    expect(result!.envOverride.OPENCLAW_STATE_DIR).toBe(result!.stateDir);
+    const cfg = JSON.parse(readFileSync(join(result!.stateDir, 'openclaw.json'), 'utf8'));
+    const qwen = cfg.agents.list.find((a: { id: string }) => a.id === 'qwen-agent');
+    expect(qwen.workspace).toBe(scratch);
+    // Other agents are unchanged
+    const glm = cfg.agents.list.find((a: { id: string }) => a.id === 'glm-agent');
+    expect(glm.workspace).toBe('/some/old/glm-workspace');
+    rmSync(result!.stateDir, { recursive: true, force: true });
+  });
+
+  it('symlinks state-dir contents (excluding openclaw.json) so plugins/agents are reachable', () => {
+    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const result = provisionOpenclawState(req, scratch, 'qwen-agent');
+    expect(result).not.toBeNull();
+    expect(existsSync(join(result!.stateDir, 'agents'))).toBe(true);
+    expect(existsSync(join(result!.stateDir, 'extensions'))).toBe(true);
+    expect(existsSync(join(result!.stateDir, 'openclaw.json'))).toBe(true);
+    rmSync(result!.stateDir, { recursive: true, force: true });
+  });
+
+  it("does not mutate the user's source openclaw.json", () => {
+    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const before = readFileSync(join(fakeOpenclaw, 'openclaw.json'), 'utf8');
+    const result = provisionOpenclawState(req, scratch, 'qwen-agent');
+    const after = readFileSync(join(fakeOpenclaw, 'openclaw.json'), 'utf8');
+    expect(after).toBe(before);
+    rmSync(result!.stateDir, { recursive: true, force: true });
+  });
+});

--- a/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
+++ b/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
@@ -23,6 +23,10 @@ func cmdDriveCopilot(args []string) int {
 	interactive := fs.Bool("interactive", false, "launch REPL-style interactive session")
 	preflight := fs.Bool("preflight", false, "run startup validations and exit without starting session")
 	verbose := fs.Bool("verbose", false, "log every Decision JSON to stderr")
+	// Slice 6c: tier-driven model passes through from the activity dispatcher
+	// (CHITIN_MODEL_COPILOT_T0..T4 + COPILOT_TIER_MODEL defaults). Empty
+	// = SDK default (currently gpt-4.1, set in copilot.Run).
+	model := fs.String("model", "", "model id to pass to Copilot SDK SessionConfig (empty = driver default)")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: chitin-kernel drive copilot [flags] [prompt]")
 		fs.PrintDefaults()
@@ -53,6 +57,7 @@ func cmdDriveCopilot(args []string) int {
 		Cwd:         *cwd,
 		Interactive: *interactive,
 		Verbose:     *verbose,
+		Model:       *model,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/go/execution-kernel/internal/driver/copilot/driver.go
+++ b/go/execution-kernel/internal/driver/copilot/driver.go
@@ -21,6 +21,10 @@ type RunOpts struct {
 	Cwd         string
 	Interactive bool
 	Verbose     bool
+	// Slice 6c: tier-driven model passes through from
+	// `chitin-kernel drive copilot --model <id>`. Empty string falls
+	// back to the SDK driver default (gpt-4.1, see invariant note).
+	Model string
 }
 
 // PreflightOpts configures a Preflight check.
@@ -92,8 +96,12 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 	// ever firing OnPermissionRequest, which bypasses chitin governance entirely.
 	// AvailableTools: nil = all built-in tools remain available so the model
 	// can call shell, file-read, file-write, and other Copilot built-ins.
+	model := opts.Model
+	if model == "" {
+		model = "gpt-4.1"
+	}
 	session, err := client.SDKClient().CreateSession(ctx, &copilotsdk.SessionConfig{
-		Model:               "gpt-4.1",
+		Model:               model,
 		OnPermissionRequest: handler.OnPermissionRequest,
 	})
 	if err != nil {

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -11,6 +11,16 @@ export const TaskClassSchema = z.enum([
 
 export const RiskLevelSchema = z.enum(['low', 'medium', 'high', 'irreversible']);
 
+// Slice 6c: tier hint for the dispatcher. The grooming agent assigns a
+// tier per backlog entry (T0 mechanical, T4 strongest programmatic, T5
+// human-only). Activity dispatch uses the tier to pick a model per
+// driver — T0 → cheapest available, T4 → strongest. Optional because
+// not every workflow comes from the grooming pipeline yet (manual
+// dispatches exist); when absent, drivers fall back to their default
+// model. T5 is intentionally absent from the enum: that tier is human-
+// only, no programmatic driver should ever receive a T5 ExecutionRequest.
+export const TierSchema = z.enum(['T0', 'T1', 'T2', 'T3', 'T4']);
+
 // Driver tiers for the swarm. The 2026-04-30 framing that excluded
 // `claude-code` was based on a misread of Anthropic's terms — verified
 // 2026-05-02 against code.claude.com/docs/en/headless that headless mode
@@ -74,6 +84,10 @@ export const ExecutionRequestSchema = z
     // spawns the agent there. When absent (slice 1-4 behavior), the
     // activity runs in a tempdir and any agent edits are discarded.
     base_ref: GitRefSchema.optional(),
+    // Slice 6c: optional tier hint. When set, dispatch resolves a
+    // tier-appropriate model for the chosen driver (e.g., T0 →
+    // claude-haiku for claude-code-headless). Absent = driver default.
+    tier: TierSchema.optional(),
   })
   .superRefine((req, ctx) => {
     if (req.network_policy === 'open' && (req.risk_level === 'high' || req.risk_level === 'irreversible')) {
@@ -99,3 +113,4 @@ export type DriverId = z.infer<typeof DriverIdSchema>;
 export type NetworkPolicy = z.infer<typeof NetworkPolicySchema>;
 export type WritePolicy = z.infer<typeof WritePolicySchema>;
 export type Bounds = z.infer<typeof BoundsSchema>;
+export type Tier = z.infer<typeof TierSchema>;

--- a/libs/contracts/tests/execution-request.schema.test.ts
+++ b/libs/contracts/tests/execution-request.schema.test.ts
@@ -179,4 +179,26 @@ describe('ExecutionRequestSchema', () => {
     const bad = { ...validRequest, base_ref: 'a'.repeat(129) };
     expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
   });
+
+  // Slice 6c: optional tier hint for model routing.
+  it('accepts a request without tier (driver-default model)', () => {
+    expect(() => ExecutionRequestSchema.parse(validRequest)).not.toThrow();
+  });
+
+  it('accepts each valid tier value (T0..T4)', () => {
+    for (const tier of ['T0', 'T1', 'T2', 'T3', 'T4'] as const) {
+      const ok = { ...validRequest, tier };
+      expect(() => ExecutionRequestSchema.parse(ok)).not.toThrow();
+    }
+  });
+
+  it('rejects T5 tier (human-only escalation; not programmatic)', () => {
+    const bad = { ...validRequest, tier: 'T5' as never };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects invalid tier strings', () => {
+    const bad = { ...validRequest, tier: 'tier-zero' as never };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

Closes the three real gaps slice-5b's post-mortem surfaced. Bundled per Jared's call.

**The gaps:**

1. **Slice-5b's demo wasn't gated.** Chitin's PreToolUse hook for claude-code is workspace-scoped (`~/workspace/.claude/settings.json`). The swarm spawns `claude` in `~/.cache/chitin/swarm-worktrees/<wfid>/` — outside the workspace dir, so the hook never applied. The global `~/.claude/settings.json` has only a no-op capture script. Result: zero chain entries for the swarm's edits despite Claude Code firing 1100+ hook invocations.

2. **local-qwen via openclaw didn't see worktree files.** The agent's read tool resolves paths against its statically-configured workspace (`~/.openclaw/workspaces/qwen-agent`), not the spawned process cwd. Pre-fix demo: agent reported "no chitin.yaml in current directory" despite chitin.yaml being in the worktree.

3. **No tier routing → every dispatch went to T4.** Slice 5b's $0.20/turn at Opus 4.7 for a 3-line YAML edit was the architecture's "tier routing" claim breaking down — only T4 worked, so everything became T4.

## Fixes

### 6a — Worktree-local `.claude/settings.json`
`writeWorktreeClaudeSettings(worktreePath)` writes a project-level settings.json with the chitin PreToolUse hook. Claude Code merges hooks across scopes (managed > local > project > user; arrays concatenate), so this **adds** chitin gating on top of the user's global config — doesn't replace it.

### 6b — Per-workflow `OPENCLAW_STATE_DIR` with workspace remap
`provisionOpenclawState(req, worktree, agentId)` builds a transient state dir at `~/.cache/chitin/swarm-worktrees/<wfid>-openclaw-state/` that symlinks the user's openclaw subdirs (agents, plugins, extensions) but rewrites `openclaw.json` to redirect the requested agent's workspace to the worktree. Spawned openclaw reads via `OPENCLAW_STATE_DIR`. The user's source config is **never mutated** — concurrent workflows don't race on a shared mutable.

### 6c — Tier-based model routing
- New optional `ExecutionRequest.tier` (`T0`..`T4`; `T5` rejected — human-only).
- `CLAUDE_TIER_MODEL`: T0/T1 → `claude-haiku-4-5`, T2/T3 → `claude-sonnet-4-6`, T4 → `claude-opus-4-7`.
- `COPILOT_TIER_MODEL`: T0/T1 → `gpt-4.1` free, T2 → `claude-haiku-4.5`, T3 → `claude-sonnet-4.6`, T4 → `claude-opus-4.7`.
- Per-tier env override: `CHITIN_MODEL_<DRIVER_KEY>_<TIER>=<id>`.
- Activity dispatch threads `--model` into both `claude -p` and `chitin-kernel drive copilot`. Go side: `drive_copilot.go` parses `--model`, threads through `RunOpts.Model` to SDK `SessionConfig.Model`. Empty falls back to driver default.
- Local-* drivers ignore tier (model is set at openclaw agent-creation time per slice 3) — tier still flows for the audit log.

## End-to-end three-driver verification

Same task (chitin.yaml append) dispatched via each driver. **All three hit the chitin gate's `no-governance-self-modification` deny:**

```
2026-05-02T01:39:42Z agent=copilot-cli   file.read     ...slice6-smoke-copilot/...   default-allow-reads
2026-05-02T01:39:50Z agent=claude-code   file.read     ...slice6-smoke-cch/...       default-allow-reads
2026-05-02T01:39:54Z agent=claude-code   file.write    ...slice6-smoke-cch/...       no-governance-self-modification  ← 6a
2026-05-02T01:43:11Z agent=qwen-agent    file.write    chitin.yaml                   no-governance-self-modification  ← 6b
```

Pre-slice-6 baseline: claude-code-headless edits on 2026-05-02 → **zero chain entries** despite agent succeeding.
Post-slice-6: claude-code-headless edits on chitin.yaml → **deny entry in chain**, agent reports failure.

Tier routing inline-verified:
```
T0 claude-code-headless → --model claude-haiku-4-5
T4 copilot              → --model claude-opus-4.7
```

## Tests

- 17 new in `apps/temporal-worker/test/slice6.test.ts` covering tier resolution, env overrides, plan-invocation wiring, settings.json shape, openclaw state-dir contents, source-config non-mutation
- 4 new schema tests for `tier` field
- 153/153 vitest pass; Go build clean

## Diff

6 files changed, +486/-19:
- `libs/contracts/src/execution-request.schema.ts` (+15) — `TierSchema` + optional field
- `libs/contracts/tests/execution-request.schema.test.ts` (+27) — 4 new tests
- `apps/temporal-worker/src/activity.ts` (+154) — tier maps, settings injection, openclaw state remap, finally cleanup
- `apps/temporal-worker/test/slice6.test.ts` (+247, new) — 17 tests
- `go/execution-kernel/cmd/chitin-kernel/drive_copilot.go` (+5) — `--model` flag
- `go/execution-kernel/internal/driver/copilot/driver.go` (+11) — `RunOpts.Model` thread-through

## PR #94 fate (separate decision)

PR #94 (the gov-policy-allow-pr-merge fix that slice 5b's demo produced) was made BEFORE slice 6a wired the gate. Content is correct (3-line YAML add); audit trail isn't (no `agent=claude-code` chain entry). Operator decision: close + redo via slice 6 → cheap T0 path with proper auditing, or keep as-is acknowledging the audit gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)