### PR TITLE
feat(phase-2): review-graph pure-function core (step 1 of 3)

### DIFF
--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -1,0 +1,322 @@
+// Phase 2 of the swarm-as-software-factory design. The pure-function
+// core of the review-tier escalation graph from
+// docs/design/2026-05-02-swarm-as-software-factory.md §5.
+//
+// This module is deliberately *just* the brains:
+//   - `computeStartingTier(prMeta, entry)` — reads the §5 trigger
+//     matrix and returns the starting reviewer tier + whether the PR
+//     is T5-shape (governance-self-modification path) for the
+//     gatekeeper to short-circuit on.
+//   - `escalateOneTier(currentTier)` — bumps to the next tier,
+//     saturating at R4.
+//   - `shouldEscalateToOperator(reviewerOutput)` — the rule for
+//     stopping the graph and pinging the human.
+//
+// Temporal workflow + dispatcher integration land in follow-up
+// slices. Keeping the brains separable from Temporal means we can
+// table-test every row of the §5 matrix without spinning up a
+// workflow runtime — and a future change to the matrix is one PR
+// against this file with new test rows, not a workflow rewrite.
+
+import type { Tier } from '@chitin/contracts';
+import type { BacklogEntry } from './grooming/parse-backlog.ts';
+
+// Review-tier ordinal vocabulary. R0 = "Copilot bot review only"
+// (the GitHub side fires this automatically on every PR — chitin
+// doesn't dispatch it). R1..R3 are dispatched as workflows at
+// progressively heavier driver+model combinations. R4 = "stop, ping
+// the operator" — terminal.
+export type ReviewTier = 'R0' | 'R1' | 'R2' | 'R3' | 'R4';
+
+const TIER_ORDER: readonly ReviewTier[] = ['R0', 'R1', 'R2', 'R3', 'R4'] as const;
+
+function ord(t: ReviewTier): number {
+  return TIER_ORDER.indexOf(t);
+}
+
+function maxTier(a: ReviewTier, b: ReviewTier): ReviewTier {
+  return ord(a) >= ord(b) ? a : b;
+}
+
+/**
+ * The (driver, model) pair the review-graph workflow dispatches at
+ * each tier. R0 is intentionally non-dispatchable here — Copilot's
+ * server-side review fires on PR open without us asking. R4 is
+ * non-dispatchable too — it's the "ping operator" terminal.
+ *
+ * R1: copilot/gpt-4.1 — free, fast, mid-confidence
+ * R2: copilot/sonnet-4.6 — free under Pro plan, sonnet-class
+ * R3: claude-code-headless/opus-4.7 — paid, ~$0.10–0.50/run
+ *
+ * Format mirrors `TIER_DRIVER` in dispatcher.ts so a future caller
+ * can pick the spawn args by reading this map alone.
+ */
+export const REVIEW_TIER_DRIVER: Record<ReviewTier, { driver: string | null; model: string | null }> = {
+  R0: { driver: null, model: null },                                          // GH bot, not dispatched
+  R1: { driver: 'copilot', model: 'gpt-4.1' },
+  R2: { driver: 'copilot', model: 'claude-sonnet-4.6' },
+  R3: { driver: 'claude-code-headless', model: 'claude-opus-4-7' },
+  R4: { driver: null, model: null },                                          // operator, not dispatched
+};
+
+/**
+ * Inputs to `computeStartingTier`. Captures the PR-side state the
+ * dispatcher learns at apply-step time, plus the originating entry
+ * so file-scope and implementor-tier checks have what they need.
+ *
+ * Field shapes match what `apps/temporal-worker/src/grooming/
+ * apply-workflow-result.ts` already records in the result envelope —
+ * the graph executor (next slice) will project an `ApplyResult`
+ * into a `PrMeta` shape.
+ */
+export interface PrMeta {
+  /** From `worktree.diff_shortstat` — total insertions + deletions. */
+  diff_loc: number;
+  /** From `worktree.diff_shortstat` — file count. */
+  files_changed: number;
+  /** Files in the diff (as repo-relative paths). Used for path-scope
+   *  bumps. May be empty if the apply step couldn't enumerate (rare;
+   *  treat as "unknown — defer to LOC-based bumps"). */
+  files: string[];
+  /** Number of inline review comments Copilot's GH bot has left.
+   *  Often unknown at the moment the review-graph kicks off (Copilot
+   *  is racing the dispatcher). When undefined, we don't bump on
+   *  this signal — the graph re-evaluates after R0 settles. */
+  copilot_comment_count?: number;
+  /** Pull request URL — purely audit context, not used in tier
+   *  decisions. Surfaced in tier-decision logs so the chain can be
+   *  traversed back to the PR. */
+  pr_url?: string;
+}
+
+/**
+ * Result of `computeStartingTier`. Returns the tier *plus* the
+ * reasons (so logs + telemetry can show which rule fired) plus a
+ * `t5_shape` flag for paths the chitin policy considers
+ * governance-self-modification — those always escalate at the
+ * gatekeeper layer regardless of the reviewer chain's verdict.
+ */
+export interface ReviewTierDecision {
+  tier: ReviewTier;
+  /** True if the PR touches `chitin.yaml` / `.chitin/` /
+   *  governance-config paths. The review chain still runs (audit
+   *  matters) but the gatekeeper layer must escalate even on
+   *  approval. */
+  t5_shape: boolean;
+  /** Human-readable explanations of which rules bumped the tier.
+   *  One entry per fired rule. Empty when starting tier is the
+   *  default R0. */
+  reasons: string[];
+}
+
+// File-scope rules. Order is intentional: T5-shape check runs
+// independently (sets the `t5_shape` flag, doesn't change tier).
+//
+// Kernel-internals + schema files are starting-tier bumps because
+// they're load-bearing surfaces — a bug in normalize.go or in the
+// ExecutionRequest schema cascades broadly. Worth a heavy reviewer
+// even on small diffs.
+
+const T5_PATH_PREFIXES: readonly string[] = [
+  // chitin.yaml at any level (root + any subdir)
+  // .chitin/ directory at any level
+  // The kernel's gov hook installer (writes to live settings.json)
+  // — covered by R3 bump too, but T5 flag fires regardless of
+  // tier outcome since these are governance config.
+];
+
+const T5_FILENAMES: readonly string[] = ['chitin.yaml'];
+
+const T5_PATH_FRAGMENTS: readonly string[] = [
+  '/.chitin/',
+  '.chitin/',
+];
+
+const KERNEL_INTERNAL_PREFIXES: readonly string[] = [
+  'go/execution-kernel/internal/gov/',
+  'go/execution-kernel/internal/canon/',
+  'go/execution-kernel/internal/govhookinstall/',
+  'go/execution-kernel/internal/hookinstall/',
+  'go/execution-kernel/internal/driver/',
+  'go/execution-kernel/internal/normalize/',
+];
+
+const SCHEMA_PATH_REGEX = /^libs\/contracts\/src\/[\w.-]+\.schema\.ts$/;
+
+function isT5Shape(file: string): boolean {
+  if (T5_FILENAMES.includes(file)) return true;
+  // Match `chitin.yaml` at any nested path
+  if (file === 'chitin.yaml' || file.endsWith('/chitin.yaml')) return true;
+  for (const frag of T5_PATH_FRAGMENTS) {
+    if (file.includes(frag)) return true;
+  }
+  for (const pre of T5_PATH_PREFIXES) {
+    if (file.startsWith(pre)) return true;
+  }
+  return false;
+}
+
+function isKernelInternal(file: string): boolean {
+  for (const pre of KERNEL_INTERNAL_PREFIXES) {
+    if (file.startsWith(pre)) return true;
+  }
+  return false;
+}
+
+function isSchemaFile(file: string): boolean {
+  return SCHEMA_PATH_REGEX.test(file);
+}
+
+/**
+ * Compute the starting reviewer tier from §5's trigger matrix.
+ *
+ * Pure function. Each rule sets a *minimum* tier; the final tier is
+ * the maximum across rules. Defaults to R0 (Copilot bot — fires
+ * server-side, no dispatch needed). The reasons array names which
+ * rules contributed.
+ *
+ * Trigger matrix (mirrors the design doc §5 table):
+ *
+ * | Signal | Bumps to | Threshold |
+ * |--------|----------|-----------|
+ * | Copilot bot leaves > N comments | R1 | N=2 |
+ * | Diff > N LOC OR > M files (mid) | R2 | 200 LOC / 10 files |
+ * | Diff > N LOC OR > M files (high) | R3 | 500 LOC / 20 files |
+ * | Touches schema files | R2 minimum | always |
+ * | Touches kernel internals | R3 minimum | always |
+ * | Implementor was tier T3+ | R2 minimum | always |
+ *
+ * The "previous-attempt history" rule is deferred — it requires a
+ * state-store lookup; future enhancement.
+ */
+export function computeStartingTier(prMeta: PrMeta, entry: BacklogEntry): ReviewTierDecision {
+  let tier: ReviewTier = 'R0';
+  const reasons: string[] = [];
+  let t5_shape = false;
+
+  // Copilot comment count
+  if (prMeta.copilot_comment_count !== undefined && prMeta.copilot_comment_count > 2) {
+    tier = maxTier(tier, 'R1');
+    reasons.push(`Copilot bot left ${prMeta.copilot_comment_count} comments (> 2)`);
+  }
+
+  // Diff size — high cutoff first so we attribute correctly
+  if (prMeta.diff_loc > 500 || prMeta.files_changed > 20) {
+    tier = maxTier(tier, 'R3');
+    reasons.push(
+      prMeta.diff_loc > 500
+        ? `large diff (${prMeta.diff_loc} LOC > 500)`
+        : `wide diff (${prMeta.files_changed} files > 20)`,
+    );
+  } else if (prMeta.diff_loc > 200 || prMeta.files_changed > 10) {
+    tier = maxTier(tier, 'R2');
+    reasons.push(
+      prMeta.diff_loc > 200
+        ? `mid-size diff (${prMeta.diff_loc} LOC > 200)`
+        : `mid-width diff (${prMeta.files_changed} files > 10)`,
+    );
+  }
+
+  // File-scope rules
+  let kernelHit = false;
+  let schemaHit = false;
+  for (const f of prMeta.files) {
+    if (isT5Shape(f)) t5_shape = true;
+    if (isKernelInternal(f)) kernelHit = true;
+    if (isSchemaFile(f)) schemaHit = true;
+  }
+  if (kernelHit) {
+    tier = maxTier(tier, 'R3');
+    reasons.push('touches kernel internals (gov / canon / hookinstall / driver / normalize)');
+  }
+  if (schemaHit) {
+    tier = maxTier(tier, 'R2');
+    reasons.push('touches a libs/contracts schema file');
+  }
+
+  // Implementor tier — entry.tier is a string from yaml frontmatter
+  // (BacklogEntry.tier is `string | undefined`); coerce + check.
+  if (entry.tier === 'T3' || entry.tier === 'T4') {
+    tier = maxTier(tier, 'R2');
+    reasons.push(`implementor was tier ${entry.tier}`);
+  }
+
+  return { tier, t5_shape, reasons };
+}
+
+/**
+ * Bump to the next reviewer tier. Saturates at R4 (the terminal
+ * "ping operator" tier — escalating past R4 doesn't make sense).
+ *
+ * Used by the review-graph workflow when a reviewer at the current
+ * tier requests-changes-with-low-confidence or explicitly returns
+ * `decision: 'escalate'`.
+ */
+export function escalateOneTier(current: ReviewTier): ReviewTier {
+  const next: Record<ReviewTier, ReviewTier> = {
+    R0: 'R1',
+    R1: 'R2',
+    R2: 'R3',
+    R3: 'R4',
+    R4: 'R4',
+  };
+  return next[current];
+}
+
+/**
+ * Structured output the reviewer-role agents emit at every tier
+ * (modeled here so the workflow + adversarial prompt have a single
+ * source of truth). The actual prompt template that produces this
+ * shape lands in the `agent-adversarial-review-pass` entry; this
+ * module just defines the contract.
+ */
+export interface ReviewerOutput {
+  decision: 'approve' | 'request_changes' | 'escalate';
+  confidence: 'high' | 'medium' | 'low';
+  findings: ReviewerFinding[];
+}
+
+export interface ReviewerFinding {
+  /** 🔴 = real bug, blocks merge. 🟡 = worth fixing, doesn't block.
+   *  🟢 = doc/nit. */
+  severity: '🔴' | '🟡' | '🟢';
+  file: string;
+  line?: number;
+  category: 'bug' | 'test_gap' | 'design' | 'doc';
+  summary: string;
+  suggested_fix?: string;
+}
+
+/**
+ * Decide whether the review-graph should stop and ping the
+ * operator (R4) instead of merging or escalating to the next tier.
+ *
+ * Rules (any one fires → escalate):
+ *   - reviewer explicitly returned `decision: 'escalate'`
+ *   - reviewer returned `confidence: 'low'` AND found at least one
+ *     🔴 finding (low confidence on a real bug means don't trust the
+ *     fix the reviewer suggested — get a human eye)
+ *
+ * NOT covered here (handled at the gatekeeper layer):
+ *   - T5-shape paths (escalate regardless of reviewer approval)
+ *   - CI failure
+ *   - bucket-B telemetry alarm
+ *   - diff-vs-file:scope mismatch
+ *
+ * Those are merge-time gates, not reviewer-tier-graph escalations.
+ * They feed the gatekeeper's "auto-merge or escalate" call after
+ * the review chain settles.
+ */
+export function shouldEscalateToOperator(out: ReviewerOutput): boolean {
+  if (out.decision === 'escalate') return true;
+  if (out.confidence === 'low' && out.findings.some((f) => f.severity === '🔴')) return true;
+  return false;
+}
+
+export const __test__ = {
+  ord,
+  maxTier,
+  isT5Shape,
+  isKernelInternal,
+  isSchemaFile,
+};

--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -18,7 +18,6 @@
 // workflow runtime — and a future change to the matrix is one PR
 // against this file with new test rows, not a workflow rewrite.
 
-import type { Tier } from '@chitin/contracts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 
 // Review-tier ordinal vocabulary. R0 = "Copilot bot review only"
@@ -116,20 +115,20 @@ export interface ReviewTierDecision {
 // they're load-bearing surfaces — a bug in normalize.go or in the
 // ExecutionRequest schema cascades broadly. Worth a heavy reviewer
 // even on small diffs.
-
-const T5_PATH_PREFIXES: readonly string[] = [
-  // chitin.yaml at any level (root + any subdir)
-  // .chitin/ directory at any level
-  // The kernel's gov hook installer (writes to live settings.json)
-  // — covered by R3 bump too, but T5 flag fires regardless of
-  // tier outcome since these are governance config.
-];
+//
+// T5 path coverage mirrors the `no-governance-self-modification`
+// regex in `chitin.yaml` (see id: no-governance-self-modification):
+//   target_regex: '(?:(?:^|/)chitin\.yaml$|(?:^|/)\.chitin/|(?:^|/)\.hermes/plugins/chitin-governance/)'
+// Keep this list in sync with that regex; both are governance-
+// self-modification guards and a hole in either is a hole in both.
 
 const T5_FILENAMES: readonly string[] = ['chitin.yaml'];
 
 const T5_PATH_FRAGMENTS: readonly string[] = [
   '/.chitin/',
   '.chitin/',
+  '/.hermes/plugins/chitin-governance/',
+  '.hermes/plugins/chitin-governance/',
 ];
 
 const KERNEL_INTERNAL_PREFIXES: readonly string[] = [
@@ -149,9 +148,6 @@ function isT5Shape(file: string): boolean {
   if (file === 'chitin.yaml' || file.endsWith('/chitin.yaml')) return true;
   for (const frag of T5_PATH_FRAGMENTS) {
     if (file.includes(frag)) return true;
-  }
-  for (const pre of T5_PATH_PREFIXES) {
-    if (file.startsWith(pre)) return true;
   }
   return false;
 }
@@ -186,8 +182,14 @@ function isSchemaFile(file: string): boolean {
  * | Touches kernel internals | R3 minimum | always |
  * | Implementor was tier T3+ | R2 minimum | always |
  *
- * The "previous-attempt history" rule is deferred — it requires a
- * state-store lookup; future enhancement.
+ * Two §5 rules are intentionally deferred:
+ *   - "Touches public API exports (top-level `export`s in `apps/*`)
+ *     → R2 minimum" — requires reading the diff content (not just
+ *     paths) to detect `+export ...` lines. The path-only signal is
+ *     too noisy (every TS module has exports). Encode this when the
+ *     workflow has the diff body in hand (step 3).
+ *   - "Previous-attempt history" — requires a state-store lookup;
+ *     future enhancement that consumes `parent_workflow_id` chains.
  */
 export function computeStartingTier(prMeta: PrMeta, entry: BacklogEntry): ReviewTierDecision {
   let tier: ReviewTier = 'R0';
@@ -291,11 +293,25 @@ export interface ReviewerFinding {
  * Decide whether the review-graph should stop and ping the
  * operator (R4) instead of merging or escalating to the next tier.
  *
- * Rules (any one fires → escalate):
- *   - reviewer explicitly returned `decision: 'escalate'`
- *   - reviewer returned `confidence: 'low'` AND found at least one
- *     🔴 finding (low confidence on a real bug means don't trust the
- *     fix the reviewer suggested — get a human eye)
+ * Called specifically when the chain is at R3 (the heaviest
+ * dispatchable reviewer) and needs to decide R3-resolves-here vs.
+ * R4-escalate-to-human. Rules (any one fires → escalate):
+ *
+ *   - reviewer explicitly returned `decision: 'escalate'` — they
+ *     self-flagged something they can't decide at this tier.
+ *   - reviewer returned `confidence: 'low'` — at R3, low confidence
+ *     means "the heaviest reviewer in the graph couldn't fully
+ *     evaluate this PR." Per design §5 + the operator's stated rule
+ *     ("if Headless Claude Opus can't figure it out, escalate it up
+ *     to me"), low confidence at R3 is the operator's signal.
+ *
+ * Note that `decision: 'request_changes'` with high/medium
+ * confidence does NOT trigger operator escalation — that path
+ * loops back to the implementor with the reviewer's findings (the
+ * implementor either fixes and re-pushes, or the apply step errors
+ * and the chain ends naturally). 🔴 findings on their own don't
+ * block the operator's time when the reviewer is confident in the
+ * fix; the implementor-rerun handles them.
  *
  * NOT covered here (handled at the gatekeeper layer):
  *   - T5-shape paths (escalate regardless of reviewer approval)
@@ -309,7 +325,7 @@ export interface ReviewerFinding {
  */
 export function shouldEscalateToOperator(out: ReviewerOutput): boolean {
   if (out.decision === 'escalate') return true;
-  if (out.confidence === 'low' && out.findings.some((f) => f.severity === '🔴')) return true;
+  if (out.confidence === 'low') return true;
   return false;
 }
 

--- a/apps/temporal-worker/test/review-graph.test.ts
+++ b/apps/temporal-worker/test/review-graph.test.ts
@@ -81,6 +81,11 @@ describe('isT5Shape', () => {
     ['apps/some/chitin.yaml', true],
     ['.chitin/policy.yaml', true],
     ['some/.chitin/anything.txt', true],
+    // The chitin.yaml `no-governance-self-modification` regex covers
+    // `.hermes/plugins/chitin-governance/` too; mirror that here so a
+    // hole in one is a hole in the other.
+    ['.hermes/plugins/chitin-governance/manifest.json', true],
+    ['some/.hermes/plugins/chitin-governance/anything.ts', true],
   ])('matches %s as T5-shape', (path, expected) => {
     expect(isT5Shape(path)).toBe(expected);
   });
@@ -324,7 +329,11 @@ describe('shouldEscalateToOperator', () => {
     expect(shouldEscalateToOperator(out({ decision: 'escalate' }))).toBe(true);
   });
 
-  it('returns true on confidence: low + at least one 🔴 finding', () => {
+  it('returns true on confidence: low alone (R3 couldn\'t decide → operator)', () => {
+    expect(shouldEscalateToOperator(out({ confidence: 'low' }))).toBe(true);
+  });
+
+  it('returns true on confidence: low + 🔴 finding', () => {
     expect(
       shouldEscalateToOperator(
         out({
@@ -335,25 +344,36 @@ describe('shouldEscalateToOperator', () => {
     ).toBe(true);
   });
 
-  it('returns false on confidence: low + only 🟡/🟢 findings (low confidence on nits is fine)', () => {
+  it('returns true on confidence: low + only 🟡/🟢 findings (low alone fires regardless of finding severity)', () => {
     expect(
       shouldEscalateToOperator(
         out({
           confidence: 'low',
           findings: [
             { severity: '🟡', file: 'x.ts', category: 'design', summary: 'nit' },
-            { severity: '🟢', file: 'x.ts', category: 'doc', summary: 'typo' },
           ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false on confidence: medium + 🔴 finding (medium = trust the reviewer; implementor re-runs)', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'medium',
+          findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
         }),
       ),
     ).toBe(false);
   });
 
-  it('returns false on confidence: medium + 🔴 finding (medium = trust the reviewer)', () => {
+  it('returns false on confidence: high + 🔴 finding + request_changes (request_changes loops to implementor, not operator)', () => {
     expect(
       shouldEscalateToOperator(
         out({
-          confidence: 'medium',
+          decision: 'request_changes',
+          confidence: 'high',
           findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
         }),
       ),

--- a/apps/temporal-worker/test/review-graph.test.ts
+++ b/apps/temporal-worker/test/review-graph.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REVIEW_TIER_DRIVER,
+  computeStartingTier,
+  escalateOneTier,
+  shouldEscalateToOperator,
+  __test__,
+  type PrMeta,
+  type ReviewTier,
+  type ReviewerOutput,
+} from '../src/review-graph.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+
+const { isT5Shape, isKernelInternal, isSchemaFile, maxTier } = __test__;
+
+function makeEntry(overrides: Partial<BacklogEntry> = {}): BacklogEntry {
+  return {
+    id: 'e1',
+    status: 'ready',
+    description: 'desc',
+    rawFrontmatter: '```yaml\nid: e1\nstatus: ready\n```',
+    rawSection: '### e1',
+    tier: 'T1',
+    ...overrides,
+  };
+}
+
+function makePrMeta(overrides: Partial<PrMeta> = {}): PrMeta {
+  return {
+    diff_loc: 50,
+    files_changed: 2,
+    files: ['apps/temporal-worker/src/foo.ts'],
+    ...overrides,
+  };
+}
+
+// ─── escalateOneTier ─────────────────────────────────────────────────────
+
+describe('escalateOneTier', () => {
+  it.each([
+    ['R0', 'R1'],
+    ['R1', 'R2'],
+    ['R2', 'R3'],
+    ['R3', 'R4'],
+    ['R4', 'R4'],  // saturates
+  ] as [ReviewTier, ReviewTier][])('%s -> %s', (input, expected) => {
+    expect(escalateOneTier(input)).toBe(expected);
+  });
+});
+
+// ─── REVIEW_TIER_DRIVER shape ────────────────────────────────────────────
+
+describe('REVIEW_TIER_DRIVER', () => {
+  it('has exactly 5 entries (R0-R4)', () => {
+    expect(Object.keys(REVIEW_TIER_DRIVER).sort()).toEqual(['R0', 'R1', 'R2', 'R3', 'R4']);
+  });
+
+  it('R0 (Copilot bot) and R4 (operator) are non-dispatchable (driver/model null)', () => {
+    expect(REVIEW_TIER_DRIVER.R0).toEqual({ driver: null, model: null });
+    expect(REVIEW_TIER_DRIVER.R4).toEqual({ driver: null, model: null });
+  });
+
+  it('R1-R3 each have a real driver+model', () => {
+    for (const t of ['R1', 'R2', 'R3'] as const) {
+      expect(REVIEW_TIER_DRIVER[t].driver).toBeTruthy();
+      expect(REVIEW_TIER_DRIVER[t].model).toBeTruthy();
+    }
+  });
+
+  it('R3 routes to claude-code-headless + opus (the heavy-reviewer tier)', () => {
+    expect(REVIEW_TIER_DRIVER.R3.driver).toBe('claude-code-headless');
+    expect(REVIEW_TIER_DRIVER.R3.model).toContain('opus');
+  });
+});
+
+// ─── path-classification helpers ─────────────────────────────────────────
+
+describe('isT5Shape', () => {
+  it.each([
+    ['chitin.yaml', true],
+    ['apps/some/chitin.yaml', true],
+    ['.chitin/policy.yaml', true],
+    ['some/.chitin/anything.txt', true],
+  ])('matches %s as T5-shape', (path, expected) => {
+    expect(isT5Shape(path)).toBe(expected);
+  });
+
+  it.each([
+    'apps/temporal-worker/src/dispatcher.ts',
+    'libs/contracts/src/execution-request.schema.ts',
+    'docs/swarm-backlog.md',
+    'README.md',
+    'chitin.config.ts',  // similar prefix, not the actual file
+  ])('does not match unrelated path %s', (path) => {
+    expect(isT5Shape(path)).toBe(false);
+  });
+});
+
+describe('isKernelInternal', () => {
+  it.each([
+    ['go/execution-kernel/internal/gov/normalize.go', true],
+    ['go/execution-kernel/internal/canon/normalize.go', true],
+    ['go/execution-kernel/internal/govhookinstall/install.go', true],
+    ['go/execution-kernel/internal/hookinstall/install.go', true],
+    ['go/execution-kernel/internal/driver/copilot/handler.go', true],
+    ['go/execution-kernel/internal/normalize/normalize.go', true],
+  ])('matches %s as kernel internal', (path, expected) => {
+    expect(isKernelInternal(path)).toBe(expected);
+  });
+
+  it.each([
+    'go/execution-kernel/cmd/chitin-kernel/main.go',
+    'apps/temporal-worker/src/dispatcher.ts',
+    'libs/contracts/src/event.schema.ts',
+  ])('does not match non-kernel-internal path %s', (path) => {
+    expect(isKernelInternal(path)).toBe(false);
+  });
+});
+
+describe('isSchemaFile', () => {
+  it('matches libs/contracts schema files', () => {
+    expect(isSchemaFile('libs/contracts/src/execution-request.schema.ts')).toBe(true);
+    expect(isSchemaFile('libs/contracts/src/event.schema.ts')).toBe(true);
+  });
+
+  it('does not match non-schema files in libs/contracts', () => {
+    expect(isSchemaFile('libs/contracts/src/index.ts')).toBe(false);
+    expect(isSchemaFile('libs/contracts/src/hash.ts')).toBe(false);
+  });
+
+  it('does not match schema files outside libs/contracts', () => {
+    expect(isSchemaFile('apps/foo/something.schema.ts')).toBe(false);
+  });
+});
+
+// ─── computeStartingTier — §5 trigger matrix, one row per case ───────────
+
+describe('computeStartingTier — default cases', () => {
+  it('returns R0 for a tiny diff with no special signals (the cheap-merge case)', () => {
+    const out = computeStartingTier(makePrMeta(), makeEntry());
+    expect(out.tier).toBe('R0');
+    expect(out.t5_shape).toBe(false);
+    expect(out.reasons).toEqual([]);
+  });
+
+  it('returns R0 for an empty file list (apply step couldn\'t enumerate; defer to size signals)', () => {
+    const out = computeStartingTier(makePrMeta({ files: [], diff_loc: 5, files_changed: 0 }), makeEntry());
+    expect(out.tier).toBe('R0');
+  });
+});
+
+describe('computeStartingTier — Copilot comment trigger (R1)', () => {
+  it('does not bump on 0/1/2 Copilot comments', () => {
+    for (const n of [0, 1, 2]) {
+      const out = computeStartingTier(makePrMeta({ copilot_comment_count: n }), makeEntry());
+      expect(out.tier).toBe('R0');
+    }
+  });
+
+  it('bumps to R1 on 3+ Copilot comments', () => {
+    const out = computeStartingTier(makePrMeta({ copilot_comment_count: 3 }), makeEntry());
+    expect(out.tier).toBe('R1');
+    expect(out.reasons.some((r) => r.includes('Copilot') && r.includes('3'))).toBe(true);
+  });
+
+  it('bumps to R1 on a high comment count without conflict', () => {
+    const out = computeStartingTier(makePrMeta({ copilot_comment_count: 12 }), makeEntry());
+    expect(out.tier).toBe('R1');
+  });
+
+  it('does not regress when copilot_comment_count is undefined (unknown ≠ trigger)', () => {
+    const out = computeStartingTier(makePrMeta({ copilot_comment_count: undefined }), makeEntry());
+    expect(out.tier).toBe('R0');
+  });
+});
+
+describe('computeStartingTier — diff size triggers (R2 mid, R3 high)', () => {
+  it('bumps to R2 at 201 LOC (just over mid threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 201, files_changed: 5 }), makeEntry());
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes('mid-size'))).toBe(true);
+  });
+
+  it('does NOT bump at exactly 200 LOC (boundary — > 200 is the rule)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 200, files_changed: 5 }), makeEntry());
+    expect(out.tier).toBe('R0');
+  });
+
+  it('bumps to R2 at 11 files (just over mid threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 50, files_changed: 11 }), makeEntry());
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes('mid-width'))).toBe(true);
+  });
+
+  it('bumps to R3 at 501 LOC (just over high threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 501, files_changed: 5 }), makeEntry());
+    expect(out.tier).toBe('R3');
+  });
+
+  it('bumps to R3 at 21 files (just over high threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 50, files_changed: 21 }), makeEntry());
+    expect(out.tier).toBe('R3');
+  });
+
+  it('attributes R3 to LOC when both LOC and files cross the high threshold', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 600, files_changed: 25 }), makeEntry());
+    expect(out.tier).toBe('R3');
+    // LOC is checked first in the high-cutoff branch — reason mentions LOC
+    expect(out.reasons.some((r) => r.includes('large diff'))).toBe(true);
+  });
+});
+
+describe('computeStartingTier — file-scope triggers', () => {
+  it('bumps to R2 minimum when touching a schema file', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['libs/contracts/src/execution-request.schema.ts'] }),
+      makeEntry(),
+    );
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes('schema'))).toBe(true);
+  });
+
+  it('bumps to R3 minimum when touching kernel internals (overrides R2 schema bump)', () => {
+    const out = computeStartingTier(
+      makePrMeta({
+        files: [
+          'libs/contracts/src/execution-request.schema.ts',
+          'go/execution-kernel/internal/gov/normalize.go',
+        ],
+      }),
+      makeEntry(),
+    );
+    expect(out.tier).toBe('R3');
+    expect(out.reasons.some((r) => r.includes('kernel internals'))).toBe(true);
+  });
+
+  it('flags t5_shape on chitin.yaml without bumping tier (gatekeeper handles T5)', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['chitin.yaml'] }),
+      makeEntry(),
+    );
+    expect(out.t5_shape).toBe(true);
+  });
+
+  it('flags t5_shape on .chitin/ paths', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['.chitin/something.yaml', 'apps/temporal-worker/src/foo.ts'] }),
+      makeEntry(),
+    );
+    expect(out.t5_shape).toBe(true);
+  });
+
+  it('does not flag t5_shape on schema files (those are R2 bump, not governance-self-mod)', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['libs/contracts/src/execution-request.schema.ts'] }),
+      makeEntry(),
+    );
+    expect(out.t5_shape).toBe(false);
+  });
+});
+
+describe('computeStartingTier — implementor-tier trigger', () => {
+  it.each(['T3', 'T4'] as const)('bumps to R2 when entry.tier = %s', (entryTier) => {
+    const out = computeStartingTier(makePrMeta(), makeEntry({ tier: entryTier }));
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes(entryTier))).toBe(true);
+  });
+
+  it.each(['T0', 'T1', 'T2'] as const)('does not bump for entry.tier = %s', (entryTier) => {
+    const out = computeStartingTier(makePrMeta(), makeEntry({ tier: entryTier }));
+    expect(out.tier).toBe('R0');
+  });
+});
+
+describe('computeStartingTier — multiple triggers compose to maximum', () => {
+  it('takes the max across multiple bump rules', () => {
+    // Schema (R2) + kernel-internals (R3) + T3 (R2) + 600 LOC (R3) + 4 comments (R1)
+    // → max = R3
+    const out = computeStartingTier(
+      makePrMeta({
+        diff_loc: 600,
+        files_changed: 8,
+        copilot_comment_count: 4,
+        files: [
+          'libs/contracts/src/execution-request.schema.ts',
+          'go/execution-kernel/internal/gov/normalize.go',
+        ],
+      }),
+      makeEntry({ tier: 'T3' }),
+    );
+    expect(out.tier).toBe('R3');
+    // All five rules should have contributed — reasons logs each
+    expect(out.reasons.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('R0 starting tier carries empty reasons (silent-default audit signal)', () => {
+    const out = computeStartingTier(makePrMeta(), makeEntry());
+    expect(out.tier).toBe('R0');
+    expect(out.reasons).toEqual([]);
+  });
+});
+
+// ─── shouldEscalateToOperator ─────────────────────────────────────────────
+
+describe('shouldEscalateToOperator', () => {
+  function out(overrides: Partial<ReviewerOutput> = {}): ReviewerOutput {
+    return {
+      decision: 'approve',
+      confidence: 'high',
+      findings: [],
+      ...overrides,
+    };
+  }
+
+  it('returns false for clean approve+high', () => {
+    expect(shouldEscalateToOperator(out())).toBe(false);
+  });
+
+  it('returns false for request_changes+high (handled by escalate-tier, not operator)', () => {
+    expect(shouldEscalateToOperator(out({ decision: 'request_changes' }))).toBe(false);
+  });
+
+  it('returns true on explicit decision: escalate', () => {
+    expect(shouldEscalateToOperator(out({ decision: 'escalate' }))).toBe(true);
+  });
+
+  it('returns true on confidence: low + at least one 🔴 finding', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'low',
+          findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false on confidence: low + only 🟡/🟢 findings (low confidence on nits is fine)', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'low',
+          findings: [
+            { severity: '🟡', file: 'x.ts', category: 'design', summary: 'nit' },
+            { severity: '🟢', file: 'x.ts', category: 'doc', summary: 'typo' },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false on confidence: medium + 🔴 finding (medium = trust the reviewer)', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'medium',
+          findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// ─── maxTier helper ──────────────────────────────────────────────────────
+
+describe('maxTier', () => {
+  it.each([
+    ['R0', 'R0', 'R0'],
+    ['R0', 'R3', 'R3'],
+    ['R3', 'R0', 'R3'],
+    ['R2', 'R3', 'R3'],
+    ['R4', 'R4', 'R4'],
+  ] as [ReviewTier, ReviewTier, ReviewTier][])('maxTier(%s, %s) = %s', (a, b, expected) => {
+    expect(maxTier(a, b)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Step 1 of 3 toward `review-graph-executor` (entry filed in PR #131; design in PR #129 §5). Pure brains for the review-tier escalation graph — separable from Temporal so the §5 trigger matrix can be table-tested in isolation. Workflow + dispatcher integration follow in steps 2 + 3.

**This PR is meant to be a clean review surface for the trigger-matrix encoding before any workflow code lands on top.** If a threshold is wrong, a path classifier misses a case, or a rule attribution is off, every reviewer escalation downstream will be wrong — better to read the table here than catch it later.

## What's in it

- `apps/temporal-worker/src/review-graph.ts` (~290 LOC):
  - `ReviewTier` enum R0..R4 (Copilot bot / R1-R3 dispatched / R4 operator-only)
  - `REVIEW_TIER_DRIVER` map (R0+R4 non-dispatchable; R1=copilot/gpt-4.1, R2=copilot/sonnet-4.6, R3=cch/opus-4-7)
  - `computeStartingTier(prMeta, entry)` → `{tier, t5_shape, reasons[]}` reading §5's matrix
  - `escalateOneTier()` — bumps with R4 saturation
  - `ReviewerOutput` / `ReviewerFinding` structured-output contracts
  - `shouldEscalateToOperator()` — operator-escalation rule
- `apps/temporal-worker/test/review-graph.test.ts` (65 tests, table-driven)

## Encoded triggers (please verify)

Each rule sets a *minimum*; final tier is the max. Reasons[] logs what fired.

| Signal | Bumps to | Boundary |
|--------|----------|----------|
| Copilot bot left > 2 inline comments | R1 | 3 triggers, 2 doesn't |
| Diff > 200 LOC OR > 10 files (mid) | R2 | 201/11 trigger, 200/10 don't |
| Diff > 500 LOC OR > 20 files (high) | R3 | 501/21 trigger, 500/20 don't |
| Touches `libs/contracts/src/*.schema.ts` | R2 minimum | regex-anchored |
| Touches `go/execution-kernel/internal/{gov,canon,driver,hookinstall,govhookinstall,normalize}/` | R3 minimum | prefix match |
| Implementor `entry.tier` ∈ {T3, T4} | R2 minimum | exact match |

`t5_shape` flag (set independently — gatekeeper escalates on this regardless of reviewer approval):
- `chitin.yaml` (root + nested) → t5_shape = true
- `.chitin/` paths (any depth) → t5_shape = true

## What's NOT in this PR

- Temporal `reviewGraphWorkflow` — step 3
- Dispatcher integration (PR-opened → enqueue review-graph) — step 3
- Reviewer-role prompt template (replaces PR #130's stub) — step 2 (`agent-adversarial-review-pass` entry)
- "Previous-attempt history" trigger from §5 — needs a state-store lookup, deferred
- Auto-merge gatekeeper integration — separate entry

## Test plan

- [x] 65 tests pass; full `apps/temporal-worker` suite at 176/176
- [ ] Read the trigger table above — flag any threshold or path-prefix that's off before step 3 builds the workflow on top
- [ ] Specifically: are any kernel-internal subpaths missing? (`internal/temporal/`? `internal/notify/`? Should `cmd/` count?)
- [ ] Should the file-scope rules also bump on `apps/temporal-worker/src/dispatcher.ts` or `apps/temporal-worker/src/activity.ts` (the swarm's central nervous system)? Currently they don't — relying on diff-size + entry-tier to catch heavy dispatcher work.

## Notes

The reasons[] field is intentionally human-readable rather than structured — it's primarily a telemetry / debugging surface. If a downstream consumer needs to programmatically introspect "which rule fired," we add a parallel `triggers: ReviewTrigger[]` enum field in step 3.