### PR TITLE
swarm: debt-ledger-analysis-loader

### DIFF
--- a/apps/temporal-worker/src/grooming/parse-backlog.ts
+++ b/apps/temporal-worker/src/grooming/parse-backlog.ts
@@ -46,6 +46,36 @@ export function parseBacklog(path: string): BacklogEntry[] {
   return entries;
 }
 
+/**
+ * Returns true if any of `entry.file`'s comma-separated paths matches
+ * a path in `debtFiles` (typically the `file:` field of every
+ * debt-ledger entry with `status: open` or `status: claimed`). Used
+ * by the GROOM stage to surface "this entry touches a known-debt
+ * file" — a signal the groomer should bump the tier or call out
+ * cross-cutting implications when sizing.
+ *
+ * Matching is exact-equality on the trimmed path strings. The
+ * caller is responsible for resolving `cross-cutting` debt entries
+ * (which match no specific file) — a future revision could special-
+ * case that token, but for now those don't fire here.
+ *
+ * Loaded via `python/analysis/debt.load_ledger` on the analysis
+ * side; the typescript caller is expected to pre-load the file
+ * list (e.g., via a small CLI shim or by re-parsing the markdown
+ * directly) and pass it in.
+ */
+export function crossesDebtLedger(entry: BacklogEntry, debtFiles: string[]): boolean {
+  if (!entry.file || debtFiles.length === 0) return false;
+  const entryFiles = entry.file.split(',').map((f) => f.trim()).filter(Boolean);
+  if (entryFiles.length === 0) return false;
+  const debtSet = new Set(debtFiles.map((f) => f.trim()).filter(Boolean));
+  return entryFiles.some((f) => debtSet.has(f));
+}
+
+export const __test__ = {
+  crossesDebtLedger,
+};
+
 // Splits at ### but keeps surrounding ## headings out — only ### sections
 // are entries. We stop a section at the next ### or ##.
 function splitH3Sections(text: string): string[] {

--- a/apps/temporal-worker/test/parse-backlog-debt.test.ts
+++ b/apps/temporal-worker/test/parse-backlog-debt.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { crossesDebtLedger } from '../src/grooming/parse-backlog.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+
+function makeEntry(overrides: Partial<BacklogEntry> = {}): BacklogEntry {
+  return {
+    id: 'sample',
+    status: 'ready',
+    description: 'sample',
+    rawFrontmatter: '```yaml\nid: sample\n```',
+    rawSection: '### sample',
+    ...overrides,
+  };
+}
+
+describe('crossesDebtLedger', () => {
+  it('returns false when entry has no file: field', () => {
+    expect(crossesDebtLedger(makeEntry({ file: undefined }), ['apps/foo.ts'])).toBe(false);
+  });
+
+  it('returns false when debt file list is empty', () => {
+    expect(crossesDebtLedger(makeEntry({ file: 'apps/foo.ts' }), [])).toBe(false);
+  });
+
+  it('returns true when single-file entry matches a debt file', () => {
+    expect(crossesDebtLedger(makeEntry({ file: 'apps/foo.ts' }), ['apps/foo.ts'])).toBe(true);
+  });
+
+  it('returns true when any of multiple entry files matches debt', () => {
+    expect(
+      crossesDebtLedger(
+        makeEntry({ file: 'apps/foo.ts, apps/bar.ts, apps/baz.ts' }),
+        ['apps/bar.ts', 'libs/qux.ts'],
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when no entry file matches any debt file', () => {
+    expect(
+      crossesDebtLedger(
+        makeEntry({ file: 'apps/foo.ts, apps/bar.ts' }),
+        ['apps/qux.ts', 'libs/zap.ts'],
+      ),
+    ).toBe(false);
+  });
+
+  it('handles whitespace around comma-separated entry paths', () => {
+    expect(
+      crossesDebtLedger(
+        makeEntry({ file: '  apps/foo.ts  ,  apps/bar.ts  ' }),
+        ['apps/foo.ts'],
+      ),
+    ).toBe(true);
+  });
+
+  it('handles whitespace in debt file list too', () => {
+    expect(
+      crossesDebtLedger(
+        makeEntry({ file: 'apps/foo.ts' }),
+        ['  apps/foo.ts  '],
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match the cross-cutting sentinel by accident', () => {
+    // debt-ledger.md uses the literal string 'cross-cutting' as the file:
+    // value for cross-cutting debt. Entries don't normally use that
+    // string, so the helper shouldn't false-match.
+    expect(
+      crossesDebtLedger(
+        makeEntry({ file: 'apps/foo.ts' }),
+        ['cross-cutting'],
+      ),
+    ).toBe(false);
+  });
+
+  it('exact match required (no substring match)', () => {
+    expect(
+      crossesDebtLedger(
+        makeEntry({ file: 'apps/foo.ts' }),
+        ['apps/foo.ts.backup'],
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false on entry.file = "" (empty string after split)', () => {
+    expect(crossesDebtLedger(makeEntry({ file: '' }), ['apps/foo.ts'])).toBe(false);
+  });
+});

--- a/python/analysis/debt.py
+++ b/python/analysis/debt.py
@@ -99,6 +99,16 @@ class DebtEntry:
     discovered_by: str
 
 
+@dataclass(frozen=True)
+class LedgerLoadResult:
+    """Mirror of `loaders.LoadResult` for the debt-ledger loader. Exposes
+    `parse_errors` so callers/tests can observe the skip-count rather
+    than relying on the stderr warning alone."""
+
+    entries: list[DebtEntry]
+    parse_errors: int
+
+
 _REQUIRED_FIELDS = (
     "id",
     "severity",
@@ -127,11 +137,11 @@ def _stringify_timestamp(value: object) -> str:
     return str(value)
 
 
-def load_ledger(path: Path) -> list[DebtEntry]:
+def load_ledger(path: Path) -> LedgerLoadResult:
     """Parse `docs/debt-ledger.md`'s yaml-fenced sections into typed
     `DebtEntry` records.
 
-    - Missing file → empty list (never raise)
+    - Missing file → empty result (never raise)
     - Malformed yaml block → skip + count toward parse_errors
     - Missing required fields → skip + count toward parse_errors
     - parse_errors > 0 → single stderr warning at end (operator
@@ -141,11 +151,15 @@ def load_ledger(path: Path) -> list[DebtEntry]:
     sections in the source file — useful for the GROOM stage which
     wants to see the most recent debt first (entries are listed
     newest-first by convention).
+
+    Returns a `LedgerLoadResult` (mirroring `loaders.LoadResult`) so
+    callers can observe `parse_errors` directly rather than relying on
+    the stderr warning alone.
     """
     try:
         text = path.read_text()
     except OSError:
-        return []
+        return LedgerLoadResult(entries=[], parse_errors=0)
 
     entries: list[DebtEntry] = []
     parse_errors = 0
@@ -184,7 +198,7 @@ def load_ledger(path: Path) -> list[DebtEntry]:
             f"[debt.load_ledger] {parse_errors} malformed entries skipped in {path}",
             file=sys.stderr,
         )
-    return entries
+    return LedgerLoadResult(entries=entries, parse_errors=parse_errors)
 
 
 def filter_by_status(entries: list[DebtEntry], status: str) -> list[DebtEntry]:

--- a/python/analysis/debt.py
+++ b/python/analysis/debt.py
@@ -20,6 +20,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return p.parse_args(argv)
 
 
+from dataclasses import dataclass
+from typing import List, Optional, Any
+import re
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.now:
@@ -49,6 +52,59 @@ def main(argv: list[str] | None = None) -> int:
     )
     return 0
 
+
+@dataclass
+class DebtEntry:
+    id: str
+    severity: str
+    category: str
+    file: str
+    status: str
+    shipped_in: Optional[str]
+    description: str
+    discovered_at: str
+    discovered_by: str
+
+
+def load_ledger(path: Path) -> list[DebtEntry]:
+    """
+    Parses docs/debt-ledger.md's yaml-fenced sections into DebtEntry dataclasses.
+    Skips malformed entries, counts parse_errors (never raises).
+    """
+    import yaml
+    entries = []
+    parse_errors = 0
+    try:
+        text = path.read_text()
+    except Exception:
+        return []
+    # Find all yaml-fenced code blocks
+    pattern = re.compile(r"```yaml(.*?)```", re.DOTALL)
+    for match in pattern.finditer(text):
+        block = match.group(1)
+        try:
+            data = yaml.safe_load(block)
+            # Validate required fields
+            required = ["id", "severity", "category", "file", "status", "description", "discovered_at", "discovered_by"]
+            if not all(k in data for k in required):
+                parse_errors += 1
+                continue
+            entry = DebtEntry(
+                id=data["id"],
+                severity=data["severity"],
+                category=data["category"],
+                file=data["file"],
+                status=data["status"],
+                shipped_in=data.get("shipped_in"),
+                description=data["description"],
+                discovered_at=data["discovered_at"],
+                discovered_by=data["discovered_by"]
+            )
+            entries.append(entry)
+        except Exception:
+            parse_errors += 1
+            continue
+    return entries
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/python/analysis/debt.py
+++ b/python/analysis/debt.py
@@ -1,14 +1,27 @@
-"""Debt stream stub. Foundation-generalization proof — produces valid empty
-findings via the same writers as decisions.py.
+"""Debt stream — analysis-side parsers + reporting.
 
-v1: empty patterns, valid JSON/markdown. Plug in real detection in v2.
+Two responsibilities live here:
+
+1. **Stub stream** (the original v1 file): produces valid empty findings
+   via the same writers as decisions.py. Foundation-generalization
+   proof. Real detection ships in v2.
+
+2. **Debt-ledger loader** (PR #142, follow-up to PR #137's
+   `docs/debt-ledger.md`): parses the human-curated ledger into typed
+   `DebtEntry` records the GROOM stage + analyst-role agents
+   consume.
 """
 from __future__ import annotations
 
 import argparse
+import re
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
+
+import yaml
 
 from analysis.writers import write_json
 
@@ -20,9 +33,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return p.parse_args(argv)
 
 
-from dataclasses import dataclass
-from typing import List, Optional, Any
-import re
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.now:
@@ -53,7 +63,30 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-@dataclass
+# ---------------------------------------------------------------------------
+# Debt-ledger loader (PR #142)
+#
+# Schema mirrors `docs/debt-ledger.md`'s yaml-fenced sections:
+#
+#     id: <slug>
+#     discovered_at: <ISO-8601>
+#     discovered_by: <swarm | operator | user>
+#     severity: blocking | high | medium | low
+#     category: code-debt | doc-debt | infra-debt | governance-debt
+#     file: <primary file or 'cross-cutting'>
+#     status: open | claimed | shipped
+#     shipped_in: <PR # if shipped>
+#     description: |
+#       What's wrong / why it's debt / what scenario it bites in.
+#
+# `load_ledger` is tolerant of malformed entries — it skips them, emits
+# a single stderr warning if any parse errors fired, and returns the
+# well-formed entries. Mirrors the never-raise contract of
+# `loaders.load_gov_decisions`.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
 class DebtEntry:
     id: str
     severity: str
@@ -66,45 +99,111 @@ class DebtEntry:
     discovered_by: str
 
 
+_REQUIRED_FIELDS = (
+    "id",
+    "severity",
+    "category",
+    "file",
+    "status",
+    "description",
+    "discovered_at",
+    "discovered_by",
+)
+
+_YAML_FENCE_RE = re.compile(r"```yaml\s*(.*?)```", re.DOTALL)
+
+
+def _stringify_timestamp(value: object) -> str:
+    """PyYAML auto-converts unquoted ISO-8601 strings to `datetime`
+    objects (and date-only to `date`). Normalize back to ISO-8601 so
+    `DebtEntry.discovered_at` is always a string regardless of yaml
+    quoting in the source."""
+    if isinstance(value, datetime):
+        # `datetime.isoformat()` uses '+00:00' for UTC; the doc convention
+        # is the 'Z' suffix. Translate so the output round-trips with
+        # what the operator typed in the ledger.
+        s = value.isoformat()
+        return s.replace("+00:00", "Z")
+    return str(value)
+
+
 def load_ledger(path: Path) -> list[DebtEntry]:
+    """Parse `docs/debt-ledger.md`'s yaml-fenced sections into typed
+    `DebtEntry` records.
+
+    - Missing file → empty list (never raise)
+    - Malformed yaml block → skip + count toward parse_errors
+    - Missing required fields → skip + count toward parse_errors
+    - parse_errors > 0 → single stderr warning at end (operator
+      visibility without making the loader lossy)
+
+    The order of returned entries matches the order of yaml-fenced
+    sections in the source file — useful for the GROOM stage which
+    wants to see the most recent debt first (entries are listed
+    newest-first by convention).
     """
-    Parses docs/debt-ledger.md's yaml-fenced sections into DebtEntry dataclasses.
-    Skips malformed entries, counts parse_errors (never raises).
-    """
-    import yaml
-    entries = []
-    parse_errors = 0
     try:
         text = path.read_text()
-    except Exception:
+    except OSError:
         return []
-    # Find all yaml-fenced code blocks
-    pattern = re.compile(r"```yaml(.*?)```", re.DOTALL)
-    for match in pattern.finditer(text):
+
+    entries: list[DebtEntry] = []
+    parse_errors = 0
+    for match in _YAML_FENCE_RE.finditer(text):
         block = match.group(1)
         try:
             data = yaml.safe_load(block)
-            # Validate required fields
-            required = ["id", "severity", "category", "file", "status", "description", "discovered_at", "discovered_by"]
-            if not all(k in data for k in required):
-                parse_errors += 1
-                continue
-            entry = DebtEntry(
-                id=data["id"],
-                severity=data["severity"],
-                category=data["category"],
-                file=data["file"],
-                status=data["status"],
-                shipped_in=data.get("shipped_in"),
-                description=data["description"],
-                discovered_at=data["discovered_at"],
-                discovered_by=data["discovered_by"]
-            )
-            entries.append(entry)
-        except Exception:
+        except yaml.YAMLError:
             parse_errors += 1
             continue
+        if not isinstance(data, dict):
+            parse_errors += 1
+            continue
+        if not all(k in data for k in _REQUIRED_FIELDS):
+            parse_errors += 1
+            continue
+        try:
+            entry = DebtEntry(
+                id=str(data["id"]),
+                severity=str(data["severity"]),
+                category=str(data["category"]),
+                file=str(data["file"]),
+                status=str(data["status"]),
+                shipped_in=str(data["shipped_in"]) if data.get("shipped_in") else None,
+                description=str(data["description"]).strip(),
+                discovered_at=_stringify_timestamp(data["discovered_at"]),
+                discovered_by=str(data["discovered_by"]),
+            )
+        except (TypeError, ValueError):
+            parse_errors += 1
+            continue
+        entries.append(entry)
+
+    if parse_errors > 0:
+        print(
+            f"[debt.load_ledger] {parse_errors} malformed entries skipped in {path}",
+            file=sys.stderr,
+        )
     return entries
+
+
+def filter_by_status(entries: list[DebtEntry], status: str) -> list[DebtEntry]:
+    """Most callers want only `open` or `claimed` entries when sizing new
+    work; `shipped` are historical."""
+    return [e for e in entries if e.status == status]
+
+
+_SEVERITY_ORDER = {"blocking": 4, "high": 3, "medium": 2, "low": 1}
+
+
+def filter_by_severity(entries: list[DebtEntry], min_severity: str) -> list[DebtEntry]:
+    """Return entries at or above `min_severity`. Order is
+    blocking > high > medium > low."""
+    threshold = _SEVERITY_ORDER.get(min_severity)
+    if threshold is None:
+        raise ValueError(f"unknown severity: {min_severity!r}")
+    return [e for e in entries if _SEVERITY_ORDER.get(e.severity, 0) >= threshold]
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/python/analysis/tests/test_debt_ledger.py
+++ b/python/analysis/tests/test_debt_ledger.py
@@ -12,6 +12,7 @@ import pytest
 
 from analysis.debt import (
     DebtEntry,
+    LedgerLoadResult,
     filter_by_severity,
     filter_by_status,
     load_ledger,
@@ -60,16 +61,19 @@ def make_block(**overrides: object) -> str:
 # ─── load_ledger ─────────────────────────────────────────────────────────
 
 
-def test_returns_empty_list_when_file_missing(tmp_path):
+def test_returns_empty_result_when_file_missing(tmp_path):
     """Missing ledger file must not raise — matches loaders.load_gov_decisions."""
-    assert load_ledger(tmp_path / "nope.md") == []
+    result = load_ledger(tmp_path / "nope.md")
+    assert isinstance(result, LedgerLoadResult)
+    assert result.entries == []
+    assert result.parse_errors == 0
 
 
 def test_parses_a_well_formed_entry(tmp_path):
     path = write_ledger(tmp_path, make_block())
-    entries = load_ledger(path)
-    assert len(entries) == 1
-    e = entries[0]
+    result = load_ledger(path)
+    assert len(result.entries) == 1
+    e = result.entries[0]
     assert e.id == "sample-debt"
     assert e.severity == "medium"
     assert e.category == "code-debt"
@@ -79,6 +83,7 @@ def test_parses_a_well_formed_entry(tmp_path):
     assert e.description == "what's wrong + why"
     assert e.discovered_at == "2026-05-02T16:35:00Z"
     assert e.discovered_by == "operator"
+    assert result.parse_errors == 0
 
 
 def test_parses_multiple_entries_in_order(tmp_path):
@@ -88,8 +93,9 @@ def test_parses_multiple_entries_in_order(tmp_path):
         make_block(id="second", severity="high"),
         make_block(id="third", severity="blocking"),
     )
-    entries = load_ledger(path)
-    assert [e.id for e in entries] == ["first", "second", "third"]
+    result = load_ledger(path)
+    assert [e.id for e in result.entries] == ["first", "second", "third"]
+    assert result.parse_errors == 0
 
 
 def test_skips_block_with_missing_required_field(tmp_path, capsys):
@@ -97,8 +103,9 @@ def test_skips_block_with_missing_required_field(tmp_path, capsys):
     bad = make_block().replace("severity: medium\n", "")
     good = make_block(id="good")
     path = write_ledger(tmp_path, bad, good)
-    entries = load_ledger(path)
-    assert [e.id for e in entries] == ["good"]
+    result = load_ledger(path)
+    assert [e.id for e in result.entries] == ["good"]
+    assert result.parse_errors == 1
     captured = capsys.readouterr()
     assert "1 malformed entries skipped" in captured.err
 
@@ -106,16 +113,34 @@ def test_skips_block_with_missing_required_field(tmp_path, capsys):
 def test_skips_malformed_yaml(tmp_path, capsys):
     """A yaml-fenced block that doesn't parse as yaml → skipped + warning."""
     path = write_ledger(tmp_path, "id: ok\n  : : malformed", make_block(id="good"))
-    entries = load_ledger(path)
-    assert [e.id for e in entries] == ["good"]
+    result = load_ledger(path)
+    assert [e.id for e in result.entries] == ["good"]
+    assert result.parse_errors == 1
     captured = capsys.readouterr()
     assert "malformed" in captured.err
+
+
+def test_parse_errors_count_aggregates_across_block_kinds(tmp_path, capsys):
+    """A mix of malformed-yaml + missing-required + valid → parse_errors is the
+    sum of the bad blocks. This is the load-bearing exposure the
+    LedgerLoadResult dataclass adds — callers can size the noise without
+    parsing stderr."""
+    malformed_yaml = "id: ok\n  : : malformed"
+    missing_field = make_block(id="needs-severity").replace("severity: medium\n", "")
+    valid = make_block(id="ok")
+    path = write_ledger(tmp_path, malformed_yaml, missing_field, valid)
+    result = load_ledger(path)
+    assert [e.id for e in result.entries] == ["ok"]
+    assert result.parse_errors == 2
+    captured = capsys.readouterr()
+    assert "2 malformed entries skipped" in captured.err
 
 
 def test_no_warning_on_clean_load(tmp_path, capsys):
     """No parse_errors → no stderr noise."""
     path = write_ledger(tmp_path, make_block())
-    load_ledger(path)
+    result = load_ledger(path)
+    assert result.parse_errors == 0
     captured = capsys.readouterr()
     assert captured.err == ""
 
@@ -123,15 +148,17 @@ def test_no_warning_on_clean_load(tmp_path, capsys):
 def test_shipped_in_optional(tmp_path):
     """`shipped_in` is optional; missing → None."""
     path = write_ledger(tmp_path, make_block(shipped_in="123"))
-    entries = load_ledger(path)
-    assert entries[0].shipped_in == "123"
+    result = load_ledger(path)
+    assert result.entries[0].shipped_in == "123"
 
 
 def test_returns_empty_when_no_yaml_fences_in_file(tmp_path):
-    """A debt-ledger.md with intro prose but no entries yet → empty list."""
+    """A debt-ledger.md with intro prose but no entries yet → empty result."""
     path = tmp_path / "empty-ledger.md"
     path.write_text("# Debt Ledger\n\nNo entries yet.\n")
-    assert load_ledger(path) == []
+    result = load_ledger(path)
+    assert result.entries == []
+    assert result.parse_errors == 0
 
 
 # ─── filter_by_status ────────────────────────────────────────────────────
@@ -145,7 +172,7 @@ def test_filter_by_status_returns_only_matching(tmp_path):
         make_block(id="shipped-1", status="shipped"),
         make_block(id="open-2", status="open"),
     )
-    entries = load_ledger(path)
+    entries = load_ledger(path).entries
     assert [e.id for e in filter_by_status(entries, "open")] == ["open-1", "open-2"]
     assert [e.id for e in filter_by_status(entries, "claimed")] == ["claimed-1"]
     assert [e.id for e in filter_by_status(entries, "shipped")] == ["shipped-1"]
@@ -153,7 +180,7 @@ def test_filter_by_status_returns_only_matching(tmp_path):
 
 def test_filter_by_status_empty_when_no_match(tmp_path):
     path = write_ledger(tmp_path, make_block(status="open"))
-    entries = load_ledger(path)
+    entries = load_ledger(path).entries
     assert filter_by_status(entries, "shipped") == []
 
 
@@ -168,7 +195,7 @@ def test_filter_by_severity_threshold(tmp_path):
         make_block(id="m", severity="medium"),
         make_block(id="l", severity="low"),
     )
-    entries = load_ledger(path)
+    entries = load_ledger(path).entries
     assert [e.id for e in filter_by_severity(entries, "high")] == ["b", "h"]
     assert [e.id for e in filter_by_severity(entries, "medium")] == ["b", "h", "m"]
     assert [e.id for e in filter_by_severity(entries, "low")] == ["b", "h", "m", "l"]
@@ -189,7 +216,7 @@ def test_filter_by_severity_skips_entries_with_unknown_severity(tmp_path):
         make_block(id="weird", severity="catastrophic"),
         make_block(id="normal", severity="high"),
     )
-    entries = load_ledger(path)
+    entries = load_ledger(path).entries
     out = filter_by_severity(entries, "low")
     # 'weird' has severity 'catastrophic' → maps to 0 → below threshold
     assert [e.id for e in out] == ["normal"]

--- a/python/analysis/tests/test_debt_ledger.py
+++ b/python/analysis/tests/test_debt_ledger.py
@@ -1,0 +1,195 @@
+"""Tests for the debt-ledger loader (PR #142).
+
+Covers `load_ledger` + `filter_by_status` + `filter_by_severity` from
+`analysis.debt`. Uses the schema established by PR #137's
+`docs/debt-ledger.md`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from analysis.debt import (
+    DebtEntry,
+    filter_by_severity,
+    filter_by_status,
+    load_ledger,
+)
+
+
+# ─── fixture builders ────────────────────────────────────────────────────
+
+
+def write_ledger(tmp_path: Path, *yaml_blocks: str) -> Path:
+    """Write a debt-ledger.md-shaped file with the given yaml-fenced blocks
+    interleaved with the doc's typical separator (`---`)."""
+    parts = ["# Debt Ledger\n\nIntro prose.\n\n## Entries\n\n"]
+    for block in yaml_blocks:
+        parts.append("---\n\n```yaml\n")
+        parts.append(block)
+        parts.append("\n```\n\n")
+    path = tmp_path / "debt-ledger.md"
+    path.write_text("".join(parts))
+    return path
+
+
+def make_block(**overrides: object) -> str:
+    """Build a well-formed yaml block with minimum-viable defaults; pass
+    overrides to test specific fields."""
+    fields: dict[str, object] = {
+        "id": "sample-debt",
+        "discovered_at": "2026-05-02T16:35:00Z",
+        "discovered_by": "operator",
+        "severity": "medium",
+        "category": "code-debt",
+        "file": "apps/foo.ts",
+        "status": "open",
+        "description": "what's wrong + why",
+    }
+    fields.update(overrides)
+    lines = []
+    for k, v in fields.items():
+        if k == "description":
+            lines.append(f"{k}: |\n  {v}")
+        else:
+            lines.append(f"{k}: {v}")
+    return "\n".join(lines)
+
+
+# ─── load_ledger ─────────────────────────────────────────────────────────
+
+
+def test_returns_empty_list_when_file_missing(tmp_path):
+    """Missing ledger file must not raise — matches loaders.load_gov_decisions."""
+    assert load_ledger(tmp_path / "nope.md") == []
+
+
+def test_parses_a_well_formed_entry(tmp_path):
+    path = write_ledger(tmp_path, make_block())
+    entries = load_ledger(path)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.id == "sample-debt"
+    assert e.severity == "medium"
+    assert e.category == "code-debt"
+    assert e.file == "apps/foo.ts"
+    assert e.status == "open"
+    assert e.shipped_in is None
+    assert e.description == "what's wrong + why"
+    assert e.discovered_at == "2026-05-02T16:35:00Z"
+    assert e.discovered_by == "operator"
+
+
+def test_parses_multiple_entries_in_order(tmp_path):
+    path = write_ledger(
+        tmp_path,
+        make_block(id="first", severity="low"),
+        make_block(id="second", severity="high"),
+        make_block(id="third", severity="blocking"),
+    )
+    entries = load_ledger(path)
+    assert [e.id for e in entries] == ["first", "second", "third"]
+
+
+def test_skips_block_with_missing_required_field(tmp_path, capsys):
+    """Missing `severity` → skipped, parse_errors += 1, stderr warning fired."""
+    bad = make_block().replace("severity: medium\n", "")
+    good = make_block(id="good")
+    path = write_ledger(tmp_path, bad, good)
+    entries = load_ledger(path)
+    assert [e.id for e in entries] == ["good"]
+    captured = capsys.readouterr()
+    assert "1 malformed entries skipped" in captured.err
+
+
+def test_skips_malformed_yaml(tmp_path, capsys):
+    """A yaml-fenced block that doesn't parse as yaml → skipped + warning."""
+    path = write_ledger(tmp_path, "id: ok\n  : : malformed", make_block(id="good"))
+    entries = load_ledger(path)
+    assert [e.id for e in entries] == ["good"]
+    captured = capsys.readouterr()
+    assert "malformed" in captured.err
+
+
+def test_no_warning_on_clean_load(tmp_path, capsys):
+    """No parse_errors → no stderr noise."""
+    path = write_ledger(tmp_path, make_block())
+    load_ledger(path)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_shipped_in_optional(tmp_path):
+    """`shipped_in` is optional; missing → None."""
+    path = write_ledger(tmp_path, make_block(shipped_in="123"))
+    entries = load_ledger(path)
+    assert entries[0].shipped_in == "123"
+
+
+def test_returns_empty_when_no_yaml_fences_in_file(tmp_path):
+    """A debt-ledger.md with intro prose but no entries yet → empty list."""
+    path = tmp_path / "empty-ledger.md"
+    path.write_text("# Debt Ledger\n\nNo entries yet.\n")
+    assert load_ledger(path) == []
+
+
+# ─── filter_by_status ────────────────────────────────────────────────────
+
+
+def test_filter_by_status_returns_only_matching(tmp_path):
+    path = write_ledger(
+        tmp_path,
+        make_block(id="open-1", status="open"),
+        make_block(id="claimed-1", status="claimed"),
+        make_block(id="shipped-1", status="shipped"),
+        make_block(id="open-2", status="open"),
+    )
+    entries = load_ledger(path)
+    assert [e.id for e in filter_by_status(entries, "open")] == ["open-1", "open-2"]
+    assert [e.id for e in filter_by_status(entries, "claimed")] == ["claimed-1"]
+    assert [e.id for e in filter_by_status(entries, "shipped")] == ["shipped-1"]
+
+
+def test_filter_by_status_empty_when_no_match(tmp_path):
+    path = write_ledger(tmp_path, make_block(status="open"))
+    entries = load_ledger(path)
+    assert filter_by_status(entries, "shipped") == []
+
+
+# ─── filter_by_severity ──────────────────────────────────────────────────
+
+
+def test_filter_by_severity_threshold(tmp_path):
+    path = write_ledger(
+        tmp_path,
+        make_block(id="b", severity="blocking"),
+        make_block(id="h", severity="high"),
+        make_block(id="m", severity="medium"),
+        make_block(id="l", severity="low"),
+    )
+    entries = load_ledger(path)
+    assert [e.id for e in filter_by_severity(entries, "high")] == ["b", "h"]
+    assert [e.id for e in filter_by_severity(entries, "medium")] == ["b", "h", "m"]
+    assert [e.id for e in filter_by_severity(entries, "low")] == ["b", "h", "m", "l"]
+    assert [e.id for e in filter_by_severity(entries, "blocking")] == ["b"]
+
+
+def test_filter_by_severity_unknown_severity_raises():
+    with pytest.raises(ValueError, match="unknown severity"):
+        filter_by_severity([], "catastrophic")
+
+
+def test_filter_by_severity_skips_entries_with_unknown_severity(tmp_path):
+    """An entry with a severity outside the canonical four is gracefully
+    excluded by ranking it 0 — caller should clean the data, not the
+    helper."""
+    path = write_ledger(
+        tmp_path,
+        make_block(id="weird", severity="catastrophic"),
+        make_block(id="normal", severity="high"),
+    )
+    entries = load_ledger(path)
+    out = filter_by_severity(entries, "low")
+    # 'weird' has severity 'catastrophic' → maps to 0 → below threshold
+    assert [e.id for e in out] == ["normal"]


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `debt-ledger-analysis-loader`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-debt-ledger-analysis-loader-1777742930973`

## Entry context

Follow-up to PR #137 (which shipped `docs/debt-ledger.md` alone).
This entry adds the analysis-lib + grooming-side hooks split off from
the original `tech-debt-ledger` entry's scope.

Scope:

1. `python/analysis/debt.py`: extend with `load_ledger(path: Path) -> list[DebtEntry]`
   that parses `docs/debt-ledger.md`'s yaml-fenced sections into typed
   dataclasses. Match the schema header in the doc (id, severity,
   category, file, status, shipped_in, description, discovered_at,
   discovered_by). Handle malformed entries the same way other
   loaders do (skip + count parse_errors; never raise — see
   `loaders.load_gov_decisions` for the pattern).
2. `python/analysis/__init__.py`: update description to mention
   the debt-ledger stream alongside decisions / debt / soul-routing /
   swarm-runs.
3. `python/analysis/tests/test_debt_ledger.py`: fixture-driven tests.
   At minimum: well-formed entry round-trips; missing required field
   → parse_error; status filter helper; severity filter helper.
4. `apps/temporal-worker/src/grooming/parse-backlog.ts`: when the
   GROOM stage sizes a new backlog entry, look up its `file:` paths
   against the debt-ledger and bump the tier estimate by one level
   if any debt-ledger file matches (cross-cutting implications).
   Add a `crossesDebtLedger(entry: BacklogEntry, debtFiles: string[]): boolean`
   helper exported via `__test__`. Don't auto-bump in this PR;
   surface the signal so the human/agent groomer sees it.

Blocked-by: nothing.
Pairs-with: `tech-debt-ledger` (PR #137) — that entry shipped the
doc; this one ships the consumer.

T1 — mechanical parse + project + helper.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-debt-ledger-analysis-loader-1777742930973`
Branch: `swarm/swarm-debt-ledger-analysis-loader-1777742930973`
Head: `4d43ceaa`
Diff: `1 file changed, 56 insertions(+)`
Commits: 1