### PR TITLE
docs(swarm-backlog): prioritize qwen-layer entries for swarm self-tuning

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -84,42 +84,6 @@ asserting `executeRequestWorkflow.name === WORKFLOW_NAME`.
 
 ---
 
-### `repo-regex-tighten`
-
-```yaml
-id: repo-regex-tighten
-tier: T0
-status: ready
-estimated_loc: 4
-blocks: []
-file: libs/contracts/src/execution-request.schema.ts
-references_issue: 82
-```
-
-`^[^/\s]+\/[^/\s]+$` accepts `..foo/..bar` because `..` matches `[^/\s]+`.
-Tighten to forbid leading `.` — e.g., `^[\w][\w.-]*/[\w][\w.-]*$`. Add tests
-that reject `../foo`, `..foo/bar`, `foo/../bar`, and accept `chitinhq/chitin`.
-
----
-
-### `read-vs-read_file-file_path-alias`
-
-```yaml
-id: read-vs-read_file-file_path-alias
-tier: T0
-status: ready
-estimated_loc: 6
-blocks: []
-file: go/execution-kernel/internal/gov/normalize.go
-```
-
-Slice 3 added `case "read"` with `path` → `file_path` alias fallback, but the
-existing `case "read_file"` has no fallback. Make `read_file` use the same
-alias logic for parity. Add a test that `read_file({file_path: "/x"})` and
-`read_file({path: "/x"})` produce the same Action.
-
----
-
 ## Qwen-layer reliability (T0→copilot until these ship)
 
 These five entries together aim to flip `TIER_DRIVER[T0]` back from
@@ -228,6 +192,42 @@ end-to-end on local-qwen. Status `blocked` until the dependencies
 land — the dispatcher's `pickEntryToDispatch` doesn't currently
 respect blocks (slice 8 work) but a human reviewer will catch a
 premature merge.
+
+---
+
+### `repo-regex-tighten`
+
+```yaml
+id: repo-regex-tighten
+tier: T0
+status: ready
+estimated_loc: 4
+blocks: []
+file: libs/contracts/src/execution-request.schema.ts
+references_issue: 82
+```
+
+`^[^/\s]+\/[^/\s]+$` accepts `..foo/..bar` because `..` matches `[^/\s]+`.
+Tighten to forbid leading `.` — e.g., `^[\w][\w.-]*/[\w][\w.-]*$`. Add tests
+that reject `../foo`, `..foo/bar`, `foo/../bar`, and accept `chitinhq/chitin`.
+
+---
+
+### `read-vs-read_file-file_path-alias`
+
+```yaml
+id: read-vs-read_file-file_path-alias
+tier: T0
+status: ready
+estimated_loc: 6
+blocks: []
+file: go/execution-kernel/internal/gov/normalize.go
+```
+
+Slice 3 added `case "read"` with `path` → `file_path` alias fallback, but the
+existing `case "read_file"` has no fallback. Make `read_file` use the same
+alias logic for parity. Add a test that `read_file({file_path: "/x"})` and
+`read_file({path: "/x"})` produce the same Action.
 
 ---
 


### PR DESCRIPTION
## Summary

Moves the \`Qwen-layer reliability\` section above the remaining T0 entries (\`repo-regex-tighten\`, \`read-vs-read_file-file_path-alias\`) in \`swarm-backlog.md\`. Per Jared's \"have the swarm work on tuning itself for now\" — the dispatcher picks the first ready entry in file order, so reordering = reprioritizing.

## Why

Previous order had the qwen-fix entries last; the swarm would drain the existing T0 backlog (3-4 small mechanical fixes) first and only THEN circle back to its own self-improvement. The qwen-layer fixes are higher-leverage:

- \`dispatcher-prompt-relative-path-prefix\` (T1) — fixes the prompt bug that broke slice-7-tuning's first live run (qwen3-coder:30b interpreting \`apps/foo\` as \`/apps/foo\`)
- \`dispatcher-prompt-scope-discipline\` (T1) — refuses out-of-scope edits, which would have caught the test-file scope drift on PR #102 before it became a CI failure
- \`activity-include-hook-events-flag\` (T1) — surfaces tool-call events so future failures don't require grep-stderr-archaeology
- \`qwen-ollama-stream-instability-investigation\` (T2) — characterizes the ollama stream crash so we know what to fix at the model layer
- \`dispatcher-flip-t0-back-to-local-qwen\` (T0, blocked) — the final flip once the three blockers ship

After this PR merges and the next dispatcher tick fires (≤5 min from merge), the swarm picks \`dispatcher-prompt-relative-path-prefix\` and produces a PR with the \`./\` path prefix fix.

Then the next tick picks the next entry. Then the next. Each one improves the swarm's ability to do the NEXT entry. Recursive self-improvement, governed by the chitin gate, reviewed by humans before merge.

## What's NOT in scope

- The dispatcher still doesn't respect \`blocks: [...]\` — \`dispatcher-flip-t0-back-to-local-qwen\` is marked \`status: blocked\` so the dispatcher's \`pickEntryToDispatch\` skips it via the status filter, not the blocks logic. Fixing the dispatcher to respect blocks is slice-8 work.
- No code changes here. Pure docs reorder. Parser test still passes (the format is order-preserving by design).

## Test plan

- [x] \`pnpm exec vitest run apps/temporal-worker/test/grooming-parse-backlog\` — 8/8 passing post-reorder
- [x] \`grep -n '^###'\` shows new order: qwen-layer entries between \`workflow-name-drift-test\` and \`repo-regex-tighten\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)