### PR TITLE
swarm: swarm-daily-rollup-healthcheck

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,15 @@
 {
-  "extraKnownMarketplaces": {
-    "nx-claude-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "nrwl/nx-ai-agents-config"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "chitin-kernel gate evaluate --hook-stdin --agent=claude-code"
+          }
+        ]
       }
-    }
-  },
-  "enabledPlugins": {
-    "nx@nx-claude-plugins": true
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,13 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "chitin-kernel gate evaluate --hook-stdin --agent=claude-code"
-          }
-        ]
+  "extraKnownMarketplaces": {
+    "nx-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "nrwl/nx-ai-agents-config"
       }
-    ]
+    }
+  },
+  "enabledPlugins": {
+    "nx@nx-claude-plugins": true
   }
 }

--- a/infra/systemd/chitin-swarm-rollup.service
+++ b/infra/systemd/chitin-swarm-rollup.service
@@ -1,0 +1,20 @@
+# One-shot service fired by chitin-swarm-rollup.timer.
+# Runs the Python rollup, posts to Slack if CHITIN_SLACK_WEBHOOK_URL is set,
+# and writes ~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json.
+# Exits non-zero if any health alarms fired (visible in journalctl --user -u chitin-swarm-rollup).
+
+[Unit]
+Description=Chitin swarm daily health rollup
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+# Optional per-user secrets (CHITIN_SLACK_WEBHOOK_URL etc).
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=%h/workspace/chitin/scripts/swarm-daily-rollup.sh
+StandardOutput=journal
+StandardError=journal
+# 60s is generous for a pure-Python analysis pass over local files.
+TimeoutStartSec=60

--- a/infra/systemd/chitin-swarm-rollup.timer
+++ b/infra/systemd/chitin-swarm-rollup.timer
@@ -1,0 +1,18 @@
+# Daily swarm health rollup — fires at 06:00 local time.
+# Install alongside chitin-swarm-rollup.service:
+#   cp infra/systemd/chitin-swarm-rollup.{service,timer} ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now chitin-swarm-rollup.timer
+
+[Unit]
+Description=Chitin swarm daily health rollup
+
+[Timer]
+# Fire at 06:00 local time every day.
+OnCalendar=*-*-* 06:00:00
+# If the system was off at 06:00, run once on next boot.
+Persistent=true
+Unit=chitin-swarm-rollup.service
+
+[Install]
+WantedBy=timers.target

--- a/python/analysis/swarm_health.py
+++ b/python/analysis/swarm_health.py
@@ -1,152 +1,95 @@
 """Daily rollup of swarm dispatch health metrics.
 
-Invariant: generate_rollup(runs, since, until) returns a RollupReport
-where every metric covers exactly those SwarmRun records whose
-dispatched_at is in [since, until).
+Invariant: ``generate_rollup(runs, since, until)`` returns a
+``RollupReport`` where every metric covers exactly those ``SwarmRun``
+records whose ``dispatched_at`` is in ``[since, until)``.
+
+Loading + parsing of the marker / envelope schema lives in
+``analysis.swarm_runs`` (shipped in PR #126) and is reused here. We add
+a marker-only "in-flight" count alongside, so a workflow whose marker
+was written but envelope hasn't landed yet (e.g. workflow still running
+or temporal lost the envelope) doesn't get silently dropped from the
+total dispatch count.
 
 Usage:
-    cd python && python -m analysis.swarm_health [--window 24h] [--state-dir ...] [--tmp-dir ...]
+    cd python/analysis && uv run python -m analysis.swarm_health [--window 24h]
 """
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import re
 import sys
-import urllib.request
 import urllib.error
+import urllib.request
 from collections import Counter, defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
+from analysis.loaders import Window
+from analysis.swarm_runs import (
+    SwarmRun,
+    bucket_b_rate as _swarm_bucket_b_rate,
+    cost_by_driver as _swarm_cost_by_driver,
+    load_swarm_runs,
+)
+
 # Short-run: agent exited in < 15s with zero commits — gave up fast.
 SHORT_RUN_MS = 15_000
-# Alarms
+# Alarm thresholds.
 SUCCESS_ALARM_PCT = 70.0   # < this triggers LOW SUCCESS alarm
 SHORT_RUN_ALARM_PCT = 25.0  # > this triggers HIGH SHORT-RUN alarm
 QWEN_IDLE_ALARM_PCT = 80.0  # > this triggers QWEN IDLE alarm
-
-
-@dataclass(frozen=True)
-class SwarmRun:
-    entry_id: str
-    workflow_id: str
-    tier: str
-    driver: str
-    dispatched_at: datetime
-    exit_code: int
-    duration_ms: int
-    commits_added: int
-    has_uncommitted_changes: bool
-    bucket_b: bool
 
 
 @dataclass
 class RollupReport:
     window_since: datetime
     window_until: datetime
-    total_runs: int
+    total_runs: int                              # markers + envelopes joined (envelope processed)
+    in_flight_or_lost: int                       # markers w/o envelopes (workflow still running OR envelope lost)
     dispatches_by_driver: dict[str, int]
     dispatches_by_tier: dict[str, int]
-    # per key: {"success": int, "total": int}
-    success_by_driver: dict[str, dict[str, int]]
+    success_by_driver: dict[str, dict[str, int]]   # per key: {"success": int, "total": int}
     success_by_tier: dict[str, dict[str, int]]
     bucket_b_count: int
     bucket_b_rate: float
-    short_run_by_driver: dict[str, dict[str, int]]
+    short_run_by_driver: dict[str, dict[str, int]]   # per key: {"short": int, "total": int}
     short_run_by_tier: dict[str, dict[str, int]]
     local_qwen_t0_total: int
-    local_qwen_t0_idle: int  # T0 runs NOT on local-qwen
-    cost_total_usd: Optional[float]
+    local_qwen_t0_idle: int                          # T0 runs NOT on local-qwen
+    cost_total_usd: float
     cost_by_driver: dict[str, float]
-    failure_modes: dict[str, int]   # mode -> count, top 3 surfaced in Slack
+    failure_modes: dict[str, int]                    # mode -> count
     alarms: list[str]
 
 
 # ---------------------------------------------------------------------------
-# Data loading
+# Loading
 # ---------------------------------------------------------------------------
 
-_BUCKET_B_RE = re.compile(r"settings\.json\.chitin-backup-")
-_COST_RE = re.compile(r"cost:\s*\$([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
-_TOTAL_COST_RE = re.compile(r"Total cost:\s*\$([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+def _load_marker_count(state_dir: Path, window: Window) -> int:
+    """Count markers whose dispatched_at is in ``window``.
 
-
-def _bucket_b_heuristic(stdout_tail: str) -> bool:
-    """Heuristic: run contaminated diff with a settings backup artifact."""
-    return bool(_BUCKET_B_RE.search(stdout_tail))
-
-
-def _parse_cost_usd(stdout_tail: str) -> Optional[float]:
-    """Best-effort cost extraction from claude-code-headless stdout."""
-    for pattern in (_TOTAL_COST_RE, _COST_RE):
-        m = pattern.search(stdout_tail)
-        if m:
-            try:
-                return float(m.group(1))
-            except ValueError:
-                pass
-    return None
-
-
-def _load_markers(state_dir: Path) -> dict[str, dict]:
-    """Load dispatch markers keyed by workflow_id. Skips bad files silently."""
-    markers: dict[str, dict] = {}
-    if not state_dir.exists():
-        return markers
-    for p in state_dir.iterdir():
-        if p.suffix != ".json" or not p.is_file():
-            continue
-        try:
-            raw = json.loads(p.read_text())
-            wid = raw.get("workflow_id")
-            if wid:
-                markers[wid] = raw
-        except (json.JSONDecodeError, OSError):
-            pass
-    return markers
-
-
-def _load_envelopes(tmp_dir: Path) -> dict[str, dict]:
-    """Load result envelopes keyed by workflow_id. Skips bad files silently."""
-    envelopes: dict[str, dict] = {}
-    if not tmp_dir.exists():
-        return envelopes
-    for p in tmp_dir.iterdir():
-        if not (p.name.startswith("result-swarm-") and p.suffix == ".json"):
-            continue
-        try:
-            raw = json.loads(p.read_text())
-            wid = raw.get("workflow_id")
-            if wid:
-                envelopes[wid] = raw
-        except (json.JSONDecodeError, OSError):
-            pass
-    return envelopes
-
-
-def load_runs(
-    state_dir: Path,
-    tmp_dir: Path,
-    since: datetime,
-    until: datetime,
-) -> list[SwarmRun]:
-    """Load SwarmRun records whose dispatched_at is in [since, until).
-
-    Joins dispatch markers (state_dir) with result envelopes (tmp_dir)
-    by workflow_id. Runs whose marker has no matching envelope are
-    included with defaults (exit_code=-1, duration_ms=0) so dispatches
-    that are still in-flight or whose envelope was lost aren't silently
-    dropped from the count.
+    Used to compute the in-flight-or-lost gap: total markers in window
+    minus envelopes-processed = how many dispatches don't yet have an
+    outcome. ``analysis.swarm_runs.load_swarm_runs`` is envelope-driven
+    and silently drops marker-only entries; this fills that gap so the
+    rollup's "X dispatched" count matches what the dispatcher actually
+    fired.
     """
-    markers = _load_markers(state_dir)
-    envelopes = _load_envelopes(tmp_dir)
-
-    runs: list[SwarmRun] = []
-    for wid, marker in markers.items():
+    if not state_dir.exists():
+        return 0
+    count = 0
+    for path in state_dir.iterdir():
+        if path.suffix != ".json" or not path.is_file():
+            continue
+        try:
+            marker = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
         ts_str = marker.get("dispatched_at")
         if not isinstance(ts_str, str):
             continue
@@ -154,51 +97,38 @@ def load_runs(
             dispatched_at = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
         except ValueError:
             continue
-        if not (since <= dispatched_at < until):
-            continue
-
-        env = envelopes.get(wid, {})
-        result = env.get("result", {})
-        stdout_tail = result.get("stdout_tail", "")
-        worktree = result.get("worktree") or {}
-
-        runs.append(SwarmRun(
-            entry_id=marker.get("entry_id", ""),
-            workflow_id=wid,
-            tier=marker.get("tier", ""),
-            driver=marker.get("driver", ""),
-            dispatched_at=dispatched_at,
-            exit_code=result.get("exit_code", -1) if env else -1,
-            duration_ms=result.get("duration_ms", 0),
-            commits_added=worktree.get("commits_added", 0),
-            has_uncommitted_changes=bool(worktree.get("has_uncommitted_changes", False)),
-            bucket_b=_bucket_b_heuristic(stdout_tail),
-        ))
-    return runs
+        if window.since <= dispatched_at < window.until:
+            count += 1
+    return count
 
 
 # ---------------------------------------------------------------------------
-# Failure mode classification
+# Failure-mode classification
 # ---------------------------------------------------------------------------
 
 def _failure_mode(run: SwarmRun) -> str:
-    """Map a run to a canonical failure mode label.
+    """Map a no-work run to a canonical failure mode label.
 
-    Called only for runs that didn't produce committed work (commits_added == 0
-    and has_uncommitted_changes == False), so all returned strings are
-    genuine failure signals.
+    Called only for runs that produced no committed work. Tie-breaker
+    order is most-specific first so a run that's both bucket-B AND
+    short doesn't double-count.
 
-    Tie-breaker order (most specific first):
-        contamination > timeout > short-run-no-work > exit_code=1-partial > no-work
+    Order: contamination > timeout > short-run-no-work > exit_code=N
+        > no-work-produced
     """
     if run.bucket_b:
         return "contamination"
     if run.exit_code == -1:
+        # SIGKILL fired at wall_timeout (slice-7a). Distinct from a
+        # genuinely missing envelope, which doesn't reach this loader
+        # path (load_swarm_runs requires both marker AND envelope).
         return "timeout"
     if run.duration_ms < SHORT_RUN_MS and run.commits_added == 0:
         return "short-run-no-work"
     if run.exit_code != 0:
-        return "exit_code=1-partial"
+        # Use the actual exit code so future log readers don't have to
+        # guess what "partial" meant.
+        return f"exit_code={run.exit_code}"
     return "no-work-produced"
 
 
@@ -206,16 +136,20 @@ def _failure_mode(run: SwarmRun) -> str:
 # Metric computation
 # ---------------------------------------------------------------------------
 
-def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> RollupReport:
+def generate_rollup(
+    runs: list[SwarmRun],
+    in_flight_or_lost: int,
+    since: datetime,
+    until: datetime,
+) -> RollupReport:
     """Compute all health metrics over the given run list."""
-    dispatches_by_driver: Counter = Counter()
-    dispatches_by_tier: Counter = Counter()
+    dispatches_by_driver: Counter[str] = Counter()
+    dispatches_by_tier: Counter[str] = Counter()
     success_by_driver: dict[str, dict[str, int]] = defaultdict(lambda: {"success": 0, "total": 0})
     success_by_tier: dict[str, dict[str, int]] = defaultdict(lambda: {"success": 0, "total": 0})
     short_run_by_driver: dict[str, dict[str, int]] = defaultdict(lambda: {"short": 0, "total": 0})
     short_run_by_tier: dict[str, dict[str, int]] = defaultdict(lambda: {"short": 0, "total": 0})
-    failure_modes: Counter = Counter()
-    cost_by_driver: dict[str, list[float]] = defaultdict(list)
+    failure_modes: Counter[str] = Counter()
     bucket_b_count = 0
     local_qwen_t0_total = 0
     local_qwen_t0_idle = 0
@@ -224,8 +158,15 @@ def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> R
         dispatches_by_driver[run.driver] += 1
         dispatches_by_tier[run.tier] += 1
 
-        # Success = agent committed or left uncommitted tracked changes
-        produced_work = run.commits_added > 0 or run.has_uncommitted_changes
+        # Success = agent committed at least one commit on top of base_ref.
+        # has_uncommitted_changes alone isn't success: the apply step's
+        # auto-commit fallback used to ship those, which is what produced
+        # the bucket-B contamination this rollup is supposed to detect.
+        # Now (post-PR #123) un-committed changes are reverted on
+        # .claude/settings.json and the rest is auto-committed only if a
+        # tracked diff remains — so commits_added > 0 is the honest
+        # signal.
+        produced_work = run.commits_added > 0
         success_by_driver[run.driver]["total"] += 1
         success_by_tier[run.tier]["total"] += 1
         if produced_work:
@@ -234,8 +175,9 @@ def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> R
         else:
             failure_modes[_failure_mode(run)] += 1
 
-        # Short-run detection (independent of success — a bucket_b short run
-        # is already counted in contamination but also counted here for volume)
+        # Short-run detection (volume signal, independent of failure-mode
+        # bucketing): runs that exit fast with no commits are a prompt /
+        # tier-fit alarm even when not bucket-B.
         is_short = run.duration_ms < SHORT_RUN_MS and run.commits_added == 0
         short_run_by_driver[run.driver]["total"] += 1
         short_run_by_tier[run.tier]["total"] += 1
@@ -251,57 +193,56 @@ def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> R
             if run.driver != "local-qwen":
                 local_qwen_t0_idle += 1
 
-    # Cost: not available from markers alone; placeholder for future
-    # integration with gov-decisions cost_usd field or CCH stdout parsing.
-    cost_total: Optional[float] = None
-    cost_driver_map: dict[str, float] = {}
+    # Cost: reuse the swarm_runs extractor (claude-code-headless emits
+    # total_cost_usd in stdout_tail; copilot reports no per-run cost so
+    # rolls up to 0.0).
+    cost_driver_map = _swarm_cost_by_driver(runs)
+    cost_total = sum(cost_driver_map.values())
 
     n = len(runs)
-    bucket_b_rate = bucket_b_count / n if n else 0.0
+    rate = _swarm_bucket_b_rate(runs)
     alarms: list[str] = []
 
     if bucket_b_count > 0:
         alarms.append(
             f"BUCKET-B REGRESSION: {bucket_b_count}/{n} runs contaminated "
-            f"({bucket_b_rate:.1%}) — PR #123 preflight may have regressed"
+            f"({rate:.1%}) — apply-step revert (PR #123) may have regressed"
         )
 
     for driver, counts in success_by_driver.items():
         if counts["total"] > 0:
-            rate = 100.0 * counts["success"] / counts["total"]
-            if rate < SUCCESS_ALARM_PCT:
+            r = 100.0 * counts["success"] / counts["total"]
+            if r < SUCCESS_ALARM_PCT:
                 alarms.append(
-                    f"LOW SUCCESS: driver={driver} {rate:.0f}% "
+                    f"LOW SUCCESS: driver={driver} {r:.0f}% "
                     f"({counts['success']}/{counts['total']})"
                 )
 
     for tier, counts in success_by_tier.items():
         if counts["total"] > 0:
-            rate = 100.0 * counts["success"] / counts["total"]
-            if rate < SUCCESS_ALARM_PCT:
+            r = 100.0 * counts["success"] / counts["total"]
+            if r < SUCCESS_ALARM_PCT:
                 alarms.append(
-                    f"LOW SUCCESS: tier={tier} {rate:.0f}% "
+                    f"LOW SUCCESS: tier={tier} {r:.0f}% "
                     f"({counts['success']}/{counts['total']})"
                 )
 
     for driver, counts in short_run_by_driver.items():
         if counts["total"] > 0:
-            rate = 100.0 * counts["short"] / counts["total"]
-            if rate > SHORT_RUN_ALARM_PCT:
+            r = 100.0 * counts["short"] / counts["total"]
+            if r > SHORT_RUN_ALARM_PCT:
                 alarms.append(
-                    f"HIGH SHORT-RUN: driver={driver} {rate:.0f}% "
-                    f"({counts['short']}/{counts['total']}) — "
-                    "prompt template may not fit this driver's entries"
+                    f"HIGH SHORT-RUN: driver={driver} {r:.0f}% "
+                    f"({counts['short']}/{counts['total']}) — prompt template may not fit this driver"
                 )
 
     for tier, counts in short_run_by_tier.items():
         if counts["total"] > 0:
-            rate = 100.0 * counts["short"] / counts["total"]
-            if rate > SHORT_RUN_ALARM_PCT:
+            r = 100.0 * counts["short"] / counts["total"]
+            if r > SHORT_RUN_ALARM_PCT:
                 alarms.append(
-                    f"HIGH SHORT-RUN: tier={tier} {rate:.0f}% "
-                    f"({counts['short']}/{counts['total']}) — "
-                    "prompt template may not fit this tier's entries"
+                    f"HIGH SHORT-RUN: tier={tier} {r:.0f}% "
+                    f"({counts['short']}/{counts['total']}) — prompt template may not fit this tier"
                 )
 
     if local_qwen_t0_total > 0:
@@ -316,14 +257,15 @@ def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> R
         window_since=since,
         window_until=until,
         total_runs=n,
+        in_flight_or_lost=in_flight_or_lost,
         dispatches_by_driver=dict(dispatches_by_driver),
         dispatches_by_tier=dict(dispatches_by_tier),
-        success_by_driver=dict(success_by_driver),
-        success_by_tier=dict(success_by_tier),
+        success_by_driver={k: dict(v) for k, v in success_by_driver.items()},
+        success_by_tier={k: dict(v) for k, v in success_by_tier.items()},
         bucket_b_count=bucket_b_count,
-        bucket_b_rate=bucket_b_rate,
-        short_run_by_driver=dict(short_run_by_driver),
-        short_run_by_tier=dict(short_run_by_tier),
+        bucket_b_rate=rate,
+        short_run_by_driver={k: dict(v) for k, v in short_run_by_driver.items()},
+        short_run_by_tier={k: dict(v) for k, v in short_run_by_tier.items()},
         local_qwen_t0_total=local_qwen_t0_total,
         local_qwen_t0_idle=local_qwen_t0_idle,
         cost_total_usd=cost_total,
@@ -338,11 +280,12 @@ def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> R
 # ---------------------------------------------------------------------------
 
 def rollup_to_dict(report: RollupReport) -> dict:
-    """Serialize report to a JSON-serializable dict for the journal."""
+    """Serialize report to a JSON-serializable dict for the journal file."""
     return {
         "window_since": report.window_since.isoformat(),
         "window_until": report.window_until.isoformat(),
         "total_runs": report.total_runs,
+        "in_flight_or_lost": report.in_flight_or_lost,
         "dispatches_by_driver": report.dispatches_by_driver,
         "dispatches_by_tier": report.dispatches_by_tier,
         "success_by_driver": report.success_by_driver,
@@ -369,14 +312,10 @@ def format_slack(report: RollupReport) -> dict:
     blocks: list[dict] = [
         {
             "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": f"{alarm_icon} Swarm Daily Rollup — {date_str}",
-            },
-        },
+            "text": {"type": "plain_text", "text": f"{alarm_icon} Swarm Daily Rollup — {date_str}"},
+        }
     ]
 
-    # Dispatches by driver with success rate
     driver_lines = []
     for driver in sorted(report.dispatches_by_driver):
         count = report.dispatches_by_driver[driver]
@@ -393,35 +332,37 @@ def format_slack(report: RollupReport) -> dict:
         rate = int(100 * counts["success"] / total_t)
         tier_parts.append(f"{tier}: {count} ({rate}%)")
 
+    in_flight_note = (
+        f"  _+ {report.in_flight_or_lost} in-flight or lost (markers without envelopes)_"
+        if report.in_flight_or_lost > 0
+        else ""
+    )
+
     blocks.append({
         "type": "section",
         "text": {
             "type": "mrkdwn",
             "text": (
-                f"*24h dispatches — {n} total*\n"
+                f"*24h dispatches — {n} processed*\n"
                 + "\n".join(driver_lines)
+                + ("\n" + in_flight_note if in_flight_note else "")
                 + ("\n_Tiers: " + "  ".join(tier_parts) + "_" if tier_parts else "")
             ),
         },
     })
 
-    # Bucket-B
     bb_icon = "🚨" if report.bucket_b_count > 0 else "✅"
     blocks.append({
         "type": "section",
-        "fields": [
-            {
-                "type": "mrkdwn",
-                "text": (
-                    f"*Bucket-B rate*\n"
-                    f"{bb_icon} {report.bucket_b_rate:.1%} "
-                    f"({report.bucket_b_count}/{n})"
-                ),
-            },
-        ],
+        "fields": [{
+            "type": "mrkdwn",
+            "text": (
+                f"*Bucket-B rate*\n"
+                f"{bb_icon} {report.bucket_b_rate:.1%} ({report.bucket_b_count}/{n})"
+            ),
+        }],
     })
 
-    # Short-run rate per driver
     short_lines = []
     for driver in sorted(report.short_run_by_driver):
         counts = report.short_run_by_driver[driver]
@@ -439,25 +380,33 @@ def format_slack(report: RollupReport) -> dict:
             },
         })
 
-    # Local-qwen T0 idle
     if report.local_qwen_t0_total > 0:
         idle_pct = int(100 * report.local_qwen_t0_idle / report.local_qwen_t0_total)
         qw_icon = "🚨" if idle_pct > QWEN_IDLE_ALARM_PCT else "✅"
         blocks.append({
             "type": "section",
-            "fields": [
-                {
-                    "type": "mrkdwn",
-                    "text": (
-                        f"*T0 / local-qwen idle*\n"
-                        f"{qw_icon} {idle_pct}% of T0 routed away "
-                        f"({report.local_qwen_t0_idle}/{report.local_qwen_t0_total})"
-                    ),
-                },
-            ],
+            "fields": [{
+                "type": "mrkdwn",
+                "text": (
+                    f"*T0 / local-qwen idle*\n"
+                    f"{qw_icon} {idle_pct}% of T0 routed away "
+                    f"({report.local_qwen_t0_idle}/{report.local_qwen_t0_total})"
+                ),
+            }],
         })
 
-    # Top 3 failure modes
+    if report.cost_total_usd > 0:
+        cost_lines = "\n".join(
+            f"  *{d}*: ${c:.2f}" for d, c in sorted(report.cost_by_driver.items()) if c > 0
+        )
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Cost (24h): ${report.cost_total_usd:.2f}*\n{cost_lines}",
+            },
+        })
+
     top3 = list(report.failure_modes.items())[:3]
     if top3:
         lines = "\n".join(f"  · {mode}: {count}" for mode, count in top3)
@@ -466,7 +415,6 @@ def format_slack(report: RollupReport) -> dict:
             "text": {"type": "mrkdwn", "text": f"*Top failure modes*\n{lines}"},
         })
 
-    # Alarms
     if report.alarms:
         alarm_text = "\n".join(f"• {a}" for a in report.alarms)
         blocks.append({
@@ -482,7 +430,7 @@ def format_slack(report: RollupReport) -> dict:
 
 
 def post_slack(payload: dict, webhook_url: str) -> None:
-    """Post to Slack webhook. Swallows errors — visibility must not block rollup."""
+    """Post to Slack webhook. Errors are swallowed — visibility must not block rollup."""
     data = json.dumps(payload).encode()
     req = urllib.request.Request(
         webhook_url,
@@ -509,36 +457,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     home = os.environ.get("HOME", "/root")
     repo = os.environ.get("CHITIN_REPO_ROOT", f"{home}/workspace/chitin")
-    p.add_argument(
-        "--state-dir",
-        default=f"{home}/.cache/chitin/swarm-state/dispatched",
-        help="Dispatch marker directory",
-    )
-    p.add_argument(
-        "--tmp-dir",
-        default=f"{repo}/tmp",
-        help="Workflow result envelope directory",
-    )
-    p.add_argument(
-        "--rollup-dir",
-        default=f"{home}/.cache/chitin/swarm-rollups",
-        help="Journal output directory",
-    )
-    p.add_argument(
-        "--window",
-        default="24h",
-        help="Window: e.g. 24h, 7d (default: 24h)",
-    )
-    p.add_argument(
-        "--no-slack",
-        action="store_true",
-        help="Skip Slack post even if CHITIN_SLACK_WEBHOOK_URL is set",
-    )
+    p.add_argument("--state-dir", default=f"{home}/.cache/chitin/swarm-state/dispatched", help="Dispatch marker directory")
+    p.add_argument("--tmp-dir", default=f"{repo}/tmp", help="Workflow result envelope directory")
+    p.add_argument("--rollup-dir", default=f"{home}/.cache/chitin/swarm-rollups", help="Journal output directory")
+    p.add_argument("--window", default="24h", help="Window: e.g. 24h, 7d (default: 24h)")
+    p.add_argument("--no-slack", action="store_true", help="Skip Slack post even if CHITIN_SLACK_WEBHOOK_URL is set")
     return p.parse_args(argv)
 
 
 def _parse_window(s: str, now: datetime) -> tuple[datetime, datetime]:
-    """Parse 'Nd' / 'Nh' as a window [now-delta, now)."""
+    """Parse 'Nd' / 'Nh' / 'Nm' as a window [now-delta, now)."""
     if s.endswith("d"):
         delta = timedelta(days=int(s[:-1]))
     elif s.endswith("h"):
@@ -560,21 +488,20 @@ def main(argv: list[str] | None = None) -> int:
     state_dir = Path(args.state_dir)
     tmp_dir = Path(args.tmp_dir)
     rollup_dir = Path(args.rollup_dir)
+    window = Window(since=since, until=until)
 
-    runs = load_runs(state_dir, tmp_dir, since, until)
-    report = generate_rollup(runs, since, until)
+    runs = load_swarm_runs(state_dir, tmp_dir, window=window)
+    in_flight = max(_load_marker_count(state_dir, window) - len(runs), 0)
+    report = generate_rollup(runs, in_flight, since, until)
     report_dict = rollup_to_dict(report)
 
-    # Structured stdout for systemd journal
     print(json.dumps(report_dict, indent=2))
 
-    # Write journal file
     rollup_dir.mkdir(parents=True, exist_ok=True)
     journal_path = rollup_dir / f"{date_str}.json"
     journal_path.write_text(json.dumps(report_dict, indent=2))
     print(f"[rollup] wrote {journal_path}", file=sys.stderr)
 
-    # Post to Slack
     webhook = os.environ.get("CHITIN_SLACK_WEBHOOK_URL", "").strip()
     if webhook and not args.no_slack:
         post_slack(format_slack(report), webhook)

--- a/python/analysis/swarm_health.py
+++ b/python/analysis/swarm_health.py
@@ -1,0 +1,590 @@
+"""Daily rollup of swarm dispatch health metrics.
+
+Invariant: generate_rollup(runs, since, until) returns a RollupReport
+where every metric covers exactly those SwarmRun records whose
+dispatched_at is in [since, until).
+
+Usage:
+    cd python && python -m analysis.swarm_health [--window 24h] [--state-dir ...] [--tmp-dir ...]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+# Short-run: agent exited in < 15s with zero commits — gave up fast.
+SHORT_RUN_MS = 15_000
+# Alarms
+SUCCESS_ALARM_PCT = 70.0   # < this triggers LOW SUCCESS alarm
+SHORT_RUN_ALARM_PCT = 25.0  # > this triggers HIGH SHORT-RUN alarm
+QWEN_IDLE_ALARM_PCT = 80.0  # > this triggers QWEN IDLE alarm
+
+
+@dataclass(frozen=True)
+class SwarmRun:
+    entry_id: str
+    workflow_id: str
+    tier: str
+    driver: str
+    dispatched_at: datetime
+    exit_code: int
+    duration_ms: int
+    commits_added: int
+    has_uncommitted_changes: bool
+    bucket_b: bool
+
+
+@dataclass
+class RollupReport:
+    window_since: datetime
+    window_until: datetime
+    total_runs: int
+    dispatches_by_driver: dict[str, int]
+    dispatches_by_tier: dict[str, int]
+    # per key: {"success": int, "total": int}
+    success_by_driver: dict[str, dict[str, int]]
+    success_by_tier: dict[str, dict[str, int]]
+    bucket_b_count: int
+    bucket_b_rate: float
+    short_run_by_driver: dict[str, dict[str, int]]
+    short_run_by_tier: dict[str, dict[str, int]]
+    local_qwen_t0_total: int
+    local_qwen_t0_idle: int  # T0 runs NOT on local-qwen
+    cost_total_usd: Optional[float]
+    cost_by_driver: dict[str, float]
+    failure_modes: dict[str, int]   # mode -> count, top 3 surfaced in Slack
+    alarms: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+_BUCKET_B_RE = re.compile(r"settings\.json\.chitin-backup-")
+_COST_RE = re.compile(r"cost:\s*\$([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+_TOTAL_COST_RE = re.compile(r"Total cost:\s*\$([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+
+
+def _bucket_b_heuristic(stdout_tail: str) -> bool:
+    """Heuristic: run contaminated diff with a settings backup artifact."""
+    return bool(_BUCKET_B_RE.search(stdout_tail))
+
+
+def _parse_cost_usd(stdout_tail: str) -> Optional[float]:
+    """Best-effort cost extraction from claude-code-headless stdout."""
+    for pattern in (_TOTAL_COST_RE, _COST_RE):
+        m = pattern.search(stdout_tail)
+        if m:
+            try:
+                return float(m.group(1))
+            except ValueError:
+                pass
+    return None
+
+
+def _load_markers(state_dir: Path) -> dict[str, dict]:
+    """Load dispatch markers keyed by workflow_id. Skips bad files silently."""
+    markers: dict[str, dict] = {}
+    if not state_dir.exists():
+        return markers
+    for p in state_dir.iterdir():
+        if p.suffix != ".json" or not p.is_file():
+            continue
+        try:
+            raw = json.loads(p.read_text())
+            wid = raw.get("workflow_id")
+            if wid:
+                markers[wid] = raw
+        except (json.JSONDecodeError, OSError):
+            pass
+    return markers
+
+
+def _load_envelopes(tmp_dir: Path) -> dict[str, dict]:
+    """Load result envelopes keyed by workflow_id. Skips bad files silently."""
+    envelopes: dict[str, dict] = {}
+    if not tmp_dir.exists():
+        return envelopes
+    for p in tmp_dir.iterdir():
+        if not (p.name.startswith("result-swarm-") and p.suffix == ".json"):
+            continue
+        try:
+            raw = json.loads(p.read_text())
+            wid = raw.get("workflow_id")
+            if wid:
+                envelopes[wid] = raw
+        except (json.JSONDecodeError, OSError):
+            pass
+    return envelopes
+
+
+def load_runs(
+    state_dir: Path,
+    tmp_dir: Path,
+    since: datetime,
+    until: datetime,
+) -> list[SwarmRun]:
+    """Load SwarmRun records whose dispatched_at is in [since, until).
+
+    Joins dispatch markers (state_dir) with result envelopes (tmp_dir)
+    by workflow_id. Runs whose marker has no matching envelope are
+    included with defaults (exit_code=-1, duration_ms=0) so dispatches
+    that are still in-flight or whose envelope was lost aren't silently
+    dropped from the count.
+    """
+    markers = _load_markers(state_dir)
+    envelopes = _load_envelopes(tmp_dir)
+
+    runs: list[SwarmRun] = []
+    for wid, marker in markers.items():
+        ts_str = marker.get("dispatched_at")
+        if not isinstance(ts_str, str):
+            continue
+        try:
+            dispatched_at = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if not (since <= dispatched_at < until):
+            continue
+
+        env = envelopes.get(wid, {})
+        result = env.get("result", {})
+        stdout_tail = result.get("stdout_tail", "")
+        worktree = result.get("worktree") or {}
+
+        runs.append(SwarmRun(
+            entry_id=marker.get("entry_id", ""),
+            workflow_id=wid,
+            tier=marker.get("tier", ""),
+            driver=marker.get("driver", ""),
+            dispatched_at=dispatched_at,
+            exit_code=result.get("exit_code", -1) if env else -1,
+            duration_ms=result.get("duration_ms", 0),
+            commits_added=worktree.get("commits_added", 0),
+            has_uncommitted_changes=bool(worktree.get("has_uncommitted_changes", False)),
+            bucket_b=_bucket_b_heuristic(stdout_tail),
+        ))
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# Failure mode classification
+# ---------------------------------------------------------------------------
+
+def _failure_mode(run: SwarmRun) -> str:
+    """Map a run to a canonical failure mode label.
+
+    Called only for runs that didn't produce committed work (commits_added == 0
+    and has_uncommitted_changes == False), so all returned strings are
+    genuine failure signals.
+
+    Tie-breaker order (most specific first):
+        contamination > timeout > short-run-no-work > exit_code=1-partial > no-work
+    """
+    if run.bucket_b:
+        return "contamination"
+    if run.exit_code == -1:
+        return "timeout"
+    if run.duration_ms < SHORT_RUN_MS and run.commits_added == 0:
+        return "short-run-no-work"
+    if run.exit_code != 0:
+        return "exit_code=1-partial"
+    return "no-work-produced"
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+def generate_rollup(runs: list[SwarmRun], since: datetime, until: datetime) -> RollupReport:
+    """Compute all health metrics over the given run list."""
+    dispatches_by_driver: Counter = Counter()
+    dispatches_by_tier: Counter = Counter()
+    success_by_driver: dict[str, dict[str, int]] = defaultdict(lambda: {"success": 0, "total": 0})
+    success_by_tier: dict[str, dict[str, int]] = defaultdict(lambda: {"success": 0, "total": 0})
+    short_run_by_driver: dict[str, dict[str, int]] = defaultdict(lambda: {"short": 0, "total": 0})
+    short_run_by_tier: dict[str, dict[str, int]] = defaultdict(lambda: {"short": 0, "total": 0})
+    failure_modes: Counter = Counter()
+    cost_by_driver: dict[str, list[float]] = defaultdict(list)
+    bucket_b_count = 0
+    local_qwen_t0_total = 0
+    local_qwen_t0_idle = 0
+
+    for run in runs:
+        dispatches_by_driver[run.driver] += 1
+        dispatches_by_tier[run.tier] += 1
+
+        # Success = agent committed or left uncommitted tracked changes
+        produced_work = run.commits_added > 0 or run.has_uncommitted_changes
+        success_by_driver[run.driver]["total"] += 1
+        success_by_tier[run.tier]["total"] += 1
+        if produced_work:
+            success_by_driver[run.driver]["success"] += 1
+            success_by_tier[run.tier]["success"] += 1
+        else:
+            failure_modes[_failure_mode(run)] += 1
+
+        # Short-run detection (independent of success — a bucket_b short run
+        # is already counted in contamination but also counted here for volume)
+        is_short = run.duration_ms < SHORT_RUN_MS and run.commits_added == 0
+        short_run_by_driver[run.driver]["total"] += 1
+        short_run_by_tier[run.tier]["total"] += 1
+        if is_short:
+            short_run_by_driver[run.driver]["short"] += 1
+            short_run_by_tier[run.tier]["short"] += 1
+
+        if run.bucket_b:
+            bucket_b_count += 1
+
+        if run.tier == "T0":
+            local_qwen_t0_total += 1
+            if run.driver != "local-qwen":
+                local_qwen_t0_idle += 1
+
+    # Cost: not available from markers alone; placeholder for future
+    # integration with gov-decisions cost_usd field or CCH stdout parsing.
+    cost_total: Optional[float] = None
+    cost_driver_map: dict[str, float] = {}
+
+    n = len(runs)
+    bucket_b_rate = bucket_b_count / n if n else 0.0
+    alarms: list[str] = []
+
+    if bucket_b_count > 0:
+        alarms.append(
+            f"BUCKET-B REGRESSION: {bucket_b_count}/{n} runs contaminated "
+            f"({bucket_b_rate:.1%}) — PR #123 preflight may have regressed"
+        )
+
+    for driver, counts in success_by_driver.items():
+        if counts["total"] > 0:
+            rate = 100.0 * counts["success"] / counts["total"]
+            if rate < SUCCESS_ALARM_PCT:
+                alarms.append(
+                    f"LOW SUCCESS: driver={driver} {rate:.0f}% "
+                    f"({counts['success']}/{counts['total']})"
+                )
+
+    for tier, counts in success_by_tier.items():
+        if counts["total"] > 0:
+            rate = 100.0 * counts["success"] / counts["total"]
+            if rate < SUCCESS_ALARM_PCT:
+                alarms.append(
+                    f"LOW SUCCESS: tier={tier} {rate:.0f}% "
+                    f"({counts['success']}/{counts['total']})"
+                )
+
+    for driver, counts in short_run_by_driver.items():
+        if counts["total"] > 0:
+            rate = 100.0 * counts["short"] / counts["total"]
+            if rate > SHORT_RUN_ALARM_PCT:
+                alarms.append(
+                    f"HIGH SHORT-RUN: driver={driver} {rate:.0f}% "
+                    f"({counts['short']}/{counts['total']}) — "
+                    "prompt template may not fit this driver's entries"
+                )
+
+    for tier, counts in short_run_by_tier.items():
+        if counts["total"] > 0:
+            rate = 100.0 * counts["short"] / counts["total"]
+            if rate > SHORT_RUN_ALARM_PCT:
+                alarms.append(
+                    f"HIGH SHORT-RUN: tier={tier} {rate:.0f}% "
+                    f"({counts['short']}/{counts['total']}) — "
+                    "prompt template may not fit this tier's entries"
+                )
+
+    if local_qwen_t0_total > 0:
+        idle_pct = 100.0 * local_qwen_t0_idle / local_qwen_t0_total
+        if idle_pct > QWEN_IDLE_ALARM_PCT:
+            alarms.append(
+                f"QWEN IDLE: {idle_pct:.0f}% of T0 routed away from local-qwen "
+                f"({local_qwen_t0_idle}/{local_qwen_t0_total}) — 3090 underused"
+            )
+
+    return RollupReport(
+        window_since=since,
+        window_until=until,
+        total_runs=n,
+        dispatches_by_driver=dict(dispatches_by_driver),
+        dispatches_by_tier=dict(dispatches_by_tier),
+        success_by_driver=dict(success_by_driver),
+        success_by_tier=dict(success_by_tier),
+        bucket_b_count=bucket_b_count,
+        bucket_b_rate=bucket_b_rate,
+        short_run_by_driver=dict(short_run_by_driver),
+        short_run_by_tier=dict(short_run_by_tier),
+        local_qwen_t0_total=local_qwen_t0_total,
+        local_qwen_t0_idle=local_qwen_t0_idle,
+        cost_total_usd=cost_total,
+        cost_by_driver=cost_driver_map,
+        failure_modes=dict(failure_modes.most_common()),
+        alarms=alarms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def rollup_to_dict(report: RollupReport) -> dict:
+    """Serialize report to a JSON-serializable dict for the journal."""
+    return {
+        "window_since": report.window_since.isoformat(),
+        "window_until": report.window_until.isoformat(),
+        "total_runs": report.total_runs,
+        "dispatches_by_driver": report.dispatches_by_driver,
+        "dispatches_by_tier": report.dispatches_by_tier,
+        "success_by_driver": report.success_by_driver,
+        "success_by_tier": report.success_by_tier,
+        "bucket_b_count": report.bucket_b_count,
+        "bucket_b_rate": report.bucket_b_rate,
+        "short_run_by_driver": report.short_run_by_driver,
+        "short_run_by_tier": report.short_run_by_tier,
+        "local_qwen_t0_total": report.local_qwen_t0_total,
+        "local_qwen_t0_idle": report.local_qwen_t0_idle,
+        "cost_total_usd": report.cost_total_usd,
+        "cost_by_driver": report.cost_by_driver,
+        "failure_modes": report.failure_modes,
+        "alarms": report.alarms,
+    }
+
+
+def format_slack(report: RollupReport) -> dict:
+    """Format the rollup as a Slack blocks payload."""
+    date_str = report.window_since.strftime("%Y-%m-%d")
+    n = report.total_runs
+    alarm_icon = "🚨" if report.alarms else "✅"
+
+    blocks: list[dict] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"{alarm_icon} Swarm Daily Rollup — {date_str}",
+            },
+        },
+    ]
+
+    # Dispatches by driver with success rate
+    driver_lines = []
+    for driver in sorted(report.dispatches_by_driver):
+        count = report.dispatches_by_driver[driver]
+        counts = report.success_by_driver.get(driver, {"success": 0, "total": count})
+        total_d = counts["total"] or 1
+        rate = int(100 * counts["success"] / total_d)
+        driver_lines.append(f"  *{driver}*: {count} dispatches  {rate}% success")
+
+    tier_parts = []
+    for tier in sorted(report.dispatches_by_tier):
+        count = report.dispatches_by_tier[tier]
+        counts = report.success_by_tier.get(tier, {"success": 0, "total": count})
+        total_t = counts["total"] or 1
+        rate = int(100 * counts["success"] / total_t)
+        tier_parts.append(f"{tier}: {count} ({rate}%)")
+
+    blocks.append({
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": (
+                f"*24h dispatches — {n} total*\n"
+                + "\n".join(driver_lines)
+                + ("\n_Tiers: " + "  ".join(tier_parts) + "_" if tier_parts else "")
+            ),
+        },
+    })
+
+    # Bucket-B
+    bb_icon = "🚨" if report.bucket_b_count > 0 else "✅"
+    blocks.append({
+        "type": "section",
+        "fields": [
+            {
+                "type": "mrkdwn",
+                "text": (
+                    f"*Bucket-B rate*\n"
+                    f"{bb_icon} {report.bucket_b_rate:.1%} "
+                    f"({report.bucket_b_count}/{n})"
+                ),
+            },
+        ],
+    })
+
+    # Short-run rate per driver
+    short_lines = []
+    for driver in sorted(report.short_run_by_driver):
+        counts = report.short_run_by_driver[driver]
+        total_d = counts["total"] or 1
+        rate = int(100 * counts["short"] / total_d)
+        icon = "🚨" if rate > SHORT_RUN_ALARM_PCT else "·"
+        short_lines.append(f"  {icon} {driver}: {rate}% ({counts['short']}/{counts['total']})")
+
+    if short_lines:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Short-run rate* (< 15s, 0 commits)\n" + "\n".join(short_lines),
+            },
+        })
+
+    # Local-qwen T0 idle
+    if report.local_qwen_t0_total > 0:
+        idle_pct = int(100 * report.local_qwen_t0_idle / report.local_qwen_t0_total)
+        qw_icon = "🚨" if idle_pct > QWEN_IDLE_ALARM_PCT else "✅"
+        blocks.append({
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*T0 / local-qwen idle*\n"
+                        f"{qw_icon} {idle_pct}% of T0 routed away "
+                        f"({report.local_qwen_t0_idle}/{report.local_qwen_t0_total})"
+                    ),
+                },
+            ],
+        })
+
+    # Top 3 failure modes
+    top3 = list(report.failure_modes.items())[:3]
+    if top3:
+        lines = "\n".join(f"  · {mode}: {count}" for mode, count in top3)
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Top failure modes*\n{lines}"},
+        })
+
+    # Alarms
+    if report.alarms:
+        alarm_text = "\n".join(f"• {a}" for a in report.alarms)
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*🚨 Alarms*\n{alarm_text}"},
+        })
+
+    fallback = (
+        f"{alarm_icon} Swarm rollup {date_str}: {n} dispatches, "
+        f"{report.bucket_b_count} bucket-B, {len(report.alarms)} alarm(s)"
+    )
+    return {"text": fallback, "blocks": blocks}
+
+
+def post_slack(payload: dict, webhook_url: str) -> None:
+    """Post to Slack webhook. Swallows errors — visibility must not block rollup."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        webhook_url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            if resp.status not in (200, 201, 204):
+                print(f"[rollup] slack post non-ok: {resp.status}", file=sys.stderr)
+    except urllib.error.URLError as exc:
+        print(f"[rollup] slack post failed: {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="analysis.swarm_health",
+        description="Daily swarm dispatch health rollup.",
+    )
+    home = os.environ.get("HOME", "/root")
+    repo = os.environ.get("CHITIN_REPO_ROOT", f"{home}/workspace/chitin")
+    p.add_argument(
+        "--state-dir",
+        default=f"{home}/.cache/chitin/swarm-state/dispatched",
+        help="Dispatch marker directory",
+    )
+    p.add_argument(
+        "--tmp-dir",
+        default=f"{repo}/tmp",
+        help="Workflow result envelope directory",
+    )
+    p.add_argument(
+        "--rollup-dir",
+        default=f"{home}/.cache/chitin/swarm-rollups",
+        help="Journal output directory",
+    )
+    p.add_argument(
+        "--window",
+        default="24h",
+        help="Window: e.g. 24h, 7d (default: 24h)",
+    )
+    p.add_argument(
+        "--no-slack",
+        action="store_true",
+        help="Skip Slack post even if CHITIN_SLACK_WEBHOOK_URL is set",
+    )
+    return p.parse_args(argv)
+
+
+def _parse_window(s: str, now: datetime) -> tuple[datetime, datetime]:
+    """Parse 'Nd' / 'Nh' as a window [now-delta, now)."""
+    if s.endswith("d"):
+        delta = timedelta(days=int(s[:-1]))
+    elif s.endswith("h"):
+        delta = timedelta(hours=int(s[:-1]))
+    elif s.endswith("m"):
+        delta = timedelta(minutes=int(s[:-1]))
+    else:
+        raise ValueError(f"Unrecognized window: {s!r}. Use Nd, Nh, or Nm.")
+    return now - delta, now
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    now = datetime.now(tz=timezone.utc)
+    since, until = _parse_window(args.window, now)
+    date_str = since.strftime("%Y-%m-%d")
+
+    state_dir = Path(args.state_dir)
+    tmp_dir = Path(args.tmp_dir)
+    rollup_dir = Path(args.rollup_dir)
+
+    runs = load_runs(state_dir, tmp_dir, since, until)
+    report = generate_rollup(runs, since, until)
+    report_dict = rollup_to_dict(report)
+
+    # Structured stdout for systemd journal
+    print(json.dumps(report_dict, indent=2))
+
+    # Write journal file
+    rollup_dir.mkdir(parents=True, exist_ok=True)
+    journal_path = rollup_dir / f"{date_str}.json"
+    journal_path.write_text(json.dumps(report_dict, indent=2))
+    print(f"[rollup] wrote {journal_path}", file=sys.stderr)
+
+    # Post to Slack
+    webhook = os.environ.get("CHITIN_SLACK_WEBHOOK_URL", "").strip()
+    if webhook and not args.no_slack:
+        post_slack(format_slack(report), webhook)
+        print("[rollup] posted to Slack", file=sys.stderr)
+
+    if report.alarms:
+        print(f"[rollup] {len(report.alarms)} alarm(s) fired", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/tests/test_swarm_health.py
+++ b/python/analysis/tests/test_swarm_health.py
@@ -1,0 +1,332 @@
+"""Tests for the swarm-daily-rollup health module."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from analysis.loaders import Window
+from analysis.swarm_health import (
+    SHORT_RUN_MS,
+    SUCCESS_ALARM_PCT,
+    _failure_mode,
+    _parse_window,
+    format_slack,
+    generate_rollup,
+    main,
+    rollup_to_dict,
+)
+from analysis.swarm_runs import SwarmRun
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────
+
+
+def make_run(
+    *,
+    entry_id: str = "e1",
+    tier: str = "T0",
+    driver: str = "copilot",
+    dispatched_at: datetime = datetime(2026, 5, 2, 4, 0, tzinfo=timezone.utc),
+    exit_code: int = 0,
+    duration_ms: int = 30_000,
+    commits_added: int = 1,
+    diff_shortstat: str = "1 file changed, 3 insertions(+)",
+    pr_url: str | None = None,
+    cost_usd: float | None = None,
+    model: str | None = None,
+    bucket_b: bool = False,
+) -> SwarmRun:
+    return SwarmRun(
+        entry_id=entry_id, tier=tier, driver=driver, dispatched_at=dispatched_at,
+        exit_code=exit_code, duration_ms=duration_ms, commits_added=commits_added,
+        diff_shortstat=diff_shortstat, pr_url=pr_url, cost_usd=cost_usd, model=model,
+        bucket_b=bucket_b,
+    )
+
+
+SINCE = datetime(2026, 5, 2, 0, 0, tzinfo=timezone.utc)
+UNTIL = datetime(2026, 5, 3, 0, 0, tzinfo=timezone.utc)
+
+
+# ─── _failure_mode tie-breaker (Copilot R-L143 + R-L202) ─────────────────
+
+
+def test_failure_mode_prioritizes_contamination_over_timeout():
+    run = make_run(bucket_b=True, exit_code=-1, duration_ms=1, commits_added=0)
+    assert _failure_mode(run) == "contamination"
+
+
+def test_failure_mode_timeout_for_exit_minus_one():
+    run = make_run(exit_code=-1, duration_ms=1_800_000, commits_added=0, bucket_b=False)
+    assert _failure_mode(run) == "timeout"
+
+
+def test_failure_mode_short_run_when_under_15s_no_commits():
+    run = make_run(exit_code=0, duration_ms=8_000, commits_added=0, bucket_b=False)
+    assert _failure_mode(run) == "short-run-no-work"
+
+
+def test_failure_mode_uses_actual_exit_code_not_partial_label():
+    """Copilot R-L202: pre-fix, any non-zero exit was labelled
+    'exit_code=1-partial', which is wrong for exit codes other than 1.
+    The fix uses the actual numeric exit code."""
+    run = make_run(exit_code=2, duration_ms=60_000, commits_added=0, bucket_b=False)
+    assert _failure_mode(run) == "exit_code=2"
+
+    run_137 = make_run(exit_code=137, duration_ms=60_000, commits_added=0, bucket_b=False)
+    assert _failure_mode(run_137) == "exit_code=137"
+
+
+def test_failure_mode_no_work_when_clean_exit_no_commits():
+    run = make_run(exit_code=0, duration_ms=60_000, commits_added=0, bucket_b=False)
+    assert _failure_mode(run) == "no-work-produced"
+
+
+# ─── generate_rollup alarms ──────────────────────────────────────────────
+
+
+def test_rollup_no_alarms_on_healthy_runs():
+    # Tier T1 so we don't trip the QWEN IDLE alarm (that fires only on
+    # T0 routed-away-from-local-qwen, which copilot-on-T0 always is).
+    runs = [
+        make_run(entry_id=f"e{i}", driver="copilot", tier="T1", commits_added=1)
+        for i in range(5)
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    assert report.alarms == []
+    assert report.bucket_b_count == 0
+    assert report.bucket_b_rate == 0.0
+    assert report.success_by_driver["copilot"] == {"success": 5, "total": 5}
+
+
+def test_rollup_fires_bucket_b_alarm_on_any_contamination():
+    runs = [
+        make_run(entry_id="ok", commits_added=1),
+        make_run(entry_id="bad", commits_added=1, bucket_b=True),
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    assert report.bucket_b_count == 1
+    assert any("BUCKET-B REGRESSION" in a for a in report.alarms)
+
+
+def test_rollup_low_success_alarm_per_driver():
+    """Copilot's L213: alarm-condition coverage. < 70% triggers LOW SUCCESS."""
+    runs = [
+        make_run(entry_id="s1", driver="cch", tier="T2", commits_added=1),
+        make_run(entry_id="f1", driver="cch", tier="T2", exit_code=1, duration_ms=60_000, commits_added=0),
+        make_run(entry_id="f2", driver="cch", tier="T2", exit_code=1, duration_ms=60_000, commits_added=0),
+        make_run(entry_id="f3", driver="cch", tier="T2", exit_code=1, duration_ms=60_000, commits_added=0),
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    # 1/4 = 25% < 70% → alarm
+    assert any("LOW SUCCESS: driver=cch" in a for a in report.alarms)
+
+
+def test_rollup_high_short_run_alarm():
+    runs = [
+        make_run(entry_id=f"sr{i}", driver="cch", tier="T2",
+                 exit_code=0, duration_ms=5_000, commits_added=0)  # 5s, no commits
+        for i in range(3)
+    ] + [
+        make_run(entry_id="ok", driver="cch", tier="T2", commits_added=1, duration_ms=120_000),
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    # 3/4 = 75% short-run rate > 25% → alarm
+    assert any("HIGH SHORT-RUN: driver=cch" in a for a in report.alarms)
+
+
+def test_rollup_qwen_idle_alarm_when_t0_routed_away():
+    runs = [
+        make_run(entry_id=f"t0_{i}", driver="copilot", tier="T0", commits_added=1)
+        for i in range(10)
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    # 10/10 = 100% T0 routed away from local-qwen → alarm
+    assert report.local_qwen_t0_total == 10
+    assert report.local_qwen_t0_idle == 10
+    assert any("QWEN IDLE" in a for a in report.alarms)
+
+
+def test_rollup_no_qwen_alarm_when_some_t0_on_local_qwen():
+    runs = [
+        make_run(entry_id="qwen", driver="local-qwen", tier="T0", commits_added=1),
+        make_run(entry_id="cop", driver="copilot", tier="T0", commits_added=1),
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    # 1/2 = 50% idle ≤ 80% threshold → no alarm
+    assert all("QWEN IDLE" not in a for a in report.alarms)
+
+
+# ─── cost extraction (Copilot R-L258) ────────────────────────────────────
+
+
+def test_rollup_aggregates_cost_from_cch_runs():
+    runs = [
+        make_run(entry_id="c1", driver="cch", tier="T2", commits_added=1, cost_usd=0.10),
+        make_run(entry_id="c2", driver="cch", tier="T2", commits_added=1, cost_usd=0.25),
+        make_run(entry_id="cop", driver="copilot", tier="T0", commits_added=1, cost_usd=None),
+    ]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    assert report.cost_total_usd == pytest.approx(0.35)
+    assert report.cost_by_driver["cch"] == pytest.approx(0.35)
+    # copilot reports no per-run cost; rolls up to 0.0 (not None).
+    assert report.cost_by_driver["copilot"] == 0.0
+
+
+# ─── in-flight gap surfaced ──────────────────────────────────────────────
+
+
+def test_rollup_carries_in_flight_count_for_slack():
+    report = generate_rollup([make_run(commits_added=1)], in_flight_or_lost=3, since=SINCE, until=UNTIL)
+    assert report.in_flight_or_lost == 3
+    payload = format_slack(report)
+    text = json.dumps(payload)
+    assert "in-flight or lost" in text
+
+
+# ─── empty-runs corner ───────────────────────────────────────────────────
+
+
+def test_empty_runs_produce_clean_report_no_zerodiv():
+    report = generate_rollup([], in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    assert report.total_runs == 0
+    assert report.bucket_b_rate == 0.0
+    assert report.alarms == []
+
+
+# ─── format_slack smoke ──────────────────────────────────────────────────
+
+
+def test_format_slack_returns_blocks_structure():
+    # T1 to avoid the QWEN IDLE alarm — see comment on
+    # test_rollup_no_alarms_on_healthy_runs.
+    runs = [make_run(commits_added=1, driver="copilot", tier="T1")]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    payload = format_slack(report)
+    assert payload["text"].startswith("✅")
+    assert any(b["type"] == "header" for b in payload["blocks"])
+
+
+def test_format_slack_alarm_icon_when_alarms_present():
+    runs = [make_run(commits_added=1, bucket_b=True)]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    payload = format_slack(report)
+    assert payload["text"].startswith("🚨")
+
+
+# ─── rollup_to_dict round-trip ───────────────────────────────────────────
+
+
+def test_rollup_to_dict_is_json_serializable():
+    runs = [make_run(commits_added=1)]
+    report = generate_rollup(runs, in_flight_or_lost=0, since=SINCE, until=UNTIL)
+    d = rollup_to_dict(report)
+    json.dumps(d)  # must not raise
+
+
+# ─── _parse_window ───────────────────────────────────────────────────────
+
+
+def test_parse_window_supports_d_h_m():
+    now = datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc)
+    s, u = _parse_window("24h", now)
+    assert u == now and (u - s) == timedelta(hours=24)
+    s, u = _parse_window("7d", now)
+    assert (u - s) == timedelta(days=7)
+    s, u = _parse_window("30m", now)
+    assert (u - s) == timedelta(minutes=30)
+
+
+def test_parse_window_rejects_unknown_unit():
+    with pytest.raises(ValueError, match="Unrecognized window"):
+        _parse_window("1y", datetime.now(tz=timezone.utc))
+
+
+# ─── main() end-to-end (Copilot R-L213) ──────────────────────────────────
+
+
+def test_main_writes_journal_and_exits_zero_when_healthy(tmp_path, monkeypatch, capsys):
+    """End-to-end: main reads markers + envelopes, writes a journal,
+    exits 0 on no alarms."""
+    state_dir = tmp_path / "state"
+    tmp_dir = tmp_path / "tmp"
+    rollup_dir = tmp_path / "rollups"
+    state_dir.mkdir(); tmp_dir.mkdir()
+
+    # One healthy run within the last 24h.
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    (state_dir / "e1.json").write_text(json.dumps({
+        # Tier T1 so the healthy run doesn't trip the QWEN IDLE alarm
+        # (T0 routed away from local-qwen).
+        "entry_id": "e1", "workflow_id": "swarm-1", "tier": "T1", "driver": "copilot",
+        "dispatched_at": ts,
+    }))
+    (tmp_dir / "result-swarm-1.json").write_text(json.dumps({
+        "workflow_id": "swarm-1",
+        "result": {
+            "exit_code": 0, "stdout_tail": "", "stderr_tail": "", "duration_ms": 24_000,
+            "worktree": {
+                "path": "/tmp/wt", "branch": "swarm/test", "head_sha": "abc",
+                "commits_added": 1, "has_uncommitted_changes": False,
+                "diff_shortstat": "1 file changed, 3 insertions(+)",
+            },
+        },
+    }))
+
+    monkeypatch.delenv("CHITIN_SLACK_WEBHOOK_URL", raising=False)
+    rc = main([
+        "--state-dir", str(state_dir),
+        "--tmp-dir", str(tmp_dir),
+        "--rollup-dir", str(rollup_dir),
+        "--window", "24h",
+        "--no-slack",
+    ])
+    assert rc == 0
+
+    # Journal file written + json-parseable.
+    journals = list(rollup_dir.glob("*.json"))
+    assert len(journals) == 1
+    parsed = json.loads(journals[0].read_text())
+    assert parsed["total_runs"] == 1
+    assert parsed["alarms"] == []
+
+
+def test_main_returns_one_when_alarms_fire(tmp_path, monkeypatch):
+    """End-to-end: alarm fires → exit 1 (so systemd flags the unit)."""
+    state_dir = tmp_path / "state"
+    tmp_dir = tmp_path / "tmp"
+    rollup_dir = tmp_path / "rollups"
+    state_dir.mkdir(); tmp_dir.mkdir()
+
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    # Bucket-B contaminated run (matches the byte-identical signature).
+    (state_dir / "bad.json").write_text(json.dumps({
+        "entry_id": "bad", "workflow_id": "swarm-bad", "tier": "T2",
+        "driver": "claude-code-headless", "dispatched_at": ts,
+    }))
+    (tmp_dir / "result-swarm-bad.json").write_text(json.dumps({
+        "workflow_id": "swarm-bad",
+        "result": {
+            "exit_code": 0, "stdout_tail": "", "stderr_tail": "", "duration_ms": 1_000,
+            "worktree": {
+                "path": "/tmp/wt", "branch": "swarm/bad", "head_sha": "abc",
+                "commits_added": 1, "has_uncommitted_changes": False,
+                "diff_shortstat": "1 file changed, 12 insertions(+), 10 deletions(-)",
+            },
+        },
+    }))
+
+    monkeypatch.delenv("CHITIN_SLACK_WEBHOOK_URL", raising=False)
+    rc = main([
+        "--state-dir", str(state_dir),
+        "--tmp-dir", str(tmp_dir),
+        "--rollup-dir", str(rollup_dir),
+        "--window", "24h",
+        "--no-slack",
+    ])
+    assert rc == 1

--- a/scripts/swarm-daily-rollup.sh
+++ b/scripts/swarm-daily-rollup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# swarm-daily-rollup.sh — Daily swarm health rollup.
+# Called by chitin-swarm-rollup.service. Exits non-zero if alarms fired.
+set -euo pipefail
+
+REPO_ROOT="${CHITIN_REPO_ROOT:-$HOME/workspace/chitin}"
+
+cd "$REPO_ROOT/python"
+exec python3 -m analysis.swarm_health "$@"


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `swarm-daily-rollup-healthcheck`
Tier: `T2`  •  Driver: `claude-code-headless`
Workflow: `swarm-swarm-daily-rollup-healthcheck-1777732395102`

## Entry context

Telemetry without alarms is just data. The bucket-B contamination
overnight 2026-05-02 looked indistinguishable from healthy
dispatch_complete events in Slack — operator only noticed because
they happened to inspect 18 PRs by hand the next morning. We need a
daily rollup that flags drift.

Output (Slack channel + structured stdout for journal):
- 24h dispatches by driver
- Bucket-B rate (target: 0% post-PR #123 fix; alarm: > 0% =
  regression of the apply-step revert)
- Success rate per driver and per tier (alarm: < 70%)
- Cost summary (claude-code-headless $/run; total)
- Local-qwen idle-percentage (we're paying for cloud when the 3090
  could be working — alarm: > 80% T0 routed away from local-qwen)
- **Short-run rate per driver/tier** (runs with `duration_ms < 15s`
  AND `commits_added == 0`). Overnight 2026-05-02 had two CCH T2
  bucket-B runs at 7.8s and 9.0s — agent burned <10s and gave up.
  That's a different failure mode from "agent worked, then declined"
  and worth surfacing separately so prompt-tuning vs apply-step
  fixes target the right thing. Alarm: > 25% short-run rate on any
  driver suggests the prompt template doesn't fit that tier's
  entries.
- Top 3 failure modes (timeout, exit_code=1 partial, contamination,
  short-run-no-work)

Wire-up:
- Cron: `chitin-swarm-rollup.timer` fires daily at 06:00 local.
- Service runs `swarm-daily-rollup.sh` which calls the Python
  rollup, posts to `CHITIN_SLACK_WEBHOOK_URL` if set, and writes
  `~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json` for trend
  analysis.

T2: cross-cutting (Python analysis + Slack notifier reuse + systemd
timer). Blocked by `analysis-swarm-runs-loader` since the rollup is
its first real consumer.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-swarm-daily-rollup-healthcheck-1777732395102`
Branch: `swarm/swarm-swarm-daily-rollup-healthcheck-1777732395102`
Head: `166172a9`
Diff: `12 files changed, 718 insertions(+), 475 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)