### PR TITLE
swarm: activity-include-hook-events-flag

### DIFF
--- a/apps/temporal-worker/src/activity-types.ts
+++ b/apps/temporal-worker/src/activity-types.ts
@@ -8,10 +8,37 @@ export interface ActivityResult {
   // the branch and open a PR.
   worktree?: WorktreeResult;
   /**
-   * Parsed summary of hook events emitted by the agent (if available).
-   * Only present when --include-hook-events was passed and the agent supports it.
+   * Hook events extracted from the agent's stream-json output.
+   *
+   * Only present when --include-hook-events was passed AND the parser
+   * found at least one well-formed event in the bounded stdout tail.
+   * The set is a best-effort projection from the tail window — events
+   * older than TAIL_BYTES of stdout will not appear.
+   *
+   * Each entry is a typed projection of the underlying agent hook
+   * event (claude-code or openclaw), keeping only the fields downstream
+   * consumers (apply-step, audit log) actually use.
    */
-  hookEvents?: any[];
+  hook_events?: HookEventSummary[];
+}
+
+/**
+ * Stable, narrow projection of an agent hook event. Both claude-code
+ * (PreToolUse / PostToolUse / Stop / etc.) and openclaw (before_tool_call,
+ * subagent_spawning, etc.) emit events with these fields populated.
+ *
+ * Fields are optional because event types vary — a Stop event has no
+ * tool_name, a Notification event has no decision, etc.
+ */
+export interface HookEventSummary {
+  /** Event family — e.g. 'PreToolUse', 'before_tool_call', 'Stop'. */
+  hook_name?: string;
+  /** Tool the event references when applicable. */
+  tool_name?: string;
+  /** allow / deny / error when the event reports a gate decision. */
+  decision?: 'allow' | 'deny' | 'error';
+  /** Human-readable explanation when present. */
+  reason?: string;
 }
 
 export interface WorktreeResult {

--- a/apps/temporal-worker/src/activity-types.ts
+++ b/apps/temporal-worker/src/activity-types.ts
@@ -7,6 +7,11 @@ export interface ActivityResult {
   // activity created a worktree. Apply-step uses worktree_path to push
   // the branch and open a PR.
   worktree?: WorktreeResult;
+  /**
+   * Parsed summary of hook events emitted by the agent (if available).
+   * Only present when --include-hook-events was passed and the agent supports it.
+   */
+  hookEvents?: any[];
 }
 
 export interface WorktreeResult {

--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, copyFileSync, existsSync, rmSync, mkdirSync, readFileSync,
 import { tmpdir, homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
-import type { ActivityResult, WorktreeResult } from './activity-types.ts';
+import type { ActivityResult, HookEventSummary, WorktreeResult } from './activity-types.ts';
 
 // Bytes of stdout/stderr returned to Temporal in ActivityResult. Buffers
 // during the run are bounded at 2x this value (see runAgentTurn), so
@@ -425,28 +425,17 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
       }, req.bounds.wall_timeout_s * 1000);
       child.on('close', (code) => {
         clearTimeout(killTimer);
-        // Parse hook events from stream-json output if present
-        let hookEvents: any[] | undefined = undefined;
-        try {
-          // Only attempt to parse if --include-hook-events was passed
-          if (plan.args.includes('--include-hook-events')) {
-            // Look for hook events in the tail of stdout
-            // (Assume each event is a JSON object on its own line)
-            const lines = stdout.split('\n');
-            hookEvents = lines
-              .map(line => {
-                try { return JSON.parse(line); } catch { return undefined; }
-              })
-              .filter(ev => ev && ev.type === 'hook_event');
-            if (hookEvents.length === 0) hookEvents = undefined;
-          }
-        } catch {}
+        const tailStdout = stdout.slice(-TAIL_BYTES);
+        const tailStderr = stderr.slice(-TAIL_BYTES);
+        const hookEvents = plan.args.includes('--include-hook-events')
+          ? extractHookEvents(tailStdout)
+          : undefined;
         resolvePromise({
           exit_code: code ?? -1,
-          stdout_tail: stdout.slice(-TAIL_BYTES),
-          stderr_tail: stderr.slice(-TAIL_BYTES),
+          stdout_tail: tailStdout,
+          stderr_tail: tailStderr,
           duration_ms: Date.now() - start,
-          ...(hookEvents ? { hookEvents } : {}),
+          ...(hookEvents ? { hook_events: hookEvents } : {}),
         });
       });
       child.on('error', reject);
@@ -483,6 +472,41 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
   return result;
 }
 
+/**
+ * Project the agent's stream-json stdout tail into a typed
+ * HookEventSummary[]. Best-effort — events older than TAIL_BYTES are
+ * lost, and lines that don't parse as JSON are silently skipped.
+ *
+ * We only forward fields downstream consumers actually use; other
+ * fields on the source event are intentionally dropped to keep the
+ * audit-log payload small.
+ */
+function extractHookEvents(stdoutTail: string): HookEventSummary[] | undefined {
+  const out: HookEventSummary[] = [];
+  for (const line of stdoutTail.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    const ev = parsed as Record<string, unknown>;
+    if (ev.type !== 'hook_event') continue;
+    const summary: HookEventSummary = {};
+    if (typeof ev.hook_name === 'string') summary.hook_name = ev.hook_name;
+    if (typeof ev.tool_name === 'string') summary.tool_name = ev.tool_name;
+    if (ev.decision === 'allow' || ev.decision === 'deny' || ev.decision === 'error') {
+      summary.decision = ev.decision;
+    }
+    if (typeof ev.reason === 'string') summary.reason = ev.reason;
+    out.push(summary);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 export const __test__ = {
   planInvocation,
   resolvePolicySrc,
@@ -494,6 +518,7 @@ export const __test__ = {
   resolveCopilotModel,
   writeWorktreeClaudeSettings,
   provisionOpenclawState,
+  extractHookEvents,
   DRIVER_AGENT_MAP,
   SWARM_WORKTREES_ROOT,
   CLAUDE_TIER_MODEL,

--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -110,6 +110,7 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
       // boundary, and it still fires via the worktree's project settings.
       const args = [
         '-p', req.prompt,
+        '--include-hook-events',
         '--dangerously-skip-permissions',
         '--allowedTools', process.env.CHITIN_CLAUDE_ALLOWED_TOOLS ?? DEFAULT_CLAUDE_ALLOWED_TOOLS,
         '--output-format', 'stream-json',
@@ -139,6 +140,7 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
           '--local',
           '--agent', resolveAgent(driver),
           '--json',
+          '--include-hook-events',
           '--timeout', String(req.bounds.wall_timeout_s),
           '--message', req.prompt,
         ],
@@ -423,11 +425,28 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
       }, req.bounds.wall_timeout_s * 1000);
       child.on('close', (code) => {
         clearTimeout(killTimer);
+        // Parse hook events from stream-json output if present
+        let hookEvents: any[] | undefined = undefined;
+        try {
+          // Only attempt to parse if --include-hook-events was passed
+          if (plan.args.includes('--include-hook-events')) {
+            // Look for hook events in the tail of stdout
+            // (Assume each event is a JSON object on its own line)
+            const lines = stdout.split('\n');
+            hookEvents = lines
+              .map(line => {
+                try { return JSON.parse(line); } catch { return undefined; }
+              })
+              .filter(ev => ev && ev.type === 'hook_event');
+            if (hookEvents.length === 0) hookEvents = undefined;
+          }
+        } catch {}
         resolvePromise({
           exit_code: code ?? -1,
           stdout_tail: stdout.slice(-TAIL_BYTES),
           stderr_tail: stderr.slice(-TAIL_BYTES),
           duration_ms: Date.now() - start,
+          ...(hookEvents ? { hookEvents } : {}),
         });
       });
       child.on('error', reject);

--- a/apps/temporal-worker/test/activity.test.ts
+++ b/apps/temporal-worker/test/activity.test.ts
@@ -90,6 +90,73 @@ describe('planInvocation', () => {
       else process.env.CHITIN_CLAUDE_ALLOWED_TOOLS = saved;
     }
   });
+
+  it('claude-code-headless includes --include-hook-events for chain visibility', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['claude-code-headless'] });
+    expect(plan.args).toContain('--include-hook-events');
+  });
+
+  it('local-* (openclaw) drivers include --include-hook-events for chain visibility', () => {
+    for (const driver of ['local-qwen', 'local-glm', 'local-deepseek'] as const) {
+      const plan = planInvocation({ ...baseReq, allowed_drivers: [driver] });
+      expect(plan.command).toBe('openclaw');
+      expect(plan.args).toContain('--include-hook-events');
+    }
+  });
+});
+
+describe('extractHookEvents', () => {
+  const { extractHookEvents } = __test__;
+
+  it('returns undefined when stdout has no hook_event lines', () => {
+    expect(extractHookEvents('')).toBeUndefined();
+    expect(extractHookEvents('not json\n{"type":"other"}\n')).toBeUndefined();
+  });
+
+  it('projects only the documented summary fields', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'hook_event',
+        hook_name: 'PreToolUse',
+        tool_name: 'Bash',
+        decision: 'allow',
+        reason: 'allowed',
+        // extra fields that should be dropped
+        agent_id: 'test',
+        timestamp: '2026-05-02T00:00:00Z',
+      }),
+      JSON.stringify({
+        type: 'hook_event',
+        hook_name: 'PreToolUse',
+        tool_name: 'Edit',
+        decision: 'deny',
+        reason: 'no-governance-self-modification',
+      }),
+    ].join('\n');
+    expect(extractHookEvents(stdout)).toEqual([
+      { hook_name: 'PreToolUse', tool_name: 'Bash', decision: 'allow', reason: 'allowed' },
+      {
+        hook_name: 'PreToolUse',
+        tool_name: 'Edit',
+        decision: 'deny',
+        reason: 'no-governance-self-modification',
+      },
+    ]);
+  });
+
+  it('skips non-JSON lines, JSON without type=hook_event, and unknown decisions', () => {
+    const stdout = [
+      'plain log line',
+      '{"type":"telemetry","value":1}',
+      JSON.stringify({ type: 'hook_event', hook_name: 'Stop' }),
+      JSON.stringify({ type: 'hook_event', tool_name: 'Read', decision: 'maybe' }),
+    ].join('\n');
+    const events = extractHookEvents(stdout);
+    expect(events).toEqual([
+      { hook_name: 'Stop' },
+      { tool_name: 'Read' }, // unknown decision dropped, kept the rest
+    ]);
+  });
 });
 
 describe('resolvePolicySrc', () => {


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `activity-include-hook-events-flag`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-activity-include-hook-events-flag-1777693132219`

## Entry context

Add `--include-hook-events` to the `claude -p` invocation and the
openclaw `agent` invocation (where supported). When the agent's tool
calls fail (e.g., `ENOENT` on a misinterpreted path), the hook events
in the structured stream-json output give the operator visibility
without grepping verbose stderr. Update activity-types `ActivityResult`
to expose a parsed `hookEvents` summary.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-activity-include-hook-events-flag-1777693132219`
Branch: `swarm/swarm-activity-include-hook-events-flag-1777693132219`
Head: `3a98aeeb`
Diff: `2 files changed, 24 insertions(+)`
Commits: 0 (+ auto-committed uncommitted state)