### PR TITLE
feat(slice-7): autonomous swarm — SIGKILL fix + dispatcher + systemd units

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -372,6 +372,15 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
   let result: ActivityResult;
   try {
     result = await new Promise<ActivityResult>((resolvePromise, reject) => {
+      // Slice 7a: spawn detached so the child becomes the leader of its own
+      // process group. On wall_timeout SIGKILL we then kill the whole group
+      // (process.kill(-pid)) instead of just the parent. Without this,
+      // grandchildren (model runners under openclaw, or claude's worker
+      // subprocesses) inherit the stdout pipe and keep it open after the
+      // parent dies — Node's 'close' event waits for FDs to close, never
+      // fires, and the activity hangs to Temporal's startToCloseTimeout
+      // (15 min). With this fix, the timer-fired kill propagates and the
+      // close event arrives within ~1s.
       const child = spawn(plan.command, plan.args, {
         cwd: workDir,
         env: {
@@ -382,6 +391,7 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
           CHITIN_RUN_ID: req.run_id,
         },
         stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
       });
 
       // Bounded ring buffers — only the tail is reported, so growing strings
@@ -395,7 +405,22 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
       child.stdout.on('data', (b) => (stdout = tail(stdout, b.toString(), TAIL_CAP)));
       child.stderr.on('data', (b) => (stderr = tail(stderr, b.toString(), TAIL_CAP)));
 
-      const killTimer = setTimeout(() => child.kill('SIGKILL'), req.bounds.wall_timeout_s * 1000);
+      const killTimer = setTimeout(() => {
+        if (child.pid !== undefined) {
+          try {
+            // Negative pid = process group. Kills child + all its descendants
+            // (openclaw + model runner + ollama + ...). Belt-and-suspenders:
+            // also force-close stdout/stderr in case the descendant tree is
+            // still holding pipes after SIGKILL (rare but real on overloaded
+            // systems where SIGKILL takes a tick to propagate).
+            process.kill(-child.pid, 'SIGKILL');
+          } catch {
+            // ESRCH = process already exited. No-op.
+          }
+        }
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+      }, req.bounds.wall_timeout_s * 1000);
       child.on('close', (code) => {
         clearTimeout(killTimer);
         resolvePromise({

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -1,0 +1,333 @@
+// Slice 7b: autonomous dispatcher. Runs on a schedule (systemd timer or
+// equivalent), picks the next ready backlog entry, submits one workflow.
+//
+// Invariants:
+//   - At most one swarm workflow in flight at a time. If any
+//     swarm-<entry-id>-* workflow is currently RUNNING in Temporal, this
+//     tick exits without dispatching.
+//   - Each backlog entry is dispatched at most once per origin. If a
+//     branch swarm/swarm-<entry-id>-* exists on origin (open or merged
+//     PR), the entry is considered handled and skipped on subsequent
+//     ticks.
+//   - T5 entries are never dispatched (human-only escalation).
+//
+// Failure modes:
+//   - Workflow submit fails: log to stderr, exit non-zero so systemd
+//     surfaces the failure. Next tick retries.
+//   - Workflow times out (wall_timeout SIGKILL fires per slice 7a fix):
+//     activity returns exit_code=-1, apply step skips PR, branch may
+//     still exist (push happened before close). Operator sees in
+//     gov-decisions chain + Temporal UI.
+//   - Apply step fails: branch is pushed but no PR. Operator runs
+//     apply manually with the result file.
+//
+// Usage:
+//   pnpm exec tsx apps/temporal-worker/src/dispatcher.ts [--dry-run]
+//
+//   --dry-run: print the entry that would be dispatched, exit 0
+//   without submitting.
+
+import { Connection, Client } from '@temporalio/client';
+import { ExecutionRequestSchema } from '@chitin/contracts';
+import type { DriverId, Tier } from '@chitin/contracts';
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { homedir } from 'node:os';
+import type { ActivityResult } from './activity-types.ts';
+import type { executeRequestWorkflow } from './workflow.ts';
+import { parseBacklog, type BacklogEntry } from './grooming/parse-backlog.ts';
+
+const WORKFLOW_NAME = 'executeRequestWorkflow';
+const TASK_QUEUE = 'chitin-worker-q';
+const BACKLOG_PATH = resolve(process.cwd(), 'docs/swarm-backlog.md');
+const TMP_DIR = resolve(process.cwd(), 'tmp');
+// Slice 7b: persistent markers for dispatched entries. Prevents the
+// infinite-loop case where the agent is denied on every tool call
+// (e.g., the entry references chitin.yaml, which no-governance-self-
+// modification blocks): worktree stays clean, no branch is pushed,
+// next tick re-picks the same entry forever. Operator deletes the
+// marker to allow re-dispatch.
+const STATE_DIR = resolve(homedir(), '.cache/chitin/swarm-state/dispatched');
+
+// Tier → driver routing. The cheapest driver capable of the work.
+const TIER_DRIVER: Record<Tier, DriverId> = {
+  T0: 'local-qwen',                  // free, mechanical
+  T1: 'copilot',                     // Copilot GPT-4.1 free
+  T2: 'claude-code-headless',        // claude-haiku-4-5
+  T3: 'claude-code-headless',        // claude-sonnet-4-6
+  T4: 'claude-code-headless',        // claude-opus-4-7
+};
+
+// Per-entry wall_timeout — short enough that a stuck workflow doesn't
+// hold the queue long, generous enough that real work has room. The
+// wall_timeout is enforced by activity SIGKILL (slice 7a). Activities
+// that finish naturally before this don't pay the cost.
+const TIER_WALL_TIMEOUT_S: Record<Tier, number> = {
+  T0: 180,
+  T1: 240,
+  T2: 360,
+  T3: 600,
+  T4: 600,
+};
+
+const TIER_MAX_TOOL_CALLS: Record<Tier, number> = {
+  T0: 10,
+  T1: 15,
+  T2: 25,
+  T3: 50,
+  T4: 50,
+};
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function log(level: 'info' | 'warn' | 'error', msg: string, data?: Record<string, unknown>) {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    component: 'dispatcher',
+    msg,
+    ...(data ?? {}),
+  });
+  // info → stdout, warn/error → stderr (systemd journal separates them).
+  if (level === 'info') console.log(line);
+  else console.error(line);
+}
+
+function sanitize(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_\-:.]/g, '-');
+}
+
+// True if origin has any branch matching swarm/swarm-<entry-id>-* — i.e.,
+// the entry has been dispatched to completion (branch persists past PR
+// merge unless deleted, and stays through PR open). We fetch first so the
+// remote ref state is current; auto-prune deleted remote branches.
+function entryHasOriginBranch(entryId: string): boolean {
+  try {
+    git(['fetch', '--prune', 'origin']);
+  } catch (err) {
+    log('warn', 'git fetch failed; falling back to cached refs', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    const out = git([
+      'for-each-ref',
+      '--format=%(refname:short)',
+      `refs/remotes/origin/swarm/swarm-${entryId}-*`,
+    ]);
+    return out.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Find any currently-running swarm workflow via the Temporal client.
+// We use the visibility list-workflows endpoint with a simple status
+// filter. Returns the workflow_id of the first running one, or null.
+async function findRunningSwarmWorkflow(client: Client): Promise<string | null> {
+  // The query language Temporal supports varies by server config; fall
+  // back to a broad list + manual filter. Limit to a small number for
+  // cheap polling.
+  for await (const wf of client.workflow.list({ query: "ExecutionStatus='Running'" })) {
+    if (wf.workflowId.startsWith('swarm-')) {
+      return wf.workflowId;
+    }
+  }
+  return null;
+}
+
+function entryHasDispatchMarker(entryId: string): boolean {
+  const path = resolve(STATE_DIR, `${entryId}.json`);
+  return existsSync(path);
+}
+
+function writeDispatchMarker(entryId: string, workflowId: string, tier: Tier, driver: DriverId) {
+  mkdirSync(STATE_DIR, { recursive: true });
+  const path = resolve(STATE_DIR, `${entryId}.json`);
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        entry_id: entryId,
+        workflow_id: workflowId,
+        tier,
+        driver,
+        dispatched_at: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
+  for (const entry of entries) {
+    if (entry.status !== 'ready') continue;
+    // T5 is human-only — skip even if the schema permits it (it doesn't,
+    // but the tier field on the file might).
+    if (entry.tier === 'T5') {
+      log('info', 'skip T5 entry (human-only)', { entry_id: entry.id });
+      continue;
+    }
+    if (!entry.tier || !(entry.tier in TIER_DRIVER)) {
+      log('warn', 'skip entry without recognized tier', {
+        entry_id: entry.id,
+        tier: entry.tier,
+      });
+      continue;
+    }
+    if (entryHasOriginBranch(entry.id)) {
+      log('info', 'skip entry: swarm/<id> branch exists on origin', { entry_id: entry.id });
+      continue;
+    }
+    if (entryHasDispatchMarker(entry.id)) {
+      log('info', 'skip entry: dispatch marker present (operator must rm to retry)', {
+        entry_id: entry.id,
+        marker: resolve(STATE_DIR, `${entry.id}.json`),
+      });
+      continue;
+    }
+    return entry;
+  }
+  return null;
+}
+
+function buildPrompt(entry: BacklogEntry): string {
+  // The entry's description (post-grooming) already contains the
+  // implementation steps. Wrap it with a "do this end-to-end" frame
+  // so the agent commits the change rather than just describing it.
+  return `You are picking up a backlog entry. Read the description carefully, make the change in the current working directory, run any tests the entry requires, and commit your work with a clear message. If anything is ambiguous, do the conservative thing — do not invent scope. Do not modify chitin.yaml or any file under .chitin/ (governance is human-only).
+
+ENTRY ID: ${entry.id}
+
+ENTRY:
+${entry.description}
+
+When done, your worktree should have either commits or staged-but-uncommitted changes that the apply pipeline will push as a PR. Output a one-line summary of what you did, then stop.`;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  log('info', 'dispatcher start', { dryRun });
+
+  const conn = await Connection.connect({ address: '127.0.0.1:7233' });
+  const client = new Client({ connection: conn, namespace: 'default' });
+
+  try {
+    const running = await findRunningSwarmWorkflow(client);
+    if (running) {
+      log('info', 'swarm workflow already in flight; exiting', { running });
+      return;
+    }
+
+    const entries = parseBacklog(BACKLOG_PATH);
+    const entry = pickEntryToDispatch(entries);
+    if (!entry) {
+      log('info', 'no ready entry to dispatch this tick');
+      return;
+    }
+    const tier = entry.tier as Tier;
+    const driver = TIER_DRIVER[tier];
+    const wallTimeout = TIER_WALL_TIMEOUT_S[tier];
+    const maxToolCalls = TIER_MAX_TOOL_CALLS[tier];
+    const workflowId = `swarm-${sanitize(entry.id)}-${Date.now()}`;
+
+    log('info', 'selected entry', {
+      entry_id: entry.id,
+      tier,
+      driver,
+      wall_timeout_s: wallTimeout,
+      workflow_id: workflowId,
+    });
+
+    if (dryRun) {
+      log('info', 'dry-run; would submit', { workflow_id: workflowId });
+      return;
+    }
+
+    const req = ExecutionRequestSchema.parse({
+      schema_version: '1',
+      workflow_id: workflowId,
+      run_id: `${workflowId}-attempt-1`,
+      repo: 'chitinhq/chitin',
+      task_class: 'refactor',
+      risk_level: 'low',
+      allowed_drivers: [driver],
+      network_policy: 'allowlist',
+      write_policy: 'worktree',
+      bounds: { max_tool_calls: maxToolCalls, max_cost_usd: 0, wall_timeout_s: wallTimeout },
+      prompt: buildPrompt(entry),
+      base_ref: 'main',
+      tier,
+    });
+
+    // Write the marker BEFORE submit. If submit fails, marker still
+    // present → operator's intent is "this entry was attempted; don't
+    // auto-retry." Manual rm to retry. This is intentionally pessimistic:
+    // the swarm doesn't quietly retry without operator review.
+    writeDispatchMarker(entry.id, workflowId, tier, driver);
+
+    const handle = await client.workflow.start<typeof executeRequestWorkflow>(WORKFLOW_NAME, {
+      args: [req],
+      taskQueue: TASK_QUEUE,
+      workflowId,
+    });
+    log('info', 'workflow started', { workflow_id: workflowId });
+
+    const result = (await handle.result()) as ActivityResult;
+    mkdirSync(TMP_DIR, { recursive: true });
+    const envelopePath = resolve(TMP_DIR, `result-${workflowId}.json`);
+    writeFileSync(
+      envelopePath,
+      JSON.stringify(
+        {
+          workflow_id: workflowId,
+          result,
+          pr_title: `swarm: ${entry.id}`,
+          pr_body:
+            `Picked up by the autonomous dispatcher (slice 7).\n\n` +
+            `Backlog entry: \`${entry.id}\`\n` +
+            `Tier: \`${tier}\`  •  Driver: \`${driver}\`\n` +
+            `Workflow: \`${workflowId}\`\n\n` +
+            `## Entry context\n\n${entry.description.slice(0, 4000)}\n`,
+        },
+        null,
+        2,
+      ),
+    );
+    log('info', 'workflow complete', {
+      workflow_id: workflowId,
+      exit_code: result.exit_code,
+      duration_ms: result.duration_ms,
+      worktree_present: !!result.worktree,
+      commits_added: result.worktree?.commits_added ?? 0,
+      uncommitted: result.worktree?.has_uncommitted_changes ?? false,
+    });
+
+    // Run apply step inline. apply-workflow-result.ts handles push + PR
+    // when the worktree has work, no-ops otherwise. Best-effort: failures
+    // are logged but don't propagate (operator can run manually).
+    try {
+      const applyOutput = execSync(
+        `pnpm exec tsx apps/temporal-worker/src/grooming/apply-workflow-result.ts --result ${envelopePath} --apply`,
+        { encoding: 'utf8' },
+      );
+      log('info', 'apply step output', { output: applyOutput.slice(-2000) });
+    } catch (err) {
+      log('warn', 'apply step failed (run manually)', {
+        envelope: envelopePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  } finally {
+    await conn.close();
+  }
+}
+
+main().catch((err) => {
+  log('error', 'dispatcher fatal', { error: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/apps/temporal-worker/src/grooming/apply-workflow-result.ts
+++ b/apps/temporal-worker/src/grooming/apply-workflow-result.ts
@@ -69,14 +69,30 @@ async function main() {
     return;
   }
 
+  // Slice 7 finding: don't auto-commit just because porcelain shows
+  // uncommitted state. Some agents (openclaw qwen via the slice-6b
+  // workspace remap) write bootstrap/identity files into the worktree
+  // at session start that aren't related to the assigned task — auto-
+  // committing those produces a junk PR with no relationship to the
+  // backlog entry. Heuristic: only auto-commit when there are TRACKED
+  // file modifications (`diff --shortstat` non-empty). Untracked-only
+  // changes are likely agent side effects, not the work product.
   if (wt.has_uncommitted_changes) {
-    console.log('[apply-result] auto-committing uncommitted changes…');
-    git(wt.path, ['add', '-A']);
-    git(wt.path, [
-      'commit',
-      '-m',
-      defaultCommitMessage(env),
-    ]);
+    const trackedDiff = git(wt.path, ['--no-pager', 'diff', '--shortstat']).length > 0;
+    if (trackedDiff) {
+      console.log('[apply-result] auto-committing tracked uncommitted changes…');
+      git(wt.path, ['add', '-A']);
+      git(wt.path, ['commit', '-m', defaultCommitMessage(env)]);
+    } else {
+      console.log('[apply-result] worktree has untracked-only changes (likely agent bootstrap files); skipping auto-commit.');
+      // If there are no committed changes either, treat as no-work-done
+      // and skip push entirely (don't pollute origin with empty branches).
+      if (wt.commits_added === 0) {
+        console.log('[apply-result] no committed work; skipping push and PR.');
+        cleanupWorktree(repoRoot, wt);
+        return;
+      }
+    }
   }
 
   console.log(`[apply-result] pushing ${wt.branch}…`);

--- a/apps/temporal-worker/test/sigkill-propagation.test.ts
+++ b/apps/temporal-worker/test/sigkill-propagation.test.ts
@@ -1,0 +1,114 @@
+// Slice 7a: integration test for wall_timeout SIGKILL propagation.
+//
+// Pre-fix behavior: spawn(...) without detached:true leaves the child
+// in the activity process's own process group. SIGKILL hits the parent
+// only; grandchildren inherit stdout pipes and keep them open. Node's
+// 'close' event waits for the pipes to close → hang to Temporal's
+// 15-min startToCloseTimeout.
+//
+// Post-fix behavior: detached:true makes the child a process group
+// leader; process.kill(-pid, 'SIGKILL') kills the whole group, FDs
+// close, 'close' fires within ~1s.
+//
+// We can't unit-test the activity wrapper directly (it's tied to
+// ExecutionRequest semantics + workflow plumbing), but we CAN test the
+// underlying spawn-and-kill mechanics that runAgentTurn relies on.
+// This test reproduces the activity's spawn/kill contract in isolation.
+
+import { describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+
+const SHORT_TIMEOUT_MS = 1500; // wall_timeout simulation
+const CLOSE_FIRE_BUDGET_MS = 1500; // how long after kill before close should fire
+
+describe('slice 7a — wall_timeout SIGKILL propagation', () => {
+  it('detached spawn + group kill: close event fires within budget after timer', async () => {
+    // Reproduce the activity's pattern: parent shell that exec-spawns a
+    // long-running grandchild (sleep) which inherits stdout. Without group
+    // kill, killing only the parent leaves grandchild owning the pipe.
+    const command = '/bin/bash';
+    const args = ['-c', 'sleep 60 & wait'];
+
+    const start = Date.now();
+    const result = await new Promise<{ closeMs: number; killed: boolean }>((resolve) => {
+      const child = spawn(command, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
+      });
+
+      let killed = false;
+      const killTimer = setTimeout(() => {
+        if (child.pid !== undefined) {
+          try {
+            process.kill(-child.pid, 'SIGKILL');
+            killed = true;
+          } catch {
+            // ESRCH = already exited
+          }
+        }
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+      }, SHORT_TIMEOUT_MS);
+
+      child.on('close', () => {
+        clearTimeout(killTimer);
+        resolve({ closeMs: Date.now() - start, killed });
+      });
+    });
+
+    // Total wall: timer (1500ms) + close-fire budget (1500ms) = ~3s ceiling.
+    // Pre-fix this would hit the test runner's default 5s timeout.
+    expect(result.killed).toBe(true);
+    expect(result.closeMs).toBeLessThan(SHORT_TIMEOUT_MS + CLOSE_FIRE_BUDGET_MS);
+  }, 10_000);
+
+  it("regression guard: NON-detached spawn would not propagate to grandchildren (control case)", async () => {
+    // This test documents the bug we fixed by demonstrating the broken
+    // pattern still has the issue. We expect EITHER close to fire (some
+    // shells propagate signals to children even without setpgid, e.g.
+    // when the shell itself is the parent and waits) OR for it to take
+    // longer than the detached-group case. The point is to anchor the
+    // fix behavior — not to re-fail on every CI run.
+    //
+    // We use a tighter budget here just to prove the contrast: detached
+    // ALWAYS finishes inside SHORT_TIMEOUT_MS + CLOSE_FIRE_BUDGET_MS;
+    // non-detached MAY exceed it depending on the kernel/shell.
+
+    const command = '/bin/bash';
+    const args = ['-c', 'sleep 60 & wait'];
+
+    const start = Date.now();
+    const closed = await new Promise<boolean>((resolve) => {
+      const child = spawn(command, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // detached intentionally OMITTED — bug-mode
+      });
+
+      const killTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL'); // parent only — does NOT take the group
+        } catch {}
+      }, 500);
+
+      const safetyTimer = setTimeout(() => resolve(false), 4000);
+
+      child.on('close', () => {
+        clearTimeout(killTimer);
+        clearTimeout(safetyTimer);
+        resolve(true);
+      });
+    });
+    // We don't assert pass/fail here — the exact behavior depends on the
+    // shell's signal propagation. We just record the timing as a sanity
+    // anchor: detached fixes the worst case; this control may pass or
+    // fail depending on environment.
+    const elapsed = Date.now() - start;
+    if (closed) {
+      // pass-through — environment happens to propagate
+      expect(elapsed).toBeGreaterThan(0);
+    } else {
+      // hung — exactly the bug scenario the slice 7a fix avoids
+      expect(elapsed).toBeGreaterThanOrEqual(4000);
+    }
+  }, 10_000);
+});

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,103 @@
+# Chitin systemd units (slice 7)
+
+User-mode systemd units that run the autonomous swarm: worker daemon
++ dispatcher timer. Per-user — no sudo required to install.
+
+## What's here
+
+| Unit | Type | Purpose |
+|------|------|---------|
+| `chitin-worker.service` | long-running | Temporal worker, polls `chitin-worker-q`, runs activities. |
+| `chitin-dispatcher.service` | oneshot | Single tick: reads backlog, picks next ready entry, submits workflow, runs apply step. |
+| `chitin-dispatcher.timer` | timer | Fires the dispatcher every 5 minutes. |
+
+## Install
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp infra/systemd/*.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now chitin-worker
+systemctl --user enable --now chitin-dispatcher.timer
+```
+
+To survive logout (start at boot):
+
+```bash
+sudo loginctl enable-linger $USER
+```
+
+## Operate
+
+```bash
+# Live logs
+journalctl --user -u chitin-worker -f
+journalctl --user -u chitin-dispatcher -f
+
+# Status
+systemctl --user status chitin-worker
+systemctl --user list-timers --all
+
+# Pause the swarm (stop dispatcher; worker keeps polling)
+systemctl --user stop chitin-dispatcher.timer
+
+# Hard stop everything
+systemctl --user stop chitin-dispatcher.timer chitin-worker
+```
+
+## Manual one-shot
+
+```bash
+# Dispatch a single tick on demand (no timer)
+systemctl --user start chitin-dispatcher.service
+
+# Or run dispatcher directly (dry-run available)
+cd ~/workspace/chitin
+pnpm exec tsx apps/temporal-worker/src/dispatcher.ts --dry-run
+pnpm exec tsx apps/temporal-worker/src/dispatcher.ts
+```
+
+## What gets dispatched
+
+The dispatcher's invariants:
+
+- **At most one swarm workflow in flight at a time.** If any workflow
+  with id matching `swarm-*` is RUNNING in Temporal, the tick exits
+  without dispatching. Sequential by design — no parallel runs eating
+  the queue out of order.
+- **Each backlog entry dispatched at most once per origin.** If a
+  branch matching `swarm/swarm-<entry-id>-*` exists on origin (open
+  or merged PR), the entry is skipped. Re-dispatch requires deleting
+  the branch.
+- **T5 entries are never dispatched** — those are human-only
+  (governance changes, irreversible decisions, ambiguous strategy).
+
+## Tier → driver routing (slice 7c)
+
+| Tier | Driver | Wall timeout | Cost |
+|------|--------|--------------|------|
+| T0 | `local-qwen` (qwen3-coder:30b) | 180s | $0 (local) |
+| T1 | `copilot` (GPT-4.1 free) | 240s | $0 |
+| T2 | `claude-code-headless` (haiku) | 360s | low |
+| T3 | `claude-code-headless` (sonnet) | 600s | medium |
+| T4 | `claude-code-headless` (opus) | 600s | high |
+
+## Failure modes
+
+- **Workflow hangs:** wall_timeout SIGKILL (slice 7a) propagates to
+  the process group, agent dies within ~1s of the timer, activity
+  returns `exit_code=-1`. Apply step skips PR. Operator sees in
+  `gov-decisions` chain + Temporal UI.
+- **Apply step fails (push or PR open):** worktree may have unpushed
+  commits; envelope file persists in `tmp/result-<wfid>.json`. Operator
+  re-runs `apply-workflow-result.ts --result <path> --apply`.
+- **Worker crashes:** `Restart=on-failure` brings it back in 10s.
+- **Dispatcher tick errors:** systemd records exit code, next timer
+  tick retries.
+
+## Pause for governance changes
+
+Slice 6 verified that the swarm cannot edit `chitin.yaml` (the
+`no-governance-self-modification` rule blocks all agents). But if you
+want a hard stop on the swarm during an incident, the timer-stop above
+takes effect within seconds.

--- a/infra/systemd/chitin-dispatcher.service
+++ b/infra/systemd/chitin-dispatcher.service
@@ -1,0 +1,30 @@
+# Slice 7d: dispatcher one-shot, fired by chitin-dispatcher.timer.
+#
+# Reads docs/swarm-backlog.md, picks the next ready entry, submits one
+# Temporal workflow, waits for completion, runs apply step. Idempotent:
+# if a swarm/<entry-id>-* branch exists on origin OR a swarm-* workflow
+# is currently running, this exits without dispatching.
+#
+# Install (paired with chitin-dispatcher.timer):
+#   cp infra/systemd/chitin-dispatcher.{service,timer} ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now chitin-dispatcher.timer
+
+[Unit]
+Description=Chitin swarm dispatcher — one tick of backlog dispatch
+# Need the worker up to actually process workflows we submit.
+After=chitin-worker.service
+Wants=chitin-worker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/dispatcher.ts
+StandardOutput=journal
+StandardError=journal
+# A single dispatch cycle should never run longer than this. If it does,
+# something's wrong (hung workflow, stuck git, etc.) — kill the timer
+# tick and let the next one retry.
+TimeoutStartSec=900

--- a/infra/systemd/chitin-dispatcher.timer
+++ b/infra/systemd/chitin-dispatcher.timer
@@ -1,0 +1,16 @@
+# Slice 7d: fires chitin-dispatcher.service every 5 minutes.
+
+[Unit]
+Description=Chitin swarm dispatcher — periodic backlog drain
+
+[Timer]
+# First tick 30s after boot (give the worker time to connect).
+OnBootSec=30s
+# Subsequent ticks every 5 min.
+OnUnitActiveSec=5min
+# If we missed a tick (system was off), don't catch up — just resume.
+Persistent=false
+Unit=chitin-dispatcher.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/systemd/chitin-worker.service
+++ b/infra/systemd/chitin-worker.service
@@ -1,0 +1,32 @@
+# Slice 7d: Temporal worker as a long-running user service.
+#
+# Install (per-user, no sudo):
+#   mkdir -p ~/.config/systemd/user
+#   cp infra/systemd/chitin-worker.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now chitin-worker
+#   journalctl --user -u chitin-worker -f
+#
+# To enable on boot regardless of login:
+#   sudo loginctl enable-linger $USER
+
+[Unit]
+Description=Chitin Temporal Worker — autonomous swarm execution plane
+After=network.target
+# Soft dependency on docker — Temporal stack runs in compose.
+Wants=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/worker.ts
+Restart=on-failure
+RestartSec=10
+# Keep stdout/stderr in the journal so journalctl is the operator surface.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

The swarm goes from **"manual dispatch only"** to **"runs 24/7 on a 5-min cron"** with hard safety invariants. Three components bundled per `i want it autonomous`:

### 7a — wall_timeout_s SIGKILL propagation

`spawn(cmd, args, { detached: true })` makes the child a process-group leader. On wall_timeout fire, `process.kill(-pid, 'SIGKILL')` kills the whole group instead of just the parent. Belt-and-suspenders: also `child.stdout?.destroy()` for the rare overloaded-system case where SIGKILL takes a tick to propagate.

**Pre-fix:** openclaw's grandchildren (model runners, ollama processes) inherited stdout pipes and kept them open after parent SIGKILL. Node's `'close'` event waited for the pipes — never fired. Activity hung to Temporal's 15-min `startToCloseTimeout`. Verified earlier this session in slice-5/5b runs.

**Post-fix:** SIGKILL → close fires within ~1s. Verified in `apps/temporal-worker/test/sigkill-propagation.test.ts` (real spawn with hung grandchild; close completes in <3s total wall).

### 7b — autonomous dispatcher

`apps/temporal-worker/src/dispatcher.ts` reads `docs/swarm-backlog.md`, picks the next ready entry that:

1. Has a recognized tier (T0..T4; T5 always skipped — human-only)
2. Has no `swarm/<entry-id>-*` branch on origin (avoids re-dispatching entries that already produced PRs)
3. Has no dispatch marker (`~/.cache/chitin/swarm-state/dispatched/<entry-id>.json`) — operator removes to retry

Concurrency: at most one `swarm-*` workflow in flight. Dispatcher checks Temporal's running list before picking; exits if any is running. Sequential by design, no parallel runs eating the queue out of order.

Marker is written **before** submit so a failed submit still locks out auto-retry. Intentional pessimism: no quiet retries without operator review.

### 7c — tier → driver routing

```ts
T0 → local-qwen (free)              wall_timeout 180s, max_tool_calls 10
T1 → copilot (GPT-4.1 free)         240s, 15
T2 → claude-code-headless (haiku)   360s, 25
T3 → claude-code-headless (sonnet)  600s, 50
T4 → claude-code-headless (opus)    600s, 50
```

Cheapest tier the work needs. Slice 6c's `CLAUDE_TIER_MODEL` / `COPILOT_TIER_MODEL` maps pick the model.

### 7d — systemd user units (`infra/systemd/`)

- `chitin-worker.service` — long-running, `Restart=on-failure`
- `chitin-dispatcher.service` + `.timer` — oneshot every 5 min, 30s post-boot grace
- README walks through install + operate + pause

### Apply step hardening

`apply-workflow-result.ts` now only auto-commits when there are TRACKED file changes (`diff --shortstat` non-empty). Untracked-only changes (openclaw bootstrap files written into the worktree by slice-6b's workspace remap) are NOT committed and the branch is not pushed. **Pre-fix:** the first slice-7 dispatch produced an empty branch with garbage commits — had to `git push --delete` it. **Post-fix:** verified live that origin stays clean.

## End-to-end live verification

Three dispatcher ticks observed this session:

```
tick 1: gov-policy-allow-pr-merge      → SIGKILL@180s → no work → no push  ✓
tick 2: gov-policy-allow-pr-merge      → skipped (marker) ✓
        normalize-decision-params-truthiness → SIGKILL@180s → no work → no push  ✓
```

Origin has zero `swarm/*` branches after both runs. **The autonomy IS working** — the apply-step heuristic correctly identifies "agent didn't actually do work" and refuses to push.

## Real production signal

`qwen3-coder:30b` on the 3090 isn't completing T0 tasks within 180s wall_timeout. The agent runs, hits wall_timeout, exits cleanly via slice 7a. Two paths forward:

1. **Bump T0 wall_timeout to 300-600s** — gives the model more time
2. **Tune the prompt** — current `buildPrompt` may not be eliciting tool dispatches reliably from qwen3-coder

Either path is a follow-up. The slice-7 architecture is correct and safe regardless: failed runs don't pollute origin, markers prevent infinite loops, queue drains predictably.

## Diff

8 files changed, +677/-8:

- `apps/temporal-worker/src/activity.ts` (+25/-3) — detached spawn + group kill
- `apps/temporal-worker/src/dispatcher.ts` (+~270, new) — autonomous loop
- `apps/temporal-worker/src/grooming/apply-workflow-result.ts` (+18/-5) — tracked-only auto-commit heuristic
- `apps/temporal-worker/test/sigkill-propagation.test.ts` (+~90, new) — 2 tests
- `infra/systemd/*.service`, `*.timer`, `README.md` (new) — deployment

## Test plan

- [x] `pnpm exec tsc -p apps/temporal-worker/tsconfig.json --noEmit` clean
- [x] `pnpm exec vitest run apps/temporal-worker/test/sigkill-propagation` — 2/2 passing
- [x] systemd install + 3 dispatcher ticks observed end-to-end
- [x] Origin clean (no `swarm/*` branches from either failed run)
- [ ] Copilot review
- [ ] Adversarial review

## Operate

```bash
# Pause the swarm (worker keeps polling)
systemctl --user stop chitin-dispatcher.timer

# Hard stop everything
systemctl --user stop chitin-dispatcher.timer chitin-worker

# Live logs
journalctl --user -u chitin-dispatcher -f
```

## Architecture invariants preserved

- **Self-governance:** chitin.yaml + .chitin/* edits remain T5 (human only). Slice 6 verified the gate denies all three drivers; slice 7 verified the marker logic correctly handles entries the gate refuses.
- **Cost discipline:** tier routing keeps Opus for last-resort work; T0 mechanical work runs free on the 3090. Today's runs all cost $0.
- **Audit trail:** every gate decision lands in `gov-decisions` chain. Markers are local-only state (not gov), so audit reads chain + Temporal history, not the marker dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)