### PR TITLE
swarm: repo-regex-tighten

### DIFF
--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -70,7 +70,7 @@ export const ExecutionRequestSchema = z
     schema_version: z.literal('1'),
     workflow_id: TemporalIdSchema,
     run_id: TemporalIdSchema,
-    repo: z.string().regex(/^[^/\s]+\/[^/\s]+$/, 'must be <owner>/<name>'),
+    repo: z.string().regex(/^[\w][\w.-]*\/[\w][\w.-]*$/, 'must be <owner>/<name>'),
     files: z.array(z.string().min(1)).optional(),
     task_class: TaskClassSchema,
     risk_level: RiskLevelSchema,

--- a/libs/contracts/tests/execution-request.schema.test.ts
+++ b/libs/contracts/tests/execution-request.schema.test.ts
@@ -86,8 +86,8 @@ describe('ExecutionRequestSchema', () => {
     expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
   });
 
-  it('rejects repo with ../foo', () => {
-    const bad = { ...validRequest, repo: '../foo/bar' };
+  it('rejects repo with ../foo (owner=.., name=foo — leading-dot tightening)', () => {
+    const bad = { ...validRequest, repo: '../foo' };
     expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
   });
 

--- a/libs/contracts/tests/execution-request.schema.test.ts
+++ b/libs/contracts/tests/execution-request.schema.test.ts
@@ -66,6 +66,41 @@ describe('ExecutionRequestSchema', () => {
     expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
   });
 
+  it('rejects repo with leading dot in owner', () => {
+    const bad = { ...validRequest, repo: '.foo/bar' };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects repo with leading dot in name', () => {
+    const bad = { ...validRequest, repo: 'foo/.bar' };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects repo with ..foo/bar', () => {
+    const bad = { ...validRequest, repo: '..foo/bar' };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects repo with foo/..bar', () => {
+    const bad = { ...validRequest, repo: 'foo/..bar' };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects repo with ../foo', () => {
+    const bad = { ...validRequest, repo: '../foo/bar' };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects repo with foo/../bar', () => {
+    const bad = { ...validRequest, repo: 'foo/../bar' };
+    expect(() => ExecutionRequestSchema.parse(bad)).toThrow();
+  });
+
+  it('accepts valid repo chitinhq/chitin', () => {
+    const ok = { ...validRequest, repo: 'chitinhq/chitin' };
+    expect(() => ExecutionRequestSchema.parse(ok)).not.toThrow();
+  });
+
   it('accepts max_cost_usd = 0 (T0-only / no-cloud is legal)', () => {
     const ok = { ...validRequest, bounds: { ...validRequest.bounds, max_cost_usd: 0 } };
     expect(() => ExecutionRequestSchema.parse(ok)).not.toThrow();


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `repo-regex-tighten`
Tier: `T0`  •  Driver: `copilot`
Workflow: `swarm-repo-regex-tighten-1777692221001`

## Entry context

`^[^/\s]+\/[^/\s]+$` accepts `..foo/..bar` because `..` matches `[^/\s]+`.
Tighten to forbid leading `.` — e.g., `^[\w][\w.-]*/[\w][\w.-]*$`. Add tests
that reject `../foo`, `..foo/bar`, `foo/../bar`, and accept `chitinhq/chitin`.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-repo-regex-tighten-1777692221001`
Branch: `swarm/swarm-repo-regex-tighten-1777692221001`
Head: `1842bc2b`
Diff: `2 files changed, 36 insertions(+), 1 deletion(-)`
Commits: 1