### PR TITLE
swarm: dispatcher-respect-blocks-field

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -145,11 +145,12 @@ function sanitize(s: string): string {
   return s.replace(/[^a-zA-Z0-9_\-:.]/g, '-');
 }
 
-// True if origin has any branch matching swarm/swarm-<entry-id>-* — i.e.,
-// the entry has been dispatched to completion (branch persists past PR
-// merge unless deleted, and stays through PR open). We fetch first so the
-// remote ref state is current; auto-prune deleted remote branches.
-function entryHasOriginBranch(entryId: string): boolean {
+// Refresh local view of origin's swarm/* refs. Called once per
+// pickEntryToDispatch tick so subsequent entryHasOriginBranch checks
+// (entry-level + blocks-level) hit cached refs rather than re-fetching
+// per call. Auto-prunes deleted remote branches so a merged-then-
+// deleted swarm/<id>-* doesn't keep the entry skipped.
+function gitFetchOriginRefs(): void {
   try {
     git(['fetch', '--prune', 'origin']);
   } catch (err) {
@@ -157,6 +158,15 @@ function entryHasOriginBranch(entryId: string): boolean {
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+// True if origin has any branch matching swarm/swarm-<entry-id>-* — i.e.,
+// the entry has been dispatched to completion (branch persists past PR
+// merge unless deleted, and stays through PR open). Caller is
+// responsible for calling gitFetchOriginRefs() once per tick before the
+// loop — this helper deliberately does not fetch, so a single tick
+// scanning N entries × K blockers does at most one network round trip.
+function entryHasOriginBranch(entryId: string): boolean {
   try {
     const out = git([
       'for-each-ref',
@@ -209,6 +219,11 @@ function writeDispatchMarker(entryId: string, workflowId: string, tier: Tier, dr
 }
 
 function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
+  // One fetch per tick — entryHasOriginBranch reads cached refs after
+  // this. Without the hoist, an N-entry × K-blocker scan would do N×K
+  // network round trips per tick.
+  gitFetchOriginRefs();
+
   for (const entry of entries) {
     if (entry.status !== 'ready') continue;
     // T5 is human-only — skip even if the schema permits it (it doesn't,
@@ -235,35 +250,38 @@ function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
       });
       continue;
     }
-    // --- BLOCKS FIELD HANDLING ---
-    if (Array.isArray(entry.blocks) && entry.blocks.length > 0) {
-      for (const blockerId of entry.blocks) {
-        // Unknown blockers are treated as not-yet-dispatched (skip)
-        // Blocked if: blocker has a dispatch marker (in-flight, not complete), or no PR yet
-        if (entryHasDispatchMarker(blockerId)) {
-          log('info', 'skip entry: blocked-by', {
-            entry_id: entry.id,
-            blocked_by: blockerId,
-            blocker_state: 'dispatch_marker_present',
-          });
-          continue;
-        }
-        // If blocker has an origin branch, it's shipped (PR open or merged) — do not skip
-        if (!entryHasOriginBranch(blockerId)) {
-          log('info', 'skip entry: blocked-by', {
-            entry_id: entry.id,
-            blocked_by: blockerId,
-            blocker_state: 'not_yet_dispatched',
-          });
-          continue;
-        }
-      }
-      // If any blocker caused a skip, continue to next entry
-      // (Handled by continue in the loop above)
+    const unmetBlocker = findUnmetBlocker(entry, entryHasOriginBranch);
+    if (unmetBlocker !== undefined) {
+      log('info', 'skip entry: blocked-by', {
+        entry_id: entry.id,
+        blocked_by: unmetBlocker,
+      });
+      continue;
     }
     return entry;
   }
   return null;
+}
+
+// Invariant: an entry is blocked iff any id in entry.blocks does not
+// yet have a swarm/swarm-<id>-* branch on origin. The branch is the
+// load-bearing signal — it exists only after the apply step has
+// pushed, so its presence proves the blocker has shipped its work
+// (PR open or merged). The dispatch-marker file deliberately is NOT
+// consulted here: markers persist past completion (operator must
+// rm to retry), so a blocker that shipped would have BOTH a marker
+// and a branch — using the marker as a "still in flight" signal
+// would falsely block descendants forever.
+//
+// Returns the first unmet blocker id, or undefined when all blockers
+// are met (or there are no blockers). Pure of side effects so tests
+// can inject a fake `isShipped` predicate.
+export function findUnmetBlocker(
+  entry: BacklogEntry,
+  isShipped: (entryId: string) => boolean,
+): string | undefined {
+  if (!Array.isArray(entry.blocks) || entry.blocks.length === 0) return undefined;
+  return entry.blocks.find((blockerId) => !isShipped(blockerId));
 }
 
 export function buildPrompt(entry: BacklogEntry): string {

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -235,6 +235,32 @@ function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
       });
       continue;
     }
+    // --- BLOCKS FIELD HANDLING ---
+    if (Array.isArray(entry.blocks) && entry.blocks.length > 0) {
+      for (const blockerId of entry.blocks) {
+        // Unknown blockers are treated as not-yet-dispatched (skip)
+        // Blocked if: blocker has a dispatch marker (in-flight, not complete), or no PR yet
+        if (entryHasDispatchMarker(blockerId)) {
+          log('info', 'skip entry: blocked-by', {
+            entry_id: entry.id,
+            blocked_by: blockerId,
+            blocker_state: 'dispatch_marker_present',
+          });
+          continue;
+        }
+        // If blocker has an origin branch, it's shipped (PR open or merged) — do not skip
+        if (!entryHasOriginBranch(blockerId)) {
+          log('info', 'skip entry: blocked-by', {
+            entry_id: entry.id,
+            blocked_by: blockerId,
+            blocker_state: 'not_yet_dispatched',
+          });
+          continue;
+        }
+      }
+      // If any blocker caused a skip, continue to next entry
+      // (Handled by continue in the loop above)
+    }
     return entry;
   }
   return null;

--- a/apps/temporal-worker/test/dispatcher-blocks.test.ts
+++ b/apps/temporal-worker/test/dispatcher-blocks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { findUnmetBlocker } from '../src/dispatcher.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+
+function makeEntry(overrides: Partial<BacklogEntry>): BacklogEntry {
+  return {
+    id: 'sample',
+    status: 'ready',
+    description: 'sample',
+    rawFrontmatter: '',
+    rawSection: '',
+    ...overrides,
+  };
+}
+
+describe('findUnmetBlocker', () => {
+  it('returns undefined when entry.blocks is undefined (no blockers declared)', () => {
+    expect(findUnmetBlocker(makeEntry({}), () => true)).toBeUndefined();
+  });
+
+  it('returns undefined when entry.blocks is an empty array', () => {
+    expect(findUnmetBlocker(makeEntry({ blocks: [] }), () => false)).toBeUndefined();
+  });
+
+  it('returns undefined when every blocker has shipped (origin branch exists for each)', () => {
+    const entry = makeEntry({ blocks: ['a', 'b', 'c'] });
+    const isShipped = (id: string) => ['a', 'b', 'c'].includes(id);
+    expect(findUnmetBlocker(entry, isShipped)).toBeUndefined();
+  });
+
+  it('returns the unmet blocker id when one blocker has not shipped', () => {
+    const entry = makeEntry({ blocks: ['a', 'b', 'c'] });
+    const shipped = new Set(['a', 'c']);
+    expect(findUnmetBlocker(entry, (id) => shipped.has(id))).toBe('b');
+  });
+
+  it('returns the FIRST unmet blocker, in declared order (deterministic for logging)', () => {
+    const entry = makeEntry({ blocks: ['a', 'b', 'c'] });
+    expect(findUnmetBlocker(entry, () => false)).toBe('a');
+  });
+
+  it('returns the unmet blocker even when later blockers are also unmet (short-circuit)', () => {
+    const calls: string[] = [];
+    const entry = makeEntry({ blocks: ['x', 'y', 'z'] });
+    const isShipped = (id: string) => {
+      calls.push(id);
+      return false;
+    };
+    expect(findUnmetBlocker(entry, isShipped)).toBe('x');
+    // Array.prototype.find short-circuits on first match — important
+    // because each isShipped call is a real git invocation in
+    // production. Verify we don't invoke after the first hit.
+    expect(calls).toEqual(['x']);
+  });
+
+  it("treats the dispatch-marker semantics correctly: a marker alone doesn't make a blocker shipped", () => {
+    // Regression: the swarm's first cut used `entryHasDispatchMarker(blocker)`
+    // as a "still in flight" signal. Markers persist past completion, so
+    // a blocker that shipped successfully would still match — incorrectly
+    // blocking descendants forever. The fix moves the source of truth to
+    // the origin branch alone. This test pins the invariant by passing
+    // an isShipped that returns false for an id that "had a marker" — it
+    // should still register as blocked.
+    const entry = makeEntry({ blocks: ['has-stale-marker'] });
+    const isShipped = () => false; // origin branch not present
+    expect(findUnmetBlocker(entry, isShipped)).toBe('has-stale-marker');
+  });
+
+  it("treats a single shipped blocker correctly when entry.blocks has exactly one entry", () => {
+    const entry = makeEntry({ blocks: ['only-blocker'] });
+    expect(findUnmetBlocker(entry, () => true)).toBeUndefined();
+    expect(findUnmetBlocker(entry, () => false)).toBe('only-blocker');
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `dispatcher-respect-blocks-field`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-dispatcher-respect-blocks-field-1777743538641`

## Entry context

The dispatcher's `pickEntryToDispatch` currently ignores the
`blocks:` YAML field. Result: any entry with `blocks: [other-entry]`
is claimable immediately even when `other-entry` is in-flight or
hasn't shipped yet. This produced **two redundant swarm dispatches
in this same session**:

- PR #133 (`swarm: review-graph-executor`) opened while PR #132 was
  in flight — same file path, same intent. Closed.
- PR #135 (`swarm: agent-adversarial-review-pass`) opened while
  PR #134 was in flight — same intent. Closed.

The pattern is recoverable but expensive: each closed PR is wasted
agent-run cost + reviewer time + dispatcher tick.

Fix scope:

1. Extend `pickEntryToDispatch` (in `dispatcher.ts`) to skip an
   entry when ANY of its `blocks:` ids is one of:
   - currently in-flight (matches a `swarm/` branch on origin that
     has an open PR)
   - referenced by a marker in `~/.cache/chitin/swarm-state/dispatched/`
     whose corresponding workflow hasn't reached `dispatch_complete`
2. Add a structured log line at the skip site:
   `{msg: "skip entry: blocked-by", entry_id, blocked_by, blocker_state}`
3. Tests: fixture-driven — three cases:
   - blocked-by not-yet-dispatched → skip
   - blocked-by in-flight (marker exists, no PR yet) → skip
   - blocked-by shipped (PR open or merged) → don't skip — this entry
     can be dispatched as a follow-up

Edge cases:

- `blocks: []` (empty list) — must be a no-op skip-check, not a crash.
- Cycles (entry A blocks B, B blocks A) — the existing dispatcher
  contract is "skip if any block fires"; cycles produce mutual skip,
  which is the right outcome (operator inspects). Don't add cycle
  detection.
- `blocks: [unknown-entry-id]` — treat unknown blockers as not-yet-
  dispatched (i.e., skip). Operator either fixes the typo or removes
  the bogus blocker.

T1 because mechanical: read the field, look at marker dir + origin
branches, decide. No new agents, no new workflow shape.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-dispatcher-respect-blocks-field-1777743538641`
Branch: `swarm/swarm-dispatcher-respect-blocks-field-1777743538641`
Head: `e1fc9171`
Diff: `1 file changed, 26 insertions(+)`
Commits: 1