### PR TITLE
swarm: dispatcher-preflight-scrub-claude-settings-backup

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -270,6 +270,23 @@ REMEMBER: chat replies do nothing. Tool calls are the only thing that produces w
 }
 
 async function main() {
+  // Pre-flight: refuse to dispatch if any .claude/settings.json.chitin-backup-* artifact is present
+  const cwd = process.cwd();
+  const fs = require('fs');
+  const path = require('path');
+  const claudeBackupPattern = /^settings\.json\.chitin-backup-.*$/;
+  const claudeDir = path.join(cwd, '.claude');
+  if (fs.existsSync(claudeDir)) {
+    for (const file of fs.readdirSync(claudeDir)) {
+      if (claudeBackupPattern.test(file)) {
+        log('warn', 'preflight: claude-settings-backup artifact present', { artifact: path.join(claudeDir, file) });
+        if (typeof global.notifyTickIdle === 'function') {
+          global.notifyTickIdle('preflight: claude-settings-backup artifact present');
+        }
+        return;
+      }
+    }
+  }
   const dryRun = process.argv.includes('--dry-run');
   log('info', 'dispatcher start', { dryRun });
 

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -31,7 +31,7 @@ import { Connection, Client } from '@temporalio/client';
 import { ExecutionRequestSchema } from '@chitin/contracts';
 import type { DriverId, Tier } from '@chitin/contracts';
 import { execFileSync, execSync } from 'node:child_process';
-import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -269,24 +269,43 @@ CONSTRAINTS:
 REMEMBER: chat replies do nothing. Tool calls are the only thing that produces work. Start by reading ${targetFile} now.`;
 }
 
-async function main() {
-  // Pre-flight: refuse to dispatch if any .claude/settings.json.chitin-backup-* artifact is present
-  const cwd = process.cwd();
-  const fs = require('fs');
-  const path = require('path');
-  const claudeBackupPattern = /^settings\.json\.chitin-backup-.*$/;
-  const claudeDir = path.join(cwd, '.claude');
-  if (fs.existsSync(claudeDir)) {
-    for (const file of fs.readdirSync(claudeDir)) {
-      if (claudeBackupPattern.test(file)) {
-        log('warn', 'preflight: claude-settings-backup artifact present', { artifact: path.join(claudeDir, file) });
-        if (typeof global.notifyTickIdle === 'function') {
-          global.notifyTickIdle('preflight: claude-settings-backup artifact present');
-        }
-        return;
-      }
-    }
+// Returns true if the dispatcher should skip this tick. Looks for any
+// `.claude/settings.json.chitin-backup-*` artifact in the given cwd's
+// `.claude/` directory — that file gets swept into worktree diffs by
+// `git add -A` in the apply step and produces bucket-B contaminated
+// PRs (see docs/observations/2026-05-02-bucket-b-after-action.md).
+//
+// Exported for tests via `__test__`. Pure modulo `existsSync`/
+// `readdirSync` calls — operator-facing logging + idle-notify happen
+// in the caller.
+function findClaudeBackupArtifact(cwd: string): string | null {
+  const claudeDir = resolve(cwd, '.claude');
+  if (!existsSync(claudeDir)) return null;
+  const re = /^settings\.json\.chitin-backup-.+$/;
+  for (const file of readdirSync(claudeDir)) {
+    if (re.test(file)) return resolve(claudeDir, file);
   }
+  return null;
+}
+
+async function preflightRefuseOnClaudeBackup(): Promise<boolean> {
+  const artifact = findClaudeBackupArtifact(process.cwd());
+  if (!artifact) return false;
+  log('warn', 'preflight: claude-settings-backup artifact present', { artifact });
+  await notifyTickIdle(`preflight: claude-settings-backup artifact present (${artifact})`);
+  return true;
+}
+
+async function main() {
+  // Pre-flight: refuse to dispatch if any .claude/settings.json.chitin-backup-*
+  // artifact is present in the cwd's .claude/ dir. Background: a leftover
+  // backup file got swept into worktree diffs by `git add -A` in the apply
+  // step on 2026-05-02, producing four bucket-B contaminated PRs whose diff
+  // didn't match their title. See docs/observations/2026-05-02-bucket-b-
+  // after-action.md. Default policy is option-1 from the backlog entry —
+  // hard refuse, operator deletes the artifact manually before next tick.
+  if (await preflightRefuseOnClaudeBackup()) return;
+
   const dryRun = process.argv.includes('--dry-run');
   log('info', 'dispatcher start', { dryRun });
 
@@ -471,6 +490,8 @@ async function main() {
     await conn.close();
   }
 }
+
+export const __test__ = { findClaudeBackupArtifact };
 
 // Only auto-run when invoked as a script. Importing buildPrompt or other
 // helpers from tests must not open a Temporal connection.

--- a/apps/temporal-worker/test/dispatcher-preflight.test.ts
+++ b/apps/temporal-worker/test/dispatcher-preflight.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { __test__ } from '../src/dispatcher.ts';
+
+const { findClaudeBackupArtifact } = __test__;
+
+describe('findClaudeBackupArtifact', () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'chitin-preflight-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('returns null when there is no .claude directory', () => {
+    expect(findClaudeBackupArtifact(scratch)).toBeNull();
+  });
+
+  it('returns null when .claude exists but has no backup files', () => {
+    mkdirSync(join(scratch, '.claude'));
+    writeFileSync(join(scratch, '.claude', 'settings.json'), '{}');
+    expect(findClaudeBackupArtifact(scratch)).toBeNull();
+  });
+
+  it('returns the artifact path when a backup file is present', () => {
+    mkdirSync(join(scratch, '.claude'));
+    const artifactName = 'settings.json.chitin-backup-20260429T210349Z';
+    writeFileSync(join(scratch, '.claude', artifactName), '{}');
+    expect(findClaudeBackupArtifact(scratch)).toBe(join(scratch, '.claude', artifactName));
+  });
+
+  it('does not match settings.json itself or a similar but distinct name', () => {
+    mkdirSync(join(scratch, '.claude'));
+    writeFileSync(join(scratch, '.claude', 'settings.json'), '{}');
+    writeFileSync(join(scratch, '.claude', 'settings.json.bak'), '{}');
+    writeFileSync(join(scratch, '.claude', 'chitin-backup-20260429T210349Z'), '{}');
+    expect(findClaudeBackupArtifact(scratch)).toBeNull();
+  });
+
+  it('requires a non-empty suffix after chitin-backup-', () => {
+    // Defensive: the kernel's installer always appends a timestamp, but a
+    // truncated `settings.json.chitin-backup-` (trailing dash, no payload)
+    // is suspicious and should still trip the preflight.
+    mkdirSync(join(scratch, '.claude'));
+    writeFileSync(join(scratch, '.claude', 'settings.json.chitin-backup-'), '{}');
+    expect(findClaudeBackupArtifact(scratch)).toBeNull();
+    // A single trailing character DOES count as a backup.
+    writeFileSync(join(scratch, '.claude', 'settings.json.chitin-backup-x'), '{}');
+    expect(findClaudeBackupArtifact(scratch)).toBe(
+      join(scratch, '.claude', 'settings.json.chitin-backup-x'),
+    );
+  });
+
+  it('returns the first backup found if multiple are present', () => {
+    mkdirSync(join(scratch, '.claude'));
+    const a = 'settings.json.chitin-backup-20260101T000000Z';
+    const b = 'settings.json.chitin-backup-20260102T000000Z';
+    writeFileSync(join(scratch, '.claude', a), '{}');
+    writeFileSync(join(scratch, '.claude', b), '{}');
+    const found = findClaudeBackupArtifact(scratch);
+    expect(found).not.toBeNull();
+    expect([join(scratch, '.claude', a), join(scratch, '.claude', b)]).toContain(found);
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `dispatcher-preflight-scrub-claude-settings-backup`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-dispatcher-preflight-scrub-claude-settings-backup-1777727839656`

## Entry context

The 2026-05-02 overnight run produced four PRs (#114, #117, #118, #120
— all now closed) where the swarm worker committed only a
`.claude/settings.json` diff and no actual task implementation. Root
cause: a leftover `.claude/settings.json.chitin-backup-<ts>` artifact
in the workspace's `.claude/` directory. The agent's worktree
inherited it as untracked-then-staged content, and `git add -A` in
the apply step picked it up as the diff. The actual entry's target
file was never edited.

Fix: dispatcher pre-flight refuses to dispatch (or scrubs the
artifact first) when any `.claude/settings.json.chitin-backup-*` file
is present in the cwd at tick start. Two options:

1. **Hard refuse** — log a warn-level dispatcher event, emit
   `notifyTickIdle("preflight: claude-settings-backup artifact present")`,
   exit 0. Operator deletes the artifact manually before the next tick.
2. **Auto-scrub** — `rm` the artifact at tick start (it's a backup, by
   definition disposable), log the scrub, dispatch normally.

Option 2 is more autonomous; option 1 is safer if the artifact is ever
load-bearing. Default to option 1 unless dogfood reveals a recurring
operator burden.

Also: the four closed PRs' backlog entries (`wall-timeout-sigkill-
propagation`, `task-validate-command-pre-activity-gate`,
`chitin-install-slice-3-agents`, `rename-local-cloud-driver-misnomer`)
should be re-evaluated before re-dispatch:

- `wall-timeout-sigkill-propagation` is **already shipped in main**
  (slice-7a / PR #99) — mark completed, drop from backlog.
- `rename-local-cloud-driver-misnomer` needs a human pick from its
  three naming-convention options before any worker can claim it.
- `task-validate-command-pre-activity-gate` and
  `chitin-install-slice-3-agents` are still claimable as written.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-dispatcher-preflight-scrub-claude-settings-backup-1777727839656`
Branch: `swarm/swarm-dispatcher-preflight-scrub-claude-settings-backup-1777727839656`
Head: `cb36898e`
Diff: `1 file changed, 17 insertions(+)`
Commits: 1