### PR TITLE
fix(apply-step): revert .claude/settings.json before auto-commit; reroute T2

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -60,10 +60,16 @@ const CLAUDE_TIER_MODEL: Record<Tier, string> = {
   T4: 'claude-opus-4-7',
 };
 
+// 2026-05-02: T2 bumped from haiku → sonnet on copilot. Pairs with the
+// dispatcher.ts T2 reroute (claude-code-headless → copilot) so the model
+// class is preserved (was claude-sonnet-4-6 via CCH, now claude-sonnet-4.6
+// via copilot — same family). Without this bump the reroute would silently
+// downgrade T2 reasoning to haiku. Cost is still $0 under the Copilot Pro
+// plan.
 const COPILOT_TIER_MODEL: Record<Tier, string> = {
   T0: 'gpt-4.1',
   T1: 'gpt-4.1',
-  T2: 'claude-haiku-4.5',
+  T2: 'claude-sonnet-4.6',           // (was claude-haiku-4.5; bumped to preserve T2 reasoning quality)
   T3: 'claude-sonnet-4.6',
   T4: 'claude-opus-4.7',
 };

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -69,10 +69,21 @@ const STATE_DIR = resolve(homedir(), '.cache/chitin/swarm-state/dispatched');
 // PRs for them via this same dispatcher). Cost: still $0 under
 // Jared's Copilot plan. One-line revert to local-qwen once the local
 // model is reliable.
+// 2026-05-02: T2 temporarily routed to copilot. The overnight 2026-05-02
+// run produced 4/4 bucket-B contaminated PRs on T2/T3 claude-code-
+// headless (and 1/5 successes total). Root cause: the worker's
+// writeWorktreeClaudeSettings overwrites the worktree's
+// .claude/settings.json, and the apply step's "tracked diff" heuristic
+// auto-commits + ships the modification as task work whenever the
+// agent declined to commit real edits. The apply-step revert in
+// apply-workflow-result.revertWorktreeSettingsArtifact closes the
+// auto-commit path; once it's been live for a swarm cycle and the
+// rate stays at 0, flip T2 (and T3) back to claude-code-headless.
+// See docs/observations/2026-05-02-bucket-b-after-action.md.
 const TIER_DRIVER: Record<Tier, DriverId> = {
   T0: 'copilot',                     // Copilot GPT-4.1 free (was local-qwen — see comment)
   T1: 'copilot',                     // Copilot GPT-4.1 free
-  T2: 'claude-code-headless',        // claude-haiku-4-5
+  T2: 'copilot',                     // (was claude-code-headless — see comment above; flip back after CCH bucket-B rate stays at 0)
   T3: 'claude-code-headless',        // claude-sonnet-4-6
   T4: 'claude-code-headless',        // claude-opus-4-7
 };

--- a/apps/temporal-worker/src/grooming/apply-workflow-result.ts
+++ b/apps/temporal-worker/src/grooming/apply-workflow-result.ts
@@ -124,19 +124,40 @@ function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
-// Revert any uncommitted modification of `.claude/settings.json` in the
+// Revert any modification of `.claude/settings.json` (vs HEAD) in the
 // worktree. The worker's `writeWorktreeClaudeSettings` always touches
 // this file (to install the chitin gate hook for the spawned claude-
 // code-headless session); the modification is *not* task work and
-// shipping it produces bucket-B contamination. If the file isn't a
-// tracked modification (no entry in `git diff`), the checkout is a
-// no-op. Errors are swallowed — failing the apply step over a
-// bookkeeping revert would be worse than leaving the artifact in.
+// shipping it produces bucket-B contamination.
+//
+// Uses `git diff HEAD --` (working tree + index vs HEAD) instead of bare
+// `git diff` so the check sees modifications regardless of whether the
+// agent / a future early `git add` already staged them. Plain `git diff`
+// is index-vs-working-tree only and would silently no-op on staged
+// modifications — bucket-B would silently return.
+//
+// CAVEAT: this revert ALWAYS fires when `.claude/settings.json` differs
+// from HEAD. If a future backlog entry's `file:` field legitimately
+// names `.claude/settings.json`, the agent's edits will be silently
+// dropped. The function has no awareness of the entry — apply-step
+// inputs are just the worktree state. Two mitigations available if it
+// ever bites: (a) the entry can pre-commit its `.claude/settings.json`
+// edit before declining (auto-commit fallback then sees only that), or
+// (b) plumb the entry's file scope into apply-workflow-result and
+// gate the revert on whether the entry claims this file.
+//
+// Errors are swallowed — failing the apply step over a bookkeeping
+// revert would be worse than leaving the artifact in (and the
+// trackedDiff check still bails on no-real-work via the "no committed
+// work; skipping push and PR" branch).
 export function revertWorktreeSettingsArtifact(worktreePath: string): void {
   try {
-    const modified = git(worktreePath, ['--no-pager', 'diff', '--name-only', '--', '.claude/settings.json']);
-    if (!modified) return; // not a tracked-file modification — nothing to revert
-    git(worktreePath, ['checkout', '--', '.claude/settings.json']);
+    const modified = git(worktreePath, ['--no-pager', 'diff', 'HEAD', '--name-only', '--', '.claude/settings.json']);
+    if (!modified) return; // not a modification of a tracked file — nothing to revert
+    // `checkout HEAD --` resets the file in BOTH the index and the working
+    // tree, matching the diff scope above. Plain `checkout --` would only
+    // reset the working tree, leaving a staged modification in place.
+    git(worktreePath, ['checkout', 'HEAD', '--', '.claude/settings.json']);
     console.log('[apply-result] reverted writeWorktreeClaudeSettings artifact: .claude/settings.json');
   } catch (err) {
     console.warn(`[apply-result] revert of .claude/settings.json failed (ignored): ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/temporal-worker/src/grooming/apply-workflow-result.ts
+++ b/apps/temporal-worker/src/grooming/apply-workflow-result.ts
@@ -18,6 +18,7 @@
 import { readFileSync } from 'node:fs';
 import { execFileSync, execSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { ActivityResult, WorktreeResult } from '../activity-types.ts';
 
 interface ResultEnvelope {
@@ -77,7 +78,20 @@ async function main() {
   // backlog entry. Heuristic: only auto-commit when there are TRACKED
   // file modifications (`diff --shortstat` non-empty). Untracked-only
   // changes are likely agent side effects, not the work product.
+  //
+  // 2026-05-02 finding (bucket-B contamination): claude-code-headless
+  // worktrees ALWAYS show a tracked diff on `.claude/settings.json` —
+  // the worker's writeWorktreeClaudeSettings overwrites whatever main
+  // has there with the chitin gate hook config. That diff is byte-
+  // identical across runs and is not the agent's task work. Reverting
+  // it before the trackedDiff check makes the heuristic see only real
+  // edits, so a CCH run where the agent declined to commit task work
+  // produces no PR (instead of a "1 file changed, 12 insertions(+),
+  // 10 deletions(-)" Bucket-B PR). See
+  // docs/observations/2026-05-02-bucket-b-after-action.md for the
+  // full root-cause analysis.
   if (wt.has_uncommitted_changes) {
+    revertWorktreeSettingsArtifact(wt.path);
     const trackedDiff = git(wt.path, ['--no-pager', 'diff', '--shortstat']).length > 0;
     if (trackedDiff) {
       console.log('[apply-result] auto-committing tracked uncommitted changes…');
@@ -108,6 +122,25 @@ async function main() {
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+// Revert any uncommitted modification of `.claude/settings.json` in the
+// worktree. The worker's `writeWorktreeClaudeSettings` always touches
+// this file (to install the chitin gate hook for the spawned claude-
+// code-headless session); the modification is *not* task work and
+// shipping it produces bucket-B contamination. If the file isn't a
+// tracked modification (no entry in `git diff`), the checkout is a
+// no-op. Errors are swallowed — failing the apply step over a
+// bookkeeping revert would be worse than leaving the artifact in.
+export function revertWorktreeSettingsArtifact(worktreePath: string): void {
+  try {
+    const modified = git(worktreePath, ['--no-pager', 'diff', '--name-only', '--', '.claude/settings.json']);
+    if (!modified) return; // not a tracked-file modification — nothing to revert
+    git(worktreePath, ['checkout', '--', '.claude/settings.json']);
+    console.log('[apply-result] reverted writeWorktreeClaudeSettings artifact: .claude/settings.json');
+  } catch (err) {
+    console.warn(`[apply-result] revert of .claude/settings.json failed (ignored): ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 function defaultCommitMessage(env: ResultEnvelope): string {
@@ -159,7 +192,13 @@ function readFlag(name: string): string | null {
   return process.argv[idx + 1];
 }
 
-main().catch((err) => {
-  console.error('[apply-result] fatal:', err);
-  process.exit(1);
-});
+// Only run main() when invoked as a script. Importing
+// revertWorktreeSettingsArtifact (or any other helper) from tests
+// must not exit the process or read process.argv as a CLI.
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error('[apply-result] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/apps/temporal-worker/test/grooming-revert-settings-artifact.test.ts
+++ b/apps/temporal-worker/test/grooming-revert-settings-artifact.test.ts
@@ -84,4 +84,32 @@ describe('revertWorktreeSettingsArtifact', () => {
     expect(readFileSync(join(scratch, '.claude/settings.json'), 'utf8')).toBe(settings);
     expect(readFileSync(join(scratch, 'task.ts'), 'utf8')).toBe('// task work edit');
   });
+
+  it('reverts even when the modification has already been staged (git add)', () => {
+    // Adversarial-review concern (R1): if the call site ever runs
+    // `git add` before this revert, plain `git diff` would no-op (it
+    // only sees unstaged changes). We use `git diff HEAD` and
+    // `git checkout HEAD --` so the revert fires regardless of stage
+    // state.
+    mkdirSync(join(scratch, '.claude'));
+    const original = JSON.stringify({ extra: 'main' });
+    writeFileSync(join(scratch, '.claude/settings.json'), original);
+    git(['add', '.claude/settings.json']);
+    git(['commit', '-m', 'baseline', '--quiet']);
+
+    // Modify and stage.
+    writeFileSync(join(scratch, '.claude/settings.json'), '{"hooks":[]}');
+    git(['add', '.claude/settings.json']);
+
+    // Sanity: plain `git diff` is empty (working tree == index after
+    // the add), but `git diff HEAD` still shows the modification.
+    expect(git(['diff', '--name-only'])).toBe('');
+    expect(git(['diff', 'HEAD', '--name-only'])).toBe('.claude/settings.json');
+
+    revertWorktreeSettingsArtifact(scratch);
+
+    expect(readFileSync(join(scratch, '.claude/settings.json'), 'utf8')).toBe(original);
+    // After revert, the index should also be reset (no staged delta left).
+    expect(git(['diff', 'HEAD', '--name-only'])).toBe('');
+  });
 });

--- a/apps/temporal-worker/test/grooming-revert-settings-artifact.test.ts
+++ b/apps/temporal-worker/test/grooming-revert-settings-artifact.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { revertWorktreeSettingsArtifact } from '../src/grooming/apply-workflow-result.ts';
+
+// Build a tiny git repo with .claude/settings.json committed, then mutate
+// it (simulating writeWorktreeClaudeSettings) and verify the revert puts
+// the file back to its original tracked content.
+describe('revertWorktreeSettingsArtifact', () => {
+  let scratch: string;
+
+  function git(args: string[]): string {
+    return execFileSync('git', args, { cwd: scratch, encoding: 'utf8' }).trim();
+  }
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'chitin-revert-test-'));
+    git(['init', '--quiet']);
+    git(['config', 'user.email', 'test@example.invalid']);
+    git(['config', 'user.name', 'test']);
+    git(['config', 'commit.gpgsign', 'false']);
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('reverts a tracked .claude/settings.json modification', () => {
+    mkdirSync(join(scratch, '.claude'));
+    const original = JSON.stringify({ extraKnownMarketplaces: { nx: { source: 'github' } } }, null, 2);
+    writeFileSync(join(scratch, '.claude/settings.json'), original);
+    git(['add', '.claude/settings.json']);
+    git(['commit', '-m', 'baseline', '--quiet']);
+
+    // Simulate the worker overwriting the file.
+    const overwritten = JSON.stringify({ hooks: { PreToolUse: [{ matcher: '', hooks: [] }] } }, null, 2);
+    writeFileSync(join(scratch, '.claude/settings.json'), overwritten);
+
+    revertWorktreeSettingsArtifact(scratch);
+
+    expect(readFileSync(join(scratch, '.claude/settings.json'), 'utf8')).toBe(original);
+  });
+
+  it('is a no-op when .claude/settings.json is not modified', () => {
+    mkdirSync(join(scratch, '.claude'));
+    const original = JSON.stringify({ keep: true });
+    writeFileSync(join(scratch, '.claude/settings.json'), original);
+    git(['add', '.claude/settings.json']);
+    git(['commit', '-m', 'baseline', '--quiet']);
+
+    revertWorktreeSettingsArtifact(scratch);
+
+    expect(readFileSync(join(scratch, '.claude/settings.json'), 'utf8')).toBe(original);
+  });
+
+  it('is a no-op when there is no .claude/settings.json at all', () => {
+    // Worker may not have run writeWorktreeClaudeSettings (e.g., copilot driver).
+    writeFileSync(join(scratch, 'other.txt'), 'hello');
+    git(['add', 'other.txt']);
+    git(['commit', '-m', 'baseline', '--quiet']);
+
+    // Should not throw.
+    expect(() => revertWorktreeSettingsArtifact(scratch)).not.toThrow();
+  });
+
+  it('does not touch other modified files', () => {
+    mkdirSync(join(scratch, '.claude'));
+    const settings = JSON.stringify({ extra: 'main' });
+    writeFileSync(join(scratch, '.claude/settings.json'), settings);
+    writeFileSync(join(scratch, 'task.ts'), '// original');
+    git(['add', '.']);
+    git(['commit', '-m', 'baseline', '--quiet']);
+
+    // Worker overwrites both: .claude/settings.json (artifact) and the
+    // entry's actual target (task work). We must revert ONLY the
+    // settings.json, leaving the task work alone for staging.
+    writeFileSync(join(scratch, '.claude/settings.json'), '{"hooks":[]}');
+    writeFileSync(join(scratch, 'task.ts'), '// task work edit');
+
+    revertWorktreeSettingsArtifact(scratch);
+
+    expect(readFileSync(join(scratch, '.claude/settings.json'), 'utf8')).toBe(settings);
+    expect(readFileSync(join(scratch, 'task.ts'), 'utf8')).toBe('// task work edit');
+  });
+});

--- a/apps/temporal-worker/test/slice6.test.ts
+++ b/apps/temporal-worker/test/slice6.test.ts
@@ -120,7 +120,10 @@ describe('slice 6c — planInvocation tier wiring', () => {
   it('copilot with tier appends --model into the chitin-kernel shim args', () => {
     const planT2 = planInvocation({ ...baseReq, allowed_drivers: ['copilot'], tier: 'T2' as Tier });
     expect(planT2.args).toContain('--model');
-    expect(planT2.args[planT2.args.indexOf('--model') + 1]).toBe('claude-haiku-4.5');
+    // 2026-05-02: T2 copilot model bumped to claude-sonnet-4.6 to preserve
+    // T2 reasoning quality after the dispatcher reroute (TIER_DRIVER[T2]
+    // changed from claude-code-headless → copilot in PR #123).
+    expect(planT2.args[planT2.args.indexOf('--model') + 1]).toBe('claude-sonnet-4.6');
   });
 });
 


### PR DESCRIPTION
## Summary

Real fix for the 2026-05-02 overnight bucket-B contamination (4/5 claude-code-headless runs shipped only a `.claude/settings.json` diff with no actual task work). PR #122's preflight scrub solved a different — and as it turns out, smaller — problem: it scrubbed an untracked backup artifact in the parent repo. The actual root cause lives in the *worktree*.

## Root cause (correcting the after-action)

Confirmed by inspecting PR #114's diff: byte-identical to `writeWorktreeClaudeSettings`'s output. Chain:

1. Worker (slice 5b) provisions a fresh worktree off main.
2. `writeWorktreeClaudeSettings` (\`apps/temporal-worker/src/activity.ts:219\`) writes the chitin gate hook config to \`worktree/.claude/settings.json\` — *overwriting* whatever main had there (Nx plugin config).
3. Apply step's \`git diff --shortstat\` sees the modification (1 file changed, 12 insertions(+), 10 deletions(-)).
4. \`trackedDiff\` non-empty → auto-commit + push.
5. The PR opens with the entry's title and a generated body, but the diff is just the worker's hook config write.

This explains why bucket-B was 100% claude-code-headless and 0% copilot: copilot routes through \`chitin-kernel drive copilot\` and never touches the worktree's \`.claude/settings.json\`.

## Fix

- \`apply-workflow-result.revertWorktreeSettingsArtifact()\`: revert any tracked modification of \`.claude/settings.json\` in the worktree before the trackedDiff check. If the agent did real task work, that's the only thing the diff sees. If the agent declined, the worktree returns to clean → no auto-commit → no bogus PR.
- Added an \`import.meta.url\` guard on \`main()\` so importing the helper from tests doesn't fire the CLI (matches the pattern PR #105 introduced for dispatcher.ts).
- Routed \`TIER_DRIVER[T2]\` to copilot for now. Overnight data: T2/T3 CCH was 1/5 success; T0/T1 copilot was 9/10. Flip T2 back to CCH after this fix has been live for one swarm cycle and the bucket-B rate stays at 0.

## Test plan

- [x] 4 unit tests in \`grooming-revert-settings-artifact.test.ts\` covering: tracked-modification revert, no-op on unmodified, no-op on absent file, leaves other modified files alone.
- [x] Full \`apps/temporal-worker\` suite passes (97/97).
- [ ] After merge: watch the next CCH dispatch (T3 entries continue to route to CCH) and confirm \`.claude/settings.json\` doesn't appear in the resulting diff.
- [ ] After one clean swarm cycle, flip T2 back to CCH in a separate PR.

## Notes

The after-action doc \`docs/observations/2026-05-02-bucket-b-after-action.md\` will be corrected in a follow-up docs PR (the doc currently blames the parent-repo backup artifact, which is wrong).