### PR TITLE
swarm: read-vs-read_file-file_path-alias

### DIFF
--- a/go/execution-kernel/internal/gov/normalize.go
+++ b/go/execution-kernel/internal/gov/normalize.go
@@ -41,7 +41,11 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 	case "write", "edit":
 		return normalizeWriteFile(args), nil
 	case "read_file":
-		return Action{Type: ActFileRead, Target: stringArg(args, "path")}, nil
+		path := stringArg(args, "path")
+		if path == "" {
+			path = stringArg(args, "file_path")
+		}
+		return Action{Type: ActFileRead, Target: path}, nil
 	case "read":
 		// openclaw pi-runtime read tool — path-based file read.
 		path := stringArg(args, "path")

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -316,13 +316,13 @@ func TestNormalize_ReadFile_FilePathAlias(t *testing.T) {
 	aPath, _ := Normalize("read_file", map[string]any{"path": "/x"})
 	aFilePath, _ := Normalize("read_file", map[string]any{"file_path": "/x"})
 	if aPath.Type != ActFileRead || aFilePath.Type != ActFileRead {
-		t.Errorf("Type: got %%q and %%q, want file.read", aPath.Type, aFilePath.Type)
+		t.Errorf("Type: got %q and %q, want file.read", aPath.Type, aFilePath.Type)
 	}
 	if aPath.Target != aFilePath.Target {
-		t.Errorf("Target mismatch: path=%%q file_path=%%q", aPath.Target, aFilePath.Target)
+		t.Errorf("Target mismatch: path=%q file_path=%q", aPath.Target, aFilePath.Target)
 	}
 	if aPath.Target != "/x" {
-		t.Errorf("Target: got %%q, want /x", aPath.Target)
+		t.Errorf("Target: got %q, want /x", aPath.Target)
 	}
 }
 

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -311,6 +311,21 @@ func TestNormalize_TerminalReadOnly(t *testing.T) {
 	}
 }
 
+func TestNormalize_ReadFile_FilePathAlias(t *testing.T) {
+	// read_file should accept both path and file_path as keys
+	aPath, _ := Normalize("read_file", map[string]any{"path": "/x"})
+	aFilePath, _ := Normalize("read_file", map[string]any{"file_path": "/x"})
+	if aPath.Type != ActFileRead || aFilePath.Type != ActFileRead {
+		t.Errorf("Type: got %%q and %%q, want file.read", aPath.Type, aFilePath.Type)
+	}
+	if aPath.Target != aFilePath.Target {
+		t.Errorf("Target mismatch: path=%%q file_path=%%q", aPath.Target, aFilePath.Target)
+	}
+	if aPath.Target != "/x" {
+		t.Errorf("Target: got %%q, want /x", aPath.Target)
+	}
+}
+
 // openclaw pi-runtime tool names — closes the "exec/process/read/write/edit
 // fall through to ActUnknown" gap that left the openclaw plugin gating with
 // default-deny-unknown instead of policy-meaningful action types.


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `read-vs-read_file-file_path-alias`
Tier: `T0`  •  Driver: `copilot`
Workflow: `swarm-read-vs-read_file-file_path-alias-1777693743621`

## Entry context

Slice 3 added `case "read"` with `path` → `file_path` alias fallback, but the
existing `case "read_file"` has no fallback. Make `read_file` use the same
alias logic for parity. Add a test that `read_file({file_path: "/x"})` and
`read_file({path: "/x"})` produce the same Action.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-read-vs-read_file-file_path-alias-1777693743621`
Branch: `swarm/swarm-read-vs-read_file-file_path-alias-1777693743621`
Head: `abeb49e0`
Diff: `2 files changed, 20 insertions(+), 1 deletion(-)`
Commits: 1