### PR TITLE
swarm: dispatcher-prompt-relative-path-prefix

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -220,7 +220,7 @@ function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
   return null;
 }
 
-function buildPrompt(entry: BacklogEntry): string {
+export function buildPrompt(entry: BacklogEntry): string {
   // Slice 7-tuning: rewritten to be directive about tool use and
   // shut off chat-style replies. The pre-tuning prompt let qwen3-
   // coder:30b answer with a markdown plan instead of dispatching
@@ -233,7 +233,10 @@ function buildPrompt(entry: BacklogEntry): string {
   // agent at the file and tell it to use the read tool. The
   // verbose-step echo was likely tempting the model into "summarize
   // the steps" mode rather than executing them.
-  const targetFile = entry.file?.split(',')[0]?.trim() || 'the file named in the entry';
+    let targetFile = entry.file?.split(',')[0]?.trim() || 'the file named in the entry';
+  if (targetFile && !targetFile.startsWith('./') && !targetFile.startsWith('/')) {
+    targetFile = `./${targetFile}`;
+  }
   return `You are a swarm worker executing one backlog entry. Output text is ignored — only TOOL DISPATCHES count. If you finish without dispatching tools, the work is lost.
 
 ENTRY ID: ${entry.id}

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -34,6 +34,7 @@ import { execFileSync, execSync } from 'node:child_process';
 import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import type { ActivityResult } from './activity-types.ts';
 import type { executeRequestWorkflow } from './workflow.ts';
 import { parseBacklog, type BacklogEntry } from './grooming/parse-backlog.ts';
@@ -233,9 +234,14 @@ export function buildPrompt(entry: BacklogEntry): string {
   // agent at the file and tell it to use the read tool. The
   // verbose-step echo was likely tempting the model into "summarize
   // the steps" mode rather than executing them.
-    let targetFile = entry.file?.split(',')[0]?.trim() || 'the file named in the entry';
-  if (targetFile && !targetFile.startsWith('./') && !targetFile.startsWith('/')) {
-    targetFile = `./${targetFile}`;
+  const rawFile = entry.file?.split(',')[0]?.trim();
+  let targetFile: string;
+  if (rawFile) {
+    targetFile = rawFile.startsWith('./') || rawFile.startsWith('/')
+      ? rawFile
+      : `./${rawFile}`;
+  } else {
+    targetFile = 'the file named in the entry';
   }
   return `You are a swarm worker executing one backlog entry. Output text is ignored — only TOOL DISPATCHES count. If you finish without dispatching tools, the work is lost.
 
@@ -373,7 +379,12 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  log('error', 'dispatcher fatal', { error: err instanceof Error ? err.message : String(err) });
-  process.exit(1);
-});
+// Only auto-run when invoked as a script. Importing buildPrompt or other
+// helpers from tests must not open a Temporal connection.
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    log('error', 'dispatcher fatal', { error: err instanceof Error ? err.message : String(err) });
+    process.exit(1);
+  });
+}

--- a/apps/temporal-worker/test/dispatcher-prompt-path.test.ts
+++ b/apps/temporal-worker/test/dispatcher-prompt-path.test.ts
@@ -1,0 +1,36 @@
+import { buildPrompt } from '../src/dispatcher';
+import { describe, it, expect } from 'vitest';
+
+describe('buildPrompt', () => {
+  it('prepends ./ to relative target file paths', () => {
+    const entry = {
+      id: 'test-entry',
+      file: 'apps/foo/bar.ts',
+      description: 'desc',
+    };
+    const prompt = buildPrompt(entry as any);
+    expect(prompt).toContain('TARGET FILE: ./apps/foo/bar.ts');
+    expect(prompt).toContain('dispatch the `read` tool on ./apps/foo/bar.ts');
+    expect(prompt).toContain('Start by reading ./apps/foo/bar.ts now.');
+  });
+
+  it('does not prepend ./ if already present', () => {
+    const entry = {
+      id: 'test-entry',
+      file: './apps/foo/bar.ts',
+      description: 'desc',
+    };
+    const prompt = buildPrompt(entry as any);
+    expect(prompt).toContain('TARGET FILE: ./apps/foo/bar.ts');
+  });
+
+  it('does not prepend ./ if absolute path', () => {
+    const entry = {
+      id: 'test-entry',
+      file: '/apps/foo/bar.ts',
+      description: 'desc',
+    };
+    const prompt = buildPrompt(entry as any);
+    expect(prompt).toContain('TARGET FILE: /apps/foo/bar.ts');
+  });
+});

--- a/apps/temporal-worker/test/dispatcher-prompt-path.test.ts
+++ b/apps/temporal-worker/test/dispatcher-prompt-path.test.ts
@@ -1,36 +1,39 @@
-import { buildPrompt } from '../src/dispatcher';
+import { buildPrompt } from '../src/dispatcher.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
 import { describe, it, expect } from 'vitest';
+
+function makeEntry(overrides: Partial<BacklogEntry>): BacklogEntry {
+  return {
+    id: 'test-entry',
+    status: 'ready',
+    description: 'desc',
+    rawFrontmatter: '```yaml\nid: test-entry\nstatus: ready\n```',
+    rawSection: '### `test-entry`\n\n```yaml\nid: test-entry\nstatus: ready\n```\n\ndesc\n',
+    ...overrides,
+  };
+}
 
 describe('buildPrompt', () => {
   it('prepends ./ to relative target file paths', () => {
-    const entry = {
-      id: 'test-entry',
-      file: 'apps/foo/bar.ts',
-      description: 'desc',
-    };
-    const prompt = buildPrompt(entry as any);
+    const prompt = buildPrompt(makeEntry({ file: 'apps/foo/bar.ts' }));
     expect(prompt).toContain('TARGET FILE: ./apps/foo/bar.ts');
     expect(prompt).toContain('dispatch the `read` tool on ./apps/foo/bar.ts');
     expect(prompt).toContain('Start by reading ./apps/foo/bar.ts now.');
   });
 
   it('does not prepend ./ if already present', () => {
-    const entry = {
-      id: 'test-entry',
-      file: './apps/foo/bar.ts',
-      description: 'desc',
-    };
-    const prompt = buildPrompt(entry as any);
+    const prompt = buildPrompt(makeEntry({ file: './apps/foo/bar.ts' }));
     expect(prompt).toContain('TARGET FILE: ./apps/foo/bar.ts');
   });
 
   it('does not prepend ./ if absolute path', () => {
-    const entry = {
-      id: 'test-entry',
-      file: '/apps/foo/bar.ts',
-      description: 'desc',
-    };
-    const prompt = buildPrompt(entry as any);
+    const prompt = buildPrompt(makeEntry({ file: '/apps/foo/bar.ts' }));
     expect(prompt).toContain('TARGET FILE: /apps/foo/bar.ts');
+  });
+
+  it('does not prepend ./ to the placeholder when entry.file is missing', () => {
+    const prompt = buildPrompt(makeEntry({ file: undefined }));
+    expect(prompt).toContain('TARGET FILE: the file named in the entry');
+    expect(prompt).not.toContain('TARGET FILE: ./the file named in the entry');
   });
 });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `dispatcher-prompt-relative-path-prefix`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-dispatcher-prompt-relative-path-prefix-1777692526064`

## Entry context

The slice-7-tuning prompt names the entry's `file` field as the
`TARGET FILE`. Live run: qwen3-coder:30b interpreted the relative path
`apps/openclaw-plugin-governance/src/index.mjs` as absolute (prepended
`/`), got `ENOENT` on `/apps/...`. Patch `buildPrompt` to prepend `./`
to the target file so it's an explicit relative path: `./apps/foo`.
Add a test asserting the prompt contains `./` + the path.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-dispatcher-prompt-relative-path-prefix-1777692526064`
Branch: `swarm/swarm-dispatcher-prompt-relative-path-prefix-1777692526064`
Head: `1b8a8f67`
Diff: `2 files changed, 41 insertions(+), 2 deletions(-)`
Commits: 1