### PR TITLE
docs: correct bucket-B root cause + 3 telemetry/local-stack backlog entries

### DIFF
--- a/docs/observations/2026-05-02-bucket-b-after-action.md
+++ b/docs/observations/2026-05-02-bucket-b-after-action.md
@@ -29,42 +29,63 @@ mismatch between title (`wall-timeout-sigkill-propagation`) and diff
 by how often the apply step produces an honest PR; one-in-four false
 positives is worse than one-in-four no-PRs.
 
-## Root cause
+## Root cause (CORRECTED 2026-05-02 afternoon)
 
-The workspace's `.claude/` directory contained a leftover artifact:
+> **First analysis was wrong.** The original write-up blamed an
+> untracked backup artifact (`.claude/settings.json.chitin-backup-<ts>`)
+> in the parent repo's `.claude/` dir. That theory motivated PR #121's
+> backlog entry and PR #122's pre-flight scrub. Both shipped. Both
+> address a real but smaller issue. Neither fixes Bucket-B.
+>
+> The actual root cause was found while pulling driver-mix telemetry on
+> the 15 overnight runs: 100% of Bucket-B PRs were claude-code-headless,
+> 0% were copilot. That asymmetry is not consistent with "shared
+> backup artifact in the parent repo" (which would affect both
+> drivers equally). Re-reading PR #114's diff revealed it was
+> byte-identical to the output of `writeWorktreeClaudeSettings`.
 
-```
-.claude/settings.json.chitin-backup-20260429T210349Z
-```
+The actual chain:
 
-This was created by `chitin-kernel install --surface claude-code
---project` on 2026-04-29 — the installer's normal behavior is to back
-up the previous settings.json before overwriting. Backups are
-append-only and never auto-cleaned.
+1. The dispatcher provisions a fresh worktree off `main` for each
+   dispatch.
+2. For claude-code-headless, the worker calls
+   `writeWorktreeClaudeSettings(worktreePath)` (`apps/temporal-worker/
+   src/activity.ts:219`) before spawning the agent. This writes the
+   chitin gate hook config to `worktree/.claude/settings.json` —
+   **overwriting** whatever main had checked out there (the Nx-plugin
+   config).
+3. Whether or not the agent does any task work, the apply step's
+   "tracked diff" check (`grooming/apply-workflow-result.ts`) sees a
+   modification on `.claude/settings.json` (tracked: yes; in `git
+   diff --shortstat`: yes).
+4. `trackedDiff` non-empty → auto-commit fallback fires → pushes →
+   opens PR.
+5. The PR's title and body are generated from the entry's metadata,
+   so it *looks* like the agent did the work. The diff is just the
+   worker's hook write.
 
-The dispatcher provisions a worktree off `main` for each dispatch and
-spawns the agent in it. The agent's prompt names a specific target
-file and tells it not to invent scope. But the apply step
-(`grooming/apply-workflow-result.ts`) ran `git add -A` over the entire
-worktree to stage anything the agent had touched. The backup file
-isn't tracked on `main` — it lives only in the live workspace's
-`.claude/` directory. Each dispatch's worktree inherited it as
-untracked content.
-
-Critically, on at least four runs, the agent (claude-code-headless)
-never touched the actual target file at all — likely the wall_timeout
-fired before tool-dispatch completed, or the agent declined to commit.
-But because the backup artifact existed in the worktree and `git add
--A` swept it up, the apply step found "tracked diff" content (the
-backup file got promoted from untracked to staged), called the
-auto-commit fallback path with `defaultCommitMessage()`, and pushed.
-The PR opened with a generated title from the entry id — looking, to
-the reader, like the agent had done the work.
+Why only claude-code-headless: copilot dispatches via
+`chitin-kernel drive copilot` and never enters the `claude` CLI's
+project-settings discovery path, so the worker never touches
+`.claude/settings.json` for copilot runs. All 10 copilot dispatches
+overnight produced honest PRs; 4 of 5 CCH dispatches produced
+Bucket-B.
 
 This is **a security-shaped failure even though no security policy
-was bypassed.** The chain says: artifact + permissive `git add -A` +
-auto-commit-on-tracked-diff = ship something that looks like the
-intended work but isn't.
+was bypassed.** The chain says: worker writes hook config + apply
+step's permissive auto-commit heuristic = ship something that looks
+like the intended work but isn't.
+
+### Why the first analysis was plausible-but-wrong
+
+When I noticed four PRs with identical small diffs, the parent
+repo's untracked `.claude/settings.json.chitin-backup-*` was visibly
+present and nominally matched "something replaced settings.json with
+the chitin hook." The hypothesis would have predicted contamination
+on copilot too, but I didn't check driver-mix before publishing the
+after-action — closing the loop on driver split would have surfaced
+the wrong-cause sooner. **Lesson: ground every "why did this fail?"
+in the per-driver / per-tier breakdown before publishing.**
 
 ## How it was detected
 
@@ -81,18 +102,30 @@ absent.
 
 ## What we changed
 
-1. **Deleted the artifact** (this commit). Backups created by
-   `chitin-kernel install` will continue to land in `.claude/` —
-   future hardening is in (2) below.
+1. **Deleted the parent-repo artifact** (PR #121). Backups created by
+   `chitin-kernel install` are noisy but turned out not to be the
+   cause. Cleanup still good hygiene.
 2. **Filed `dispatcher-preflight-scrub-claude-settings-backup`** as a
-   ready entry in `swarm-backlog.md` (PR #121). Pre-flight refuses
-   (or auto-scrubs) when any `.claude/settings.json.chitin-backup-*`
+   ready entry in `swarm-backlog.md` (PR #121); the swarm picked it
+   up and shipped PR #122 implementing the preflight check. Pre-flight
+   refuses (or auto-scrubs) when any `.claude/settings.json.chitin-backup-*`
    file is present at tick start. Default to refuse unless dogfood
    shows it's a recurring operator burden.
-3. **Closed #114, #117, #118, #120** with a comment naming the root
-   cause. #114's entry is moot — the SIGKILL fix already shipped in
-   slice-7a (PR #99). The other three remain claimable; the next
-   swarm tick after (2) lands will pick them up cleanly.
+3. **Closed #114, #117, #118, #120** with a comment naming what we
+   *thought* was the root cause. #114's entry is moot — the SIGKILL
+   fix already shipped in slice-7a (PR #99). The other three remain
+   claimable. After PR #123 lands they'll dispatch cleanly.
+4. **PR #123 (the actual fix):** added
+   `revertWorktreeSettingsArtifact()` to the apply step. Before the
+   trackedDiff check, the apply step runs `git checkout --
+   .claude/settings.json` in the worktree. If the worker's hook write
+   was the only modification, the worktree returns to clean → no
+   auto-commit → no PR. If the agent did real work elsewhere, that
+   work is the only thing the heuristic sees.
+5. **PR #123 also routes T2 → copilot for now.** Overnight data: T2
+   on CCH was 1/4 success vs. T0/T1 on copilot at 9/10. Flip back to
+   CCH after this fix has been live for one swarm cycle and the
+   bucket-B rate stays at 0.
 
 ## What we did NOT change (and why)
 
@@ -100,7 +133,10 @@ absent.
   named in the entry's `file:` field." Tempting, but it punishes the
   legitimate case where an entry's target generates auxiliary files
   (e.g. updating a generated test fixture). Fix the artifact at the
-  source, not the staging step.
+  source (the worktree write), not the staging step.
+- **Did not** stop calling `writeWorktreeClaudeSettings` itself.
+  Removing it would break the chitin gate hook that makes CCH runs
+  governable. The fix is at the apply step, not the worker.
 - **Did not** force-push reset the four broken branches. Force-push
   is denied by `chitin.yaml`'s `no-force-push` rule, and rightly so —
   rewriting shared history hides this exact kind of failure from
@@ -112,35 +148,51 @@ absent.
 
 ## Generalizable lessons
 
-1. **Untracked artifacts in `.claude/`, `.git/`, dotfiles, etc. are
-   not benign.** A `git add -A` will sweep them up. The dispatcher's
-   pre-flight is now the right place to gate this.
-2. **PR title vs diff mismatch is a real failure mode the pipeline
+1. **Cross-tab the failure by driver / tier / model before publishing
+   a root-cause.** I shipped the wrong root-cause because I didn't
+   check whether bucket-B was driver-asymmetric. The 0% / 100%
+   copilot-vs-CCH split would have ruled out the parent-repo backup
+   theory immediately. *Telemetry first, narrative second.*
+2. **The worker's bootstrap writes are pipeline state.** Anything
+   `writeWorktreeClaudeSettings`, `provisionOpenclawState`, or any
+   future bootstrap helper writes into the worktree is part of the
+   diff the apply step will see. Each such write needs an explicit
+   apply-step exception OR a write target that's outside the
+   worktree's diff surface (`.gitignore`'d, `XDG_CACHE_HOME`, or via
+   `git update-index --skip-worktree`).
+3. **PR title vs diff mismatch is a real failure mode the pipeline
    doesn't catch.** Worth thinking about whether the apply step
    should refuse to push when the diff doesn't intersect the entry's
    declared `file:` field. Defer until we have a cheap way to
    express "entry's file scope" as a structured constraint that
    `apply-workflow-result.ts` can consume.
-3. **Similarity across PRs is a signal.** If you ever see N
+4. **Similarity across PRs is a signal.** If you ever see N
    autonomous-swarm PRs with the same one-file diff and divergent
    titles, do not merge any of them until you understand what's
-   common.
-4. **Installer backups are state.** Anything the kernel writes into
-   the user's working tree is part of the pipeline's environment.
-   If the installer leaves backups, the dispatcher needs an opinion
-   about them — and the kernel should probably namespace its backups
-   to a path the dispatcher's pre-flight can scrub generically (e.g.
-   `~/.cache/chitin/install-backups/<surface>/<ts>`) rather than
-   leaving them in `.claude/` next to live config.
+   common. (My initial discovery path was right; the wrong-cause
+   only got published because I stopped tracing one step too soon.)
+5. **Untracked artifacts in `.claude/`, `.git/`, dotfiles, etc. are
+   still not benign** — `git add -A` will sweep them up. PR #122's
+   pre-flight scrub is correct hygiene even though the original
+   bucket-B wasn't caused by it.
 
 ## See also
 
-- PR #121 — the pre-flight scrub backlog entry.
+- **PR #123 — the actual fix.** Apply-step revert of
+  `.claude/settings.json` + T2 reroute to copilot.
+- PR #121 — the pre-flight scrub backlog entry (correct hygiene,
+  wrong target for this bug).
+- PR #122 — the swarm-produced implementation of #121's entry. Real
+  meta-recursion: swarm shipped a fix for what we *thought* was the
+  bucket-B cause.
 - PRs #114, #117, #118, #120 — the four closed contaminated PRs;
-  comments name the root cause.
+  diff in #114 was the byte-level evidence that finally cracked the
+  real root cause.
+- `apps/temporal-worker/src/activity.ts:219` — `writeWorktreeClaudeSettings`,
+  the worker write that creates the artifact.
 - `apps/temporal-worker/src/grooming/apply-workflow-result.ts` —
   where the "tracked diff exists → auto-commit + push" heuristic
-  lives.
+  lives, and where PR #123 plants the revert.
 - `go/execution-kernel/internal/govhookinstall/install.go` — where
-  the `.claude/settings.json.chitin-backup-<ts>` filename is minted
-  by the installer.
+  the (red-herring) `.claude/settings.json.chitin-backup-<ts>`
+  filename gets minted by the installer.

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -45,6 +45,130 @@ the swarm cannot quietly grant itself broader permissions.
 
 ## Ready (claimable now)
 
+### `qwen-ollama-config-bump-and-validate`
+
+```yaml
+id: qwen-ollama-config-bump-and-validate
+tier: T2
+status: ready
+estimated_loc: 80
+blocks: []
+file: docs/runbooks/local-qwen-stack.md (new), apps/temporal-worker/src/activity.ts
+references_finding: 2026-05-02-overnight-driver-mix
+```
+
+The 2026-05-01 instability investigation (PR #112) produced a clear
+remediation list but no implementation. Overnight 2026-05-02:
+local-qwen received **0 dispatches** (TIER_DRIVER routes T0/T1 →
+copilot until the qwen layer is fixed). The 3090 sat idle while
+$0.50 went to claude-code-headless on T2/T3. Stop the bleed by
+actually shipping the recommended config.
+
+Concrete actions from the investigation:
+1. Bump ollama 0.21.0 → 0.22.x (verified current via
+   `gh api repos/ollama/ollama/releases | jq '.[0].tag_name'`).
+2. Set `OLLAMA_KV_CACHE_TYPE=q8_0` in
+   `/etc/systemd/system/ollama.service` (halves KV cache VRAM).
+3. Set `num_ctx=32768` on the qwen-agent (avoids 262144 → CPU
+   offload spill).
+4. Smoke-test by dispatching one T0 entry to local-qwen explicitly
+   (`allowed_drivers: ['local-qwen']` override) and confirm the run
+   returns exit_code=0 with the qwen3-coder agent producing a real
+   diff.
+5. Document the resulting stack in `docs/runbooks/local-qwen-stack.md`
+   so this doesn't get re-derived next time.
+
+After this lands, a follow-up entry can flip `TIER_DRIVER[T0]` from
+`copilot` back to `local-qwen` (will be a 1-line change). Keep T0
+on copilot for now — local-qwen reliability is the gate.
+
+T2 because it crosses systemd, ollama config, and verification work.
+
+---
+
+### `analysis-swarm-runs-loader`
+
+```yaml
+id: analysis-swarm-runs-loader
+tier: T1
+status: ready
+estimated_loc: 120
+blocks: []
+file: python/analysis/swarm_runs.py (new), python/analysis/tests/test_swarm_runs.py (new)
+references_finding: 2026-05-02-overnight-driver-mix
+```
+
+The Python analysis library (`python/analysis/`) only has
+`gov-decisions-*.jsonl` loaders today. The 2026-05-02 overnight-mix
+analysis (driver/tier breakdown, contamination rate, per-run cost)
+required a bespoke `/tmp/swarm-overnight-analysis.py` script. That
+substrate is the wrong place — telemetry-derived insights should
+live in the lib so future questions are queryable, not re-engineered
+each time.
+
+Schema:
+- Inputs: `~/.cache/chitin/swarm-state/dispatched/*.json` (markers)
+  joined with `tmp/result-swarm-*.json` (envelopes) by `workflow_id`.
+- Output: typed `SwarmRun` dataclasses with `entry_id`, `tier`,
+  `driver`, `dispatched_at`, `exit_code`, `duration_ms`,
+  `commits_added`, `pr_url` (parsed from stdout via `extractPrUrl`-
+  equivalent), `cost_usd` (parsed from claude-code-headless tail),
+  `model` (parsed from modelUsage), `bucket_b` (heuristic: diff is
+  byte-identical to writeWorktreeClaudeSettings output).
+- Window-filter helper matching `loaders.Window`.
+
+Implementation steps:
+- `python/analysis/swarm_runs.py`: `load_swarm_runs(state_dir, tmp_dir, window)` returning `list[SwarmRun]`.
+- Helpers for `cost_by_driver`, `outcomes_by_driver`, `bucket_b_rate`.
+- Tests using fixture marker + envelope JSON files.
+- Update `python/analysis/__init__.py` description to mention
+  decisions, debt, soul-routing, **and swarm-runs**.
+
+T1 because mechanical (parse JSON, dataclass projection, simple
+aggregations). No external services, no model calls.
+
+---
+
+### `swarm-daily-rollup-healthcheck`
+
+```yaml
+id: swarm-daily-rollup-healthcheck
+tier: T2
+status: ready
+estimated_loc: 150
+blocks: [analysis-swarm-runs-loader]
+file: python/analysis/swarm_health.py (new), scripts/swarm-daily-rollup.sh (new), infra/systemd/chitin-swarm-rollup.timer (new)
+references_finding: 2026-05-02-overnight-driver-mix
+```
+
+Telemetry without alarms is just data. The bucket-B contamination
+overnight 2026-05-02 looked indistinguishable from healthy
+dispatch_complete events in Slack — operator only noticed because
+they happened to inspect 18 PRs by hand the next morning. We need a
+daily rollup that flags drift.
+
+Output (Slack channel + structured stdout for journal):
+- 24h dispatches by driver
+- Bucket-B rate (target: 0%; alarm: > 5%)
+- Success rate per driver and per tier (alarm: < 70%)
+- Cost summary (claude-code-headless $/run; total)
+- Local-qwen idle-percentage (we're paying for cloud when the 3090
+  could be working — alarm: > 80% T0 routed away from local-qwen)
+- Top 3 failure modes (timeout, exit_code=1 partial, contamination)
+
+Wire-up:
+- Cron: `chitin-swarm-rollup.timer` fires daily at 06:00 local.
+- Service runs `swarm-daily-rollup.sh` which calls the Python
+  rollup, posts to `CHITIN_SLACK_WEBHOOK_URL` if set, and writes
+  `~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json` for trend
+  analysis.
+
+T2: cross-cutting (Python analysis + Slack notifier reuse + systemd
+timer). Blocked by `analysis-swarm-runs-loader` since the rollup is
+its first real consumer.
+
+---
+
 ### `dispatcher-preflight-scrub-claude-settings-backup`
 
 ```yaml

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -113,9 +113,24 @@ Schema:
   `driver`, `dispatched_at`, `exit_code`, `duration_ms`,
   `commits_added`, `pr_url` (parsed from stdout via `extractPrUrl`-
   equivalent), `cost_usd` (parsed from claude-code-headless tail),
-  `model` (parsed from modelUsage), `bucket_b` (heuristic: diff is
-  byte-identical to writeWorktreeClaudeSettings output).
+  `model` (parsed from modelUsage), `bucket_b` (see heuristic note
+  below).
 - Window-filter helper matching `loaders.Window`.
+
+**`bucket_b` heuristic (don't byte-match a moving target):** the
+naive "diff equals `writeWorktreeClaudeSettings`'s exact output"
+fails the next time the worker tweaks JSON spacing, adds a field, or
+appends a trailing newline. Use a structural signature instead:
+
+- post-PR-#123, the apply-step revert SHOULD eliminate this case
+  entirely — the heuristic exists to detect *regression*, not to
+  recover from it
+- structural condition: PR's modified files set is exactly
+  `{.claude/settings.json}` AND every change to that file is
+  type=`M` (modification, not addition or deletion) AND
+  `commits_added == 1` (the auto-commit fallback)
+- when this fires, raise it as a regression alarm, not just a
+  bucket_b counter — apply-step must have failed to revert
 
 Implementation steps:
 - `python/analysis/swarm_runs.py`: `load_swarm_runs(state_dir, tmp_dir, window)` returning `list[SwarmRun]`.
@@ -149,12 +164,22 @@ daily rollup that flags drift.
 
 Output (Slack channel + structured stdout for journal):
 - 24h dispatches by driver
-- Bucket-B rate (target: 0%; alarm: > 5%)
+- Bucket-B rate (target: 0% post-PR #123 fix; alarm: > 0% =
+  regression of the apply-step revert)
 - Success rate per driver and per tier (alarm: < 70%)
 - Cost summary (claude-code-headless $/run; total)
 - Local-qwen idle-percentage (we're paying for cloud when the 3090
   could be working — alarm: > 80% T0 routed away from local-qwen)
-- Top 3 failure modes (timeout, exit_code=1 partial, contamination)
+- **Short-run rate per driver/tier** (runs with `duration_ms < 15s`
+  AND `commits_added == 0`). Overnight 2026-05-02 had two CCH T2
+  bucket-B runs at 7.8s and 9.0s — agent burned <10s and gave up.
+  That's a different failure mode from "agent worked, then declined"
+  and worth surfacing separately so prompt-tuning vs apply-step
+  fixes target the right thing. Alarm: > 25% short-run rate on any
+  driver suggests the prompt template doesn't fit that tier's
+  entries.
+- Top 3 failure modes (timeout, exit_code=1 partial, contamination,
+  short-run-no-work)
 
 Wire-up:
 - Cron: `chitin-swarm-rollup.timer` fires daily at 06:00 local.


### PR DESCRIPTION
## Summary

Two-part: (1) correct this morning's bucket-B after-action — the original analysis blamed the wrong file; the real cause is in the worker, not the parent repo — and (2) file three new ready backlog entries surfaced by the corrected analysis.

## After-action correction

This morning's after-action (merged in PR #121) blamed an untracked `.claude/settings.json.chitin-backup-*` artifact in the parent repo. PR #122's preflight scrub shipped against that hypothesis. Both are correct hygiene but neither fixes bucket-B.

Real cause (found while pulling overnight driver-mix telemetry):
- 100% of bucket-B PRs were claude-code-headless; 0% were copilot.
- That's impossible if the cause were a shared parent-repo artifact.
- PR #114's diff is byte-identical to `writeWorktreeClaudeSettings`'s output.
- The chain: worker overwrites \`worktree/.claude/settings.json\` for CCH spawns → apply step's tracked-diff heuristic auto-commits → ships as task work.

PR #123 plants the actual fix (revert `.claude/settings.json` before the trackedDiff check + reroute T2 → copilot until the rate stays at 0).

The doc now records the corrected analysis, names PR #123 as the real fix, and adds a lesson: **cross-tab failures by driver / tier / model BEFORE publishing a root-cause narrative.**

## Three new ready entries

All derived from the same telemetry pass:

1. **\`qwen-ollama-config-bump-and-validate\`** (T2, ~80 LOC) — ship the remediations PR #112 documented (ollama 0.21 → 0.22, KV cache q8_0, num_ctx 32768). Overnight: local-qwen received **0 dispatches**; the 3090 sat idle while \$0.50 went to claude-code-headless.
2. **\`analysis-swarm-runs-loader\`** (T1, ~120 LOC) — extend `python/analysis/` (currently only gov-decisions-aware) to load swarm markers + envelopes by workflow_id. Telemetry questions should be queryable, not re-engineered per question (this PR's analysis required a one-off `/tmp/swarm-overnight-analysis.py`).
3. **\`swarm-daily-rollup-healthcheck\`** (T2, ~150 LOC, blocked by ↑) — daily Slack rollup of bucket-B rate, success-by-tier, cost, local-qwen idle-pct. Telemetry without alarms is just data.

## Test plan
- [ ] Read the corrected after-action root-cause section; confirm it matches the diff in PR #114 and the actual code in `apps/temporal-worker/src/activity.ts:219`.
- [ ] Confirm the three new entries are tier-correct and the \`blocks:\` chain (rollup → loader) makes sense.
- [ ] Optionally promote any of the three from `ready` to claimed if you want the swarm to grab them on the next tick.