### PR TITLE
swarm: tools-summary-structured-result

### DIFF
--- a/apps/temporal-worker/src/activity-types.ts
+++ b/apps/temporal-worker/src/activity-types.ts
@@ -3,6 +3,15 @@ export interface ActivityResult {
   stdout_tail: string;
   stderr_tail: string;
   duration_ms: number;
+  /**
+   * Structured summary of tool usage, parsed from openclaw JSON output (if present).
+   * Example: { calls: 3, tools: ["edit", "search"], failures: 1 }
+   */
+  tool_summary?: {
+    calls: number;
+    tools: string[];
+    failures: number;
+  };
   // Slice 5: present only when base_ref was set on the request and the
   // activity created a worktree. Apply-step uses worktree_path to push
   // the branch and open a PR.

--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -509,7 +509,86 @@ function extractHookEvents(stdoutTail: string): HookEventSummary[] | undefined {
   return out.length > 0 ? out : undefined;
 }
 
+/**
+ * Extract the openclaw `toolSummary` payload from the agent's stdout.
+ *
+ * openclaw's `--json` mode emits NDJSON (one JSON object per line) but
+ * older / non-streaming variants drop a final summary object containing
+ * a top-level `toolSummary`. The previous regex-based extractor was
+ * non-greedy on `{...}` which silently dropped any object containing
+ * nested braces — including the toolSummary object itself — so the
+ * field never populated in practice.
+ *
+ * Strategy: split into lines first (NDJSON path); for any line that
+ * doesn't parse, fall back to a brace-balanced scan from the end of
+ * stdout to recover the LAST complete top-level JSON object. Either
+ * path returns the typed `tool_summary` shape if a `toolSummary` field
+ * is found, otherwise undefined.
+ */
+function parseToolSummary(stdout: string): ActivityResult['tool_summary'] {
+  // Path 1 — NDJSON. Try every line. The newest summary wins (last
+  // line that has toolSummary).
+  let found: ActivityResult['tool_summary'];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    try {
+      const obj = JSON.parse(trimmed) as { toolSummary?: ActivityResult['tool_summary'] };
+      if (obj && typeof obj === 'object' && obj.toolSummary) {
+        found = obj.toolSummary;
+      }
+    } catch {
+      // Not a complete JSON line on its own — fall through.
+    }
+  }
+  if (found) return found;
+
+  // Path 2 — brace-balanced scan from the end. Walk backward from the
+  // last `}`, count braces (outside string literals), and slice when
+  // the count returns to zero. Try parsing that slice.
+  for (let end = stdout.lastIndexOf('}'); end >= 0; end = stdout.lastIndexOf('}', end - 1)) {
+    const start = findMatchingOpenBrace(stdout, end);
+    if (start < 0) continue;
+    const candidate = stdout.slice(start, end + 1);
+    try {
+      const obj = JSON.parse(candidate) as { toolSummary?: ActivityResult['tool_summary'] };
+      if (obj && typeof obj === 'object' && obj.toolSummary) return obj.toolSummary;
+    } catch {
+      // Not balanced top-level JSON — keep walking.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Walk backward from `end` (a `}` index in `s`), counting brace depth
+ * while ignoring braces inside double-quoted strings. Returns the index
+ * of the matching `{`, or -1 if no balanced opener is found.
+ */
+function findMatchingOpenBrace(s: string, end: number): number {
+  let depth = 0;
+  let inString = false;
+  for (let i = end; i >= 0; i--) {
+    const ch = s[i];
+    if (inString) {
+      if (ch === '"' && s[i - 1] !== '\\') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === '}') depth++;
+    else if (ch === '{') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
 export const __test__ = {
+  parseToolSummary,
   planInvocation,
   resolvePolicySrc,
   resolveAgent,

--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -430,12 +430,14 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
         const hookEvents = plan.args.includes('--include-hook-events')
           ? extractHookEvents(tailStdout)
           : undefined;
+        const tool_summary = plan.command === 'openclaw' ? parseToolSummary(stdout) : undefined;
         resolvePromise({
           exit_code: code ?? -1,
           stdout_tail: tailStdout,
           stderr_tail: tailStderr,
           duration_ms: Date.now() - start,
           ...(hookEvents ? { hook_events: hookEvents } : {}),
+          ...(tool_summary ? { tool_summary } : {}),
         });
       });
       child.on('error', reject);

--- a/apps/temporal-worker/test/activity.test.ts
+++ b/apps/temporal-worker/test/activity.test.ts
@@ -264,3 +264,83 @@ describe('resolveAgent', () => {
     expect(DRIVER_AGENT_MAP['local-deepseek']).toBe('deepseek-agent');
   });
 });
+
+describe('parseToolSummary', () => {
+  const { parseToolSummary } = __test__;
+
+  it('returns undefined when stdout has no toolSummary', () => {
+    expect(parseToolSummary('')).toBeUndefined();
+    expect(parseToolSummary('{"foo":1}\n{"bar":2}')).toBeUndefined();
+  });
+
+  it('extracts a flat NDJSON line containing toolSummary', () => {
+    const stdout = `{"toolSummary":{"calls":3,"tools":["edit","search"],"failures":1}}\n`;
+    expect(parseToolSummary(stdout)).toEqual({
+      calls: 3,
+      tools: ['edit', 'search'],
+      failures: 1,
+    });
+  });
+
+  it('extracts toolSummary from a wrapper object with NESTED braces (regression: previous regex dropped this)', () => {
+    // The previous /\{[\s\S]*?\}/g extraction was non-greedy on `}`,
+    // so for output like { ..., "toolSummary": { ... } } it stopped at
+    // the first inner `}` and JSON.parse always failed. The brace-
+    // balanced fallback path must handle this.
+    const stdout = [
+      'noise before the json',
+      '{"event":"final","toolSummary":{"calls":7,"tools":["read","edit","bash"],"failures":2}}',
+      'trailing log line',
+    ].join('\n');
+    expect(parseToolSummary(stdout)).toEqual({
+      calls: 7,
+      tools: ['read', 'edit', 'bash'],
+      failures: 2,
+    });
+  });
+
+  it('handles multi-line pretty-printed JSON via brace-balanced fallback', () => {
+    const stdout = [
+      'log: starting',
+      '{',
+      '  "event": "final",',
+      '  "toolSummary": {',
+      '    "calls": 2,',
+      '    "tools": ["edit", "exec"],',
+      '    "failures": 0',
+      '  }',
+      '}',
+      'log: done',
+    ].join('\n');
+    expect(parseToolSummary(stdout)).toEqual({
+      calls: 2,
+      tools: ['edit', 'exec'],
+      failures: 0,
+    });
+  });
+
+  it('skips non-JSON lines and tolerates partial output', () => {
+    const stdout = [
+      'plain log line',
+      '{"event":"telemetry","value":1}',
+      '{"toolSummary":{"calls":0,"tools":[],"failures":0}}',
+    ].join('\n');
+    expect(parseToolSummary(stdout)).toEqual({
+      calls: 0,
+      tools: [],
+      failures: 0,
+    });
+  });
+
+  it('does not get confused by braces inside string literals', () => {
+    // Failure mode: a naive bracket counter would treat `{` inside a
+    // string as opening a new object and the toolSummary extraction
+    // would slice mid-string.
+    const stdout = `{"event":"oops","note":"path was {odd}","toolSummary":{"calls":1,"tools":["x"],"failures":0}}`;
+    expect(parseToolSummary(stdout)).toEqual({
+      calls: 1,
+      tools: ['x'],
+      failures: 0,
+    });
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `tools-summary-structured-result`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-tools-summary-structured-result-1777694348455`

## Entry context

`ActivityResult.stderr_tail` is a 2000-char string slice that drops the actual
tool list openclaw emits in its verbose JSON. Add a structured field like
`tool_summary?: { calls: number; tools: string[]; failures: number }` and
parse it from the openclaw JSON output (it already emits `toolSummary`).
Surface in the workflow result so reviewers don't have to grep stderr.

---

**Groomed 2026-05-02 (0.95 confidence):** The scope is clear: add a structured field, parse existing JSON, and surface it. Multi-file but straightforward, fits T1.

Implementation steps:
- Locate where ActivityResult is defined and used.
- Add an optional tool_summary field to ActivityResult with the specified structure.
- Update the code that parses openclaw JSON output to extract toolSummary and populate tool_summary.
- Ensure tool_summary is surfaced in the workflow result object.
- Write or update tests to verify tool_summary is correctly parsed and exposed.

**Groomed 2026-05-02 (0.95 confidence):** The scope is clear: add a structured field, parse existing JSON, and surface it. Multi-file but straightforward, fits T1.

Implementation steps:
- Locate where ActivityResult is defined and used.
- Add an optional tool_summary field to ActivityResult with the specified structure.
- Update the code that parses openclaw JSON output to extract toolSummary and populate tool_summary.
- Ensure tool_summary is surfaced in the workflow result object.
- Write or update tests to verify tool_summary is correctly parsed and exposed.


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-tools-summary-structured-result-1777694348455`
Branch: `swarm/swarm-tools-summary-structured-result-1777694348455`
Head: `3a98aeeb`
Diff: `2 files changed, 29 insertions(+)`
Commits: 0 (+ auto-committed uncommitted state)