### PR TITLE
gov: allow github.pr.merge in default-allow-github-write rule

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -97,7 +97,7 @@ rules:
     reason: "GitHub read-only operations allowed"
 
   - id: default-allow-github-write
-    action: [github.issue.create, github.issue.close, github.pr.create, github.pr.close]
+    action: [github.issue.create, github.issue.close, github.pr.create, github.pr.close, github.pr.merge]
     effect: allow
     reason: "GitHub state-changing operations allowed (bounds still apply to pr.create)"
 


### PR DESCRIPTION
## Summary

One-token YAML edit: add `github.pr.merge` to the `default-allow-github-write` rule's action list.

```diff
   - id: default-allow-github-write
-    action: [github.issue.create, github.issue.close, github.pr.create, github.pr.close]
+    action: [github.issue.create, github.issue.close, github.pr.create, github.pr.close, github.pr.merge]
     effect: allow
     reason: "GitHub state-changing operations allowed (bounds still apply to pr.create)"
```

## Why

Every `gh pr merge` invocation hit `policy default is deny` and forced a workaround through `gh api -X PUT repos/.../pulls/N/merge` (which normalizes to `github.api`, picked up by `default-allow-github-read`). Same operation, same bounds, just spelled differently — closing a vocabulary gap.

## Why this is a manual PR

Chitin's `no-governance-self-modification` rule (correctly) forbids agents from editing their own governance config. Slice 6 PR #96 verified that all three drivers (copilot, claude-code-headless, qwen-agent) hit that deny when they tried to edit `chitin.yaml`. So governance changes have to come through human review by design — that's the architecture working as intended.

This PR replaces closed PR #94, which was produced by the slice-5b swarm demo before slice 6 wired the gate properly. PR #94's content was correct but its audit trail was incomplete (no chain entry for the swarm's edit because the hook didn't fire from outside the workspace dir).

## Test plan

- [x] Single-line YAML edit, syntactically valid
- [x] No code touched, no tests needed beyond CI's existing YAML lint
- [ ] CI green
- [ ] Operator review

🤖 Generated with [Claude Code](https://claude.com/claude-code)