### PR TITLE
feat(swarm): Slack notifier for dispatcher events + TimeoutStartSec fix

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -37,6 +37,12 @@ import { homedir } from 'node:os';
 import type { ActivityResult } from './activity-types.ts';
 import type { executeRequestWorkflow } from './workflow.ts';
 import { parseBacklog, type BacklogEntry } from './grooming/parse-backlog.ts';
+import {
+  notifyDispatchStart,
+  notifyDispatchComplete,
+  notifyDispatchError,
+  extractPrUrl,
+} from './notify.ts';
 
 const WORKFLOW_NAME = 'executeRequestWorkflow';
 const TASK_QUEUE = 'chitin-worker-q';
@@ -313,14 +319,30 @@ async function main() {
     // the swarm doesn't quietly retry without operator review.
     writeDispatchMarker(entry.id, workflowId, tier, driver);
 
-    const handle = await client.workflow.start<typeof executeRequestWorkflow>(WORKFLOW_NAME, {
-      args: [req],
-      taskQueue: TASK_QUEUE,
-      workflowId,
-    });
+    await notifyDispatchStart({ entry_id: entry.id, tier, driver, workflow_id: workflowId });
+
+    let handle;
+    try {
+      handle = await client.workflow.start<typeof executeRequestWorkflow>(WORKFLOW_NAME, {
+        args: [req],
+        taskQueue: TASK_QUEUE,
+        workflowId,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await notifyDispatchError({ entry_id: entry.id, workflow_id: workflowId, stage: 'submit', error: msg });
+      throw err;
+    }
     log('info', 'workflow started', { workflow_id: workflowId });
 
-    const result = (await handle.result()) as ActivityResult;
+    let result: ActivityResult;
+    try {
+      result = (await handle.result()) as ActivityResult;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await notifyDispatchError({ entry_id: entry.id, workflow_id: workflowId, stage: 'workflow', error: msg });
+      throw err;
+    }
     mkdirSync(TMP_DIR, { recursive: true });
     const envelopePath = resolve(TMP_DIR, `result-${workflowId}.json`);
     writeFileSync(
@@ -353,18 +375,40 @@ async function main() {
     // Run apply step inline. apply-workflow-result.ts handles push + PR
     // when the worktree has work, no-ops otherwise. Best-effort: failures
     // are logged but don't propagate (operator can run manually).
+    let applyOutput = '';
+    let applyFailed: Error | null = null;
     try {
-      const applyOutput = execSync(
+      applyOutput = execSync(
         `pnpm exec tsx apps/temporal-worker/src/grooming/apply-workflow-result.ts --result ${envelopePath} --apply`,
         { encoding: 'utf8' },
       );
       log('info', 'apply step output', { output: applyOutput.slice(-2000) });
     } catch (err) {
+      applyFailed = err instanceof Error ? err : new Error(String(err));
       log('warn', 'apply step failed (run manually)', {
         envelope: envelopePath,
-        error: err instanceof Error ? err.message : String(err),
+        error: applyFailed.message,
       });
     }
+
+    const prUrl = extractPrUrl(applyOutput);
+    if (applyFailed) {
+      await notifyDispatchError({
+        entry_id: entry.id,
+        workflow_id: workflowId,
+        stage: 'apply',
+        error: applyFailed.message,
+      });
+    }
+    await notifyDispatchComplete({
+      entry_id: entry.id,
+      workflow_id: workflowId,
+      exit_code: result.exit_code,
+      duration_ms: result.duration_ms,
+      commits_added: result.worktree?.commits_added ?? 0,
+      uncommitted: result.worktree?.has_uncommitted_changes ?? false,
+      pr_url: prUrl,
+    });
   } finally {
     await conn.close();
   }

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -41,6 +41,7 @@ import {
   notifyDispatchStart,
   notifyDispatchComplete,
   notifyDispatchError,
+  notifyTickIdle,
   extractPrUrl,
 } from './notify.ts';
 
@@ -269,6 +270,7 @@ async function main() {
     const running = await findRunningSwarmWorkflow(client);
     if (running) {
       log('info', 'swarm workflow already in flight; exiting', { running });
+      await notifyTickIdle(`workflow already in flight (${running})`);
       return;
     }
 
@@ -276,6 +278,7 @@ async function main() {
     const entry = pickEntryToDispatch(entries);
     if (!entry) {
       log('info', 'no ready entry to dispatch this tick');
+      await notifyTickIdle('no ready entry to dispatch');
       return;
     }
     const tier = entry.tier as Tier;
@@ -319,8 +322,6 @@ async function main() {
     // the swarm doesn't quietly retry without operator review.
     writeDispatchMarker(entry.id, workflowId, tier, driver);
 
-    await notifyDispatchStart({ entry_id: entry.id, tier, driver, workflow_id: workflowId });
-
     let handle;
     try {
       handle = await client.workflow.start<typeof executeRequestWorkflow>(WORKFLOW_NAME, {
@@ -333,6 +334,10 @@ async function main() {
       await notifyDispatchError({ entry_id: entry.id, workflow_id: workflowId, stage: 'submit', error: msg });
       throw err;
     }
+    // notifyDispatchStart fires AFTER successful submit so a failed
+    // workflow.start() doesn't claim a workflow exists in Slack that
+    // never actually got created.
+    await notifyDispatchStart({ entry_id: entry.id, tier, driver, workflow_id: workflowId });
     log('info', 'workflow started', { workflow_id: workflowId });
 
     let result: ActivityResult;
@@ -392,12 +397,35 @@ async function main() {
     }
 
     const prUrl = extractPrUrl(applyOutput);
+    // apply-workflow-result.ts catches `gh pr create` failures and returns
+    // null instead of throwing, so applyFailed is null but no PR landed.
+    // Detect the warning it emits so the operator still sees a Slack alert.
+    const prCreateSilentlyFailed =
+      !applyFailed &&
+      !prUrl &&
+      /\[apply-result\] gh pr create failed/.test(applyOutput);
+    // The push step ran iff we got past the apply step (no exception) AND
+    // apply didn't bail on "no committed work; skipping push and PR." If
+    // apply ran the auto-commit branch + pushed, commits_added (captured
+    // before apply ran) understates reality.
+    const applyAutoCommitted = /\[apply-result\] auto-committing tracked uncommitted changes/.test(applyOutput);
+    const pushed = !applyFailed && /\[apply-result\] pushing /.test(applyOutput);
+
     if (applyFailed) {
       await notifyDispatchError({
         entry_id: entry.id,
         workflow_id: workflowId,
         stage: 'apply',
         error: applyFailed.message,
+      });
+    } else if (prCreateSilentlyFailed) {
+      await notifyDispatchError({
+        entry_id: entry.id,
+        workflow_id: workflowId,
+        stage: 'apply',
+        error:
+          `gh pr create failed (branch ${result.worktree?.branch ?? '?'} pushed but no PR opened — open manually: ` +
+          `gh pr create --head ${result.worktree?.branch ?? '<branch>'} --title "swarm: ${entry.id}")`,
       });
     }
     await notifyDispatchComplete({
@@ -408,6 +436,9 @@ async function main() {
       commits_added: result.worktree?.commits_added ?? 0,
       uncommitted: result.worktree?.has_uncommitted_changes ?? false,
       pr_url: prUrl,
+      apply_failed: !!applyFailed || prCreateSilentlyFailed,
+      pushed,
+      auto_committed: applyAutoCommitted,
     });
   } finally {
     await conn.close();

--- a/apps/temporal-worker/src/notify.ts
+++ b/apps/temporal-worker/src/notify.ts
@@ -98,21 +98,45 @@ export interface DispatchComplete {
   workflow_id: string;
   exit_code: number;
   duration_ms: number;
+  /** From the activity result (captured before apply ran). May understate
+   *  reality if apply auto-committed tracked uncommitted changes — see
+   *  auto_committed. */
   commits_added: number;
   uncommitted: boolean;
   pr_url?: string;
+  /** True when the apply step (or PR creation inside it) failed. The
+   *  operator already got a separate notifyDispatchError; this flag is
+   *  for the summary so we don't render misleading "no work produced"
+   *  text in the same channel. */
+  apply_failed?: boolean;
+  /** True when the apply step actually pushed the branch to origin. */
+  pushed?: boolean;
+  /** True when apply auto-committed tracked uncommitted changes (so
+   *  commits_added=0 from the activity result no longer means "no
+   *  work"). */
+  auto_committed?: boolean;
 }
 
 export async function notifyDispatchComplete(ev: DispatchComplete): Promise<void> {
-  const ok = ev.exit_code === 0 && ev.commits_added > 0;
-  const icon = ev.pr_url ? '✅' : ok ? '🟢' : ev.exit_code === 0 ? '⚪' : '❌';
+  // "Real work produced" considers both committed and auto-committed work,
+  // and treats a successful push as evidence regardless of commits_added
+  // (since apply only pushes when there's tracked work to push).
+  const producedWork = ev.commits_added > 0 || ev.auto_committed === true || ev.pushed === true;
+  const ok = ev.exit_code === 0 && producedWork;
+  const icon = ev.apply_failed ? '⚠️' : ev.pr_url ? '✅' : ok ? '🟢' : ev.exit_code === 0 ? '⚪' : '❌';
   const summary = ev.pr_url
     ? `PR opened — <${ev.pr_url}|${ev.pr_url.split('/').pop()}>`
-    : ok
-      ? `committed ${ev.commits_added} (no PR yet)`
-      : ev.exit_code === 0
-        ? 'no work produced (empty worktree)'
-        : `exit ${ev.exit_code}`;
+    : ev.apply_failed
+      ? ev.pushed
+        ? 'apply failed after push — branch is on origin, PR creation/cleanup needs manual attention (see error)'
+        : 'apply failed (see error notification)'
+      : ok
+        ? ev.pushed
+          ? `pushed ${ev.commits_added || (ev.auto_committed ? 'auto-committed' : '?')} commit(s) but no PR URL captured`
+          : `committed ${ev.commits_added} (no PR yet)`
+        : ev.exit_code === 0
+          ? 'no work produced (empty worktree)'
+          : `exit ${ev.exit_code}`;
   const dur = (ev.duration_ms / 1000).toFixed(1);
   await postSlack({
     text: `${icon} ${ev.entry_id} — ${summary} (${dur}s)`,
@@ -129,7 +153,10 @@ export async function notifyDispatchComplete(ev: DispatchComplete): Promise<void
         elements: [
           {
             type: 'mrkdwn',
-            text: `exit \`${ev.exit_code}\`  •  ${dur}s  •  commits *${ev.commits_added}*  •  uncommitted *${ev.uncommitted}*  •  wf \`${ev.workflow_id}\``,
+            text:
+              `exit \`${ev.exit_code}\`  •  ${dur}s  •  commits *${ev.commits_added}*` +
+              (ev.auto_committed ? ' (+auto)' : '') +
+              `  •  pushed *${ev.pushed ? 'yes' : 'no'}*  •  uncommitted *${ev.uncommitted}*  •  wf \`${ev.workflow_id}\``,
           },
         ],
       },

--- a/apps/temporal-worker/src/notify.ts
+++ b/apps/temporal-worker/src/notify.ts
@@ -1,0 +1,193 @@
+// Slack notifier for the autonomous swarm — gives the operator
+// visibility into dispatcher events without tailing journalctl.
+//
+// Activation: set CHITIN_SLACK_WEBHOOK_URL to a Slack incoming webhook
+// URL (Slack Apps → Incoming Webhooks → New). If unset, every notify*
+// call is a no-op — safe to leave wired up in dev environments where
+// the operator hasn't configured Slack yet.
+//
+// Failure mode: every Slack call has a 3s timeout and swallows errors.
+// A flaky Slack endpoint must NEVER block dispatch; visibility is
+// nice-to-have, the swarm running is the actual product.
+
+import type { DriverId, Tier } from '@chitin/contracts';
+
+const SLACK_WEBHOOK_URL = process.env.CHITIN_SLACK_WEBHOOK_URL?.trim();
+const SLACK_TIMEOUT_MS = 3000;
+
+interface SlackBlock {
+  type: string;
+  text?: { type: string; text: string };
+  fields?: Array<{ type: string; text: string }>;
+  elements?: Array<{ type: string; text: string }>;
+}
+
+interface SlackPayload {
+  text: string;
+  blocks?: SlackBlock[];
+}
+
+async function postSlack(payload: SlackPayload): Promise<void> {
+  if (!SLACK_WEBHOOK_URL) return;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), SLACK_TIMEOUT_MS);
+  try {
+    const resp = await fetch(SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+    if (!resp.ok) {
+      // Fire-and-forget: log to stderr but do not throw.
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          level: 'warn',
+          component: 'notify',
+          msg: 'slack post non-ok',
+          status: resp.status,
+        }),
+      );
+    }
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        component: 'notify',
+        msg: 'slack post failed',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface DispatchStart {
+  entry_id: string;
+  tier: Tier;
+  driver: DriverId;
+  workflow_id: string;
+}
+
+export async function notifyDispatchStart(ev: DispatchStart): Promise<void> {
+  await postSlack({
+    text: `🦞 dispatch start \`${ev.entry_id}\` (${ev.tier} → ${ev.driver})`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*🦞 swarm dispatch start*  \`${ev.entry_id}\``,
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          { type: 'mrkdwn', text: `tier *${ev.tier}*  •  driver *${ev.driver}*  •  wf \`${ev.workflow_id}\`` },
+        ],
+      },
+    ],
+  });
+}
+
+export interface DispatchComplete {
+  entry_id: string;
+  workflow_id: string;
+  exit_code: number;
+  duration_ms: number;
+  commits_added: number;
+  uncommitted: boolean;
+  pr_url?: string;
+}
+
+export async function notifyDispatchComplete(ev: DispatchComplete): Promise<void> {
+  const ok = ev.exit_code === 0 && ev.commits_added > 0;
+  const icon = ev.pr_url ? '✅' : ok ? '🟢' : ev.exit_code === 0 ? '⚪' : '❌';
+  const summary = ev.pr_url
+    ? `PR opened — <${ev.pr_url}|${ev.pr_url.split('/').pop()}>`
+    : ok
+      ? `committed ${ev.commits_added} (no PR yet)`
+      : ev.exit_code === 0
+        ? 'no work produced (empty worktree)'
+        : `exit ${ev.exit_code}`;
+  const dur = (ev.duration_ms / 1000).toFixed(1);
+  await postSlack({
+    text: `${icon} ${ev.entry_id} — ${summary} (${dur}s)`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `${icon} *${ev.entry_id}* — ${summary}`,
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `exit \`${ev.exit_code}\`  •  ${dur}s  •  commits *${ev.commits_added}*  •  uncommitted *${ev.uncommitted}*  •  wf \`${ev.workflow_id}\``,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+export interface DispatchError {
+  entry_id: string;
+  workflow_id?: string;
+  stage: 'submit' | 'workflow' | 'apply';
+  error: string;
+}
+
+export async function notifyDispatchError(ev: DispatchError): Promise<void> {
+  await postSlack({
+    text: `🚨 dispatch error \`${ev.entry_id}\` at ${ev.stage}: ${ev.error.slice(0, 300)}`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*🚨 dispatch error*  \`${ev.entry_id}\` — ${ev.stage}`,
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '```' + ev.error.slice(0, 2000) + '```',
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ev.workflow_id ? `wf \`${ev.workflow_id}\`` : 'no workflow id',
+          },
+        ],
+      },
+    ],
+  });
+}
+
+export async function notifyTickIdle(reason: string): Promise<void> {
+  // Optional, very low-noise: only post if explicitly enabled, since
+  // most ticks are idle and we don't want to spam the channel.
+  if (process.env.CHITIN_SLACK_NOTIFY_IDLE !== '1') return;
+  await postSlack({
+    text: `💤 dispatcher idle — ${reason}`,
+  });
+}
+
+// Pull the first https://github.com/.../pull/<n> URL out of arbitrary
+// text (typically the apply step's stdout/stderr).
+const PR_URL_RE = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/;
+export function extractPrUrl(text: string): string | undefined {
+  const m = text.match(PR_URL_RE);
+  return m ? m[0] : undefined;
+}

--- a/apps/temporal-worker/test/notify.test.ts
+++ b/apps/temporal-worker/test/notify.test.ts
@@ -1,0 +1,151 @@
+// Tests for the Slack notifier. We assert two invariants:
+//   1. With CHITIN_SLACK_WEBHOOK_URL unset, every notify* call is a
+//      true no-op — fetch must never be called.
+//   2. extractPrUrl correctly pulls the GitHub PR URL out of the apply
+//      step's stdout/stderr, which is how the dispatcher decides
+//      whether to attach a PR link to the Slack message.
+//
+// Why no end-to-end test against a fake server: the notifier is fire-
+// and-forget; correctness of "Slack received the right blocks" is
+// confirmed by manual smoke-test once the user wires the webhook.
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+describe('notify (Slack disabled)', () => {
+  let originalUrl: string | undefined;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalUrl = process.env.CHITIN_SLACK_WEBHOOK_URL;
+    delete process.env.CHITIN_SLACK_WEBHOOK_URL;
+    fetchSpy = vi.spyOn(globalThis, 'fetch' as never);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env.CHITIN_SLACK_WEBHOOK_URL;
+    else process.env.CHITIN_SLACK_WEBHOOK_URL = originalUrl;
+    fetchSpy.mockRestore();
+    vi.resetModules();
+  });
+
+  it('notifyDispatchStart is a no-op when webhook URL is unset', async () => {
+    const { notifyDispatchStart } = await import('../src/notify.ts');
+    await notifyDispatchStart({
+      entry_id: 'test-entry',
+      tier: 'T1',
+      driver: 'copilot',
+      workflow_id: 'wf-1',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('notifyDispatchComplete is a no-op when webhook URL is unset', async () => {
+    const { notifyDispatchComplete } = await import('../src/notify.ts');
+    await notifyDispatchComplete({
+      entry_id: 'test-entry',
+      workflow_id: 'wf-1',
+      exit_code: 0,
+      duration_ms: 1000,
+      commits_added: 1,
+      uncommitted: false,
+      pr_url: 'https://github.com/org/repo/pull/42',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('notifyDispatchError is a no-op when webhook URL is unset', async () => {
+    const { notifyDispatchError } = await import('../src/notify.ts');
+    await notifyDispatchError({
+      entry_id: 'test-entry',
+      workflow_id: 'wf-1',
+      stage: 'submit',
+      error: 'boom',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('extractPrUrl', () => {
+  it('finds the first github PR url in arbitrary text', async () => {
+    const { extractPrUrl } = await import('../src/notify.ts');
+    const text = `
+      ok 12 files changed, 30 insertions(+), 5 deletions(-)
+      pull request created at https://github.com/chitinhq/chitin/pull/107
+      done
+    `;
+    expect(extractPrUrl(text)).toBe('https://github.com/chitinhq/chitin/pull/107');
+  });
+
+  it('returns undefined when no PR url is present', async () => {
+    const { extractPrUrl } = await import('../src/notify.ts');
+    expect(extractPrUrl('apply skipped — no tracked diff')).toBeUndefined();
+  });
+
+  it('matches owners and repos with dots, dashes, underscores', async () => {
+    const { extractPrUrl } = await import('../src/notify.ts');
+    const text = 'See https://github.com/foo.bar/baz_qux/pull/9';
+    expect(extractPrUrl(text)).toBe('https://github.com/foo.bar/baz_qux/pull/9');
+  });
+
+  it('picks the first url when multiple are present', async () => {
+    const { extractPrUrl } = await import('../src/notify.ts');
+    const text = `
+      previous: https://github.com/a/b/pull/1
+      current:  https://github.com/a/b/pull/2
+    `;
+    expect(extractPrUrl(text)).toBe('https://github.com/a/b/pull/1');
+  });
+});
+
+describe('notify (Slack enabled, mocked fetch)', () => {
+  let originalUrl: string | undefined;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalUrl = process.env.CHITIN_SLACK_WEBHOOK_URL;
+    process.env.CHITIN_SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T/B/C';
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch' as never)
+      .mockResolvedValue(new Response('ok', { status: 200 }) as never);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env.CHITIN_SLACK_WEBHOOK_URL;
+    else process.env.CHITIN_SLACK_WEBHOOK_URL = originalUrl;
+    fetchSpy.mockRestore();
+    vi.resetModules();
+  });
+
+  it('posts to the webhook with a JSON body when enabled', async () => {
+    const { notifyDispatchStart } = await import('../src/notify.ts');
+    await notifyDispatchStart({
+      entry_id: 'foo',
+      tier: 'T0',
+      driver: 'copilot',
+      workflow_id: 'wf-x',
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://hooks.slack.com/services/T/B/C');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.text).toContain('foo');
+    expect(body.text).toContain('T0');
+    expect(body.blocks).toBeDefined();
+  });
+
+  it('does not throw when fetch rejects (visibility is best-effort)', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('connection refused'));
+    const { notifyDispatchStart } = await import('../src/notify.ts');
+    await expect(
+      notifyDispatchStart({
+        entry_id: 'foo',
+        tier: 'T0',
+        driver: 'copilot',
+        workflow_id: 'wf-x',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -125,9 +125,10 @@ opt-in.
 
 | Event | Trigger | Example |
 |-------|---------|---------|
-| `dispatch_start` | entry picked, workflow submitted | `🦞 swarm dispatch start <entry-id>` |
-| `dispatch_complete` | workflow + apply finished | `✅ <entry-id> — PR opened — #N` (or 🟢 / ⚪ / ❌ depending on outcome) |
-| `dispatch_error` | submit / workflow / apply failure | `🚨 dispatch error <entry-id> at <stage>` with stack |
+| `dispatch_start` | entry picked, workflow successfully submitted | `🦞 swarm dispatch start <entry-id>` (only fires after `client.workflow.start()` returns; submit failures emit `dispatch_error` instead) |
+| `dispatch_complete` | workflow + apply finished | `✅ <entry-id> — PR opened — #N` (or `🟢` `⚪` `❌` `⚠️` depending on outcome — apply failures render `⚠️` and link the operator to the paired `dispatch_error`) |
+| `dispatch_error` | submit / workflow / apply failure (incl. silent `gh pr create` failure after a successful push) | `🚨 dispatch error <entry-id> at <stage>` with the failure's `error.message` (truncated to 2000 chars; no stack trace — stack contents can leak sensitive paths through Slack retention) |
+| `dispatch_idle` | tick had nothing to do (no ready entry, or workflow already in flight) | `💤 dispatcher idle — <reason>`. Only emitted when `CHITIN_SLACK_NOTIFY_IDLE=1` (off by default since most ticks are idle) |
 
 Failures during posting (timeout, 5xx) are logged at warn level and
 swallowed — visibility is nice-to-have, dispatch correctness comes

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -95,6 +95,44 @@ The dispatcher's invariants:
 - **Dispatcher tick errors:** systemd records exit code, next timer
   tick retries.
 
+## Slack notifications (optional)
+
+The dispatcher posts events to a Slack incoming webhook so the operator
+can stay aware of swarm activity without tailing journalctl. If the
+webhook URL is unset, every notify call is a no-op — Slack is purely
+opt-in.
+
+**Setup:**
+
+1. In Slack, create an incoming webhook (Apps → "Incoming Webhooks" →
+   New). Pick the channel that should receive swarm events. Copy the
+   `https://hooks.slack.com/services/T.../B.../...` URL.
+2. Drop the URL into a per-user systemd environment file:
+   ```bash
+   mkdir -p ~/.config/systemd/user
+   cat >> ~/.config/systemd/user/chitin.env <<'EOF'
+   CHITIN_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...
+   # Optional: also post when a tick has nothing to do (defaults to silent).
+   # CHITIN_SLACK_NOTIFY_IDLE=1
+   EOF
+   chmod 600 ~/.config/systemd/user/chitin.env
+   ```
+3. The unit files already include `EnvironmentFile=-%h/.config/systemd/user/chitin.env`,
+   so `systemctl --user daemon-reload` picks it up. The leading dash
+   means the file is optional — if it's missing, the unit still starts.
+
+**What gets posted:**
+
+| Event | Trigger | Example |
+|-------|---------|---------|
+| `dispatch_start` | entry picked, workflow submitted | `🦞 swarm dispatch start <entry-id>` |
+| `dispatch_complete` | workflow + apply finished | `✅ <entry-id> — PR opened — #N` (or 🟢 / ⚪ / ❌ depending on outcome) |
+| `dispatch_error` | submit / workflow / apply failure | `🚨 dispatch error <entry-id> at <stage>` with stack |
+
+Failures during posting (timeout, 5xx) are logged at warn level and
+swallowed — visibility is nice-to-have, dispatch correctness comes
+first.
+
 ## Pause for governance changes
 
 Slice 6 verified that the swarm cannot edit `chitin.yaml` (the

--- a/infra/systemd/chitin-dispatcher.service
+++ b/infra/systemd/chitin-dispatcher.service
@@ -21,10 +21,17 @@ Type=oneshot
 WorkingDirectory=%h/workspace/chitin
 Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
 Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+# Optional per-user secrets (CHITIN_SLACK_WEBHOOK_URL etc). Leading dash
+# = file is optional; absence is fine.
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
 ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/dispatcher.ts
 StandardOutput=journal
 StandardError=journal
 # A single dispatch cycle should never run longer than this. If it does,
 # something's wrong (hung workflow, stuck git, etc.) — kill the timer
 # tick and let the next one retry.
-TimeoutStartSec=900
+#
+# Must be > the largest tier wall_timeout in dispatcher.ts (currently
+# T2/T3/T4 = 1800s) plus headroom for activity SIGKILL grace + apply
+# step. 2400s = 40min gives ~10min headroom over 1800s wall.
+TimeoutStartSec=2400

--- a/infra/systemd/chitin-worker.service
+++ b/infra/systemd/chitin-worker.service
@@ -21,6 +21,9 @@ Type=simple
 WorkingDirectory=%h/workspace/chitin
 Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
 Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+# Optional per-user secrets (CHITIN_SLACK_WEBHOOK_URL etc). Leading dash
+# = file is optional; absence is fine.
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
 ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/worker.ts
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
## Summary

- New `apps/temporal-worker/src/notify.ts` — Slack webhook posts for `dispatch_start`, `dispatch_complete` (with PR URL), `dispatch_error` (with stage).
- Wired into the dispatcher at submit, post-workflow, and post-apply.
- All posts best-effort: 3s timeout, errors swallowed → flaky Slack never blocks the swarm.
- Setup is opt-in via `CHITIN_SLACK_WEBHOOK_URL` env. Unset = no-op.
- `EnvironmentFile=-%h/.config/systemd/user/chitin.env` added to both units (leading dash = optional file).
- Bumps `TimeoutStartSec` 900 → 2400 on chitin-dispatcher.service. The slice-7-tuning bump of T2/T3/T4 wall_timeouts to 1800s opened a window where systemd killed the dispatcher one-shot mid-workflow, producing pushed branches with no PR. 2400s = 10min headroom.

## Why now

User asked overnight for visibility into swarm activity while they sleep. Without this, the only monitor surface is `journalctl --user -u chitin-dispatcher -f`, which doesn't survive logout.

## Operator setup (after merge)

```bash
mkdir -p ~/.config/systemd/user
cat > ~/.config/systemd/user/chitin.env <<'ENV'
CHITIN_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...
ENV
chmod 600 ~/.config/systemd/user/chitin.env
cp infra/systemd/*.service infra/systemd/*.timer ~/.config/systemd/user/
systemctl --user daemon-reload
```

Webhook URL comes from Slack → Apps → Incoming Webhooks → New.

## Test plan

- [x] 9 unit tests covering disabled mode (no fetch), enabled mode (URL, body, blocks), error swallowing, regex-based PR URL extraction
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Dispatcher dry-run smoke (`pnpm exec tsx apps/temporal-worker/src/dispatcher.ts --dry-run`)
- [ ] Manual smoke against a live Slack webhook (operator does this once after merge by configuring chitin.env and starting a dry dispatch)
