### PR TITLE
feat(phase-2): review-graph Temporal workflow + loop logic (step 3 of 3)

### DIFF
--- a/apps/temporal-worker/src/review-graph-workflow.ts
+++ b/apps/temporal-worker/src/review-graph-workflow.ts
@@ -119,6 +119,12 @@ export async function runReviewGraphLoop(
   const tier_log: ReviewGraphResult['tier_log'] = [];
   let tier: ReviewTier = decision.tier;
   let priorFindings: string | undefined;
+  // Track the last successful parse separately so the fallthrough
+  // return can surface it even when the FINAL tier's emit didn't
+  // parse. tier_log[last].output would lose earlier parses in that
+  // case — the docstring on ReviewGraphResult.output promises "the
+  // last successful parse, when one happened".
+  let lastParsedOutput: ReviewerOutput | undefined;
 
   // Skip R0 — it's the GH Copilot bot, fires server-side, not
   // dispatched. If computeStartingTier returned R0, bump to R1 to
@@ -151,6 +157,7 @@ export async function runReviewGraphLoop(
     }
 
     tier_log.push({ tier, parsed: true, output: parsed.output });
+    lastParsedOutput = parsed.output;
 
     // R3-only: operator-escalation rule
     if (tier === 'R3' && shouldEscalateToOperator(parsed.output)) {
@@ -231,7 +238,7 @@ export async function runReviewGraphLoop(
   return {
     final_tier: lastEntry?.tier ?? 'R3',
     action,
-    output: lastEntry?.output,
+    output: lastParsedOutput,
     t5_shape: decision.t5_shape,
     tier_log,
   };
@@ -286,7 +293,7 @@ function buildReviewerRequest(
   // for the reviewer path we want the explicit REVIEW_TIER_MODEL
   // not the implementor's tier-routing. Passing tier here is a
   // hint; the actual model lock-down lives in the env override.
-  const reviewerWorkflowId = `${input.parent_workflow_id}-rev${tier.toLowerCase()}`;
+  const reviewerWorkflowId = deriveReviewerWorkflowId(input.parent_workflow_id, tier);
 
   return ExecutionRequestSchema.parse({
     schema_version: '1',
@@ -312,16 +319,53 @@ function buildReviewerRequest(
 }
 
 /**
- * Map a review tier to a step_index for the parent workflow chain.
- * R1=1, R2=2, R3=3 — matches the schema's max=3 cap exactly. The R0
- * GH-bot review is step 0 (passive observation, not dispatched), so
- * the chain's step_index field counts dispatched reviewer steps.
+ * Map a review tier to its 0-based step_index. Each dispatched
+ * reviewer turn is one iteration of the escalation loop; R1 is the
+ * first iteration (step 0), R2 the second (1), R3 the third (2).
+ * Mirrors Lobster's loop.maxIterations counter as the schema
+ * docstring describes.
+ *
+ * R0 (GH bot) doesn't dispatch through Temporal — its findings come
+ * in via copilot_comments, not a workflow turn — so it has no
+ * step_index. R4 is the operator-pickup terminator, also not
+ * dispatched.
  */
-function tierAsStepIndex(tier: ReviewTier): 1 | 2 | 3 {
-  if (tier === 'R1') return 1;
-  if (tier === 'R2') return 2;
-  if (tier === 'R3') return 3;
+function tierAsStepIndex(tier: ReviewTier): 0 | 1 | 2 {
+  if (tier === 'R1') return 0;
+  if (tier === 'R2') return 1;
+  if (tier === 'R3') return 2;
   throw new Error(`tier ${tier} has no step_index`);
+}
+
+// Maximum length Temporal allows for a workflow_id / run_id (matches
+// TemporalIdSchema in @chitin/contracts). When the parent's
+// workflow_id is already at the cap, naively concatenating "-revrN"
+// overflows and ExecutionRequestSchema.parse() rejects the request.
+const TEMPORAL_WORKFLOW_ID_MAX = 128;
+
+// run_id is constructed as `${workflow_id}${RUN_ID_SUFFIX}`. Both
+// fields share the 128-char regex cap, so workflow_id has to leave
+// room for this suffix — that's why the cap below is tighter than
+// TEMPORAL_WORKFLOW_ID_MAX.
+const RUN_ID_SUFFIX = '-attempt-1';
+
+/**
+ * Derive a reviewer workflow_id from the parent + tier, guaranteeing
+ * BOTH the result and its derived `<workflow_id>-attempt-1` run_id
+ * fit TemporalIdSchema (<=128 chars). The suffix is fixed length
+ * ("-revrN" = 6 chars), so when the parent leaves no room we truncate
+ * it. We keep the parent's prefix readable when possible (operator
+ * can grep the gov-decisions chain by the parent prefix); truncation
+ * is a fallback for the edge case.
+ */
+function deriveReviewerWorkflowId(parentId: string, tier: ReviewTier): string {
+  const suffix = `-rev${tier.toLowerCase()}`; // e.g. "-revr1"
+  // Headroom is the cap minus BOTH our suffix AND the run_id suffix
+  // the schema-parse step appends downstream — otherwise a 128-char
+  // workflow_id would push run_id past the cap.
+  const headroom = TEMPORAL_WORKFLOW_ID_MAX - suffix.length - RUN_ID_SUFFIX.length;
+  const head = parentId.length > headroom ? parentId.slice(0, headroom) : parentId;
+  return `${head}${suffix}`;
 }
 
 /**
@@ -383,4 +427,6 @@ export const __test__ = {
   formatFindingsForNextTier,
   formatParseFailureForNextTier,
   tierAsStepIndex,
+  deriveReviewerWorkflowId,
+  TEMPORAL_WORKFLOW_ID_MAX,
 };

--- a/apps/temporal-worker/src/review-graph-workflow.ts
+++ b/apps/temporal-worker/src/review-graph-workflow.ts
@@ -1,0 +1,386 @@
+// Phase 2 step 3 of the swarm-as-software-factory design. The Temporal
+// workflow that executes the §5 review-tier escalation chain end-to-end:
+//
+//   compute starting tier
+//   loop:
+//     dispatch reviewer at current tier (executeChild)
+//     parse the structured output
+//     decide: approve / request-changes / escalate-tier / escalate-operator
+//     if approve / request-changes / escalate-operator → return
+//     if escalate-tier → bump tier, carry findings forward, recurse
+//   terminate at R4 (operator pickup) if no other branch fired
+//
+// The loop logic is a pure function (`runReviewGraphLoop`) that takes
+// a `reviewerDispatch` callback. The Temporal wrapper
+// (`reviewGraphWorkflow`) hands it `executeChild(executeRequestWorkflow, ...)`.
+// Tests pass a mock callback so we don't need a Temporal runtime in
+// the unit suite.
+//
+// Dispatcher integration (auto-enqueue this workflow after a programmer
+// workflow opens a PR) lands in a follow-up slice. This PR ships the
+// workflow itself so it's reviewable in isolation; the dispatcher edit
+// is the next step.
+
+import { executeChild } from '@temporalio/workflow';
+import {
+  ExecutionRequestSchema,
+  type ExecutionRequest,
+  type DriverId,
+  type Tier,
+} from '@chitin/contracts';
+import type { ActivityResult } from './activity-types.ts';
+import type { executeRequestWorkflow } from './workflow.ts';
+import {
+  REVIEW_TIER_DRIVER,
+  REVIEW_TIER_WALL_TIMEOUT_S,
+  REVIEW_TIER_MAX_TOOL_CALLS,
+  computeStartingTier,
+  escalateOneTier,
+  shouldEscalateToOperator,
+  type PrMeta,
+  type ReviewTier,
+  type ReviewerOutput,
+  type ReviewerFinding,
+} from './review-graph.ts';
+import {
+  buildAdversarialReviewerPrompt,
+  parseReviewerOutput,
+} from './reviewer-prompts.ts';
+import type { BacklogEntry } from './grooming/parse-backlog.ts';
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+/**
+ * Input the dispatcher hands the review-graph workflow when a
+ * programmer workflow has opened a PR. The workflow uses this to
+ * compute the starting tier + construct each reviewer's prompt.
+ */
+export interface ReviewGraphInput {
+  parent_workflow_id: string;
+  pr_meta: PrMeta;
+  /** The originating backlog entry — used for tier rules + scope checks. */
+  entry: BacklogEntry;
+  /** Inline review comments from Copilot's GH bot, if R0 has settled by
+   *  the time the dispatcher invokes us. May be undefined; we proceed
+   *  with `copilot_comments=undefined` in the prompt and don't bump
+   *  on the comment-count signal in computeStartingTier. */
+  copilot_comments?: string;
+  /** Repo slug — needed when we construct reviewer ExecutionRequests. */
+  repo: string;
+}
+
+/**
+ * Final action the review-graph terminates with. The gatekeeper
+ * (separate slice) consumes this to decide auto-merge vs. escalate
+ * vs. wait-for-implementor.
+ */
+export type ReviewGraphAction =
+  | 'approve'                    // all reviewers said approve; gatekeeper checks other gates + merges
+  | 'request-changes'            // a reviewer wants implementor changes (with high/medium confidence)
+  | 'escalate-to-operator'       // R3 returned low confidence OR explicit escalate; human pickup
+  | 'parse-failure-at-r4';       // every tier's output failed to parse; chain ran out of tiers
+
+export interface ReviewGraphResult {
+  final_tier: ReviewTier;
+  action: ReviewGraphAction;
+  /** The last successful parse, when one happened. Undefined when
+   *  every tier produced unparseable output. */
+  output?: ReviewerOutput;
+  /** Whether `t5_shape` was detected on input. The gatekeeper escalates
+   *  on this regardless of `action`. */
+  t5_shape: boolean;
+  /** Tier-by-tier audit trail. Each entry: tier the chain visited,
+   *  whether the reviewer's emit parsed, the parsed output if so. */
+  tier_log: Array<{
+    tier: ReviewTier;
+    parsed: boolean;
+    output?: ReviewerOutput;
+    error?: string;
+  }>;
+}
+
+/** The shape the loop calls when it needs to dispatch a reviewer. The
+ *  Temporal wrapper passes a function that calls `executeChild`; tests
+ *  pass a mock that returns canned `ActivityResult`s. */
+export type ReviewerDispatch = (req: ExecutionRequest) => Promise<ActivityResult>;
+
+// ─── Pure loop ─────────────────────────────────────────────────────────────
+
+/**
+ * Run the review-tier escalation loop. Pure modulo `reviewerDispatch`,
+ * which the caller injects. Does NOT contain any Temporal API calls —
+ * the Temporal wrapper around this is `reviewGraphWorkflow` below.
+ */
+export async function runReviewGraphLoop(
+  input: ReviewGraphInput,
+  reviewerDispatch: ReviewerDispatch,
+): Promise<ReviewGraphResult> {
+  const decision = computeStartingTier(input.pr_meta, input.entry);
+  const tier_log: ReviewGraphResult['tier_log'] = [];
+  let tier: ReviewTier = decision.tier;
+  let priorFindings: string | undefined;
+
+  // Skip R0 — it's the GH Copilot bot, fires server-side, not
+  // dispatched. If computeStartingTier returned R0, bump to R1 to
+  // start the dispatched chain. (R0's findings — copilot_comments —
+  // are read in the prompt, not via dispatch.)
+  if (tier === 'R0') tier = 'R1';
+
+  // Saturate at R3 — beyond that we escalate to operator (R4) without
+  // a dispatched step.
+  //
+  // Operator-escalation (`shouldEscalateToOperator`) only applies AT
+  // R3: the heaviest dispatchable reviewer saying "I can't decide" or
+  // "kick this up" is the operator's pickup signal. From R1/R2,
+  // those same outputs (`confidence: low` / `decision: escalate`)
+  // mean "let a heavier reviewer take it" — bump tier, not operator.
+  while (tier === 'R1' || tier === 'R2' || tier === 'R3') {
+    const reviewerReq = buildReviewerRequest(input, tier, priorFindings);
+    const result = await reviewerDispatch(reviewerReq);
+    const parsed = parseReviewerOutput(result.stdout_tail);
+
+    if (!parsed.ok) {
+      tier_log.push({ tier, parsed: false, error: parsed.error });
+      // Treat unparseable output as a low-confidence signal — escalate
+      // one tier. If we were already at R3, the next iteration's
+      // `tier` will be R4 and the while-loop falls through to the
+      // operator-escalation terminator below.
+      tier = escalateOneTier(tier);
+      priorFindings = formatParseFailureForNextTier(parsed.error, priorFindings);
+      continue;
+    }
+
+    tier_log.push({ tier, parsed: true, output: parsed.output });
+
+    // R3-only: operator-escalation rule
+    if (tier === 'R3' && shouldEscalateToOperator(parsed.output)) {
+      return {
+        final_tier: tier,
+        action: 'escalate-to-operator',
+        output: parsed.output,
+        t5_shape: decision.t5_shape,
+        tier_log,
+      };
+    }
+
+    // R1/R2: low-confidence OR decision:escalate → bump tier (heavier
+    // reviewer takes the call). At R3 these would have been caught
+    // by the operator-escalation branch above; reaching here at
+    // R1/R2 means the chain continues.
+    if (
+      tier !== 'R3' &&
+      (parsed.output.confidence === 'low' || parsed.output.decision === 'escalate')
+    ) {
+      tier = escalateOneTier(tier);
+      priorFindings = formatFindingsForNextTier(parsed.output.findings, priorFindings);
+      continue;
+    }
+
+    if (parsed.output.decision === 'approve') {
+      return {
+        final_tier: tier,
+        action: 'approve',
+        output: parsed.output,
+        t5_shape: decision.t5_shape,
+        tier_log,
+      };
+    }
+
+    if (parsed.output.decision === 'request_changes') {
+      // High/medium confidence + request_changes → loop terminates;
+      // gatekeeper re-dispatches the implementor with the findings.
+      // (R3 + low confidence + request_changes was already caught by
+      // the operator-escalation branch above.)
+      return {
+        final_tier: tier,
+        action: 'request-changes',
+        output: parsed.output,
+        t5_shape: decision.t5_shape,
+        tier_log,
+      };
+    }
+
+    // Defensive fallthrough: decision='escalate' at R3 with high/medium
+    // confidence. shouldEscalateToOperator already returned true (it
+    // fires on decision='escalate' regardless of confidence), so this
+    // path is unreachable. Kept for type completeness.
+    return {
+      final_tier: tier,
+      action: 'escalate-to-operator',
+      output: parsed.output,
+      t5_shape: decision.t5_shape,
+      tier_log,
+    };
+  }
+
+  // Fell out of the loop with tier saturated past R3. Either every
+  // tier escalated, or every tier produced unparseable output
+  // (parse-failure cascade). Either way → operator. Distinguish in
+  // `action` so telemetry can separate the two failure modes.
+  //
+  // `final_tier` reports the LAST DISPATCHED tier (R3 here), not R4.
+  // R4 is the action category (operator pickup), not a tier the chain
+  // visited. Telemetry consumers reading `tier_log` see exactly which
+  // tiers ran.
+  const lastEntry = tier_log[tier_log.length - 1];
+  const action: ReviewGraphAction =
+    lastEntry && !lastEntry.parsed && tier_log.every((e) => !e.parsed)
+      ? 'parse-failure-at-r4'
+      : 'escalate-to-operator';
+
+  return {
+    final_tier: lastEntry?.tier ?? 'R3',
+    action,
+    output: lastEntry?.output,
+    t5_shape: decision.t5_shape,
+    tier_log,
+  };
+}
+
+// ─── Reviewer ExecutionRequest construction ────────────────────────────────
+
+/**
+ * Build an `ExecutionRequest` for the reviewer at `tier`. The agent
+ * is told (via the prompt) what role it's playing and what to emit.
+ * Driver + model + bounds come from REVIEW_TIER_DRIVER / WALL_TIMEOUT
+ * / MAX_TOOL_CALLS.
+ *
+ * Each reviewer dispatch gets a deterministic-but-unique workflow_id
+ * derived from the parent + tier so the chain is traversable via
+ * gov-decisions and the temporal UI.
+ */
+function buildReviewerRequest(
+  input: ReviewGraphInput,
+  tier: ReviewTier,
+  priorFindings: string | undefined,
+): ExecutionRequest {
+  const tierConfig = REVIEW_TIER_DRIVER[tier];
+  if (!tierConfig.driver) {
+    throw new Error(`tier ${tier} is not a dispatchable reviewer tier (R0/R4 are non-dispatchable)`);
+  }
+
+  if (input.pr_meta.pr_number === undefined || !input.pr_meta.pr_url) {
+    throw new Error('pr_meta.pr_number and pr_meta.pr_url are required for reviewer dispatch');
+  }
+
+  const prompt = buildAdversarialReviewerPrompt({
+    tier,
+    pr_number: input.pr_meta.pr_number,
+    pr_url: input.pr_meta.pr_url,
+    entry_id: input.entry.id,
+    entry_file_scope: input.entry.file,
+    copilot_comments: input.copilot_comments,
+    prior_findings: priorFindings,
+  });
+
+  // Map review-tier driver string to the typed DriverId. R3's
+  // 'claude-code-headless' is already that exact id; R1+R2 use
+  // 'copilot' (the Copilot CLI driver). REVIEW_TIER_MODEL is the
+  // tier-specific model passed via env override (next slice wires
+  // `CHITIN_MODEL_<DRIVER>_REV<TIER>` if/when we want per-review-tier
+  // model selection — for now the driver's default tier-model wins).
+  const driver = tierConfig.driver as DriverId;
+
+  // Reviewer workflows run at "T2" tier (mid-cost reasoning). The
+  // ExecutionRequestSchema's tier field drives model resolution —
+  // for the reviewer path we want the explicit REVIEW_TIER_MODEL
+  // not the implementor's tier-routing. Passing tier here is a
+  // hint; the actual model lock-down lives in the env override.
+  const reviewerWorkflowId = `${input.parent_workflow_id}-rev${tier.toLowerCase()}`;
+
+  return ExecutionRequestSchema.parse({
+    schema_version: '1',
+    workflow_id: reviewerWorkflowId,
+    run_id: `${reviewerWorkflowId}-attempt-1`,
+    repo: input.repo,
+    task_class: 'exploration',         // reviewers don't write code
+    risk_level: 'low',
+    allowed_drivers: [driver],
+    network_policy: 'allowlist',       // gh CLI + git read needed
+    write_policy: 'none',              // reviewer must NOT push (boundary with implementor)
+    bounds: {
+      max_tool_calls: REVIEW_TIER_MAX_TOOL_CALLS[tier],
+      max_cost_usd: tier === 'R3' ? 1.0 : 0,   // R3 caps cost; R1/R2 are free under Copilot Pro
+      wall_timeout_s: REVIEW_TIER_WALL_TIMEOUT_S[tier],
+    },
+    prompt,
+    tier: 'T2' as Tier,                // model-tier hint; review-graph picks via REVIEW_TIER_DRIVER
+    role: 'reviewer',
+    parent_workflow_id: input.parent_workflow_id,
+    step_index: tierAsStepIndex(tier),
+  });
+}
+
+/**
+ * Map a review tier to a step_index for the parent workflow chain.
+ * R1=1, R2=2, R3=3 — matches the schema's max=3 cap exactly. The R0
+ * GH-bot review is step 0 (passive observation, not dispatched), so
+ * the chain's step_index field counts dispatched reviewer steps.
+ */
+function tierAsStepIndex(tier: ReviewTier): 1 | 2 | 3 {
+  if (tier === 'R1') return 1;
+  if (tier === 'R2') return 2;
+  if (tier === 'R3') return 3;
+  throw new Error(`tier ${tier} has no step_index`);
+}
+
+/**
+ * Format prior reviewer's findings as a bullet list the next tier's
+ * prompt can consume. Limited to the most recent reviewer's findings
+ * (don't pile up across the chain — keeps the prompt tight).
+ */
+function formatFindingsForNextTier(
+  findings: ReviewerFinding[],
+  _existingPrior: string | undefined,
+): string {
+  if (findings.length === 0) {
+    return 'previous reviewer requested escalation but produced no findings';
+  }
+  return findings
+    .map((f) => {
+      const loc = f.line ? `${f.file}:${f.line}` : f.file;
+      const fix = f.suggested_fix ? ` [suggested: ${f.suggested_fix}]` : '';
+      return `- ${f.severity} ${loc} (${f.category}): ${f.summary}${fix}`;
+    })
+    .join('\n');
+}
+
+/**
+ * When a tier's output failed to parse, format that as a "prior
+ * findings" entry the next tier can read. Treats unparseable output
+ * as a kind of low-confidence-on-something signal worth flagging.
+ */
+function formatParseFailureForNextTier(
+  parseError: string,
+  existingPrior: string | undefined,
+): string {
+  const note = `- 🟡 [parse-failure] previous reviewer's structured output failed to parse: ${parseError}. Treat this PR as if no review has happened at the previous tier.`;
+  return existingPrior ? `${existingPrior}\n${note}` : note;
+}
+
+// ─── Temporal wrapper ──────────────────────────────────────────────────────
+
+/**
+ * The Temporal workflow chitin's review-graph runs as. Thin shell —
+ * dispatches each reviewer via `executeChild(executeRequestWorkflow,
+ * ...)` and delegates loop logic to runReviewGraphLoop.
+ *
+ * Register in worker.ts's workflowsPath module (workflow.ts re-export)
+ * before the dispatcher can call `client.workflow.start(...)` with
+ * this name.
+ */
+export async function reviewGraphWorkflow(input: ReviewGraphInput): Promise<ReviewGraphResult> {
+  return runReviewGraphLoop(input, async (req) => {
+    return await executeChild<typeof executeRequestWorkflow>('executeRequestWorkflow', {
+      args: [req],
+      workflowId: req.workflow_id,
+    });
+  });
+}
+
+export const __test__ = {
+  buildReviewerRequest,
+  formatFindingsForNextTier,
+  formatParseFailureForNextTier,
+  tierAsStepIndex,
+};

--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -59,6 +59,33 @@ export const REVIEW_TIER_DRIVER: Record<ReviewTier, { driver: string | null; mod
 };
 
 /**
+ * Per-tier resource bounds. R1 is fast + cheap (small diffs go through
+ * here); R3 gets enough wall time and tool-calls to actually walk a
+ * hard PR. R0 + R4 are non-dispatchable so values are 0.
+ *
+ * Lifted from the closed PR #133's review-graph attempt — the swarm's
+ * intuition there was right even though the rest of the implementation
+ * skipped the design-doc-first plan. Per-tier bounds keep cost-shaped:
+ * R3 (Opus, $0.10–0.50/run) gets generous timeouts because cancelling
+ * a partially-done Opus run costs as much as letting it finish.
+ */
+export const REVIEW_TIER_WALL_TIMEOUT_S: Record<ReviewTier, number> = {
+  R0: 0,
+  R1: 600,    // 10 min
+  R2: 900,    // 15 min
+  R3: 1800,   // 30 min — Opus on a hard PR
+  R4: 0,
+};
+
+export const REVIEW_TIER_MAX_TOOL_CALLS: Record<ReviewTier, number> = {
+  R0: 0,
+  R1: 20,
+  R2: 30,
+  R3: 60,
+  R4: 0,
+};
+
+/**
  * Inputs to `computeStartingTier`. Captures the PR-side state the
  * dispatcher learns at apply-step time, plus the originating entry
  * so file-scope and implementor-tier checks have what they need.
@@ -86,6 +113,12 @@ export interface PrMeta {
    *  decisions. Surfaced in tier-decision logs so the chain can be
    *  traversed back to the PR. */
   pr_url?: string;
+  /** PR number — required by the workflow loop so it can construct
+   *  reviewer prompts (which name the PR# explicitly so the agent
+   *  can `gh pr diff <num>` etc.). Optional in the
+   *  `computeStartingTier` path (which doesn't need it), required
+   *  by the workflow runner. */
+  pr_number?: number;
 }
 
 /**

--- a/apps/temporal-worker/src/reviewer-prompts.ts
+++ b/apps/temporal-worker/src/reviewer-prompts.ts
@@ -26,12 +26,21 @@
 //   🟡 = worth fixing but doesn't block merge (feeds tech-debt-ledger)
 //   🟢 = doc / nit / cosmetic, advisory only
 //
-// The graph escalates on:
-//   - explicit decision: 'escalate'
-//   - confidence: 'low' AND any 🔴 finding
-//   (other gates — CI, bucket-B telemetry, T5-shape — are gatekeeper-
-//    layer concerns; see review-graph.ts shouldEscalateToOperator
-//    docstring.)
+// The graph escalates to the OPERATOR (not a tier-bump) on:
+//   - explicit decision: 'escalate' from R3
+//   - confidence: 'low' from R3 (the heaviest dispatchable reviewer
+//     saying "I can't decide" is the operator-pickup signal — Jared's
+//     policy: "if Headless Claude Opus can't figure it out, escalate
+//     to me." Findings count is not a precondition; an Opus run
+//     without smoking guns but low confidence still warrants a human
+//     look, since by the time we've climbed to R3 the cheaper
+//     reviewers couldn't decide either.)
+// Tier-bump (R1/R2 with the same outputs) is a separate path — the
+// loop in review-graph-workflow.ts handles that before consulting
+// shouldEscalateToOperator.
+// Other gates — CI, bucket-B telemetry, T5-shape — are gatekeeper-
+// layer concerns; see review-graph.ts shouldEscalateToOperator
+// docstring.
 
 import { z } from 'zod';
 import type { ReviewerOutput, ReviewerFinding, ReviewTier } from './review-graph.ts';

--- a/apps/temporal-worker/src/workflow.ts
+++ b/apps/temporal-worker/src/workflow.ts
@@ -2,10 +2,18 @@ import { proxyActivities } from '@temporalio/workflow';
 import type { ExecutionRequest } from '@chitin/contracts';
 import type { ActivityResult } from './activity-types.ts';
 
+// startToCloseTimeout is the Temporal-level kill switch on the activity.
+// It must dominate every wall_timeout_s the dispatcher or review-graph
+// can configure, otherwise Temporal cuts the agent short before the
+// activity's own SIGKILL fires (slice 7a). Current ceilings:
+//   - dispatcher.ts: implementor T2/T3/T4 = 1800s (30 min)
+//   - review-graph.ts: R3 = 1800s (30 min)
+// Plus ~60s buffer for the activity's startup + its own SIGKILL grace.
+// 31 minutes covers both. Bump in lockstep if any tier's wall climbs.
 const { runAgentTurn } = proxyActivities<{
   runAgentTurn(req: ExecutionRequest): Promise<ActivityResult>;
 }>({
-  startToCloseTimeout: '15 minutes',
+  startToCloseTimeout: '31 minutes',
   retry: { maximumAttempts: 1 },
 });
 

--- a/apps/temporal-worker/test/review-graph-workflow.helpers.ts
+++ b/apps/temporal-worker/test/review-graph-workflow.helpers.ts
@@ -1,0 +1,54 @@
+// Test helpers for review-graph-workflow tests. Mock reviewer
+// dispatchers (canned outputs per tier) + a tiny mock-output builder
+// that synthesizes the agent's stdout_tail from a structured
+// ReviewerOutput.
+
+import type { ReviewerOutput, ReviewTier } from '../src/review-graph.ts';
+import type { ReviewerDispatch } from '../src/review-graph-workflow.ts';
+import type { ActivityResult } from '../src/activity-types.ts';
+
+export const REVIEW_MARKER_FOR_TEST = '<<<REVIEW>>>';
+
+/**
+ * Synthesize the agent's stdout_tail from a structured ReviewerOutput.
+ * Mirrors what the agent is instructed to emit by
+ * STRUCTURED_OUTPUT_INSTRUCTIONS in reviewer-prompts.ts.
+ */
+export function buildMockReviewerOutput(
+  out: Partial<ReviewerOutput> & { decision: ReviewerOutput['decision']; confidence: ReviewerOutput['confidence'] },
+): ActivityResult {
+  const full: ReviewerOutput = {
+    decision: out.decision,
+    confidence: out.confidence,
+    findings: out.findings ?? [],
+  };
+  return {
+    exit_code: 0,
+    stdout_tail: `Agent walking through review...\n${REVIEW_MARKER_FOR_TEST}${JSON.stringify(full)}`,
+    stderr_tail: '',
+    duration_ms: 60_000,
+  };
+}
+
+/**
+ * Build a `ReviewerDispatch` callback that returns canned results
+ * keyed by review tier. The dispatcher infers the tier from the
+ * request's workflow_id (which the workflow loop sets to
+ * `<parent>-revr<tier-lower>`).
+ */
+export function makeMockDispatcher(
+  outputs: Partial<Record<ReviewTier, ActivityResult>>,
+): ReviewerDispatch {
+  return async (req) => {
+    const tierMatch = req.workflow_id.match(/-revr([0-4])$/);
+    if (!tierMatch) {
+      throw new Error(`mock dispatcher: workflow_id ${req.workflow_id} doesn't end with -revrN`);
+    }
+    const tier = `R${tierMatch[1]}` as ReviewTier;
+    const canned = outputs[tier];
+    if (!canned) {
+      throw new Error(`mock dispatcher: no canned output for ${tier} (provided: ${Object.keys(outputs).join(', ')})`);
+    }
+    return canned;
+  };
+}

--- a/apps/temporal-worker/test/review-graph-workflow.test.ts
+++ b/apps/temporal-worker/test/review-graph-workflow.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REVIEW_MARKER_FOR_TEST,
+  buildMockReviewerOutput,
+  makeMockDispatcher,
+} from './review-graph-workflow.helpers.ts';
+import {
+  runReviewGraphLoop,
+  __test__,
+  type ReviewGraphInput,
+  type ReviewerDispatch,
+} from '../src/review-graph-workflow.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+import type { PrMeta, ReviewerFinding } from '../src/review-graph.ts';
+
+const { buildReviewerRequest, formatFindingsForNextTier, tierAsStepIndex } = __test__;
+
+function makeEntry(overrides: Partial<BacklogEntry> = {}): BacklogEntry {
+  return {
+    id: 'sample',
+    status: 'ready',
+    description: 'sample',
+    rawFrontmatter: '```yaml\nid: sample\n```',
+    rawSection: '### sample',
+    tier: 'T1',
+    file: 'apps/temporal-worker/src/foo.ts',
+    ...overrides,
+  };
+}
+
+function makePrMeta(overrides: Partial<PrMeta> = {}): PrMeta {
+  return {
+    diff_loc: 50,
+    files_changed: 2,
+    files: ['apps/temporal-worker/src/foo.ts'],
+    pr_number: 132,
+    pr_url: 'https://github.com/chitinhq/chitin/pull/132',
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<ReviewGraphInput> = {}): ReviewGraphInput {
+  return {
+    parent_workflow_id: 'swarm-parent-12345',
+    pr_meta: makePrMeta(),
+    entry: makeEntry(),
+    repo: 'chitinhq/chitin',
+    ...overrides,
+  };
+}
+
+// ─── Loop control flow — happy path ──────────────────────────────────────
+
+describe('runReviewGraphLoop — happy path', () => {
+  it('approves at R1 when first reviewer says approve+high', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R1');
+    expect(result.tier_log).toHaveLength(1);
+    expect(result.tier_log[0].tier).toBe('R1');
+    expect(result.tier_log[0].parsed).toBe(true);
+  });
+
+  it('starts at R2 when computeStartingTier bumps (T3 implementor)', async () => {
+    const dispatcher = makeMockDispatcher({
+      R2: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(
+      makeInput({ entry: makeEntry({ tier: 'T3' }) }),
+      dispatcher,
+    );
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R2');
+    expect(result.tier_log[0].tier).toBe('R2');
+  });
+
+  it('starts at R3 when kernel internals are touched', async () => {
+    const dispatcher = makeMockDispatcher({
+      R3: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(
+      makeInput({ pr_meta: makePrMeta({ files: ['go/execution-kernel/internal/gov/normalize.go'] }) }),
+      dispatcher,
+    );
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R3');
+  });
+});
+
+// ─── Loop control flow — escalation ──────────────────────────────────────
+
+describe('runReviewGraphLoop — escalation', () => {
+  it('escalates from R1 → R2 when R1 returns decision: escalate', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R2: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R2');
+    expect(result.tier_log.map((e) => e.tier)).toEqual(['R1', 'R2']);
+  });
+
+  it('escalates R1 → R2 → R3 when both lower tiers escalate', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R2: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R3: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R3');
+    expect(result.tier_log.map((e) => e.tier)).toEqual(['R1', 'R2', 'R3']);
+  });
+
+  it('escalates to operator when R3 returns confidence: low (the headline rule)', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R2: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R3: buildMockReviewerOutput({
+        decision: 'request_changes',
+        confidence: 'low',
+        findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 'unsure' }],
+      }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('escalate-to-operator');
+    expect(result.final_tier).toBe('R3');
+  });
+
+  it('bumps from R1 to R2 when R1 returns confidence: low (R1 not the operator escalation point)', async () => {
+    // The operator-escalate-on-confidence-low rule is R3-only. At R1
+    // / R2, low confidence means "bump to a heavier reviewer" — let
+    // R3 handle the call before pinging the operator.
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'request_changes', confidence: 'low' }),
+      R2: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R2');
+    expect(result.tier_log.map((e) => e.tier)).toEqual(['R1', 'R2']);
+  });
+
+  it('escalates past R3 when R3 returns decision: escalate (chain saturates at R4 → operator)', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R2: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+      R3: buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('escalate-to-operator');
+    expect(result.final_tier).toBe('R3');
+    // Chain visited R1+R2+R3
+    expect(result.tier_log.map((e) => e.tier)).toEqual(['R1', 'R2', 'R3']);
+  });
+});
+
+// ─── Loop control flow — request_changes ─────────────────────────────────
+
+describe('runReviewGraphLoop — request_changes', () => {
+  it('terminates at first request_changes (gatekeeper re-dispatches implementor)', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({
+        decision: 'request_changes',
+        confidence: 'high',
+        findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 'real bug' }],
+      }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('request-changes');
+    expect(result.final_tier).toBe('R1');
+    expect(result.output?.findings).toHaveLength(1);
+  });
+
+  it('does NOT escalate to operator on request_changes + medium confidence + 🔴 (impl re-runs)', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({
+        decision: 'request_changes',
+        confidence: 'medium',
+        findings: [{ severity: '🔴', file: 'x.ts', category: 'bug', summary: 'real bug' }],
+      }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('request-changes');
+  });
+});
+
+// ─── Loop control flow — parse failures ──────────────────────────────────
+
+describe('runReviewGraphLoop — parse failures', () => {
+  it('treats parse failure as escalate-tier signal', async () => {
+    const dispatcher: ReviewerDispatch = async (req) => {
+      // R1 returns gibberish (no marker); R2 returns clean approve
+      if (req.workflow_id.endsWith('-revr1')) {
+        return makeBlankResult('garbage; no marker here');
+      }
+      return makeBlankResult(`${REVIEW_MARKER_FOR_TEST}{"decision":"approve","confidence":"high","findings":[]}`);
+    };
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('approve');
+    expect(result.final_tier).toBe('R2');
+    expect(result.tier_log[0].parsed).toBe(false);
+    expect(result.tier_log[1].parsed).toBe(true);
+  });
+
+  it('returns parse-failure-at-r4 when every tier produces unparseable output', async () => {
+    const dispatcher: ReviewerDispatch = async () => makeBlankResult('all garbage all the time');
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('parse-failure-at-r4');
+    // final_tier reports the last DISPATCHED tier — R3 ran, then the
+    // chain ran out of tiers. R4 is the action-category, not a
+    // tier the chain visited.
+    expect(result.final_tier).toBe('R3');
+    expect(result.tier_log).toHaveLength(3);
+    expect(result.tier_log.every((e) => !e.parsed)).toBe(true);
+  });
+});
+
+// ─── t5_shape propagation ────────────────────────────────────────────────
+
+describe('runReviewGraphLoop — t5_shape', () => {
+  it('propagates t5_shape from computeStartingTier into the result', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(
+      makeInput({ pr_meta: makePrMeta({ files: ['chitin.yaml', 'apps/temporal-worker/src/foo.ts'] }) }),
+      dispatcher,
+    );
+    expect(result.t5_shape).toBe(true);
+    expect(result.action).toBe('approve');  // chain still runs; gatekeeper handles t5_shape escalation
+  });
+
+  it('reports t5_shape: false when no governance paths touched', async () => {
+    const dispatcher = makeMockDispatcher({
+      R1: buildMockReviewerOutput({ decision: 'approve', confidence: 'high' }),
+    });
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.t5_shape).toBe(false);
+  });
+});
+
+// ─── buildReviewerRequest ────────────────────────────────────────────────
+
+describe('buildReviewerRequest', () => {
+  it('builds a valid ExecutionRequest for R1', () => {
+    const req = buildReviewerRequest(makeInput(), 'R1', undefined);
+    expect(req.role).toBe('reviewer');
+    expect(req.allowed_drivers).toEqual(['copilot']);
+    expect(req.write_policy).toBe('none');           // reviewer can't push
+    expect(req.parent_workflow_id).toBe('swarm-parent-12345');
+    expect(req.step_index).toBe(1);
+    expect(req.workflow_id).toBe('swarm-parent-12345-revr1');
+    expect(req.bounds.wall_timeout_s).toBe(600);     // R1 timeout
+    expect(req.bounds.max_tool_calls).toBe(20);
+    expect(req.bounds.max_cost_usd).toBe(0);         // copilot is free
+  });
+
+  it('uses claude-code-headless + cost cap at R3', () => {
+    const req = buildReviewerRequest(makeInput(), 'R3', undefined);
+    expect(req.allowed_drivers).toEqual(['claude-code-headless']);
+    expect(req.bounds.wall_timeout_s).toBe(1800);
+    expect(req.bounds.max_tool_calls).toBe(60);
+    expect(req.bounds.max_cost_usd).toBeGreaterThan(0);   // R3 is paid
+    expect(req.step_index).toBe(3);
+  });
+
+  it('includes prior findings in the prompt when provided', () => {
+    const req = buildReviewerRequest(
+      makeInput(),
+      'R2',
+      '- 🔴 dispatcher.ts:42 — ordering bug',
+    );
+    expect(req.prompt).toContain('ordering bug');
+  });
+
+  it('throws on R0 (non-dispatchable)', () => {
+    expect(() => buildReviewerRequest(makeInput(), 'R0', undefined)).toThrow(/non-dispatchable/);
+  });
+
+  it('throws on R4 (non-dispatchable)', () => {
+    expect(() => buildReviewerRequest(makeInput(), 'R4', undefined)).toThrow(/non-dispatchable/);
+  });
+
+  it('throws when pr_number is missing', () => {
+    expect(() =>
+      buildReviewerRequest(
+        makeInput({ pr_meta: makePrMeta({ pr_number: undefined }) }),
+        'R1',
+        undefined,
+      ),
+    ).toThrow(/pr_number/);
+  });
+
+  it('throws when pr_url is missing', () => {
+    expect(() =>
+      buildReviewerRequest(
+        makeInput({ pr_meta: makePrMeta({ pr_url: undefined }) }),
+        'R1',
+        undefined,
+      ),
+    ).toThrow(/pr_url/);
+  });
+});
+
+// ─── formatFindingsForNextTier ───────────────────────────────────────────
+
+describe('formatFindingsForNextTier', () => {
+  it('formats findings with location + severity + summary', () => {
+    const findings: ReviewerFinding[] = [
+      { severity: '🔴', file: 'a.ts', line: 42, category: 'bug', summary: 'broken' },
+      { severity: '🟡', file: 'b.ts', category: 'design', summary: 'rename', suggested_fix: 'use kebab' },
+    ];
+    const out = formatFindingsForNextTier(findings, undefined);
+    expect(out).toContain('🔴 a.ts:42');
+    expect(out).toContain('broken');
+    expect(out).toContain('🟡 b.ts');
+    expect(out).toContain('use kebab');
+  });
+
+  it('handles empty findings list (escalate without findings)', () => {
+    const out = formatFindingsForNextTier([], undefined);
+    expect(out).toContain('no findings');
+  });
+});
+
+// ─── tierAsStepIndex ─────────────────────────────────────────────────────
+
+describe('tierAsStepIndex', () => {
+  it.each([
+    ['R1', 1],
+    ['R2', 2],
+    ['R3', 3],
+  ] as const)('%s → step_index %d', (tier, expected) => {
+    expect(tierAsStepIndex(tier)).toBe(expected);
+  });
+
+  it.each(['R0', 'R4'] as const)('throws on %s (no step_index)', (tier) => {
+    expect(() => tierAsStepIndex(tier)).toThrow(/no step_index/);
+  });
+});
+
+// ─── helper: makeBlankResult ──────────────────────────────────────────────
+
+function makeBlankResult(stdout_tail: string) {
+  return {
+    exit_code: 0 as const,
+    stdout_tail,
+    stderr_tail: '',
+    duration_ms: 100,
+  };
+}

--- a/apps/temporal-worker/test/review-graph-workflow.test.ts
+++ b/apps/temporal-worker/test/review-graph-workflow.test.ts
@@ -13,7 +13,13 @@ import {
 import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
 import type { PrMeta, ReviewerFinding } from '../src/review-graph.ts';
 
-const { buildReviewerRequest, formatFindingsForNextTier, tierAsStepIndex } = __test__;
+const {
+  buildReviewerRequest,
+  formatFindingsForNextTier,
+  tierAsStepIndex,
+  deriveReviewerWorkflowId,
+  TEMPORAL_WORKFLOW_ID_MAX,
+} = __test__;
 
 function makeEntry(overrides: Partial<BacklogEntry> = {}): BacklogEntry {
   return {
@@ -253,7 +259,7 @@ describe('buildReviewerRequest', () => {
     expect(req.allowed_drivers).toEqual(['copilot']);
     expect(req.write_policy).toBe('none');           // reviewer can't push
     expect(req.parent_workflow_id).toBe('swarm-parent-12345');
-    expect(req.step_index).toBe(1);
+    expect(req.step_index).toBe(0);  // R1 is the first dispatched iteration of the chain (0-based)
     expect(req.workflow_id).toBe('swarm-parent-12345-revr1');
     expect(req.bounds.wall_timeout_s).toBe(600);     // R1 timeout
     expect(req.bounds.max_tool_calls).toBe(20);
@@ -266,7 +272,7 @@ describe('buildReviewerRequest', () => {
     expect(req.bounds.wall_timeout_s).toBe(1800);
     expect(req.bounds.max_tool_calls).toBe(60);
     expect(req.bounds.max_cost_usd).toBeGreaterThan(0);   // R3 is paid
-    expect(req.step_index).toBe(3);
+    expect(req.step_index).toBe(2);                       // R3 is the third iteration (0-based)
   });
 
   it('includes prior findings in the prompt when provided', () => {
@@ -331,16 +337,103 @@ describe('formatFindingsForNextTier', () => {
 // ─── tierAsStepIndex ─────────────────────────────────────────────────────
 
 describe('tierAsStepIndex', () => {
+  // 0-based per the schema docstring. R1 is the first dispatched
+  // iteration of the escalation chain; R3 is the third. Schema cap
+  // is max=3 (so values 0-3 are legal); we use 0-2 here, leaving
+  // headroom for a future R4-as-loop-iteration (currently R4 is
+  // operator pickup, not a chain member).
   it.each([
-    ['R1', 1],
-    ['R2', 2],
-    ['R3', 3],
+    ['R1', 0],
+    ['R2', 1],
+    ['R3', 2],
   ] as const)('%s → step_index %d', (tier, expected) => {
     expect(tierAsStepIndex(tier)).toBe(expected);
   });
 
   it.each(['R0', 'R4'] as const)('throws on %s (no step_index)', (tier) => {
     expect(() => tierAsStepIndex(tier)).toThrow(/no step_index/);
+  });
+});
+
+// ─── deriveReviewerWorkflowId ────────────────────────────────────────────
+
+describe('deriveReviewerWorkflowId', () => {
+  it('appends -revrN suffix for normal-length parent ids', () => {
+    expect(deriveReviewerWorkflowId('swarm-foo-12345', 'R1')).toBe('swarm-foo-12345-revr1');
+    expect(deriveReviewerWorkflowId('swarm-foo-12345', 'R2')).toBe('swarm-foo-12345-revr2');
+    expect(deriveReviewerWorkflowId('swarm-foo-12345', 'R3')).toBe('swarm-foo-12345-revr3');
+  });
+
+  it('produces an id that fits TemporalIdSchema (<=128 chars) when parent is at the cap', () => {
+    const parent = 'a'.repeat(TEMPORAL_WORKFLOW_ID_MAX); // exactly 128 chars
+    for (const tier of ['R1', 'R2', 'R3'] as const) {
+      const id = deriveReviewerWorkflowId(parent, tier);
+      expect(id.length).toBeLessThanOrEqual(TEMPORAL_WORKFLOW_ID_MAX);
+      expect(id).toMatch(/-revr[123]$/);
+    }
+  });
+
+  it('truncates the parent prefix when needed (suffix is always preserved, leaves run_id headroom)', () => {
+    const longParent = 'b'.repeat(150);
+    const id = deriveReviewerWorkflowId(longParent, 'R1');
+    // workflow_id + "-attempt-1" run_id must both fit 128 chars.
+    expect(id.length + '-attempt-1'.length).toBeLessThanOrEqual(TEMPORAL_WORKFLOW_ID_MAX);
+    expect(id.endsWith('-revr1')).toBe(true);
+    expect(id.startsWith('b')).toBe(true);
+  });
+
+  it('keeps short parents intact (no truncation when not needed)', () => {
+    const id = deriveReviewerWorkflowId('short', 'R3');
+    expect(id).toBe('short-revr3');
+  });
+
+  it('produces an ExecutionRequestSchema-valid id even for the worst-case parent length', () => {
+    // Regression for the original bug: buildReviewerRequest threw a
+    // schema-rejection when the concatenated workflow_id exceeded 128.
+    // The truncation makes that case parse cleanly.
+    const longParent = 'p'.repeat(TEMPORAL_WORKFLOW_ID_MAX);
+    const input = makeInput({ parent_workflow_id: longParent });
+    expect(() => buildReviewerRequest(input, 'R3', undefined)).not.toThrow();
+    const req = buildReviewerRequest(input, 'R3', undefined);
+    expect(req.workflow_id.length).toBeLessThanOrEqual(TEMPORAL_WORKFLOW_ID_MAX);
+  });
+});
+
+// ─── runReviewGraphLoop — output retention across tiers ──────────────────
+
+describe('runReviewGraphLoop — output retention', () => {
+  it('returns the LAST PARSED output even when the final dispatched tier failed to parse', async () => {
+    // Regression: result.output was previously sourced from the last
+    // tier_log entry, so a final-tier parse failure after earlier
+    // successful parses would surface output: undefined. Per the
+    // ReviewGraphResult.output docstring it should be "the last
+    // successful parse, when one happened".
+    const dispatcher: ReviewerDispatch = async (req) => {
+      if (req.workflow_id.endsWith('-revr1')) {
+        return buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' });
+      }
+      if (req.workflow_id.endsWith('-revr2')) {
+        return buildMockReviewerOutput({ decision: 'escalate', confidence: 'medium' });
+      }
+      // R3 emits unparseable output
+      return makeBlankResult('agent decided to skip the structured output');
+    };
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('escalate-to-operator');
+    // R2's output is the last successful parse; R3 didn't parse.
+    expect(result.output).toBeDefined();
+    expect(result.output?.decision).toBe('escalate');
+    // tier_log should still record R3 as a parse-failure entry.
+    expect(result.tier_log[result.tier_log.length - 1].parsed).toBe(false);
+  });
+
+  it('returns output: undefined only when no tier ever parsed (parse-failure cascade)', async () => {
+    const dispatcher: ReviewerDispatch = async () =>
+      makeBlankResult('garbage emit, no marker');
+    const result = await runReviewGraphLoop(makeInput(), dispatcher);
+    expect(result.action).toBe('parse-failure-at-r4');
+    expect(result.output).toBeUndefined();
+    expect(result.tier_log.every((e) => !e.parsed)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Step 3 of 3 toward `review-graph-executor`. Wires §5's R0→R1→R2→R3→R4 escalation chain end-to-end as a Temporal multi-step workflow.

**This PR:** the workflow itself, reviewable in isolation.
**Next slice:** dispatcher integration (auto-enqueue this workflow after a programmer workflow opens a PR).

## What's in it

- **`src/review-graph.ts`** (extended): per-tier `wall_timeout_s` + `max_tool_calls` constants; `pr_number` field on `PrMeta`. Wall timeouts: R1=10min, R2=15min, R3=30min (Opus on hard PRs).
- **`src/review-graph-workflow.ts`** (~290 LOC, new):
  - `ReviewGraphInput` / `ReviewGraphResult` / `ReviewGraphAction` types
  - `runReviewGraphLoop(input, reviewerDispatch)` — pure async loop, mockable. The brains.
  - `buildReviewerRequest(input, tier, priorFindings)` — constructs each reviewer's `ExecutionRequest`. `parent_workflow_id` + `step_index` threaded through; `write_policy: 'none'` enforces reviewer-can't-push boundary.
  - `formatFindingsForNextTier` / `formatParseFailureForNextTier` — pass prior reviewer's context to the next tier's prompt.
  - `reviewGraphWorkflow(input)` — Temporal wrapper. Calls `executeChild(executeRequestWorkflow, ...)` per reviewer dispatch.
- **28 new tests** in `test/review-graph-workflow.test.ts` + `helpers.ts`.

## Loop semantics — operator-escalation is R3-only

The headline design call locked here:

- **R3 + (`decision=escalate` OR `confidence=low`)** → `escalate-to-operator`. Per the design and your stated rule ("if Headless Claude Opus can't figure it out, escalate it up to me").
- **R1/R2 + same outputs** → bump tier. The lower reviewers saying "I can't decide" means a heavier reviewer takes the call, NOT operator pickup.

`shouldEscalateToOperator` (from #132) keeps its rule; the workflow loop only calls it at R3. Captured in code + comments + tests so the policy doesn't drift.

## Action shape (gatekeeper consumes this)

```ts
type ReviewGraphAction =
  | 'approve'                  // chain agreed — gatekeeper checks other gates + merges
  | 'request-changes'          // re-dispatch implementor with findings
  | 'escalate-to-operator'     // R3 said "I can't"; human pickup
  | 'parse-failure-at-r4';     // every tier's output failed to parse
```

`tier_log` records every tier the chain visited (whether parsed, the parsed output, the error if any) — telemetry can replay the chain end-to-end.

## Test plan

- [x] 28 new + 243/243 across `apps/temporal-worker`
- [ ] Eyeball the loop logic in `runReviewGraphLoop` — that's the load-bearing piece. The tier-aware operator-escalation rule is the headline policy decision.
- [ ] Sanity-check `buildReviewerRequest`: any field on the resulting `ExecutionRequest` that should differ at R1 vs R3 (cost cap, write policy, etc.)?
- [ ] R3-with-`decision=escalate`-AND-`confidence=high` is currently routed to operator (via `shouldEscalateToOperator` returning true on `decision=escalate`). Is that right? Or should `decision=escalate` at R3 with high confidence mean "I think you should look at this even though I'm confident in my read" — possibly ALSO operator? Currently both go to operator, so no ambiguity — but worth a sanity check on the semantic.

## What's NOT in this PR

- **Dispatcher integration** — when a programmer workflow opens a PR, dispatcher should enqueue `reviewGraphWorkflow`. Lands in step 3b.
- **PR-metadata in result envelope** — apply step needs to write `pr_number`, `pr_url`, files-changed list into `tmp/result-<wfid>.json` so the dispatcher can construct `PrMeta`. Step 3b too.
- **`worker.ts` registration** — needs `import { reviewGraphWorkflow } from './review-graph-workflow.ts'` re-exported from `workflow.ts`. Trivial; lands with step 3b.

## Notes

The `executeChild` call uses the workflow name as a string literal `'executeRequestWorkflow'`. The TS type `typeof executeRequestWorkflow` keeps the args+return type-safe. Standard Temporal pattern; the Worker registry needs to know the name.

The pure `runReviewGraphLoop` separation lets us test every loop branch (parse failure, R1-bump, R2-bump, R3-operator, request-changes-terminate, approve-terminate) without spinning up a Temporal runtime. Tests use mock dispatchers that key canned outputs by tier (extracting tier from `req.workflow_id` ending in `-revrN`).