### PR TITLE
swarm: researcher-role-prompt-template

### DIFF
--- a/apps/temporal-worker/src/researcher-prompts.ts
+++ b/apps/temporal-worker/src/researcher-prompts.ts
@@ -19,22 +19,31 @@ import { z } from 'zod';
 
 // ─── Zod schema for structured output ──────────────────────────────────────
 
-export const ResearcherCandidateSchema = z.object({
-  /** Which source the candidate came from — arxiv / reddit / hn / openclaw / ollama / etc. */
-  source: z.string().min(1),
-  /** Stable id for dedup against existing roadmap entries. Typically
-   *  the source's native id (arxiv id, reddit post id, gh release tag). */
-  id: z.string().min(1),
-  /** One-sentence summary the operator can grep through. */
-  summary: z.string().min(1),
-  /** Why this is worth surfacing as a candidate — the load-bearing
-   *  reasoning step. Empty/generic "why" rows feel like noise. */
-  why: z.string().min(1),
-});
+// .strict() rejects unknown keys: an agent that emits an extra field
+// (e.g., a `priority` it invented) is a contract violation, and
+// silently dropping it would let drift accumulate. Surface the
+// mismatch instead, so the runner logs it and we can decide whether
+// to extend the schema or tighten the prompt.
+export const ResearcherCandidateSchema = z
+  .object({
+    /** Which source the candidate came from — arxiv / reddit / hn / openclaw / ollama / etc. */
+    source: z.string().min(1),
+    /** Stable id for dedup against existing roadmap entries. Typically
+     *  the source's native id (arxiv id, reddit post id, gh release tag). */
+    id: z.string().min(1),
+    /** One-sentence summary the operator can grep through. */
+    summary: z.string().min(1),
+    /** Why this is worth surfacing as a candidate — the load-bearing
+     *  reasoning step. Empty/generic "why" rows feel like noise. */
+    why: z.string().min(1),
+  })
+  .strict();
 
-export const ResearcherCandidatesSchema = z.object({
-  candidates: z.array(ResearcherCandidateSchema),
-});
+export const ResearcherCandidatesSchema = z
+  .object({
+    candidates: z.array(ResearcherCandidateSchema),
+  })
+  .strict();
 
 export type ResearcherCandidate = z.infer<typeof ResearcherCandidateSchema>;
 export type ResearcherCandidates = z.infer<typeof ResearcherCandidatesSchema>;

--- a/apps/temporal-worker/src/researcher-prompts.ts
+++ b/apps/temporal-worker/src/researcher-prompts.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+// Output schema for researcher candidates
+export const ResearcherCandidatesSchema = z.object({
+  candidates: z.array(
+    z.object({
+      source: z.string(),
+      id: z.string(),
+      summary: z.string(),
+      why: z.string(),
+    })
+  ),
+});
+
+export type ResearcherCandidates = z.infer<typeof ResearcherCandidatesSchema>;
+
+/**
+ * Builds the prompt for the researcher agent.
+ * @param source_summaries Array of {source, summary}
+ * @param existing_candidate_ids Array of candidate IDs already found
+ * @param since_window_hours Number of hours for the research window
+ */
+export function buildResearcherPrompt({
+  source_summaries,
+  existing_candidate_ids,
+  since_window_hours,
+}: {
+  source_summaries: { source: string; summary: string }[];
+  existing_candidate_ids: string[];
+  since_window_hours: number;
+}): string {
+  return `
+You are a research agent tasked with synthesizing new candidate entries from recent sources.
+
+- Review the following source summaries (from the last ${since_window_hours} hours):
+${source_summaries.length === 0 ? '(none)' : source_summaries.map((s, i) => `  ${i + 1}. [${s.source}] ${s.summary}`).join('\n')}
+
+- Existing candidate IDs (do not duplicate):
+${existing_candidate_ids.length === 0 ? '(none)' : existing_candidate_ids.join(', ')}
+
+Your job:
+- Propose new, non-duplicate candidates based on the above sources.
+- For each, provide:
+  - source: which source the candidate is from
+  - id: a unique identifier for the candidate
+  - summary: a concise summary of the candidate
+  - why: why this is a valuable or novel candidate
+
+Output format:
+<<<CANDIDATES>>>{"candidates": [{"source": ..., "id": ..., "summary": ..., "why": ...}, ...]}
+`;
+}
+
+/**
+ * Parses the researcher's output and extracts the candidates JSON.
+ * Returns null if parsing fails or marker not found.
+ */
+export function parseResearcherOutput(stdoutTail: string): ResearcherCandidates | null {
+  const marker = '<<<CANDIDATES>>>';
+  const idx = stdoutTail.lastIndexOf(marker);
+  if (idx === -1) return null;
+  const jsonStart = idx + marker.length;
+  const jsonStr = stdoutTail.slice(jsonStart).trim();
+  try {
+    const parsed = JSON.parse(jsonStr);
+    return ResearcherCandidatesSchema.parse(parsed);
+  } catch {
+    return null;
+  }
+}

--- a/apps/temporal-worker/src/researcher-prompts.ts
+++ b/apps/temporal-worker/src/researcher-prompts.ts
@@ -1,70 +1,167 @@
+// Researcher-role prompt template + structured-output parser. Mirrors
+// the pattern reviewer-prompts.ts established in PR #134:
+//   - tier-aware prompt builder
+//   - <<<CANDIDATES>>>-marked structured emit
+//   - discriminated-union parser ({ ok, output | error })
+//
+// Used by:
+//   - the role-prompts.ts registry's `researcher` entry (BacklogEntry-
+//     level dispatch when a backlog entry has `role: researcher`)
+//   - the future external-signal-fetchers runner, which calls
+//     buildResearcherPrompt directly with richer context (source
+//     summaries, existing candidate ids, since-window) than a single
+//     BacklogEntry can carry.
+//
+// See docs/design/2026-05-02-swarm-as-software-factory.md §3 for what
+// the researcher role owns.
+
 import { z } from 'zod';
 
-// Output schema for researcher candidates
-export const ResearcherCandidatesSchema = z.object({
-  candidates: z.array(
-    z.object({
-      source: z.string(),
-      id: z.string(),
-      summary: z.string(),
-      why: z.string(),
-    })
-  ),
+// ─── Zod schema for structured output ──────────────────────────────────────
+
+export const ResearcherCandidateSchema = z.object({
+  /** Which source the candidate came from — arxiv / reddit / hn / openclaw / ollama / etc. */
+  source: z.string().min(1),
+  /** Stable id for dedup against existing roadmap entries. Typically
+   *  the source's native id (arxiv id, reddit post id, gh release tag). */
+  id: z.string().min(1),
+  /** One-sentence summary the operator can grep through. */
+  summary: z.string().min(1),
+  /** Why this is worth surfacing as a candidate — the load-bearing
+   *  reasoning step. Empty/generic "why" rows feel like noise. */
+  why: z.string().min(1),
 });
 
+export const ResearcherCandidatesSchema = z.object({
+  candidates: z.array(ResearcherCandidateSchema),
+});
+
+export type ResearcherCandidate = z.infer<typeof ResearcherCandidateSchema>;
 export type ResearcherCandidates = z.infer<typeof ResearcherCandidatesSchema>;
 
-/**
- * Builds the prompt for the researcher agent.
- * @param source_summaries Array of {source, summary}
- * @param existing_candidate_ids Array of candidate IDs already found
- * @param since_window_hours Number of hours for the research window
- */
-export function buildResearcherPrompt({
-  source_summaries,
-  existing_candidate_ids,
-  since_window_hours,
-}: {
+// ─── Prompt builder ────────────────────────────────────────────────────────
+
+export interface ResearcherPromptInputs {
+  /** One row per source the runner pulled. Newline-separated body of
+   *  recent items the agent should read — title + URL + a few-line
+   *  excerpt. */
   source_summaries: { source: string; summary: string }[];
+  /** Candidate ids already in roadmap.md's "Candidates from external
+   *  signal" section. The agent must NOT propose duplicates. */
   existing_candidate_ids: string[];
+  /** Look-back window the runner used. Surfaces in the prompt so the
+   *  agent knows recency semantics. */
   since_window_hours: number;
-}): string {
-  return `
-You are a research agent tasked with synthesizing new candidate entries from recent sources.
-
-- Review the following source summaries (from the last ${since_window_hours} hours):
-${source_summaries.length === 0 ? '(none)' : source_summaries.map((s, i) => `  ${i + 1}. [${s.source}] ${s.summary}`).join('\n')}
-
-- Existing candidate IDs (do not duplicate):
-${existing_candidate_ids.length === 0 ? '(none)' : existing_candidate_ids.join(', ')}
-
-Your job:
-- Propose new, non-duplicate candidates based on the above sources.
-- For each, provide:
-  - source: which source the candidate is from
-  - id: a unique identifier for the candidate
-  - summary: a concise summary of the candidate
-  - why: why this is a valuable or novel candidate
-
-Output format:
-<<<CANDIDATES>>>{"candidates": [{"source": ..., "id": ..., "summary": ..., "why": ...}, ...]}
-`;
 }
 
 /**
- * Parses the researcher's output and extracts the candidates JSON.
- * Returns null if parsing fails or marker not found.
+ * Structured-output instructions appended to any researcher prompt
+ * (runner-level via buildResearcherPrompt, backlog-entry-level via
+ * role-prompts.ts). Exported so the entry-level adapter doesn't drift
+ * away from the runner-level marker contract.
  */
-export function parseResearcherOutput(stdoutTail: string): ResearcherCandidates | null {
-  const marker = '<<<CANDIDATES>>>';
-  const idx = stdoutTail.lastIndexOf(marker);
-  if (idx === -1) return null;
-  const jsonStart = idx + marker.length;
-  const jsonStr = stdoutTail.slice(jsonStart).trim();
-  try {
-    const parsed = JSON.parse(jsonStr);
-    return ResearcherCandidatesSchema.parse(parsed);
-  } catch {
-    return null;
-  }
+export const RESEARCHER_OUTPUT_INSTRUCTIONS = `\
+At the END of your synthesis, emit EXACTLY ONE JSON object on a single line, prefixed with the literal token \`<<<CANDIDATES>>>\` and nothing else after the closing brace on that line. No code fence, no commentary. The runner's parser keys on \`<<<CANDIDATES>>>\`. Example:
+
+<<<CANDIDATES>>>{"candidates":[{"source":"arxiv","id":"2511.13646v3","summary":"Live-SWE-agent v3: tool-registry pattern + benchmark loop.","why":"Closest external prior art for chitin's role-typed dispatcher; v3 adds the benchmark replay we don't yet have."}]}
+
+If you find no new non-duplicate candidates worth surfacing, emit \`<<<CANDIDATES>>>{"candidates":[]}\` — empty list is fine. Do not invent low-signal candidates to fill the cap. The roadmap reader's time is more valuable than the per-candidate cost.`;
+
+/**
+ * Build the researcher's prompt. Takes source summaries the runner
+ * pre-fetched + existing candidate ids the agent must not duplicate +
+ * the look-back window for recency framing.
+ */
+export function buildResearcherPrompt(opts: ResearcherPromptInputs): string {
+  const sourceLines =
+    opts.source_summaries.length === 0
+      ? '(no source summaries — runner pulled an empty window; emit empty candidates list)'
+      : opts.source_summaries
+          .map((s, i) => `  ${i + 1}. [${s.source}] ${s.summary}`)
+          .join('\n');
+
+  const existingLine =
+    opts.existing_candidate_ids.length === 0
+      ? '(roadmap.md has no candidate ids yet)'
+      : opts.existing_candidate_ids.join(', ');
+
+  return `You are the researcher-role agent for chitin's autonomous swarm. Your job: read the source summaries below (recent activity from arxiv / Reddit / HN / openclaw / ollama / etc.) and propose new candidate entries for \`docs/roadmap.md\`'s "Candidates from external signal" section.
+
+Source summaries (last ${opts.since_window_hours} hours):
+${sourceLines}
+
+Existing candidate ids in roadmap.md (do not duplicate):
+${existingLine}
+
+Synthesis rules:
+- One candidate per genuinely-new finding. Don't over-batch related items into one row; don't fragment one finding into multiple rows.
+- The "why" field is load-bearing — spend the words on chitin-specific implications (e.g., "extends our role-typed dispatcher", "alternative to claude-code-headless"), not generic novelty.
+- Skip items that look like restatements of existing chitin work. Skip items that are pure marketing.
+- If you can't tell whether something matters from the summary, skip it. The roadmap reader trusts you to filter — false-positives are worse than false-negatives.
+
+${RESEARCHER_OUTPUT_INSTRUCTIONS}`;
 }
+
+// ─── Output parser ─────────────────────────────────────────────────────────
+
+const CANDIDATES_MARKER = '<<<CANDIDATES>>>';
+
+/**
+ * Extract the researcher's structured candidate list from agent
+ * stdout. Mirrors `parseReviewerOutput` from reviewer-prompts.ts:
+ * last-marker-wins (so a prompt example the agent echoes doesn't
+ * false-match), one-line slice (so trailing chatter doesn't break
+ * JSON.parse), strict zod validation.
+ *
+ * Returns:
+ *   { ok: true, output }   — well-formed
+ *   { ok: false, error }   — missing marker / parse failure / schema
+ *                              validation failure (with candidate slice
+ *                              for debugging)
+ */
+export function parseResearcherOutput(
+  stdoutTail: string,
+): { ok: true; output: ResearcherCandidates } | { ok: false; error: string } {
+  const lastMarker = stdoutTail.lastIndexOf(CANDIDATES_MARKER);
+  if (lastMarker < 0) {
+    return { ok: false, error: 'no <<<CANDIDATES>>> marker in stdout' };
+  }
+  const after = stdoutTail.slice(lastMarker + CANDIDATES_MARKER.length);
+  // Take only the first line — agents sometimes emit trailing chatter
+  // despite instructions; including it would fail JSON.parse on
+  // otherwise-valid output.
+  const lineEnd = after.indexOf('\n');
+  const candidate = (lineEnd >= 0 ? after.slice(0, lineEnd) : after).trim();
+  if (!candidate.startsWith('{')) {
+    return { ok: false, error: `expected JSON object after marker, got: ${truncate(candidate, 200)}` };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch (err) {
+    return {
+      ok: false,
+      error:
+        `JSON.parse failed: ${err instanceof Error ? err.message : String(err)} ` +
+        `(candidate: ${truncate(candidate, 200)})`,
+    };
+  }
+
+  const result = ResearcherCandidatesSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      ok: false,
+      error: `schema validation: ${result.error.message} (candidate: ${truncate(candidate, 200)})`,
+    };
+  }
+  return { ok: true, output: result.data };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…[+${s.length - max} more chars]`;
+}
+
+export const __test__ = {
+  CANDIDATES_MARKER,
+};

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -13,6 +13,7 @@
 
 import type { Role } from '@chitin/contracts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
+import { RESEARCHER_OUTPUT_INSTRUCTIONS } from './researcher-prompts.ts';
 
 export type RolePromptBuilder = (entry: BacklogEntry) => string;
 
@@ -47,10 +48,40 @@ CONSTRAINTS:
 REMEMBER: chat replies do nothing. Tool calls are the only thing that produces work. Start by reading ${targetFile} now.`;
 }
 
-// Stub for non-programmer roles. Future entries replace these with
-// real per-role prompts (researcher reads HN/arxiv; reviewer reads
-// the PR's diff; etc.). For now the stub frames the role and points
-// at the entry — better than crashing, worse than the eventual
+// Researcher prompt for the BacklogEntry path. The richer runner-level
+// version (buildResearcherPrompt in researcher-prompts.ts) takes
+// pre-fetched source summaries + existing-candidate ids; that path is
+// invoked by the future external-signal-fetchers runner. When a
+// backlog entry just declares `role: researcher` without that runner
+// context, the entry itself describes the research task — the agent
+// reads source material itself rather than receiving summaries. Both
+// paths emit the same `<<<CANDIDATES>>>` marker so a single parser
+// (parseResearcherOutput) handles both.
+function buildResearcherEntryPrompt(entry: BacklogEntry): string {
+  return `You are playing the researcher role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3 for the role's scope.
+
+This research task came in as a backlog entry rather than via the periodic external-signal-fetchers runner, so no source summaries are pre-fetched. Read the entry detail to learn what to research, fetch the source material yourself (arxiv abstracts, GitHub READMEs, blog posts, etc.) using available tools, then synthesize candidates for \`docs/roadmap.md\`'s "Candidates from external signal" section.
+
+ENTRY ID: ${entry.id}
+ROLE: researcher
+
+ENTRY DETAIL:
+${entry.description}
+
+Synthesis rules:
+- One candidate per genuinely-new finding. Don't over-batch related items into one row; don't fragment one finding into multiple rows.
+- The "why" field is load-bearing — spend the words on chitin-specific implications, not generic novelty.
+- Skip restatements of existing chitin work. Skip pure marketing.
+- If you can't tell whether something matters, skip it. The roadmap reader trusts you to filter — false-positives are worse than false-negatives.
+- Do not edit roadmap.md directly from this prompt. The runner inserts candidates after parsing your structured emit.
+
+${RESEARCHER_OUTPUT_INSTRUCTIONS}`;
+}
+
+// Stub for the remaining non-programmer roles. Future entries replace
+// these with real per-role prompts (reviewer reads the PR's diff; qa
+// runs validation suites; etc.). For now the stub frames the role and
+// points at the entry — better than crashing, worse than the eventual
 // dedicated template.
 function buildStubPrompt(role: Role, entry: BacklogEntry): string {
   return `You are playing the ${role} role in the chitin swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3 for what this role owns.
@@ -72,8 +103,12 @@ CONSTRAINTS:
 const ROLE_PROMPTS: Record<Role, RolePromptBuilder> = {
   programmer: buildProgrammerPrompt,
 
+  // Researcher uses its dedicated entry-level template (the runner-
+  // level template lives in researcher-prompts.ts, called directly
+  // by the external-signal-fetchers runner with richer context).
+  researcher: buildResearcherEntryPrompt,
+
   // Stubs — replaced by dedicated templates in follow-up entries.
-  researcher: (entry) => buildStubPrompt('researcher', entry),
   product: (entry) => buildStubPrompt('product', entry),
   groomer: (entry) => buildStubPrompt('groomer', entry),
   architect: (entry) => buildStubPrompt('architect', entry),
@@ -127,4 +162,5 @@ export const __test__ = {
   ROLE_PROMPTS,
   ROLE_VOCAB,
   buildStubPrompt,
+  buildResearcherEntryPrompt,
 };

--- a/apps/temporal-worker/test/researcher-prompts.test.ts
+++ b/apps/temporal-worker/test/researcher-prompts.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ResearcherCandidateSchema,
+  ResearcherCandidatesSchema,
+  RESEARCHER_OUTPUT_INSTRUCTIONS,
+  buildResearcherPrompt,
+  parseResearcherOutput,
+  __test__,
+  type ResearcherPromptInputs,
+} from '../src/researcher-prompts.ts';
+
+const { CANDIDATES_MARKER } = __test__;
+
+const baseInputs: ResearcherPromptInputs = {
+  source_summaries: [
+    { source: 'arxiv', summary: '2511.13646v3 — Live-SWE-agent v3 adds tool-registry pattern.' },
+    { source: 'reddit', summary: 'r/LocalLLaMA — qwen3-coder-30b benchmarks vs deepseek-v3.' },
+  ],
+  existing_candidate_ids: ['arxiv:2511.13646v2', 'gh-release:openclaw-v0.4'],
+  since_window_hours: 24,
+};
+
+// ─── Schema validation ─────────────────────────────────────────────────────
+
+describe('ResearcherCandidateSchema', () => {
+  it('accepts a complete candidate', () => {
+    const ok = {
+      source: 'arxiv',
+      id: '2511.13646v3',
+      summary: 'Live-SWE-agent v3: tool-registry pattern + benchmark loop.',
+      why: 'Closest external prior art for chitin role-typed dispatcher.',
+    };
+    expect(() => ResearcherCandidateSchema.parse(ok)).not.toThrow();
+  });
+
+  it('rejects empty source', () => {
+    const bad = { source: '', id: 'x', summary: 's', why: 'w' };
+    expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects empty id', () => {
+    const bad = { source: 'arxiv', id: '', summary: 's', why: 'w' };
+    expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects empty summary', () => {
+    const bad = { source: 'arxiv', id: 'x', summary: '', why: 'w' };
+    expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects empty why (load-bearing field, must not be blank)', () => {
+    const bad = { source: 'arxiv', id: 'x', summary: 's', why: '' };
+    expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects missing why entirely', () => {
+    const bad = { source: 'arxiv', id: 'x', summary: 's' };
+    expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
+  });
+});
+
+describe('ResearcherCandidatesSchema', () => {
+  it('accepts an empty list (no findings is a valid output)', () => {
+    expect(() => ResearcherCandidatesSchema.parse({ candidates: [] })).not.toThrow();
+  });
+
+  it('accepts multiple candidates', () => {
+    const ok = {
+      candidates: [
+        { source: 'arxiv', id: 'x', summary: 's1', why: 'w1' },
+        { source: 'reddit', id: 'y', summary: 's2', why: 'w2' },
+      ],
+    };
+    expect(() => ResearcherCandidatesSchema.parse(ok)).not.toThrow();
+  });
+
+  it('rejects when candidates is not an array', () => {
+    const bad = { candidates: 'not-an-array' };
+    expect(() => ResearcherCandidatesSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects when an inner candidate is malformed (validation cascades)', () => {
+    const bad = { candidates: [{ source: 'arxiv', id: 'x', summary: 's' /* missing why */ }] };
+    expect(() => ResearcherCandidatesSchema.parse(bad)).toThrow();
+  });
+});
+
+// ─── parseResearcherOutput ────────────────────────────────────────────────
+
+describe('parseResearcherOutput', () => {
+  it('extracts a well-formed payload after the marker', () => {
+    const tail = `Some chatter from the agent.\n${CANDIDATES_MARKER}{"candidates":[{"source":"arxiv","id":"2511.13646v3","summary":"Live-SWE-agent v3.","why":"Prior art for role-typed dispatch."}]}`;
+    const r = parseResearcherOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.output.candidates).toHaveLength(1);
+      expect(r.output.candidates[0].id).toBe('2511.13646v3');
+    }
+  });
+
+  it('accepts an empty candidate list (the explicit no-finding case)', () => {
+    const tail = `${CANDIDATES_MARKER}{"candidates":[]}`;
+    const r = parseResearcherOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.output.candidates).toHaveLength(0);
+  });
+
+  it('takes the LAST marker when multiple are present (echoed prompt example vs real output)', () => {
+    const tail = `Example from prompt: ${CANDIDATES_MARKER}{"candidates":[{"source":"arxiv","id":"example","summary":"s","why":"w"}]}\nReal output:\n${CANDIDATES_MARKER}{"candidates":[{"source":"reddit","id":"real","summary":"s","why":"w"}]}`;
+    const r = parseResearcherOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.output.candidates).toHaveLength(1);
+      expect(r.output.candidates[0].id).toBe('real');
+    }
+  });
+
+  it('returns ok:false when the marker is missing', () => {
+    const r = parseResearcherOutput('agent forgot to emit structured output');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('marker');
+  });
+
+  it('returns ok:false on malformed JSON after the marker', () => {
+    const r = parseResearcherOutput(`${CANDIDATES_MARKER}{"candidates":[,]}`); // bad comma
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('JSON.parse');
+  });
+
+  it('returns ok:false when JSON is valid but schema rejects (missing required field)', () => {
+    const r = parseResearcherOutput(
+      `${CANDIDATES_MARKER}{"candidates":[{"source":"arxiv","id":"x","summary":"s"}]}`,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('schema');
+  });
+
+  it('returns ok:false when post-marker content does not start with {', () => {
+    const r = parseResearcherOutput(`${CANDIDATES_MARKER}sorry no candidates today`);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('expected JSON object');
+  });
+
+  it('handles trailing newline + content after the JSON line gracefully (takes only the line)', () => {
+    const tail = `${CANDIDATES_MARKER}{"candidates":[]}\nOh and one more thing...`;
+    const r = parseResearcherOutput(tail);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects malformed JSON when trailing chatter is on the same line', () => {
+    // Same-line trailing content invalidates the JSON parse — this is
+    // expected behavior (the prompt mandates "nothing else after the
+    // closing brace on that line"). The next line is fair game.
+    const tail = `${CANDIDATES_MARKER}{"candidates":[]} oops trailing chatter`;
+    const r = parseResearcherOutput(tail);
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ─── buildResearcherPrompt ────────────────────────────────────────────────
+
+describe('buildResearcherPrompt', () => {
+  it('produces a non-empty prompt', () => {
+    const out = buildResearcherPrompt(baseInputs);
+    expect(out.length).toBeGreaterThan(500);
+  });
+
+  it('includes the source summaries verbatim in the body', () => {
+    const out = buildResearcherPrompt(baseInputs);
+    expect(out).toContain('Live-SWE-agent');
+    expect(out).toContain('qwen3-coder');
+    expect(out).toContain('[arxiv]');
+    expect(out).toContain('[reddit]');
+  });
+
+  it('includes the existing-candidate ids so the agent can dedup', () => {
+    const out = buildResearcherPrompt(baseInputs);
+    expect(out).toContain('arxiv:2511.13646v2');
+    expect(out).toContain('gh-release:openclaw-v0.4');
+    expect(out).toContain('do not duplicate');
+  });
+
+  it('includes the since-window in the prompt for recency framing', () => {
+    const out = buildResearcherPrompt({ ...baseInputs, since_window_hours: 48 });
+    expect(out).toContain('48 hours');
+  });
+
+  it('includes the structured-output marker so the agent knows to emit it', () => {
+    const out = buildResearcherPrompt(baseInputs);
+    expect(out).toContain('<<<CANDIDATES>>>');
+  });
+
+  it('embeds the synthesis rules (load-bearing why, no fragmentation, skip restatements)', () => {
+    const out = buildResearcherPrompt(baseInputs);
+    expect(out).toContain('load-bearing');
+    expect(out).toContain("Don't over-batch");
+    expect(out).toContain('restatements');
+  });
+
+  it('handles empty source_summaries gracefully (degrades to "emit empty list")', () => {
+    const out = buildResearcherPrompt({ ...baseInputs, source_summaries: [] });
+    expect(out).toContain('no source summaries');
+    expect(out).toContain('emit empty candidates list');
+  });
+
+  it('handles empty existing_candidate_ids gracefully', () => {
+    const out = buildResearcherPrompt({ ...baseInputs, existing_candidate_ids: [] });
+    expect(out).toContain('no candidate ids yet');
+  });
+});
+
+describe('RESEARCHER_OUTPUT_INSTRUCTIONS', () => {
+  it('mentions the marker (so the entry-level adapter inherits the same contract)', () => {
+    expect(RESEARCHER_OUTPUT_INSTRUCTIONS).toContain('<<<CANDIDATES>>>');
+  });
+
+  it('shows the empty-list fallback (so agents know what to emit on a quiet window)', () => {
+    expect(RESEARCHER_OUTPUT_INSTRUCTIONS).toContain('"candidates":[]');
+  });
+});
+
+// ─── End-to-end: build → mock agent output → parse round-trips ────────────
+
+describe('end-to-end prompt → parse', () => {
+  it('a well-formed agent response (matching the prompt example) parses cleanly', () => {
+    const prompt = buildResearcherPrompt(baseInputs);
+    expect(prompt).toContain(CANDIDATES_MARKER);
+
+    // Mock what an obedient agent would emit
+    const mockTail = `Step-by-step research:
+- read arxiv abstract for 2511.13646v3
+- read the reddit thread, weighted comment quality
+- decided the qwen3-coder benchmark is restating known territory; skipped
+${CANDIDATES_MARKER}{"candidates":[{"source":"arxiv","id":"2511.13646v3","summary":"Live-SWE-agent v3 adds a tool-registry pattern + benchmark loop on SWE-bench Live.","why":"Closest external prior art for chitin's role-typed dispatcher; v3's benchmark replay is something we don't have yet — worth a candidate row."}]}`;
+
+    const result = parseResearcherOutput(mockTail);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.output.candidates).toHaveLength(1);
+      expect(result.output.candidates[0].source).toBe('arxiv');
+      expect(result.output.candidates[0].id).toBe('2511.13646v3');
+    }
+  });
+
+  it('an obedient empty-window agent response parses to an empty list', () => {
+    const mockTail = `Nothing new in the window.\n${CANDIDATES_MARKER}{"candidates":[]}`;
+    const result = parseResearcherOutput(mockTail);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.output.candidates).toHaveLength(0);
+  });
+});

--- a/apps/temporal-worker/test/researcher-prompts.test.ts
+++ b/apps/temporal-worker/test/researcher-prompts.test.ts
@@ -57,11 +57,27 @@ describe('ResearcherCandidateSchema', () => {
     const bad = { source: 'arxiv', id: 'x', summary: 's' };
     expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
   });
+
+  it('rejects extra unknown keys (strict mode — surfaces agent-invented fields)', () => {
+    const bad = {
+      source: 'arxiv',
+      id: 'x',
+      summary: 's',
+      why: 'w',
+      priority: 'high', // not in schema; should fail rather than be silently dropped
+    };
+    expect(() => ResearcherCandidateSchema.parse(bad)).toThrow();
+  });
 });
 
 describe('ResearcherCandidatesSchema', () => {
   it('accepts an empty list (no findings is a valid output)', () => {
     expect(() => ResearcherCandidatesSchema.parse({ candidates: [] })).not.toThrow();
+  });
+
+  it('rejects extra unknown keys at the wrapper level (strict mode)', () => {
+    const bad = { candidates: [], notes: 'agent-added scratchpad' };
+    expect(() => ResearcherCandidatesSchema.parse(bad)).toThrow();
   });
 
   it('accepts multiple candidates', () => {

--- a/apps/temporal-worker/test/role-prompts.test.ts
+++ b/apps/temporal-worker/test/role-prompts.test.ts
@@ -84,11 +84,23 @@ describe('buildPromptForEntry', () => {
     expect(dispatched).toBe(programmer);
   });
 
-  it('routes non-programmer roles to a stub that names the role', () => {
-    const dispatched = buildPromptForEntry(makeEntry({ id: 'r-test', role: 'researcher' }));
-    expect(dispatched).toContain('researcher');
-    expect(dispatched).toContain('r-test');
+  it('routes still-stubbed non-programmer roles to a stub that names the role', () => {
+    const dispatched = buildPromptForEntry(makeEntry({ id: 'p-test', role: 'product' }));
+    expect(dispatched).toContain('product');
+    expect(dispatched).toContain('p-test');
     // Stub does NOT have the programmer's TOOL DISPATCHES preamble.
+    expect(dispatched).not.toContain('TOOL DISPATCHES count');
+  });
+
+  it('routes role: researcher to the dedicated researcher prompt (not the generic stub)', () => {
+    const dispatched = buildPromptForEntry(makeEntry({ id: 'r-test', role: 'researcher' }));
+    expect(dispatched).toContain('researcher role');
+    expect(dispatched).toContain('r-test');
+    // Researcher prompt mandates the structured-output marker — that's
+    // the load-bearing diff between the dedicated template and the
+    // generic stub.
+    expect(dispatched).toContain('<<<CANDIDATES>>>');
+    // And it doesn't borrow the programmer preamble.
     expect(dispatched).not.toContain('TOOL DISPATCHES count');
   });
 


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `researcher-role-prompt-template`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-researcher-role-prompt-template-1777743234096`

## Entry context

Replace the `researcher` role's stub in `role-prompts.ts` with a
real adversarial-research prompt template, parallel to what
`reviewer-prompts.ts` (PR #134) does for the reviewer role.

Scope:

1. New `apps/temporal-worker/src/researcher-prompts.ts`:
   - `buildResearcherPrompt({ source_summaries, existing_candidate_ids, since_window_hours })`
     — produces the agent's prompt. Tier-tone is consistent (research
     is a synthesis task; one tone fits all dispatched tiers).
   - `parseResearcherOutput(stdoutTail)` — extracts a structured
     `<<<CANDIDATES>>>{json}` emit listing new candidate entries
     `[{source, id, summary, why}]`. Mirrors the reviewer-prompts
     pattern.
   - Strict zod schema for the output.
2. Update `role-prompts.ts`: the `researcher` registry entry calls
   `buildResearcherPrompt` for backlog entries with `role: researcher`,
   threading the (limited) `BacklogEntry` context as the prompt's
   minimal input. Richer caller (the runner in
   `external-signal-fetchers`) bypasses the registry and calls
   `buildResearcherPrompt` directly with full context.
3. Tests parallel to `reviewer-prompts.test.ts`: schema validation
   (6 cases), parser (8 cases including last-marker-wins, malformed
   JSON, unknown source field), prompt builder (rendering of source
   summaries / existing candidates / since-window).

Blocked-by: nothing.
Pairs-with: `external-signal-fetchers` (which uses the prompt).

T1 because mechanical — same shape as reviewer-prompts, just
different agent persona.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-researcher-role-prompt-template-1777743234096`
Branch: `swarm/swarm-researcher-role-prompt-template-1777743234096`
Head: `dfbeea74`
Diff: `1 file changed, 70 insertions(+)`
Commits: 1