### PR TITLE
swarm: chitin-researcher-systemd-units

### DIFF
--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -12,6 +12,8 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 | `chitin-dispatcher.timer` | timer | Fires the dispatcher every 5 minutes. |
 | `chitin-researcher.service` | oneshot | Periodic research tasks, runs researcher script. |
 | `chitin-researcher.timer` | timer | Fires the researcher every 4 hours. |
+| `chitin-swarm-rollup.service` | oneshot | Daily swarm-health rollup: derives metrics from `tmp/result-swarm-*.json` + dispatcher journalctl, posts a digest to Slack. |
+| `chitin-swarm-rollup.timer` | timer | Fires the rollup once per day. |
 
 ## Install
 
@@ -22,6 +24,7 @@ systemctl --user daemon-reload
 systemctl --user enable --now chitin-worker
 systemctl --user enable --now chitin-dispatcher.timer
 systemctl --user enable --now chitin-researcher.timer
+systemctl --user enable --now chitin-swarm-rollup.timer
 ```
 
 To survive logout (start at boot):
@@ -37,6 +40,7 @@ sudo loginctl enable-linger $USER
 journalctl --user -u chitin-worker -f
 journalctl --user -u chitin-dispatcher -f
 journalctl --user -u chitin-researcher -f
+journalctl --user -u chitin-swarm-rollup -f
 
 # Status
 systemctl --user status chitin-worker
@@ -48,7 +52,7 @@ systemctl --user stop chitin-dispatcher.timer
 systemctl --user stop chitin-researcher.timer
 
 # Hard stop everything
-systemctl --user stop chitin-dispatcher.timer chitin-researcher.timer chitin-worker
+systemctl --user stop chitin-dispatcher.timer chitin-researcher.timer chitin-swarm-rollup.timer chitin-worker
 ```
 
 ## Manual one-shot

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -10,6 +10,8 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 | `chitin-worker.service` | long-running | Temporal worker, polls `chitin-worker-q`, runs activities. |
 | `chitin-dispatcher.service` | oneshot | Single tick: reads backlog, picks next ready entry, submits workflow, runs apply step. |
 | `chitin-dispatcher.timer` | timer | Fires the dispatcher every 5 minutes. |
+| `chitin-researcher.service` | oneshot | Periodic research tasks, runs researcher script. |
+| `chitin-researcher.timer` | timer | Fires the researcher every 4 hours. |
 
 ## Install
 
@@ -19,6 +21,7 @@ cp infra/systemd/*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now chitin-worker
 systemctl --user enable --now chitin-dispatcher.timer
+systemctl --user enable --now chitin-researcher.timer
 ```
 
 To survive logout (start at boot):
@@ -33,16 +36,19 @@ sudo loginctl enable-linger $USER
 # Live logs
 journalctl --user -u chitin-worker -f
 journalctl --user -u chitin-dispatcher -f
+journalctl --user -u chitin-researcher -f
 
 # Status
 systemctl --user status chitin-worker
+systemctl --user status chitin-researcher
 systemctl --user list-timers --all
 
 # Pause the swarm (stop dispatcher; worker keeps polling)
 systemctl --user stop chitin-dispatcher.timer
+systemctl --user stop chitin-researcher.timer
 
 # Hard stop everything
-systemctl --user stop chitin-dispatcher.timer chitin-worker
+systemctl --user stop chitin-dispatcher.timer chitin-researcher.timer chitin-worker
 ```
 
 ## Manual one-shot
@@ -50,11 +56,13 @@ systemctl --user stop chitin-dispatcher.timer chitin-worker
 ```bash
 # Dispatch a single tick on demand (no timer)
 systemctl --user start chitin-dispatcher.service
+systemctl --user start chitin-researcher.service
 
 # Or run dispatcher directly (dry-run available)
 cd ~/workspace/chitin
 pnpm exec tsx apps/temporal-worker/src/dispatcher.ts --dry-run
 pnpm exec tsx apps/temporal-worker/src/dispatcher.ts
+pnpm exec tsx apps/temporal-worker/src/researcher.ts
 ```
 
 ## What gets dispatched

--- a/infra/systemd/chitin-researcher.service
+++ b/infra/systemd/chitin-researcher.service
@@ -1,0 +1,18 @@
+# One-shot service fired by chitin-researcher.timer.
+# Runs the researcher script for periodic research tasks.
+
+[Unit]
+Description=Chitin swarm periodic researcher
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+# Optional per-user secrets (CHITIN_SLACK_WEBHOOK_URL etc).
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=%h/workspace/chitin/apps/temporal-worker/src/researcher.ts
+StandardOutput=journal
+StandardError=journal
+# 20min is generous for a research pass.
+TimeoutStartSec=1200

--- a/infra/systemd/chitin-researcher.service
+++ b/infra/systemd/chitin-researcher.service
@@ -8,10 +8,16 @@ Description=Chitin swarm periodic researcher
 Type=oneshot
 WorkingDirectory=%h/workspace/chitin
 Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
-Environment=PATH=%h/.local/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
 # Optional per-user secrets (CHITIN_SLACK_WEBHOOK_URL etc).
 EnvironmentFile=-%h/.config/systemd/user/chitin.env
-ExecStart=%h/workspace/chitin/apps/temporal-worker/src/researcher.ts
+# `.ts` files are not exec-able directly; route through pnpm exec tsx
+# (matching chitin-dispatcher.service). researcher.ts is shipped by
+# the paired external-signal-fetchers entry — until that lands, this
+# service will start, fail with "module not found", and the timer
+# tick exits non-zero. That's intentional per the backlog entry's
+# note: the unit is fine as text pointing at a not-yet-existing path.
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/researcher.ts
 StandardOutput=journal
 StandardError=journal
 # 20min is generous for a research pass.

--- a/infra/systemd/chitin-researcher.timer
+++ b/infra/systemd/chitin-researcher.timer
@@ -1,0 +1,14 @@
+# Systemd timer for chitin-researcher.service
+# Fires every 4 hours, persistent across reboots.
+
+[Unit]
+Description=Chitin swarm periodic researcher timer
+
+[Timer]
+OnUnitActiveSec=4h
+OnBootSec=15min
+Persistent=true
+Unit=chitin-researcher.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `chitin-researcher-systemd-units`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-chitin-researcher-systemd-units-1777743842890`

## Entry context

Paired systemd `.service` + `.timer` to fire the researcher
periodically. Mirrors the existing `chitin-dispatcher.service` /
`chitin-dispatcher.timer` and `chitin-swarm-rollup.service` /
`chitin-swarm-rollup.timer` patterns — copy them as the template.

Scope:

1. `chitin-researcher.service` (oneshot): runs
   `pnpm exec tsx apps/temporal-worker/src/researcher.ts`. Working
   directory is the chitin repo root (`Environment=` or
   `WorkingDirectory=`).
2. `chitin-researcher.timer`: fires every 4h
   (`OnUnitActiveSec=4h` + `OnBootSec=15min`), `Persistent=true`
   so a missed tick from a powered-off rig fires on the next boot.
   `Unit=chitin-researcher.service`.
3. Update `infra/systemd/README.md` with install instructions
   matching the existing dispatcher + rollup sections.

Blocked-by-then-unblocks: this entry's `.service` references
`researcher.ts`, which `external-signal-fetchers` creates. So this
timer should land paired with that one OR one tick after — the
service file itself is just text that points at a path that may
not yet exist (timer is happy to fire even if the service unit
fails; operator notices via systemd journal).

Mark `external-signal-fetchers` in `blocks:` so the dispatcher
ships them in the right order once `dispatcher-respect-blocks-field`
(PR #139) lands.

T1 — straight unit-file authoring.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-chitin-researcher-systemd-units-1777743842890`
Branch: `swarm/swarm-chitin-researcher-systemd-units-1777743842890`
Head: `19a7c45a`
Diff: `3 files changed, 41 insertions(+), 1 deletion(-)`
Commits: 1