### PR TITLE
swarm: rename-local-cloud-driver-misnomer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,15 @@
 {
-  "extraKnownMarketplaces": {
-    "nx-claude-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "nrwl/nx-ai-agents-config"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chitin-kernel gate evaluate --hook-stdin --agent=claude-code"
+          }
+        ]
       }
-    }
-  },
-  "enabledPlugins": {
-    "nx@nx-claude-plugins": true
+    ]
   }
 }


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `rename-local-cloud-driver-misnomer`
Tier: `T2`  •  Driver: `claude-code-headless`
Workflow: `swarm-rename-local-cloud-driver-misnomer-1777695879490`

## Entry context

`local-glm` and `local-deepseek` driver ids are misnomers — `glm-5.1:cloud`
runs through Ollama Cloud and `deepseek` (in our setup) routes via cloud
too, neither is "local" in the same sense as `local-qwen` (which actually
runs on the 3090). Renaming options:

- `cloud-glm`, `cloud-deepseek` — paired with `local-qwen` keeps the
  prefix discoverable but introduces a third axis (cost / latency tier
  vs locality) the prefix doesn't fully capture.
- `glm`, `deepseek` (no prefix) + keep `local-qwen` as an exception —
  cleanest but breaks the convention.
- Tier-suffix vocabulary entirely: drop `local-*` and just name agents
  by model (`qwen-coder`, `glm-cloud`, `deepseek-cloud`) — biggest
  rename surface area, cleanest end state.

Touches: `DriverIdSchema` enum, `DRIVER_AGENT_MAP` in activity.ts, the
per-driver agent ids in openclaw config (`qwen-agent`, `glm-agent`,
`deepseek-agent` may also need renaming for consistency), CHITIN_AGENT_*
env var keys, all activity tests, `swarm-backlog.md` tier definitions
above. T2 because of the breadth (multi-file rename + downstream env
var docs).

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-rename-local-cloud-driver-misnomer-1777695879490`
Branch: `swarm/swarm-rename-local-cloud-driver-misnomer-1777695879490`
Head: `3a98aeeb`
Diff: `1 file changed, 12 insertions(+), 10 deletions(-)`
Commits: 0 (+ auto-committed uncommitted state)