### PR TITLE
feat(phase-2): adversarial reviewer prompt + structured-output parser (step 2 of 3)

### DIFF
--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -1,0 +1,322 @@
+// Phase 2 of the swarm-as-software-factory design. The pure-function
+// core of the review-tier escalation graph from
+// docs/design/2026-05-02-swarm-as-software-factory.md §5.
+//
+// This module is deliberately *just* the brains:
+//   - `computeStartingTier(prMeta, entry)` — reads the §5 trigger
+//     matrix and returns the starting reviewer tier + whether the PR
+//     is T5-shape (governance-self-modification path) for the
+//     gatekeeper to short-circuit on.
+//   - `escalateOneTier(currentTier)` — bumps to the next tier,
+//     saturating at R4.
+//   - `shouldEscalateToOperator(reviewerOutput)` — the rule for
+//     stopping the graph and pinging the human.
+//
+// Temporal workflow + dispatcher integration land in follow-up
+// slices. Keeping the brains separable from Temporal means we can
+// table-test every row of the §5 matrix without spinning up a
+// workflow runtime — and a future change to the matrix is one PR
+// against this file with new test rows, not a workflow rewrite.
+
+import type { Tier } from '@chitin/contracts';
+import type { BacklogEntry } from './grooming/parse-backlog.ts';
+
+// Review-tier ordinal vocabulary. R0 = "Copilot bot review only"
+// (the GitHub side fires this automatically on every PR — chitin
+// doesn't dispatch it). R1..R3 are dispatched as workflows at
+// progressively heavier driver+model combinations. R4 = "stop, ping
+// the operator" — terminal.
+export type ReviewTier = 'R0' | 'R1' | 'R2' | 'R3' | 'R4';
+
+const TIER_ORDER: readonly ReviewTier[] = ['R0', 'R1', 'R2', 'R3', 'R4'] as const;
+
+function ord(t: ReviewTier): number {
+  return TIER_ORDER.indexOf(t);
+}
+
+function maxTier(a: ReviewTier, b: ReviewTier): ReviewTier {
+  return ord(a) >= ord(b) ? a : b;
+}
+
+/**
+ * The (driver, model) pair the review-graph workflow dispatches at
+ * each tier. R0 is intentionally non-dispatchable here — Copilot's
+ * server-side review fires on PR open without us asking. R4 is
+ * non-dispatchable too — it's the "ping operator" terminal.
+ *
+ * R1: copilot/gpt-4.1 — free, fast, mid-confidence
+ * R2: copilot/sonnet-4.6 — free under Pro plan, sonnet-class
+ * R3: claude-code-headless/opus-4.7 — paid, ~$0.10–0.50/run
+ *
+ * Format mirrors `TIER_DRIVER` in dispatcher.ts so a future caller
+ * can pick the spawn args by reading this map alone.
+ */
+export const REVIEW_TIER_DRIVER: Record<ReviewTier, { driver: string | null; model: string | null }> = {
+  R0: { driver: null, model: null },                                          // GH bot, not dispatched
+  R1: { driver: 'copilot', model: 'gpt-4.1' },
+  R2: { driver: 'copilot', model: 'claude-sonnet-4.6' },
+  R3: { driver: 'claude-code-headless', model: 'claude-opus-4-7' },
+  R4: { driver: null, model: null },                                          // operator, not dispatched
+};
+
+/**
+ * Inputs to `computeStartingTier`. Captures the PR-side state the
+ * dispatcher learns at apply-step time, plus the originating entry
+ * so file-scope and implementor-tier checks have what they need.
+ *
+ * Field shapes match what `apps/temporal-worker/src/grooming/
+ * apply-workflow-result.ts` already records in the result envelope —
+ * the graph executor (next slice) will project an `ApplyResult`
+ * into a `PrMeta` shape.
+ */
+export interface PrMeta {
+  /** From `worktree.diff_shortstat` — total insertions + deletions. */
+  diff_loc: number;
+  /** From `worktree.diff_shortstat` — file count. */
+  files_changed: number;
+  /** Files in the diff (as repo-relative paths). Used for path-scope
+   *  bumps. May be empty if the apply step couldn't enumerate (rare;
+   *  treat as "unknown — defer to LOC-based bumps"). */
+  files: string[];
+  /** Number of inline review comments Copilot's GH bot has left.
+   *  Often unknown at the moment the review-graph kicks off (Copilot
+   *  is racing the dispatcher). When undefined, we don't bump on
+   *  this signal — the graph re-evaluates after R0 settles. */
+  copilot_comment_count?: number;
+  /** Pull request URL — purely audit context, not used in tier
+   *  decisions. Surfaced in tier-decision logs so the chain can be
+   *  traversed back to the PR. */
+  pr_url?: string;
+}
+
+/**
+ * Result of `computeStartingTier`. Returns the tier *plus* the
+ * reasons (so logs + telemetry can show which rule fired) plus a
+ * `t5_shape` flag for paths the chitin policy considers
+ * governance-self-modification — those always escalate at the
+ * gatekeeper layer regardless of the reviewer chain's verdict.
+ */
+export interface ReviewTierDecision {
+  tier: ReviewTier;
+  /** True if the PR touches `chitin.yaml` / `.chitin/` /
+   *  governance-config paths. The review chain still runs (audit
+   *  matters) but the gatekeeper layer must escalate even on
+   *  approval. */
+  t5_shape: boolean;
+  /** Human-readable explanations of which rules bumped the tier.
+   *  One entry per fired rule. Empty when starting tier is the
+   *  default R0. */
+  reasons: string[];
+}
+
+// File-scope rules. Order is intentional: T5-shape check runs
+// independently (sets the `t5_shape` flag, doesn't change tier).
+//
+// Kernel-internals + schema files are starting-tier bumps because
+// they're load-bearing surfaces — a bug in normalize.go or in the
+// ExecutionRequest schema cascades broadly. Worth a heavy reviewer
+// even on small diffs.
+
+const T5_PATH_PREFIXES: readonly string[] = [
+  // chitin.yaml at any level (root + any subdir)
+  // .chitin/ directory at any level
+  // The kernel's gov hook installer (writes to live settings.json)
+  // — covered by R3 bump too, but T5 flag fires regardless of
+  // tier outcome since these are governance config.
+];
+
+const T5_FILENAMES: readonly string[] = ['chitin.yaml'];
+
+const T5_PATH_FRAGMENTS: readonly string[] = [
+  '/.chitin/',
+  '.chitin/',
+];
+
+const KERNEL_INTERNAL_PREFIXES: readonly string[] = [
+  'go/execution-kernel/internal/gov/',
+  'go/execution-kernel/internal/canon/',
+  'go/execution-kernel/internal/govhookinstall/',
+  'go/execution-kernel/internal/hookinstall/',
+  'go/execution-kernel/internal/driver/',
+  'go/execution-kernel/internal/normalize/',
+];
+
+const SCHEMA_PATH_REGEX = /^libs\/contracts\/src\/[\w.-]+\.schema\.ts$/;
+
+function isT5Shape(file: string): boolean {
+  if (T5_FILENAMES.includes(file)) return true;
+  // Match `chitin.yaml` at any nested path
+  if (file === 'chitin.yaml' || file.endsWith('/chitin.yaml')) return true;
+  for (const frag of T5_PATH_FRAGMENTS) {
+    if (file.includes(frag)) return true;
+  }
+  for (const pre of T5_PATH_PREFIXES) {
+    if (file.startsWith(pre)) return true;
+  }
+  return false;
+}
+
+function isKernelInternal(file: string): boolean {
+  for (const pre of KERNEL_INTERNAL_PREFIXES) {
+    if (file.startsWith(pre)) return true;
+  }
+  return false;
+}
+
+function isSchemaFile(file: string): boolean {
+  return SCHEMA_PATH_REGEX.test(file);
+}
+
+/**
+ * Compute the starting reviewer tier from §5's trigger matrix.
+ *
+ * Pure function. Each rule sets a *minimum* tier; the final tier is
+ * the maximum across rules. Defaults to R0 (Copilot bot — fires
+ * server-side, no dispatch needed). The reasons array names which
+ * rules contributed.
+ *
+ * Trigger matrix (mirrors the design doc §5 table):
+ *
+ * | Signal | Bumps to | Threshold |
+ * |--------|----------|-----------|
+ * | Copilot bot leaves > N comments | R1 | N=2 |
+ * | Diff > N LOC OR > M files (mid) | R2 | 200 LOC / 10 files |
+ * | Diff > N LOC OR > M files (high) | R3 | 500 LOC / 20 files |
+ * | Touches schema files | R2 minimum | always |
+ * | Touches kernel internals | R3 minimum | always |
+ * | Implementor was tier T3+ | R2 minimum | always |
+ *
+ * The "previous-attempt history" rule is deferred — it requires a
+ * state-store lookup; future enhancement.
+ */
+export function computeStartingTier(prMeta: PrMeta, entry: BacklogEntry): ReviewTierDecision {
+  let tier: ReviewTier = 'R0';
+  const reasons: string[] = [];
+  let t5_shape = false;
+
+  // Copilot comment count
+  if (prMeta.copilot_comment_count !== undefined && prMeta.copilot_comment_count > 2) {
+    tier = maxTier(tier, 'R1');
+    reasons.push(`Copilot bot left ${prMeta.copilot_comment_count} comments (> 2)`);
+  }
+
+  // Diff size — high cutoff first so we attribute correctly
+  if (prMeta.diff_loc > 500 || prMeta.files_changed > 20) {
+    tier = maxTier(tier, 'R3');
+    reasons.push(
+      prMeta.diff_loc > 500
+        ? `large diff (${prMeta.diff_loc} LOC > 500)`
+        : `wide diff (${prMeta.files_changed} files > 20)`,
+    );
+  } else if (prMeta.diff_loc > 200 || prMeta.files_changed > 10) {
+    tier = maxTier(tier, 'R2');
+    reasons.push(
+      prMeta.diff_loc > 200
+        ? `mid-size diff (${prMeta.diff_loc} LOC > 200)`
+        : `mid-width diff (${prMeta.files_changed} files > 10)`,
+    );
+  }
+
+  // File-scope rules
+  let kernelHit = false;
+  let schemaHit = false;
+  for (const f of prMeta.files) {
+    if (isT5Shape(f)) t5_shape = true;
+    if (isKernelInternal(f)) kernelHit = true;
+    if (isSchemaFile(f)) schemaHit = true;
+  }
+  if (kernelHit) {
+    tier = maxTier(tier, 'R3');
+    reasons.push('touches kernel internals (gov / canon / hookinstall / driver / normalize)');
+  }
+  if (schemaHit) {
+    tier = maxTier(tier, 'R2');
+    reasons.push('touches a libs/contracts schema file');
+  }
+
+  // Implementor tier — entry.tier is a string from yaml frontmatter
+  // (BacklogEntry.tier is `string | undefined`); coerce + check.
+  if (entry.tier === 'T3' || entry.tier === 'T4') {
+    tier = maxTier(tier, 'R2');
+    reasons.push(`implementor was tier ${entry.tier}`);
+  }
+
+  return { tier, t5_shape, reasons };
+}
+
+/**
+ * Bump to the next reviewer tier. Saturates at R4 (the terminal
+ * "ping operator" tier — escalating past R4 doesn't make sense).
+ *
+ * Used by the review-graph workflow when a reviewer at the current
+ * tier requests-changes-with-low-confidence or explicitly returns
+ * `decision: 'escalate'`.
+ */
+export function escalateOneTier(current: ReviewTier): ReviewTier {
+  const next: Record<ReviewTier, ReviewTier> = {
+    R0: 'R1',
+    R1: 'R2',
+    R2: 'R3',
+    R3: 'R4',
+    R4: 'R4',
+  };
+  return next[current];
+}
+
+/**
+ * Structured output the reviewer-role agents emit at every tier
+ * (modeled here so the workflow + adversarial prompt have a single
+ * source of truth). The actual prompt template that produces this
+ * shape lands in the `agent-adversarial-review-pass` entry; this
+ * module just defines the contract.
+ */
+export interface ReviewerOutput {
+  decision: 'approve' | 'request_changes' | 'escalate';
+  confidence: 'high' | 'medium' | 'low';
+  findings: ReviewerFinding[];
+}
+
+export interface ReviewerFinding {
+  /** 🔴 = real bug, blocks merge. 🟡 = worth fixing, doesn't block.
+   *  🟢 = doc/nit. */
+  severity: '🔴' | '🟡' | '🟢';
+  file: string;
+  line?: number;
+  category: 'bug' | 'test_gap' | 'design' | 'doc';
+  summary: string;
+  suggested_fix?: string;
+}
+
+/**
+ * Decide whether the review-graph should stop and ping the
+ * operator (R4) instead of merging or escalating to the next tier.
+ *
+ * Rules (any one fires → escalate):
+ *   - reviewer explicitly returned `decision: 'escalate'`
+ *   - reviewer returned `confidence: 'low'` AND found at least one
+ *     🔴 finding (low confidence on a real bug means don't trust the
+ *     fix the reviewer suggested — get a human eye)
+ *
+ * NOT covered here (handled at the gatekeeper layer):
+ *   - T5-shape paths (escalate regardless of reviewer approval)
+ *   - CI failure
+ *   - bucket-B telemetry alarm
+ *   - diff-vs-file:scope mismatch
+ *
+ * Those are merge-time gates, not reviewer-tier-graph escalations.
+ * They feed the gatekeeper's "auto-merge or escalate" call after
+ * the review chain settles.
+ */
+export function shouldEscalateToOperator(out: ReviewerOutput): boolean {
+  if (out.decision === 'escalate') return true;
+  if (out.confidence === 'low' && out.findings.some((f) => f.severity === '🔴')) return true;
+  return false;
+}
+
+export const __test__ = {
+  ord,
+  maxTier,
+  isT5Shape,
+  isKernelInternal,
+  isSchemaFile,
+};

--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -18,7 +18,6 @@
 // workflow runtime — and a future change to the matrix is one PR
 // against this file with new test rows, not a workflow rewrite.
 
-import type { Tier } from '@chitin/contracts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 
 // Review-tier ordinal vocabulary. R0 = "Copilot bot review only"
@@ -116,20 +115,20 @@ export interface ReviewTierDecision {
 // they're load-bearing surfaces — a bug in normalize.go or in the
 // ExecutionRequest schema cascades broadly. Worth a heavy reviewer
 // even on small diffs.
-
-const T5_PATH_PREFIXES: readonly string[] = [
-  // chitin.yaml at any level (root + any subdir)
-  // .chitin/ directory at any level
-  // The kernel's gov hook installer (writes to live settings.json)
-  // — covered by R3 bump too, but T5 flag fires regardless of
-  // tier outcome since these are governance config.
-];
+//
+// T5 path coverage mirrors the `no-governance-self-modification`
+// regex in `chitin.yaml` (see id: no-governance-self-modification):
+//   target_regex: '(?:(?:^|/)chitin\.yaml$|(?:^|/)\.chitin/|(?:^|/)\.hermes/plugins/chitin-governance/)'
+// Keep this list in sync with that regex; both are governance-
+// self-modification guards and a hole in either is a hole in both.
 
 const T5_FILENAMES: readonly string[] = ['chitin.yaml'];
 
 const T5_PATH_FRAGMENTS: readonly string[] = [
   '/.chitin/',
   '.chitin/',
+  '/.hermes/plugins/chitin-governance/',
+  '.hermes/plugins/chitin-governance/',
 ];
 
 const KERNEL_INTERNAL_PREFIXES: readonly string[] = [
@@ -149,9 +148,6 @@ function isT5Shape(file: string): boolean {
   if (file === 'chitin.yaml' || file.endsWith('/chitin.yaml')) return true;
   for (const frag of T5_PATH_FRAGMENTS) {
     if (file.includes(frag)) return true;
-  }
-  for (const pre of T5_PATH_PREFIXES) {
-    if (file.startsWith(pre)) return true;
   }
   return false;
 }
@@ -186,8 +182,14 @@ function isSchemaFile(file: string): boolean {
  * | Touches kernel internals | R3 minimum | always |
  * | Implementor was tier T3+ | R2 minimum | always |
  *
- * The "previous-attempt history" rule is deferred — it requires a
- * state-store lookup; future enhancement.
+ * Two §5 rules are intentionally deferred:
+ *   - "Touches public API exports (top-level `export`s in `apps/*`)
+ *     → R2 minimum" — requires reading the diff content (not just
+ *     paths) to detect `+export ...` lines. The path-only signal is
+ *     too noisy (every TS module has exports). Encode this when the
+ *     workflow has the diff body in hand (step 3).
+ *   - "Previous-attempt history" — requires a state-store lookup;
+ *     future enhancement that consumes `parent_workflow_id` chains.
  */
 export function computeStartingTier(prMeta: PrMeta, entry: BacklogEntry): ReviewTierDecision {
   let tier: ReviewTier = 'R0';
@@ -291,11 +293,25 @@ export interface ReviewerFinding {
  * Decide whether the review-graph should stop and ping the
  * operator (R4) instead of merging or escalating to the next tier.
  *
- * Rules (any one fires → escalate):
- *   - reviewer explicitly returned `decision: 'escalate'`
- *   - reviewer returned `confidence: 'low'` AND found at least one
- *     🔴 finding (low confidence on a real bug means don't trust the
- *     fix the reviewer suggested — get a human eye)
+ * Called specifically when the chain is at R3 (the heaviest
+ * dispatchable reviewer) and needs to decide R3-resolves-here vs.
+ * R4-escalate-to-human. Rules (any one fires → escalate):
+ *
+ *   - reviewer explicitly returned `decision: 'escalate'` — they
+ *     self-flagged something they can't decide at this tier.
+ *   - reviewer returned `confidence: 'low'` — at R3, low confidence
+ *     means "the heaviest reviewer in the graph couldn't fully
+ *     evaluate this PR." Per design §5 + the operator's stated rule
+ *     ("if Headless Claude Opus can't figure it out, escalate it up
+ *     to me"), low confidence at R3 is the operator's signal.
+ *
+ * Note that `decision: 'request_changes'` with high/medium
+ * confidence does NOT trigger operator escalation — that path
+ * loops back to the implementor with the reviewer's findings (the
+ * implementor either fixes and re-pushes, or the apply step errors
+ * and the chain ends naturally). 🔴 findings on their own don't
+ * block the operator's time when the reviewer is confident in the
+ * fix; the implementor-rerun handles them.
  *
  * NOT covered here (handled at the gatekeeper layer):
  *   - T5-shape paths (escalate regardless of reviewer approval)
@@ -309,7 +325,7 @@ export interface ReviewerFinding {
  */
 export function shouldEscalateToOperator(out: ReviewerOutput): boolean {
   if (out.decision === 'escalate') return true;
-  if (out.confidence === 'low' && out.findings.some((f) => f.severity === '🔴')) return true;
+  if (out.confidence === 'low') return true;
   return false;
 }
 

--- a/apps/temporal-worker/src/reviewer-prompts.ts
+++ b/apps/temporal-worker/src/reviewer-prompts.ts
@@ -1,0 +1,220 @@
+// Phase 2 step 2 of the swarm-as-software-factory design. The
+// adversarial-review prompt template the review-graph (review-graph.ts)
+// dispatches to at tiers R1-R3 + the structured-output parser the
+// graph consumes from the agent's stdout.
+//
+// Replaces the `reviewer` role's stub from PR #130. The prompt is
+// modeled on the manual adversarial-review passes from this session:
+// they catch what Copilot misses (PR #78's 8/11 real-bug rate;
+// today's bucket-B root-cause discovery; PR #109's notification-
+// ordering bug) and the recipe is reproducible.
+//
+// Contract (mirrors ReviewerOutput / ReviewerFinding in review-graph.ts):
+//
+//   {
+//     "decision": "approve" | "request_changes" | "escalate",
+//     "confidence": "high" | "medium" | "low",
+//     "findings": [
+//       {"severity": "🔴" | "🟡" | "🟢", "file": "...", "line": 42,
+//        "category": "bug" | "test_gap" | "design" | "doc",
+//        "summary": "...", "suggested_fix": "..."}
+//     ]
+//   }
+//
+// Severity rules (also embedded in the prompt — must stay in sync):
+//   🔴 = real bug, blocks merge
+//   🟡 = worth fixing but doesn't block merge (feeds tech-debt-ledger)
+//   🟢 = doc / nit / cosmetic, advisory only
+//
+// The graph escalates on:
+//   - explicit decision: 'escalate'
+//   - confidence: 'low' AND any 🔴 finding
+//   (other gates — CI, bucket-B telemetry, T5-shape — are gatekeeper-
+//    layer concerns; see review-graph.ts shouldEscalateToOperator
+//    docstring.)
+
+import { z } from 'zod';
+import type { ReviewerOutput, ReviewerFinding, ReviewTier } from './review-graph.ts';
+
+// ─── Zod schema for the agent's JSON output ────────────────────────────────
+
+// The agent emits findings using emoji severity markers — easier for
+// the LLM to produce reliably than (e.g.) integer levels. The schema
+// validates them strictly so a hallucinated `🔵` or omitted field
+// fails parse and the graph can react (typically: re-prompt or
+// escalate-tier).
+
+export const ReviewerFindingSchema: z.ZodType<ReviewerFinding> = z.object({
+  severity: z.enum(['🔴', '🟡', '🟢']),
+  file: z.string().min(1),
+  line: z.number().int().positive().optional(),
+  category: z.enum(['bug', 'test_gap', 'design', 'doc']),
+  summary: z.string().min(1),
+  suggested_fix: z.string().optional(),
+});
+
+export const ReviewerOutputSchema: z.ZodType<ReviewerOutput> = z.object({
+  decision: z.enum(['approve', 'request_changes', 'escalate']),
+  confidence: z.enum(['high', 'medium', 'low']),
+  findings: z.array(ReviewerFindingSchema),
+});
+
+// ─── Prompt builder ────────────────────────────────────────────────────────
+
+export interface ReviewerPromptInputs {
+  /** Reviewer tier this prompt is for. Used to set tone (R1 = quick,
+   *  R3 = adversarial-deep). */
+  tier: ReviewTier;
+  /** PR number for context — agents read GitHub via gh CLI when
+   *  needed; this saves them a discovery hop. */
+  pr_number: number;
+  /** PR URL — same as above. */
+  pr_url: string;
+  /** Backlog entry id — what the PR is supposed to be doing. */
+  entry_id: string;
+  /** The entry's declared file: scope as a comma-separated string.
+   *  Used for the diff-vs-scope mismatch check (the bucket-B
+   *  detection signal). Empty / undefined = entry didn't declare a
+   *  scope; reviewer evaluates without that constraint. */
+  entry_file_scope?: string;
+  /** Inline review comments Copilot's GH bot has left, formatted as
+   *  newline-separated bullets the agent can verify one-by-one.
+   *  Empty when Copilot hasn't reviewed yet (R0 still pending). */
+  copilot_comments?: string;
+  /** Previous reviewer's findings (when escalating from a lower
+   *  tier). Newline-separated bullets. Empty on first dispatch. */
+  prior_findings?: string;
+}
+
+const STRUCTURED_OUTPUT_INSTRUCTIONS = `\
+At the END of your review, emit EXACTLY ONE JSON object on a single line, prefixed with the literal token \`<<<REVIEW>>>\` and nothing else after the closing brace on that line. No code fence, no commentary. The graph's parser keys on \`<<<REVIEW>>>\`. Example:
+
+<<<REVIEW>>>{"decision":"request_changes","confidence":"high","findings":[{"severity":"🔴","file":"apps/temporal-worker/src/dispatcher.ts","line":372,"category":"bug","summary":"writeDispatchMarker fires before submit, so a submit failure leaves a marker without a workflow.","suggested_fix":"Move writeDispatchMarker after client.workflow.start() returns."}]}
+
+Severity rules (load-bearing — match these EXACTLY):
+- 🔴 = real bug. Blocks merge. Examples: incorrect logic, missing null/undefined guards, race conditions, security issues, incorrect git semantics, type errors that would crash at runtime.
+- 🟡 = worth fixing but doesn't block merge. Examples: naming nits with real cost, missing test cases for non-obvious branches, code-smell that will rot, a TODO that should be filed in the debt ledger.
+- 🟢 = cosmetic / doc / typo / advisory only. No merge gate.
+
+Decision rules:
+- "approve" — no 🔴 findings; the PR is mergeable as-is.
+- "request_changes" — at least one 🔴; PR needs fixes before merge.
+- "escalate" — you found something the next reviewer tier should weigh in on (e.g., architectural design call you don't feel confident judging at this tier).
+
+Confidence rules:
+- "high" — you read every changed line, verified each Copilot comment against the actual code, and tested the assertions you make. No reasonable next-tier reviewer would flip your decision.
+- "medium" — you skimmed parts; if you returned 'approve' someone could plausibly find a 🔴 you missed.
+- "low" — you can't fully evaluate the PR at this tier. Either escalate or request_changes.
+
+The graph escalates to the next tier (or to a human at R3) when decision='escalate' OR (confidence='low' AND any 🔴 finding). So: if you're uncertain about a 🔴 finding, mark confidence:'low' rather than guessing.`;
+
+const TIER_TONE: Record<ReviewTier, string> = {
+  R0: '',  // not dispatched
+  R1: `You are a tier-1 reviewer (Copilot CLI / GPT-4.1). Aim for a quick but rigorous pass — read the diff, verify each Copilot bot comment against actual code, flag obvious bugs. If something feels off but you'd need deep reasoning to be sure, return decision:'escalate' rather than guessing — a heavier reviewer (R2/R3) will pick it up.`,
+  R2: `You are a tier-2 reviewer (Copilot CLI / Claude Sonnet 4.6). The PR has been bumped to you because it's mid-complexity, touches a schema/public-API surface, or the implementor was T3+. Treat this as the equivalent of a careful staff-engineer review: verify each line of the diff makes the change the entry asked for, no more no less. The 'diff doesn't match the entry's declared file: scope' check is a hard 🔴 — that's how bucket-B contamination got past the apply step on 2026-05-02 (4 PRs shipped a settings.json overwrite labeled as feature work).`,
+  R3: `You are a tier-3 reviewer (Claude Opus 4.7). The PR has been bumped to you because it's heavy: large diff, kernel internals, or the lower-tier reviewers escalated. Treat yourself as a hostile reviewer:
+- Look for cases the code doesn't handle (empty input, null/undefined, race conditions, edge values).
+- Question assumptions: are the comments correct? does the test prove what it claims?
+- Verify EACH Copilot bot comment against the actual code — do not auto-dismiss any (per chitin memory, PR #78 caught 8/11 real bugs Copilot flagged).
+- Read the entry's declared file: scope and confirm the diff intersects it. If the diff is exclusively in files NOT named in the entry, that's a bucket-B contamination signature — emit a 🔴 with category:'design' and suggest closing-and-redispatching.
+- Cross-check telemetry implications: does this change degrade success rates for any driver/tier? Is bucket-B preventable with this code?`,
+  R4: '',  // not dispatched
+};
+
+/**
+ * Build the adversarial-review prompt for a given tier. Returns a
+ * single string the dispatcher passes as the agent's system+user
+ * prompt (the wrapper that decides system-vs-user split lives in
+ * activity.ts; this function just produces the content).
+ */
+export function buildAdversarialReviewerPrompt(opts: ReviewerPromptInputs): string {
+  const tierTone = TIER_TONE[opts.tier];
+  if (!tierTone) {
+    throw new Error(`tier ${opts.tier} is not a dispatchable reviewer tier (R0/R4 are non-dispatchable)`);
+  }
+
+  const scopeBlock = opts.entry_file_scope
+    ? `Entry's declared file: scope (the agent should ONLY have changed files matching these globs):\n${opts.entry_file_scope}`
+    : `Entry's file: scope was not declared. Evaluate without the diff-scope check; flag if the diff is suspiciously broad.`;
+
+  const copilotBlock = opts.copilot_comments
+    ? `Copilot bot's inline comments (verify EACH one against the actual code — do not auto-dismiss):\n${opts.copilot_comments}`
+    : `Copilot's bot review hasn't landed yet (or left no comments). Do your own pass.`;
+
+  const priorBlock = opts.prior_findings
+    ? `Previous reviewer's findings (you've been escalated to because they couldn't fully resolve):\n${opts.prior_findings}`
+    : `You're the first reviewer.`;
+
+  return `You are reviewing PR #${opts.pr_number} (${opts.pr_url}) for chitin. The PR is meant to implement backlog entry \`${opts.entry_id}\`.
+
+${tierTone}
+
+${scopeBlock}
+
+${copilotBlock}
+
+${priorBlock}
+
+YOUR TOOLS: \`gh pr diff ${opts.pr_number}\`, \`gh pr view ${opts.pr_number}\`, \`gh api repos/chitinhq/chitin/pulls/${opts.pr_number}/comments\`, plus \`read\` on any file in the repo. You're allowed to run tests; you're allowed to query telemetry via \`python/analysis/\`. You're NOT allowed to push to the PR's branch — that's the implementor's job; if you find a 🔴 the graph re-dispatches to the implementor (or escalates to a higher reviewer).
+
+${STRUCTURED_OUTPUT_INSTRUCTIONS}`;
+}
+
+// ─── Output parser ─────────────────────────────────────────────────────────
+
+const REVIEW_MARKER = '<<<REVIEW>>>';
+
+/**
+ * Extract the reviewer's structured decision from agent stdout.
+ *
+ * The agent is instructed to emit `<<<REVIEW>>>{...json...}` on a
+ * single line at the end. We scan for the marker (last occurrence
+ * wins, so an example marker in the prompt that the agent echoes
+ * doesn't false-match), JSON-parse the slice, and validate against
+ * ReviewerOutputSchema.
+ *
+ * Returns:
+ *   { ok: true, output }      — well-formed
+ *   { ok: false, error }      — missing marker, JSON parse error, or
+ *                                schema validation failure
+ *
+ * The graph escalates a tier on { ok: false } — either the agent
+ * didn't follow the contract (next tier may; or operator), or it's
+ * a sign the prompt template needs hardening.
+ */
+export function parseReviewerOutput(
+  stdoutTail: string,
+): { ok: true; output: ReviewerOutput } | { ok: false; error: string } {
+  const lastMarker = stdoutTail.lastIndexOf(REVIEW_MARKER);
+  if (lastMarker < 0) {
+    return { ok: false, error: 'no <<<REVIEW>>> marker in stdout' };
+  }
+  const after = stdoutTail.slice(lastMarker + REVIEW_MARKER.length);
+  // Take everything up to the first newline (the contract is "one
+  // line"). This shields against trailing noise the agent might
+  // emit despite instructions.
+  const lineEnd = after.indexOf('\n');
+  const candidate = (lineEnd >= 0 ? after.slice(0, lineEnd) : after).trim();
+  if (!candidate.startsWith('{')) {
+    return { ok: false, error: `expected JSON object after marker, got: ${candidate.slice(0, 80)}` };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch (err) {
+    return { ok: false, error: `JSON.parse failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  const result = ReviewerOutputSchema.safeParse(parsed);
+  if (!result.success) {
+    return { ok: false, error: `schema validation: ${result.error.message}` };
+  }
+  return { ok: true, output: result.data };
+}
+
+export const __test__ = {
+  REVIEW_MARKER,
+  TIER_TONE,
+  STRUCTURED_OUTPUT_INSTRUCTIONS,
+};

--- a/apps/temporal-worker/src/reviewer-prompts.ts
+++ b/apps/temporal-worker/src/reviewer-prompts.ts
@@ -196,21 +196,36 @@ export function parseReviewerOutput(
   const lineEnd = after.indexOf('\n');
   const candidate = (lineEnd >= 0 ? after.slice(0, lineEnd) : after).trim();
   if (!candidate.startsWith('{')) {
-    return { ok: false, error: `expected JSON object after marker, got: ${candidate.slice(0, 80)}` };
+    return { ok: false, error: `expected JSON object after marker, got: ${truncate(candidate, 200)}` };
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(candidate);
   } catch (err) {
-    return { ok: false, error: `JSON.parse failed: ${err instanceof Error ? err.message : String(err)}` };
+    // Include the candidate slice so debugging doesn't require
+    // re-fetching the raw stdout. Truncated to keep error messages
+    // readable in logs (full slice is in stdout_tail anyway).
+    return {
+      ok: false,
+      error:
+        `JSON.parse failed: ${err instanceof Error ? err.message : String(err)} ` +
+        `(candidate: ${truncate(candidate, 200)})`,
+    };
   }
 
   const result = ReviewerOutputSchema.safeParse(parsed);
   if (!result.success) {
-    return { ok: false, error: `schema validation: ${result.error.message}` };
+    return {
+      ok: false,
+      error: `schema validation: ${result.error.message} (candidate: ${truncate(candidate, 200)})`,
+    };
   }
   return { ok: true, output: result.data };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…[+${s.length - max} more chars]`;
 }
 
 export const __test__ = {

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -77,6 +77,13 @@ const ROLE_PROMPTS: Record<Role, RolePromptBuilder> = {
   product: (entry) => buildStubPrompt('product', entry),
   groomer: (entry) => buildStubPrompt('groomer', entry),
   architect: (entry) => buildStubPrompt('architect', entry),
+  // The reviewer stub here fires only when a BACKLOG ENTRY explicitly
+  // says `role: reviewer` (rare — entries are usually programmer-shape
+  // work). The richer adversarial-review prompt the review-graph
+  // workflow dispatches at tiers R1-R3 lives in reviewer-prompts.ts —
+  // it takes PR context (diff, scope, prior findings, copilot
+  // comments) that a single BacklogEntry can't carry. See
+  // docs/design/2026-05-02-swarm-as-software-factory.md §5.
   reviewer: (entry) => buildStubPrompt('reviewer', entry),
   qa: (entry) => buildStubPrompt('qa', entry),
   gatekeeper: (entry) => buildStubPrompt('gatekeeper', entry),

--- a/apps/temporal-worker/test/review-graph.test.ts
+++ b/apps/temporal-worker/test/review-graph.test.ts
@@ -81,6 +81,11 @@ describe('isT5Shape', () => {
     ['apps/some/chitin.yaml', true],
     ['.chitin/policy.yaml', true],
     ['some/.chitin/anything.txt', true],
+    // The chitin.yaml `no-governance-self-modification` regex covers
+    // `.hermes/plugins/chitin-governance/` too; mirror that here so a
+    // hole in one is a hole in the other.
+    ['.hermes/plugins/chitin-governance/manifest.json', true],
+    ['some/.hermes/plugins/chitin-governance/anything.ts', true],
   ])('matches %s as T5-shape', (path, expected) => {
     expect(isT5Shape(path)).toBe(expected);
   });
@@ -324,7 +329,11 @@ describe('shouldEscalateToOperator', () => {
     expect(shouldEscalateToOperator(out({ decision: 'escalate' }))).toBe(true);
   });
 
-  it('returns true on confidence: low + at least one 🔴 finding', () => {
+  it('returns true on confidence: low alone (R3 couldn\'t decide → operator)', () => {
+    expect(shouldEscalateToOperator(out({ confidence: 'low' }))).toBe(true);
+  });
+
+  it('returns true on confidence: low + 🔴 finding', () => {
     expect(
       shouldEscalateToOperator(
         out({
@@ -335,25 +344,36 @@ describe('shouldEscalateToOperator', () => {
     ).toBe(true);
   });
 
-  it('returns false on confidence: low + only 🟡/🟢 findings (low confidence on nits is fine)', () => {
+  it('returns true on confidence: low + only 🟡/🟢 findings (low alone fires regardless of finding severity)', () => {
     expect(
       shouldEscalateToOperator(
         out({
           confidence: 'low',
           findings: [
             { severity: '🟡', file: 'x.ts', category: 'design', summary: 'nit' },
-            { severity: '🟢', file: 'x.ts', category: 'doc', summary: 'typo' },
           ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false on confidence: medium + 🔴 finding (medium = trust the reviewer; implementor re-runs)', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'medium',
+          findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
         }),
       ),
     ).toBe(false);
   });
 
-  it('returns false on confidence: medium + 🔴 finding (medium = trust the reviewer)', () => {
+  it('returns false on confidence: high + 🔴 finding + request_changes (request_changes loops to implementor, not operator)', () => {
     expect(
       shouldEscalateToOperator(
         out({
-          confidence: 'medium',
+          decision: 'request_changes',
+          confidence: 'high',
           findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
         }),
       ),

--- a/apps/temporal-worker/test/review-graph.test.ts
+++ b/apps/temporal-worker/test/review-graph.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REVIEW_TIER_DRIVER,
+  computeStartingTier,
+  escalateOneTier,
+  shouldEscalateToOperator,
+  __test__,
+  type PrMeta,
+  type ReviewTier,
+  type ReviewerOutput,
+} from '../src/review-graph.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+
+const { isT5Shape, isKernelInternal, isSchemaFile, maxTier } = __test__;
+
+function makeEntry(overrides: Partial<BacklogEntry> = {}): BacklogEntry {
+  return {
+    id: 'e1',
+    status: 'ready',
+    description: 'desc',
+    rawFrontmatter: '```yaml\nid: e1\nstatus: ready\n```',
+    rawSection: '### e1',
+    tier: 'T1',
+    ...overrides,
+  };
+}
+
+function makePrMeta(overrides: Partial<PrMeta> = {}): PrMeta {
+  return {
+    diff_loc: 50,
+    files_changed: 2,
+    files: ['apps/temporal-worker/src/foo.ts'],
+    ...overrides,
+  };
+}
+
+// ─── escalateOneTier ─────────────────────────────────────────────────────
+
+describe('escalateOneTier', () => {
+  it.each([
+    ['R0', 'R1'],
+    ['R1', 'R2'],
+    ['R2', 'R3'],
+    ['R3', 'R4'],
+    ['R4', 'R4'],  // saturates
+  ] as [ReviewTier, ReviewTier][])('%s -> %s', (input, expected) => {
+    expect(escalateOneTier(input)).toBe(expected);
+  });
+});
+
+// ─── REVIEW_TIER_DRIVER shape ────────────────────────────────────────────
+
+describe('REVIEW_TIER_DRIVER', () => {
+  it('has exactly 5 entries (R0-R4)', () => {
+    expect(Object.keys(REVIEW_TIER_DRIVER).sort()).toEqual(['R0', 'R1', 'R2', 'R3', 'R4']);
+  });
+
+  it('R0 (Copilot bot) and R4 (operator) are non-dispatchable (driver/model null)', () => {
+    expect(REVIEW_TIER_DRIVER.R0).toEqual({ driver: null, model: null });
+    expect(REVIEW_TIER_DRIVER.R4).toEqual({ driver: null, model: null });
+  });
+
+  it('R1-R3 each have a real driver+model', () => {
+    for (const t of ['R1', 'R2', 'R3'] as const) {
+      expect(REVIEW_TIER_DRIVER[t].driver).toBeTruthy();
+      expect(REVIEW_TIER_DRIVER[t].model).toBeTruthy();
+    }
+  });
+
+  it('R3 routes to claude-code-headless + opus (the heavy-reviewer tier)', () => {
+    expect(REVIEW_TIER_DRIVER.R3.driver).toBe('claude-code-headless');
+    expect(REVIEW_TIER_DRIVER.R3.model).toContain('opus');
+  });
+});
+
+// ─── path-classification helpers ─────────────────────────────────────────
+
+describe('isT5Shape', () => {
+  it.each([
+    ['chitin.yaml', true],
+    ['apps/some/chitin.yaml', true],
+    ['.chitin/policy.yaml', true],
+    ['some/.chitin/anything.txt', true],
+  ])('matches %s as T5-shape', (path, expected) => {
+    expect(isT5Shape(path)).toBe(expected);
+  });
+
+  it.each([
+    'apps/temporal-worker/src/dispatcher.ts',
+    'libs/contracts/src/execution-request.schema.ts',
+    'docs/swarm-backlog.md',
+    'README.md',
+    'chitin.config.ts',  // similar prefix, not the actual file
+  ])('does not match unrelated path %s', (path) => {
+    expect(isT5Shape(path)).toBe(false);
+  });
+});
+
+describe('isKernelInternal', () => {
+  it.each([
+    ['go/execution-kernel/internal/gov/normalize.go', true],
+    ['go/execution-kernel/internal/canon/normalize.go', true],
+    ['go/execution-kernel/internal/govhookinstall/install.go', true],
+    ['go/execution-kernel/internal/hookinstall/install.go', true],
+    ['go/execution-kernel/internal/driver/copilot/handler.go', true],
+    ['go/execution-kernel/internal/normalize/normalize.go', true],
+  ])('matches %s as kernel internal', (path, expected) => {
+    expect(isKernelInternal(path)).toBe(expected);
+  });
+
+  it.each([
+    'go/execution-kernel/cmd/chitin-kernel/main.go',
+    'apps/temporal-worker/src/dispatcher.ts',
+    'libs/contracts/src/event.schema.ts',
+  ])('does not match non-kernel-internal path %s', (path) => {
+    expect(isKernelInternal(path)).toBe(false);
+  });
+});
+
+describe('isSchemaFile', () => {
+  it('matches libs/contracts schema files', () => {
+    expect(isSchemaFile('libs/contracts/src/execution-request.schema.ts')).toBe(true);
+    expect(isSchemaFile('libs/contracts/src/event.schema.ts')).toBe(true);
+  });
+
+  it('does not match non-schema files in libs/contracts', () => {
+    expect(isSchemaFile('libs/contracts/src/index.ts')).toBe(false);
+    expect(isSchemaFile('libs/contracts/src/hash.ts')).toBe(false);
+  });
+
+  it('does not match schema files outside libs/contracts', () => {
+    expect(isSchemaFile('apps/foo/something.schema.ts')).toBe(false);
+  });
+});
+
+// ─── computeStartingTier — §5 trigger matrix, one row per case ───────────
+
+describe('computeStartingTier — default cases', () => {
+  it('returns R0 for a tiny diff with no special signals (the cheap-merge case)', () => {
+    const out = computeStartingTier(makePrMeta(), makeEntry());
+    expect(out.tier).toBe('R0');
+    expect(out.t5_shape).toBe(false);
+    expect(out.reasons).toEqual([]);
+  });
+
+  it('returns R0 for an empty file list (apply step couldn\'t enumerate; defer to size signals)', () => {
+    const out = computeStartingTier(makePrMeta({ files: [], diff_loc: 5, files_changed: 0 }), makeEntry());
+    expect(out.tier).toBe('R0');
+  });
+});
+
+describe('computeStartingTier — Copilot comment trigger (R1)', () => {
+  it('does not bump on 0/1/2 Copilot comments', () => {
+    for (const n of [0, 1, 2]) {
+      const out = computeStartingTier(makePrMeta({ copilot_comment_count: n }), makeEntry());
+      expect(out.tier).toBe('R0');
+    }
+  });
+
+  it('bumps to R1 on 3+ Copilot comments', () => {
+    const out = computeStartingTier(makePrMeta({ copilot_comment_count: 3 }), makeEntry());
+    expect(out.tier).toBe('R1');
+    expect(out.reasons.some((r) => r.includes('Copilot') && r.includes('3'))).toBe(true);
+  });
+
+  it('bumps to R1 on a high comment count without conflict', () => {
+    const out = computeStartingTier(makePrMeta({ copilot_comment_count: 12 }), makeEntry());
+    expect(out.tier).toBe('R1');
+  });
+
+  it('does not regress when copilot_comment_count is undefined (unknown ≠ trigger)', () => {
+    const out = computeStartingTier(makePrMeta({ copilot_comment_count: undefined }), makeEntry());
+    expect(out.tier).toBe('R0');
+  });
+});
+
+describe('computeStartingTier — diff size triggers (R2 mid, R3 high)', () => {
+  it('bumps to R2 at 201 LOC (just over mid threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 201, files_changed: 5 }), makeEntry());
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes('mid-size'))).toBe(true);
+  });
+
+  it('does NOT bump at exactly 200 LOC (boundary — > 200 is the rule)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 200, files_changed: 5 }), makeEntry());
+    expect(out.tier).toBe('R0');
+  });
+
+  it('bumps to R2 at 11 files (just over mid threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 50, files_changed: 11 }), makeEntry());
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes('mid-width'))).toBe(true);
+  });
+
+  it('bumps to R3 at 501 LOC (just over high threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 501, files_changed: 5 }), makeEntry());
+    expect(out.tier).toBe('R3');
+  });
+
+  it('bumps to R3 at 21 files (just over high threshold)', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 50, files_changed: 21 }), makeEntry());
+    expect(out.tier).toBe('R3');
+  });
+
+  it('attributes R3 to LOC when both LOC and files cross the high threshold', () => {
+    const out = computeStartingTier(makePrMeta({ diff_loc: 600, files_changed: 25 }), makeEntry());
+    expect(out.tier).toBe('R3');
+    // LOC is checked first in the high-cutoff branch — reason mentions LOC
+    expect(out.reasons.some((r) => r.includes('large diff'))).toBe(true);
+  });
+});
+
+describe('computeStartingTier — file-scope triggers', () => {
+  it('bumps to R2 minimum when touching a schema file', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['libs/contracts/src/execution-request.schema.ts'] }),
+      makeEntry(),
+    );
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes('schema'))).toBe(true);
+  });
+
+  it('bumps to R3 minimum when touching kernel internals (overrides R2 schema bump)', () => {
+    const out = computeStartingTier(
+      makePrMeta({
+        files: [
+          'libs/contracts/src/execution-request.schema.ts',
+          'go/execution-kernel/internal/gov/normalize.go',
+        ],
+      }),
+      makeEntry(),
+    );
+    expect(out.tier).toBe('R3');
+    expect(out.reasons.some((r) => r.includes('kernel internals'))).toBe(true);
+  });
+
+  it('flags t5_shape on chitin.yaml without bumping tier (gatekeeper handles T5)', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['chitin.yaml'] }),
+      makeEntry(),
+    );
+    expect(out.t5_shape).toBe(true);
+  });
+
+  it('flags t5_shape on .chitin/ paths', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['.chitin/something.yaml', 'apps/temporal-worker/src/foo.ts'] }),
+      makeEntry(),
+    );
+    expect(out.t5_shape).toBe(true);
+  });
+
+  it('does not flag t5_shape on schema files (those are R2 bump, not governance-self-mod)', () => {
+    const out = computeStartingTier(
+      makePrMeta({ files: ['libs/contracts/src/execution-request.schema.ts'] }),
+      makeEntry(),
+    );
+    expect(out.t5_shape).toBe(false);
+  });
+});
+
+describe('computeStartingTier — implementor-tier trigger', () => {
+  it.each(['T3', 'T4'] as const)('bumps to R2 when entry.tier = %s', (entryTier) => {
+    const out = computeStartingTier(makePrMeta(), makeEntry({ tier: entryTier }));
+    expect(out.tier).toBe('R2');
+    expect(out.reasons.some((r) => r.includes(entryTier))).toBe(true);
+  });
+
+  it.each(['T0', 'T1', 'T2'] as const)('does not bump for entry.tier = %s', (entryTier) => {
+    const out = computeStartingTier(makePrMeta(), makeEntry({ tier: entryTier }));
+    expect(out.tier).toBe('R0');
+  });
+});
+
+describe('computeStartingTier — multiple triggers compose to maximum', () => {
+  it('takes the max across multiple bump rules', () => {
+    // Schema (R2) + kernel-internals (R3) + T3 (R2) + 600 LOC (R3) + 4 comments (R1)
+    // → max = R3
+    const out = computeStartingTier(
+      makePrMeta({
+        diff_loc: 600,
+        files_changed: 8,
+        copilot_comment_count: 4,
+        files: [
+          'libs/contracts/src/execution-request.schema.ts',
+          'go/execution-kernel/internal/gov/normalize.go',
+        ],
+      }),
+      makeEntry({ tier: 'T3' }),
+    );
+    expect(out.tier).toBe('R3');
+    // All five rules should have contributed — reasons logs each
+    expect(out.reasons.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('R0 starting tier carries empty reasons (silent-default audit signal)', () => {
+    const out = computeStartingTier(makePrMeta(), makeEntry());
+    expect(out.tier).toBe('R0');
+    expect(out.reasons).toEqual([]);
+  });
+});
+
+// ─── shouldEscalateToOperator ─────────────────────────────────────────────
+
+describe('shouldEscalateToOperator', () => {
+  function out(overrides: Partial<ReviewerOutput> = {}): ReviewerOutput {
+    return {
+      decision: 'approve',
+      confidence: 'high',
+      findings: [],
+      ...overrides,
+    };
+  }
+
+  it('returns false for clean approve+high', () => {
+    expect(shouldEscalateToOperator(out())).toBe(false);
+  });
+
+  it('returns false for request_changes+high (handled by escalate-tier, not operator)', () => {
+    expect(shouldEscalateToOperator(out({ decision: 'request_changes' }))).toBe(false);
+  });
+
+  it('returns true on explicit decision: escalate', () => {
+    expect(shouldEscalateToOperator(out({ decision: 'escalate' }))).toBe(true);
+  });
+
+  it('returns true on confidence: low + at least one 🔴 finding', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'low',
+          findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false on confidence: low + only 🟡/🟢 findings (low confidence on nits is fine)', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'low',
+          findings: [
+            { severity: '🟡', file: 'x.ts', category: 'design', summary: 'nit' },
+            { severity: '🟢', file: 'x.ts', category: 'doc', summary: 'typo' },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false on confidence: medium + 🔴 finding (medium = trust the reviewer)', () => {
+    expect(
+      shouldEscalateToOperator(
+        out({
+          confidence: 'medium',
+          findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 's' }],
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// ─── maxTier helper ──────────────────────────────────────────────────────
+
+describe('maxTier', () => {
+  it.each([
+    ['R0', 'R0', 'R0'],
+    ['R0', 'R3', 'R3'],
+    ['R3', 'R0', 'R3'],
+    ['R2', 'R3', 'R3'],
+    ['R4', 'R4', 'R4'],
+  ] as [ReviewTier, ReviewTier, ReviewTier][])('maxTier(%s, %s) = %s', (a, b, expected) => {
+    expect(maxTier(a, b)).toBe(expected);
+  });
+});

--- a/apps/temporal-worker/test/reviewer-prompts.test.ts
+++ b/apps/temporal-worker/test/reviewer-prompts.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ReviewerOutputSchema,
+  ReviewerFindingSchema,
+  buildAdversarialReviewerPrompt,
+  parseReviewerOutput,
+  __test__,
+  type ReviewerPromptInputs,
+} from '../src/reviewer-prompts.ts';
+
+const { REVIEW_MARKER, TIER_TONE, STRUCTURED_OUTPUT_INSTRUCTIONS } = __test__;
+
+const baseInputs: ReviewerPromptInputs = {
+  tier: 'R3',
+  pr_number: 132,
+  pr_url: 'https://github.com/chitinhq/chitin/pull/132',
+  entry_id: 'review-graph-executor',
+};
+
+// ─── Schema validation ───────────────────────────────────────────────────
+
+describe('ReviewerFindingSchema', () => {
+  it('accepts a complete finding', () => {
+    const ok = {
+      severity: '🔴',
+      file: 'apps/temporal-worker/src/dispatcher.ts',
+      line: 42,
+      category: 'bug',
+      summary: 'something is broken',
+      suggested_fix: 'fix it like this',
+    };
+    expect(() => ReviewerFindingSchema.parse(ok)).not.toThrow();
+  });
+
+  it('accepts a finding without optional line/suggested_fix', () => {
+    const ok = {
+      severity: '🟡',
+      file: 'README.md',
+      category: 'doc',
+      summary: 'typo',
+    };
+    expect(() => ReviewerFindingSchema.parse(ok)).not.toThrow();
+  });
+
+  it('rejects an unknown severity emoji', () => {
+    const bad = { severity: '🔵', file: 'x.ts', category: 'bug', summary: 's' };
+    expect(() => ReviewerFindingSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects an unknown category', () => {
+    const bad = { severity: '🔴', file: 'x.ts', category: 'security', summary: 's' };
+    expect(() => ReviewerFindingSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects empty summary', () => {
+    const bad = { severity: '🔴', file: 'x.ts', category: 'bug', summary: '' };
+    expect(() => ReviewerFindingSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects negative line number', () => {
+    const bad = { severity: '🔴', file: 'x.ts', line: -1, category: 'bug', summary: 's' };
+    expect(() => ReviewerFindingSchema.parse(bad)).toThrow();
+  });
+});
+
+describe('ReviewerOutputSchema', () => {
+  it('accepts approve+empty findings', () => {
+    expect(() =>
+      ReviewerOutputSchema.parse({ decision: 'approve', confidence: 'high', findings: [] }),
+    ).not.toThrow();
+  });
+
+  it('accepts request_changes with multiple findings', () => {
+    const ok = {
+      decision: 'request_changes',
+      confidence: 'medium',
+      findings: [
+        { severity: '🔴', file: 'a.ts', category: 'bug', summary: 'crashes' },
+        { severity: '🟡', file: 'b.ts', category: 'design', summary: 'rename' },
+      ],
+    };
+    expect(() => ReviewerOutputSchema.parse(ok)).not.toThrow();
+  });
+
+  it('rejects unknown decision', () => {
+    const bad = { decision: 'merge_now', confidence: 'high', findings: [] };
+    expect(() => ReviewerOutputSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects unknown confidence', () => {
+    const bad = { decision: 'approve', confidence: 'absolute', findings: [] };
+    expect(() => ReviewerOutputSchema.parse(bad)).toThrow();
+  });
+});
+
+// ─── parseReviewerOutput ──────────────────────────────────────────────────
+
+describe('parseReviewerOutput', () => {
+  it('extracts a well-formed payload after the marker', () => {
+    const tail = `Some chatter from the agent.\n${REVIEW_MARKER}{"decision":"approve","confidence":"high","findings":[]}`;
+    const r = parseReviewerOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.output.decision).toBe('approve');
+  });
+
+  it('takes the LAST marker when multiple are present (echoed example in prompt vs. real output)', () => {
+    const tail = `Example from prompt: ${REVIEW_MARKER}{"decision":"approve","confidence":"high","findings":[]}\nReal output:\n${REVIEW_MARKER}{"decision":"request_changes","confidence":"medium","findings":[{"severity":"🔴","file":"x.ts","category":"bug","summary":"real bug"}]}`;
+    const r = parseReviewerOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.output.decision).toBe('request_changes');
+      expect(r.output.findings[0].severity).toBe('🔴');
+    }
+  });
+
+  it('returns ok:false when the marker is missing', () => {
+    const r = parseReviewerOutput('agent forgot to emit structured output');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('marker');
+  });
+
+  it('returns ok:false on malformed JSON after the marker', () => {
+    const r = parseReviewerOutput(`${REVIEW_MARKER}{"decision":"approve",}`);  // trailing comma
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('JSON.parse');
+  });
+
+  it('returns ok:false when JSON is valid but schema rejects (unknown decision)', () => {
+    const r = parseReviewerOutput(`${REVIEW_MARKER}{"decision":"merge_now","confidence":"high","findings":[]}`);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('schema');
+  });
+
+  it('returns ok:false when the post-marker content does not start with {', () => {
+    const r = parseReviewerOutput(`${REVIEW_MARKER}sorry no review today`);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('expected JSON object');
+  });
+
+  it('handles trailing newline + content after the JSON line gracefully (takes only the line)', () => {
+    const tail = `${REVIEW_MARKER}{"decision":"approve","confidence":"high","findings":[]}\nOh and one more thing...`;
+    const r = parseReviewerOutput(tail);
+    expect(r.ok).toBe(true);
+  });
+
+  it('roundtrips findings with line numbers', () => {
+    const tail = `${REVIEW_MARKER}{"decision":"request_changes","confidence":"high","findings":[{"severity":"🔴","file":"apps/temporal-worker/src/dispatcher.ts","line":372,"category":"bug","summary":"writeDispatchMarker fires before submit","suggested_fix":"reorder"}]}`;
+    const r = parseReviewerOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.output.findings[0].line).toBe(372);
+      expect(r.output.findings[0].suggested_fix).toBe('reorder');
+    }
+  });
+});
+
+// ─── buildAdversarialReviewerPrompt ──────────────────────────────────────
+
+describe('buildAdversarialReviewerPrompt', () => {
+  it('throws on R0 (Copilot bot — not dispatched programmatically)', () => {
+    expect(() => buildAdversarialReviewerPrompt({ ...baseInputs, tier: 'R0' })).toThrow(
+      /not a dispatchable reviewer tier/,
+    );
+  });
+
+  it('throws on R4 (operator escalation — not dispatched programmatically)', () => {
+    expect(() => buildAdversarialReviewerPrompt({ ...baseInputs, tier: 'R4' })).toThrow(
+      /not a dispatchable reviewer tier/,
+    );
+  });
+
+  it('produces a non-empty prompt for each dispatchable tier', () => {
+    for (const tier of ['R1', 'R2', 'R3'] as const) {
+      const out = buildAdversarialReviewerPrompt({ ...baseInputs, tier });
+      expect(out.length).toBeGreaterThan(500);
+    }
+  });
+
+  it('includes the PR number + URL + entry id in the prompt', () => {
+    const out = buildAdversarialReviewerPrompt(baseInputs);
+    expect(out).toContain('PR #132');
+    expect(out).toContain('https://github.com/chitinhq/chitin/pull/132');
+    expect(out).toContain('review-graph-executor');
+  });
+
+  it('includes the structured-output marker so the agent knows to emit it', () => {
+    const out = buildAdversarialReviewerPrompt(baseInputs);
+    expect(out).toContain('<<<REVIEW>>>');
+  });
+
+  it('includes severity rules + decision rules + confidence rules', () => {
+    const out = buildAdversarialReviewerPrompt(baseInputs);
+    expect(out).toContain('Severity rules');
+    expect(out).toContain('Decision rules');
+    expect(out).toContain('Confidence rules');
+    // Each severity emoji must appear in the rules section
+    expect(out).toContain('🔴');
+    expect(out).toContain('🟡');
+    expect(out).toContain('🟢');
+  });
+
+  it('R3 tone is more adversarial than R1', () => {
+    const r1 = buildAdversarialReviewerPrompt({ ...baseInputs, tier: 'R1' });
+    const r3 = buildAdversarialReviewerPrompt({ ...baseInputs, tier: 'R3' });
+    expect(r1).not.toContain('hostile reviewer');
+    expect(r3).toContain('hostile reviewer');
+  });
+
+  it('R2 names the bucket-B contamination signature as a 🔴 (the load-bearing diff-vs-scope check)', () => {
+    const r2 = buildAdversarialReviewerPrompt({ ...baseInputs, tier: 'R2' });
+    expect(r2).toContain('bucket-B');
+  });
+
+  it('renders the file: scope when provided', () => {
+    const out = buildAdversarialReviewerPrompt({
+      ...baseInputs,
+      entry_file_scope: 'apps/temporal-worker/src/foo.ts, libs/contracts/src/bar.ts',
+    });
+    expect(out).toContain('apps/temporal-worker/src/foo.ts');
+    expect(out).toContain('libs/contracts/src/bar.ts');
+  });
+
+  it('handles missing file: scope gracefully (degrades to "evaluate without scope check")', () => {
+    const out = buildAdversarialReviewerPrompt({ ...baseInputs, entry_file_scope: undefined });
+    expect(out).toContain('not declared');
+    expect(out).toContain('flag if the diff is suspiciously broad');
+  });
+
+  it('renders Copilot comments when provided', () => {
+    const out = buildAdversarialReviewerPrompt({
+      ...baseInputs,
+      copilot_comments: '- L42: typo\n- L100: missing null check',
+    });
+    expect(out).toContain('typo');
+    expect(out).toContain('missing null check');
+    expect(out).toContain('verify EACH one');
+  });
+
+  it("notes when Copilot hasn't reviewed yet", () => {
+    const out = buildAdversarialReviewerPrompt({ ...baseInputs, copilot_comments: undefined });
+    expect(out).toContain("hasn't landed yet");
+  });
+
+  it('renders prior reviewer findings when escalating', () => {
+    const out = buildAdversarialReviewerPrompt({
+      ...baseInputs,
+      prior_findings: '- 🔴 dispatcher.ts:42 — ordering bug',
+    });
+    expect(out).toContain('ordering bug');
+    expect(out).toContain('escalated to');
+  });
+
+  it("declares the reviewer is the first when there are no prior findings", () => {
+    const out = buildAdversarialReviewerPrompt({ ...baseInputs, prior_findings: undefined });
+    expect(out).toContain('first reviewer');
+  });
+
+  it('lists the agent tools (gh CLI + read + tests + telemetry)', () => {
+    const out = buildAdversarialReviewerPrompt(baseInputs);
+    expect(out).toContain('gh pr diff');
+    expect(out).toContain('gh pr view');
+    expect(out).toContain('python/analysis/');
+  });
+
+  it('says the reviewer must NOT push to the PR branch (boundary with implementor)', () => {
+    const out = buildAdversarialReviewerPrompt(baseInputs);
+    expect(out).toContain("NOT allowed to push");
+  });
+});
+
+// ─── End-to-end: build → mock agent output → parse round-trips ────────────
+
+describe('end-to-end prompt → parse', () => {
+  it('a well-formed agent response (matching the prompt example) parses cleanly', () => {
+    const prompt = buildAdversarialReviewerPrompt(baseInputs);
+    expect(prompt).toContain(REVIEW_MARKER);
+
+    // Mock what an obedient agent would emit
+    const mockTail = `Step-by-step review:
+- read dispatcher.ts:300-380
+- verified Copilot's L372 comment — confirmed, writeDispatchMarker fires before submit
+- ran existing tests; sigkill-propagation suite still green
+${REVIEW_MARKER}{"decision":"request_changes","confidence":"high","findings":[{"severity":"🔴","file":"apps/temporal-worker/src/dispatcher.ts","line":372,"category":"bug","summary":"writeDispatchMarker fires before client.workflow.start; if submit fails the marker is orphaned and the operator must rm to retry, but a fresh dispatch is what they actually want.","suggested_fix":"Move writeDispatchMarker after the workflow.start() try/catch — only mark on successful submit."}]}`;
+
+    const result = parseReviewerOutput(mockTail);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.output.decision).toBe('request_changes');
+      expect(result.output.confidence).toBe('high');
+      expect(result.output.findings).toHaveLength(1);
+      expect(result.output.findings[0].severity).toBe('🔴');
+      expect(result.output.findings[0].line).toBe(372);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Step 2 of 3 toward `review-graph-executor`. Replaces the `reviewer` role's stub PR #130 shipped with the real adversarial-review prompt builder + the structured-output parser the graph consumes.

**Stacked on #132** (depends on its `ReviewerOutput` / `ReviewerFinding` types). Merge order: #132 → this.

## What's in it

- **`src/reviewer-prompts.ts`** (~270 LOC):
  - `buildAdversarialReviewerPrompt({tier, pr_number, pr_url, entry_id, entry_file_scope?, copilot_comments?, prior_findings?})` — tier-specific tone (R1 quick-but-rigorous; R2 staff-engineer + bucket-B scope check; R3 hostile-reviewer + verify-each-Copilot-comment + telemetry cross-check). Throws on R0/R4 (non-dispatchable).
  - `parseReviewerOutput(stdoutTail)` — extracts `<<<REVIEW>>>{json}` from agent stdout. Takes the LAST marker (so a prompt example the agent echoes doesn't false-match), validates against zod. Returns `{ ok, output }` or `{ ok: false, error }`. Parse failure → graph escalates a tier.
  - `ReviewerOutputSchema` / `ReviewerFindingSchema` — strict zod validators. Severity constrained to the 3 emoji classes (🔴/🟡/🟢); hallucinated severities fail parse.
- **`src/role-prompts.ts`** — kept the `reviewer` stub but updated its docstring to point at `reviewer-prompts.ts` as the canonical caller. Stub only fires when a backlog entry explicitly declares `role: reviewer` at the dispatcher layer (rare). The rich reviewer prompt is for the review-graph workflow's child-workflow dispatch where the context (diff, prior findings, copilot comments) doesn't fit a single BacklogEntry.
- **35 new tests** in `test/reviewer-prompts.test.ts`. Coverage:
  - 6 finding-schema cases (severity emoji classes; category enum; line non-negative)
  - 4 output-schema cases
  - 8 parser cases (well-formed, last-marker-wins, missing marker, malformed JSON, schema-rejected JSON, non-JSON post-marker, trailing content tolerated, line-number roundtrip)
  - 15 prompt-builder cases (R0/R4 throw, R1/R2/R3 produce, content invariants, tier-tone differences, file-scope/Copilot/prior-findings render-or-fallback)
  - 1 end-to-end roundtrip (build prompt → mock agent emit → parse → assert structured output)

## Severity rules (load-bearing — embedded in prompt + schema)

- **🔴** = real bug. Blocks merge. Examples: incorrect logic, missing null/undefined guards, race conditions, security issues, runtime-crashing type errors.
- **🟡** = worth fixing but doesn't block merge. Examples: meaningful naming nits, missing tests for non-obvious branches, code-smell that will rot. Will feed `tech-debt-ledger` when that entry ships.
- **🟢** = cosmetic / doc / typo. Advisory only.

The graph escalates to operator on `decision: 'escalate'` OR `confidence: 'low'` AND any 🔴 finding. (Other gates — CI, bucket-B telemetry, T5-shape — are gatekeeper-layer concerns; see #132's `shouldEscalateToOperator` docstring.)

## What's NOT in this PR

- **The Temporal `reviewGraphWorkflow`** — step 3. This PR provides the prompt builder + parser; step 3 wires them into a multi-step workflow that calls `executeChild` per tier.
- **The dispatcher integration** (PR-opened → enqueue review-graph) — also step 3.
- **The auto-merge gatekeeper** — separate entry. Consumes the graph's final `ReviewerOutput`.

## Test plan

- [x] 35 new + 211/211 in `apps/temporal-worker`
- [ ] Read the prompt content (especially the `R3` block + structured-output instructions) — that's the load-bearing piece for whether `claude-opus-4-7` will reliably emit obedient JSON. Shape pushed back on if needed.
- [ ] Sanity-check the marker choice (`<<<REVIEW>>>`) — should it be HTML-comment-shaped (`<!-- REVIEW -->`) or something less likely to appear in arbitrary code/docs? Current marker is a plain string; very unlikely to false-match in code, but worth a 30-second think.