### PR TITLE
swarm: analysis-swarm-runs-loader

### DIFF
--- a/python/analysis/__init__.py
+++ b/python/analysis/__init__.py
@@ -1,2 +1,2 @@
-"""chitin analysis layer — decisions, debt, soul-routing streams."""
+"""chitin analysis layer — decisions, debt, soul-routing, and swarm-run streams."""
 __version__ = "0.1.0"

--- a/python/analysis/swarm_runs.py
+++ b/python/analysis/swarm_runs.py
@@ -1,0 +1,116 @@
+import os
+import json
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Dict, Any
+from datetime import datetime
+
+@dataclass
+class SwarmRun:
+    entry_id: str
+    tier: str
+    driver: str
+    dispatched_at: datetime
+    exit_code: int
+    duration_ms: int
+    commits_added: int
+    pr_url: Optional[str]
+    cost_usd: Optional[float]
+    model: Optional[str]
+    bucket_b: bool
+
+def extract_pr_url(stdout: str) -> Optional[str]:
+    match = re.search(r"https://github.com/[^\s]+/pull/\d+", stdout)
+    return match.group(0) if match else None
+
+def extract_cost_usd(stdout: str) -> Optional[float]:
+    match = re.search(r"cost: \$([0-9.]+)", stdout)
+    return float(match.group(1)) if match else None
+
+def extract_model(model_usage: Any) -> Optional[str]:
+    if isinstance(model_usage, dict):
+        return model_usage.get("model")
+    if isinstance(model_usage, str):
+        return model_usage
+    return None
+
+def is_bucket_b(diff: str, worktree_settings: str) -> bool:
+    return diff == worktree_settings
+
+def load_swarm_runs(state_dir: str, tmp_dir: str, window) -> List[SwarmRun]:
+    # Load marker files
+    markers = {}
+    for fname in os.listdir(state_dir):
+        if not fname.endswith(".json"): continue
+        with open(os.path.join(state_dir, fname)) as f:
+            marker = json.load(f)
+            workflow_id = marker.get("workflow_id")
+            if workflow_id:
+                markers[workflow_id] = marker
+
+    # Load envelope files
+    runs = []
+    for fname in os.listdir(tmp_dir):
+        if not fname.startswith("result-swarm-") or not fname.endswith(".json"): continue
+        with open(os.path.join(tmp_dir, fname)) as f:
+            envelope = json.load(f)
+            workflow_id = envelope.get("workflow_id")
+            marker = markers.get(workflow_id)
+            if not marker:
+                continue
+            dispatched_at = datetime.fromisoformat(marker["dispatched_at"]) if "dispatched_at" in marker else None
+            entry_id = marker.get("entry_id", "")
+            tier = marker.get("tier", "")
+            driver = marker.get("driver", "")
+            exit_code = envelope.get("exit_code", -1)
+            duration_ms = envelope.get("duration_ms", 0)
+            commits_added = envelope.get("commits_added", 0)
+            stdout = envelope.get("stdout", "")
+            pr_url = extract_pr_url(stdout)
+            cost_usd = extract_cost_usd(stdout)
+            model = extract_model(envelope.get("modelUsage"))
+            diff = envelope.get("diff", "")
+            worktree_settings = envelope.get("writeWorktreeClaudeSettings", "")
+            bucket_b = is_bucket_b(diff, worktree_settings)
+            run = SwarmRun(
+                entry_id=entry_id,
+                tier=tier,
+                driver=driver,
+                dispatched_at=dispatched_at,
+                exit_code=exit_code,
+                duration_ms=duration_ms,
+                commits_added=commits_added,
+                pr_url=pr_url,
+                cost_usd=cost_usd,
+                model=model,
+                bucket_b=bucket_b
+            )
+            # Window filter
+            if window is None or window.contains(dispatched_at):
+                runs.append(run)
+    return runs
+
+def cost_by_driver(runs: List[SwarmRun]) -> Dict[str, float]:
+    costs = {}
+    for run in runs:
+        if run.driver and run.cost_usd is not None:
+            costs.setdefault(run.driver, 0.0)
+            costs[run.driver] += run.cost_usd
+    return costs
+
+def outcomes_by_driver(runs: List[SwarmRun]) -> Dict[str, Dict[str, int]]:
+    outcomes = {}
+    for run in runs:
+        if run.driver:
+            d = outcomes.setdefault(run.driver, {"success": 0, "failure": 0})
+            if run.exit_code == 0:
+                d["success"] += 1
+            else:
+                d["failure"] += 1
+    return outcomes
+
+def bucket_b_rate(runs: List[SwarmRun]) -> float:
+    if not runs:
+        return 0.0
+    bucket_b_count = sum(1 for run in runs if run.bucket_b)
+    return bucket_b_count / len(runs)

--- a/python/analysis/swarm_runs.py
+++ b/python/analysis/swarm_runs.py
@@ -81,6 +81,15 @@ class SwarmRun:
 # modelUsage block. These regexes are tolerant of pretty-printed JSON
 # (whitespace between key and value) but anchor on the field name so they
 # don't false-match on entry descriptions that mention "cost" generically.
+#
+# CAVEAT (B1): the activity caps stdout_tail at TAIL_BYTES = 2000 (see
+# `apps/temporal-worker/src/activity.ts`). The claude CLI's final-message
+# JSON typically lands inside that window, but a chatty run that emits
+# a long final assistant message before the usage summary can push the
+# cost block out of the tail — the extractor returns None and the run
+# reports cost=None. Empirically the overnight 2026-05-02 run had all
+# 5 CCH costs captured. If a future cost_by_driver total diverges
+# from the Anthropic-side billing tally, suspect tail truncation first.
 _COST_RE = re.compile(r'"total_cost_usd"\s*:\s*([0-9.]+)')
 _MODEL_USAGE_RE = re.compile(r'"modelUsage"\s*:\s*\{\s*"([^"]+)"')
 _PR_URL_RE = re.compile(r'https://github\.com/[\w.-]+/[\w.-]+/pull/\d+')
@@ -95,6 +104,14 @@ _PR_URL_RE = re.compile(r'https://github\.com/[\w.-]+/[\w.-]+/pull/\d+')
 # + envelope window. Conservative — false-negative-leaning, since a
 # legitimate small PR could match the shortstat. Pair with file-list
 # inspection when escalating to an alarm.
+#
+# CAVEAT (B2): this string literal is a SNAPSHOT of what
+# writeWorktreeClaudeSettings (`apps/temporal-worker/src/activity.ts`)
+# emitted as of 2026-05-02. If that function adds a field, reformats
+# JSON, or changes whitespace, the shortstat changes and this matcher
+# silently goes to 0% bucket-B while the actual rate could be non-zero.
+# When updating writeWorktreeClaudeSettings, also update this constant
+# (and the matching test fixture in test_swarm_runs.py).
 _BUCKET_B_SHORTSTAT = "1 file changed, 12 insertions(+), 10 deletions(-)"
 
 

--- a/python/analysis/swarm_runs.py
+++ b/python/analysis/swarm_runs.py
@@ -1,12 +1,68 @@
-import os
+"""Load swarm dispatcher runs from marker + envelope files.
+
+Joins ``~/.cache/chitin/swarm-state/dispatched/<entry-id>.json`` (the
+dispatcher's persistent marker) with ``<repo>/tmp/result-swarm-<wfid>.json``
+(the workflow's result envelope) by ``workflow_id``. Output is a flat
+``SwarmRun`` dataclass per (entry × workflow) pair.
+
+Envelope schema (per ``apps/temporal-worker/src/dispatcher.ts`` + the
+``ActivityResult`` interface in ``activity-types.ts``):
+
+.. code-block::
+
+    {
+      "workflow_id": "swarm-...",
+      "pr_title": "...",
+      "pr_body": "...",
+      "result": {
+        "exit_code": 0,
+        "stdout_tail": "...",       # capped at 2000 bytes
+        "stderr_tail": "...",
+        "duration_ms": 111599,
+        "worktree": {
+          "path": "...",
+          "branch": "...",
+          "head_sha": "...",
+          "commits_added": 0,
+          "has_uncommitted_changes": true,
+          "diff_shortstat": "1 file changed, 12 insertions(+), 10 deletions(-)"
+        }
+      }
+    }
+
+Marker schema:
+
+.. code-block::
+
+    {
+      "entry_id": "...",
+      "workflow_id": "swarm-...",
+      "tier": "T0|T1|T2|T3|T4",
+      "driver": "copilot|claude-code-headless|local-qwen|...",
+      "dispatched_at": "2026-05-02T03:54:06.332Z"
+    }
+
+Cost / model are parsed out of ``stdout_tail`` for ``claude-code-headless``
+runs (the ``claude`` CLI emits a final JSON summary including
+``"total_cost_usd"`` and ``"modelUsage"``). ``copilot`` runs report no
+per-run cost — the field stays ``None``.
+"""
+from __future__ import annotations
+
 import json
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Dict, Any
 from datetime import datetime
+from pathlib import Path
+from typing import Optional
 
-@dataclass
+from analysis.loaders import Window
+
+
+@dataclass(frozen=True)
 class SwarmRun:
+    """One dispatcher tick's outcome — marker × envelope."""
+
     entry_id: str
     tier: str
     driver: str
@@ -14,103 +70,188 @@ class SwarmRun:
     exit_code: int
     duration_ms: int
     commits_added: int
+    diff_shortstat: str
     pr_url: Optional[str]
     cost_usd: Optional[float]
     model: Optional[str]
     bucket_b: bool
 
-def extract_pr_url(stdout: str) -> Optional[str]:
-    match = re.search(r"https://github.com/[^\s]+/pull/\d+", stdout)
-    return match.group(0) if match else None
 
-def extract_cost_usd(stdout: str) -> Optional[float]:
-    match = re.search(r"cost: \$([0-9.]+)", stdout)
-    return float(match.group(1)) if match else None
+# claude-code-headless's stream-json final-message tail carries the cost +
+# modelUsage block. These regexes are tolerant of pretty-printed JSON
+# (whitespace between key and value) but anchor on the field name so they
+# don't false-match on entry descriptions that mention "cost" generically.
+_COST_RE = re.compile(r'"total_cost_usd"\s*:\s*([0-9.]+)')
+_MODEL_USAGE_RE = re.compile(r'"modelUsage"\s*:\s*\{\s*"([^"]+)"')
+_PR_URL_RE = re.compile(r'https://github\.com/[\w.-]+/[\w.-]+/pull/\d+')
 
-def extract_model(model_usage: Any) -> Optional[str]:
-    if isinstance(model_usage, dict):
-        return model_usage.get("model")
-    if isinstance(model_usage, str):
-        return model_usage
-    return None
+# Bucket-B signature: the apply-step revert (PR #123) should make this
+# rate 0 going forward. Pre-fix runs had a byte-identical
+# `.claude/settings.json` overwrite — diff_shortstat exactly
+# "1 file changed, 12 insertions(+), 10 deletions(-)" with
+# commits_added=1. The structural form is preferred (modified-set ==
+# {.claude/settings.json} AND type=M) but that requires git inspection
+# of the branch. The shortstat shape is a workable proxy in the marker
+# + envelope window. Conservative — false-negative-leaning, since a
+# legitimate small PR could match the shortstat. Pair with file-list
+# inspection when escalating to an alarm.
+_BUCKET_B_SHORTSTAT = "1 file changed, 12 insertions(+), 10 deletions(-)"
 
-def is_bucket_b(diff: str, worktree_settings: str) -> bool:
-    return diff == worktree_settings
 
-def load_swarm_runs(state_dir: str, tmp_dir: str, window) -> List[SwarmRun]:
-    # Load marker files
-    markers = {}
-    for fname in os.listdir(state_dir):
-        if not fname.endswith(".json"): continue
-        with open(os.path.join(state_dir, fname)) as f:
-            marker = json.load(f)
-            workflow_id = marker.get("workflow_id")
-            if workflow_id:
-                markers[workflow_id] = marker
+def _parse_iso(s: str) -> datetime:
+    """ISO-8601 parser tolerant of the 'Z' suffix Node emits."""
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
-    # Load envelope files
-    runs = []
-    for fname in os.listdir(tmp_dir):
-        if not fname.startswith("result-swarm-") or not fname.endswith(".json"): continue
-        with open(os.path.join(tmp_dir, fname)) as f:
-            envelope = json.load(f)
-            workflow_id = envelope.get("workflow_id")
-            marker = markers.get(workflow_id)
-            if not marker:
+
+def _extract_pr_url(stdout_tail: str) -> Optional[str]:
+    m = _PR_URL_RE.search(stdout_tail)
+    return m.group(0) if m else None
+
+
+def _extract_cost_usd(stdout_tail: str) -> Optional[float]:
+    m = _COST_RE.search(stdout_tail)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except ValueError:
+        return None
+
+
+def _extract_model(stdout_tail: str) -> Optional[str]:
+    """Pull the first model id out of the modelUsage block."""
+    m = _MODEL_USAGE_RE.search(stdout_tail)
+    return m.group(1) if m else None
+
+
+def _is_bucket_b(diff_shortstat: str, commits_added: int) -> bool:
+    """Conservative bucket-B detector — see module docstring + PR #124.
+
+    Returns True iff the run's diff matches the byte-identical signature
+    of `writeWorktreeClaudeSettings`'s overwrite. Pair with file-list
+    inspection at the alarm layer; a daily-rollup that fires on this
+    signal alone will have false positives on small legitimate PRs.
+    """
+    return diff_shortstat == _BUCKET_B_SHORTSTAT and commits_added == 1
+
+
+def load_swarm_runs(state_dir: Path, tmp_dir: Path, window: Optional[Window]) -> list[SwarmRun]:
+    """Load all swarm runs in ``window`` (or all-time if ``window`` is None).
+
+    Mirrors ``loaders.load_gov_decisions`` semantics: missing input dirs
+    return an empty list rather than raising. Markers without matching
+    envelopes are skipped (envelope is the source of truth for outcome).
+    """
+    state_dir = Path(state_dir)
+    tmp_dir = Path(tmp_dir)
+
+    markers_by_wfid: dict[str, dict] = {}
+    if state_dir.exists():
+        for path in sorted(state_dir.iterdir()):
+            if path.suffix != ".json" or not path.is_file():
                 continue
-            dispatched_at = datetime.fromisoformat(marker["dispatched_at"]) if "dispatched_at" in marker else None
-            entry_id = marker.get("entry_id", "")
-            tier = marker.get("tier", "")
-            driver = marker.get("driver", "")
-            exit_code = envelope.get("exit_code", -1)
-            duration_ms = envelope.get("duration_ms", 0)
-            commits_added = envelope.get("commits_added", 0)
-            stdout = envelope.get("stdout", "")
-            pr_url = extract_pr_url(stdout)
-            cost_usd = extract_cost_usd(stdout)
-            model = extract_model(envelope.get("modelUsage"))
-            diff = envelope.get("diff", "")
-            worktree_settings = envelope.get("writeWorktreeClaudeSettings", "")
-            bucket_b = is_bucket_b(diff, worktree_settings)
-            run = SwarmRun(
-                entry_id=entry_id,
-                tier=tier,
-                driver=driver,
+            try:
+                marker = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            wfid = marker.get("workflow_id")
+            if wfid:
+                markers_by_wfid[wfid] = marker
+
+    runs: list[SwarmRun] = []
+    if not tmp_dir.exists():
+        return runs
+
+    for path in sorted(tmp_dir.iterdir()):
+        if not (path.name.startswith("result-swarm-") and path.suffix == ".json" and path.is_file()):
+            continue
+        try:
+            envelope = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        wfid = envelope.get("workflow_id")
+        marker = markers_by_wfid.get(wfid) if wfid else None
+        if not marker:
+            continue
+        if "dispatched_at" not in marker:
+            continue
+        try:
+            dispatched_at = _parse_iso(marker["dispatched_at"])
+        except (TypeError, ValueError):
+            continue
+
+        if window is not None and not (window.since <= dispatched_at < window.until):
+            continue
+
+        result = envelope.get("result") or {}
+        worktree = result.get("worktree") or {}
+        stdout_tail = result.get("stdout_tail") or ""
+        diff_shortstat = worktree.get("diff_shortstat", "") or ""
+        commits_added = worktree.get("commits_added", 0) or 0
+
+        runs.append(
+            SwarmRun(
+                entry_id=marker.get("entry_id", ""),
+                tier=marker.get("tier", ""),
+                driver=marker.get("driver", ""),
                 dispatched_at=dispatched_at,
-                exit_code=exit_code,
-                duration_ms=duration_ms,
+                exit_code=result.get("exit_code", -1),
+                duration_ms=result.get("duration_ms", 0),
                 commits_added=commits_added,
-                pr_url=pr_url,
-                cost_usd=cost_usd,
-                model=model,
-                bucket_b=bucket_b
+                diff_shortstat=diff_shortstat,
+                pr_url=_extract_pr_url(stdout_tail),
+                cost_usd=_extract_cost_usd(stdout_tail),
+                model=_extract_model(stdout_tail),
+                bucket_b=_is_bucket_b(diff_shortstat, commits_added),
             )
-            # Window filter
-            if window is None or window.contains(dispatched_at):
-                runs.append(run)
+        )
     return runs
 
-def cost_by_driver(runs: List[SwarmRun]) -> Dict[str, float]:
-    costs = {}
-    for run in runs:
-        if run.driver and run.cost_usd is not None:
-            costs.setdefault(run.driver, 0.0)
-            costs[run.driver] += run.cost_usd
-    return costs
 
-def outcomes_by_driver(runs: List[SwarmRun]) -> Dict[str, Dict[str, int]]:
-    outcomes = {}
+def cost_by_driver(runs: list[SwarmRun]) -> dict[str, float]:
+    """Sum of `cost_usd` per driver. Drivers with no per-run cost (e.g.
+    ``copilot`` under the Pro plan) report 0.0."""
+    totals: dict[str, float] = {}
     for run in runs:
-        if run.driver:
-            d = outcomes.setdefault(run.driver, {"success": 0, "failure": 0})
-            if run.exit_code == 0:
-                d["success"] += 1
-            else:
-                d["failure"] += 1
-    return outcomes
+        if not run.driver:
+            continue
+        totals.setdefault(run.driver, 0.0)
+        if run.cost_usd is not None:
+            totals[run.driver] += run.cost_usd
+    return totals
 
-def bucket_b_rate(runs: List[SwarmRun]) -> float:
+
+def outcomes_by_driver(runs: list[SwarmRun]) -> dict[str, dict[str, int]]:
+    """Per-driver breakdown across exit-code categories.
+
+    Keys: ``success`` (exit_code 0), ``partial`` (exit_code 1 — agent
+    declined or fell short), ``timeout`` (exit_code -1 — SIGKILL),
+    ``other`` (any other non-zero).
+    """
+    out: dict[str, dict[str, int]] = {}
+    for run in runs:
+        if not run.driver:
+            continue
+        bucket = out.setdefault(run.driver, {"success": 0, "partial": 0, "timeout": 0, "other": 0})
+        if run.exit_code == 0:
+            bucket["success"] += 1
+        elif run.exit_code == 1:
+            bucket["partial"] += 1
+        elif run.exit_code == -1:
+            bucket["timeout"] += 1
+        else:
+            bucket["other"] += 1
+    return out
+
+
+def bucket_b_rate(runs: list[SwarmRun]) -> float:
+    """Fraction of runs that match the bucket-B signature.
+
+    Post-PR #123 this should be 0.0. Any non-zero rate is a regression
+    signal — the apply-step revert silently failed to fire on those
+    runs.
+    """
     if not runs:
         return 0.0
-    bucket_b_count = sum(1 for run in runs if run.bucket_b)
-    return bucket_b_count / len(runs)
+    return sum(1 for r in runs if r.bucket_b) / len(runs)

--- a/python/analysis/tests/test_swarm_runs.py
+++ b/python/analysis/tests/test_swarm_runs.py
@@ -1,0 +1,252 @@
+"""Tests for the swarm-runs loader."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from analysis.loaders import Window
+from analysis.swarm_runs import (
+    SwarmRun,
+    bucket_b_rate,
+    cost_by_driver,
+    load_swarm_runs,
+    outcomes_by_driver,
+)
+
+
+# ─── fixture builders ────────────────────────────────────────────────────
+
+
+def _write_marker(state_dir: Path, entry_id: str, *, workflow_id: str, tier: str, driver: str, dispatched_at: str) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{entry_id}.json").write_text(
+        json.dumps(
+            {
+                "entry_id": entry_id,
+                "workflow_id": workflow_id,
+                "tier": tier,
+                "driver": driver,
+                "dispatched_at": dispatched_at,
+            }
+        )
+    )
+
+
+def _write_envelope(
+    tmp_dir: Path,
+    *,
+    workflow_id: str,
+    exit_code: int,
+    duration_ms: int,
+    commits_added: int,
+    diff_shortstat: str = "",
+    stdout_tail: str = "",
+) -> None:
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_dir / f"result-{workflow_id}.json").write_text(
+        json.dumps(
+            {
+                "workflow_id": workflow_id,
+                "result": {
+                    "exit_code": exit_code,
+                    "stdout_tail": stdout_tail,
+                    "stderr_tail": "",
+                    "duration_ms": duration_ms,
+                    "worktree": {
+                        "path": "/tmp/wt",
+                        "branch": "swarm/test",
+                        "head_sha": "abc12345",
+                        "commits_added": commits_added,
+                        "has_uncommitted_changes": False,
+                        "diff_shortstat": diff_shortstat,
+                    },
+                },
+                "pr_title": "swarm: test",
+                "pr_body": "test",
+            }
+        )
+    )
+
+
+# ─── tests ───────────────────────────────────────────────────────────────
+
+
+def test_returns_empty_when_state_dir_missing(tmp_path):
+    """Missing state_dir must not raise — matches loaders.load_gov_decisions."""
+    runs = load_swarm_runs(tmp_path / "no-state", tmp_path / "no-tmp", window=None)
+    assert runs == []
+
+
+def test_returns_empty_when_tmp_dir_missing(tmp_path):
+    state_dir = tmp_path / "state"
+    _write_marker(state_dir, "e1", workflow_id="swarm-1", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    runs = load_swarm_runs(state_dir, tmp_path / "no-tmp", window=None)
+    assert runs == []
+
+
+def test_joins_marker_with_envelope_by_workflow_id(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "e1", workflow_id="swarm-1", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    _write_envelope(tmp, workflow_id="swarm-1", exit_code=0, duration_ms=24000, commits_added=1, diff_shortstat="2 files changed, 5 insertions(+)")
+
+    runs = load_swarm_runs(state, tmp, window=None)
+
+    assert len(runs) == 1
+    r = runs[0]
+    assert r.entry_id == "e1"
+    assert r.tier == "T0"
+    assert r.driver == "copilot"
+    assert r.exit_code == 0
+    assert r.duration_ms == 24000
+    assert r.commits_added == 1
+    assert r.diff_shortstat == "2 files changed, 5 insertions(+)"
+    assert r.bucket_b is False
+    assert r.cost_usd is None  # copilot leaves no cost in stdout_tail
+    assert r.model is None
+
+
+def test_skips_envelopes_without_matching_marker(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_envelope(tmp, workflow_id="swarm-orphan", exit_code=0, duration_ms=1, commits_added=0)
+    assert load_swarm_runs(state, tmp, window=None) == []
+
+
+def test_window_excludes_runs_outside_range(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "early", workflow_id="swarm-early", tier="T0", driver="copilot", dispatched_at="2026-05-02T02:00:00Z")
+    _write_marker(state, "in", workflow_id="swarm-in", tier="T0", driver="copilot", dispatched_at="2026-05-02T04:00:00Z")
+    _write_marker(state, "late", workflow_id="swarm-late", tier="T0", driver="copilot", dispatched_at="2026-05-02T06:00:00Z")
+    for wf in ("swarm-early", "swarm-in", "swarm-late"):
+        _write_envelope(tmp, workflow_id=wf, exit_code=0, duration_ms=1, commits_added=0)
+
+    window = Window(
+        since=datetime(2026, 5, 2, 3, 0, tzinfo=timezone.utc),
+        until=datetime(2026, 5, 2, 5, 0, tzinfo=timezone.utc),
+    )
+    runs = load_swarm_runs(state, tmp, window=window)
+    assert [r.entry_id for r in runs] == ["in"]
+
+
+def test_extracts_cost_and_model_from_claude_stdout_tail(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "e2", workflow_id="swarm-2", tier="T2", driver="claude-code-headless", dispatched_at="2026-05-02T03:54:06Z")
+    # Mimic the claude CLI's final-message JSON snippet.
+    fake_tail = (
+        '{"stop_reason":"end_turn","total_cost_usd":0.37654,'
+        '"modelUsage":{"claude-sonnet-4-6":{"inputTokens":20,"outputTokens":4072}}}'
+    )
+    _write_envelope(tmp, workflow_id="swarm-2", exit_code=0, duration_ms=111599, commits_added=0, diff_shortstat="", stdout_tail=fake_tail)
+
+    runs = load_swarm_runs(state, tmp, window=None)
+    assert runs[0].cost_usd == pytest.approx(0.37654)
+    assert runs[0].model == "claude-sonnet-4-6"
+
+
+def test_extracts_pr_url_from_stdout_tail(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "e3", workflow_id="swarm-3", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    fake_tail = "[apply-result] PR -> https://github.com/chitinhq/chitin/pull/103"
+    _write_envelope(tmp, workflow_id="swarm-3", exit_code=0, duration_ms=24000, commits_added=1, stdout_tail=fake_tail)
+    assert load_swarm_runs(state, tmp, window=None)[0].pr_url == "https://github.com/chitinhq/chitin/pull/103"
+
+
+def test_bucket_b_signature_matches_writeWorktreeClaudeSettings_overwrite(tmp_path):
+    """The byte-identical .claude/settings.json overwrite has shortstat
+    '1 file changed, 12 insertions(+), 10 deletions(-)' with commits_added=1."""
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "e4", workflow_id="swarm-4", tier="T2", driver="claude-code-headless", dispatched_at="2026-05-02T03:54:06Z")
+    _write_envelope(
+        tmp,
+        workflow_id="swarm-4",
+        exit_code=0,
+        duration_ms=111599,
+        commits_added=1,
+        diff_shortstat="1 file changed, 12 insertions(+), 10 deletions(-)",
+    )
+    assert load_swarm_runs(state, tmp, window=None)[0].bucket_b is True
+
+
+def test_bucket_b_does_not_match_other_one_file_changes(tmp_path):
+    """A legitimate small PR that happens to be 1 file changed but with
+    different insertion/deletion counts is NOT bucket_b."""
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "e5", workflow_id="swarm-5", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    _write_envelope(
+        tmp,
+        workflow_id="swarm-5",
+        exit_code=0,
+        duration_ms=24000,
+        commits_added=1,
+        diff_shortstat="1 file changed, 3 insertions(+), 1 deletion(-)",
+    )
+    assert load_swarm_runs(state, tmp, window=None)[0].bucket_b is False
+
+
+def test_cost_by_driver_sums_per_driver(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    for i, (entry, driver, cost_in_tail) in enumerate(
+        [
+            ("e1", "claude-code-headless", '"total_cost_usd":0.10'),
+            ("e2", "claude-code-headless", '"total_cost_usd":0.25'),
+            ("e3", "copilot", ""),  # no cost reported
+        ]
+    ):
+        wf = f"swarm-{i}"
+        _write_marker(state, entry, workflow_id=wf, tier="T1", driver=driver, dispatched_at=f"2026-05-02T03:14:0{i}Z")
+        _write_envelope(tmp, workflow_id=wf, exit_code=0, duration_ms=1000, commits_added=0, stdout_tail=cost_in_tail)
+
+    runs = load_swarm_runs(state, tmp, window=None)
+    costs = cost_by_driver(runs)
+    assert costs["claude-code-headless"] == pytest.approx(0.35)
+    assert costs["copilot"] == 0.0
+
+
+def test_outcomes_by_driver_buckets_exit_codes(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    for i, (entry, exit_code) in enumerate([("ok", 0), ("partial", 1), ("timeout", -1), ("other", 2)]):
+        wf = f"swarm-{i}"
+        _write_marker(state, entry, workflow_id=wf, tier="T1", driver="copilot", dispatched_at=f"2026-05-02T03:14:0{i}Z")
+        _write_envelope(tmp, workflow_id=wf, exit_code=exit_code, duration_ms=1, commits_added=0)
+
+    by = outcomes_by_driver(load_swarm_runs(state, tmp, window=None))
+    assert by["copilot"] == {"success": 1, "partial": 1, "timeout": 1, "other": 1}
+
+
+def test_bucket_b_rate(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    bad = "1 file changed, 12 insertions(+), 10 deletions(-)"
+    good = "2 files changed, 30 insertions(+), 4 deletions(-)"
+    for i, shortstat in enumerate([bad, bad, good, good, good]):
+        wf = f"swarm-{i}"
+        _write_marker(state, f"e{i}", workflow_id=wf, tier="T2", driver="claude-code-headless", dispatched_at=f"2026-05-02T03:14:0{i}Z")
+        _write_envelope(tmp, workflow_id=wf, exit_code=0, duration_ms=1, commits_added=1, diff_shortstat=shortstat)
+
+    assert bucket_b_rate(load_swarm_runs(state, tmp, window=None)) == pytest.approx(2 / 5)
+
+
+def test_bucket_b_rate_empty_returns_zero():
+    assert bucket_b_rate([]) == 0.0
+
+
+def test_corrupt_marker_skipped_not_raised(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    state.mkdir()
+    (state / "corrupt.json").write_text("{not valid json")
+    _write_marker(state, "e1", workflow_id="swarm-1", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    _write_envelope(tmp, workflow_id="swarm-1", exit_code=0, duration_ms=1, commits_added=0)
+    runs = load_swarm_runs(state, tmp, window=None)
+    assert len(runs) == 1
+    assert runs[0].entry_id == "e1"
+
+
+def test_corrupt_envelope_skipped_not_raised(tmp_path):
+    state, tmp = tmp_path / "state", tmp_path / "tmp"
+    _write_marker(state, "e1", workflow_id="swarm-1", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    tmp.mkdir()
+    (tmp / "result-swarm-corrupt.json").write_text("{not valid json")
+    _write_envelope(tmp, workflow_id="swarm-1", exit_code=0, duration_ms=1, commits_added=0)
+    runs = load_swarm_runs(state, tmp, window=None)
+    assert len(runs) == 1

--- a/python/analysis/tests/test_swarm_runs.py
+++ b/python/analysis/tests/test_swarm_runs.py
@@ -243,10 +243,20 @@ def test_corrupt_marker_skipped_not_raised(tmp_path):
 
 
 def test_corrupt_envelope_skipped_not_raised(tmp_path):
+    """The corrupt envelope must be skipped silently AND the loader must
+    still process the well-formed sibling. The directory has TWO files
+    matching ``result-swarm-*.json``; only one yields a SwarmRun."""
     state, tmp = tmp_path / "state", tmp_path / "tmp"
     _write_marker(state, "e1", workflow_id="swarm-1", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:38Z")
+    _write_marker(state, "e-corrupt", workflow_id="swarm-corrupt", tier="T0", driver="copilot", dispatched_at="2026-05-02T03:14:39Z")
     tmp.mkdir()
     (tmp / "result-swarm-corrupt.json").write_text("{not valid json")
     _write_envelope(tmp, workflow_id="swarm-1", exit_code=0, duration_ms=1, commits_added=0)
+
+    # Sanity: the tmp dir really has TWO matching files.
+    matched = sorted(p.name for p in tmp.iterdir() if p.name.startswith("result-swarm-"))
+    assert matched == ["result-swarm-1.json", "result-swarm-corrupt.json"]
+
     runs = load_swarm_runs(state, tmp, window=None)
     assert len(runs) == 1
+    assert runs[0].entry_id == "e1"  # well-formed survived; corrupt was skipped


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `analysis-swarm-runs-loader`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-analysis-swarm-runs-loader-1777731790289`

## Entry context

The Python analysis library (`python/analysis/`) only has
`gov-decisions-*.jsonl` loaders today. The 2026-05-02 overnight-mix
analysis (driver/tier breakdown, contamination rate, per-run cost)
required a bespoke `/tmp/swarm-overnight-analysis.py` script. That
substrate is the wrong place — telemetry-derived insights should
live in the lib so future questions are queryable, not re-engineered
each time.

Schema:
- Inputs: `~/.cache/chitin/swarm-state/dispatched/*.json` (markers)
  joined with `tmp/result-swarm-*.json` (envelopes) by `workflow_id`.
- Output: typed `SwarmRun` dataclasses with `entry_id`, `tier`,
  `driver`, `dispatched_at`, `exit_code`, `duration_ms`,
  `commits_added`, `pr_url` (parsed from stdout via `extractPrUrl`-
  equivalent), `cost_usd` (parsed from claude-code-headless tail),
  `model` (parsed from modelUsage), `bucket_b` (heuristic: diff is
  byte-identical to writeWorktreeClaudeSettings output).
- Window-filter helper matching `loaders.Window`.

Implementation steps:
- `python/analysis/swarm_runs.py`: `load_swarm_runs(state_dir, tmp_dir, window)` returning `list[SwarmRun]`.
- Helpers for `cost_by_driver`, `outcomes_by_driver`, `bucket_b_rate`.
- Tests using fixture marker + envelope JSON files.
- Update `python/analysis/__init__.py` description to mention
  decisions, debt, soul-routing, **and swarm-runs**.

T1 because mechanical (parse JSON, dataclass projection, simple
aggregations). No external services, no model calls.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-analysis-swarm-runs-loader-1777731790289`
Branch: `swarm/swarm-analysis-swarm-runs-loader-1777731790289`
Head: `5c2bb94d`
Diff: `1 file changed, 116 insertions(+)`
Commits: 1