### PR TITLE
feat(dispatcher): auto-enqueue reviewGraphWorkflow after PR opens (step 3b)

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -553,6 +553,32 @@ async function main() {
       pushed,
       auto_committed: applyAutoCommitted,
     });
+
+    // Phase 2 step 3b: kick off the review-graph for the freshly-
+    // opened PR. Fire-and-forget — the next dispatcher tick is free
+    // to pick a new entry while reviewers proceed in parallel. A
+    // submit failure here is logged but never propagates: the
+    // implementor's work has shipped, and Copilot R0 still reviews
+    // server-side regardless.
+    if (prUrl) {
+      try {
+        const { enqueueReviewGraph } = await import('./review-graph-dispatch.ts');
+        await enqueueReviewGraph({
+          client,
+          taskQueue: TASK_QUEUE,
+          parent_workflow_id: workflowId,
+          pr_url: prUrl,
+          worktree: result.worktree,
+          entry,
+          repo: 'chitinhq/chitin',
+          log: (line) => console.log(line),
+        });
+      } catch (err) {
+        log('warn', 'review-graph enqueue failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   } finally {
     await conn.close();
   }

--- a/apps/temporal-worker/src/review-graph-dispatch.ts
+++ b/apps/temporal-worker/src/review-graph-dispatch.ts
@@ -1,0 +1,194 @@
+// Phase 2 step 3b: dispatcher → review-graph integration. After the
+// programmer dispatcher's apply step opens a PR, this enqueues the
+// reviewGraphWorkflow so the §5 escalation chain runs in parallel
+// with whatever the dispatcher does next (the next tick can pick a
+// new entry while the review proceeds).
+//
+// The review-graph runs as a SEPARATE top-level workflow — it doesn't
+// block the dispatcher's tick. That preserves the "one swarm
+// workflow in flight at a time" invariant on the implementor side
+// while letting reviewers proceed independently. The next tick still
+// won't dispatch a new programmer until the review-graph (and any
+// other reviewer-side work) completes, because the running-workflow
+// scan in dispatcher.ts matches `swarm-*` prefix — which the
+// reviewer-graph + reviewer dispatches inherit via parent prefix.
+//
+// Failure mode: if review-graph submit fails, log and move on. The
+// PR still exists; operator can manually start the review or merge
+// based on Copilot's R0 review. We never want a review-graph failure
+// to leave the dispatcher stuck (the implementor's work has shipped).
+
+import type { Client } from '@temporalio/client';
+import type { reviewGraphWorkflow } from './review-graph-workflow.ts';
+import type { BacklogEntry } from './grooming/parse-backlog.ts';
+import type { WorktreeResult } from './activity-types.ts';
+import type { PrMeta } from './review-graph.ts';
+
+export const REVIEW_GRAPH_WORKFLOW_NAME = 'reviewGraphWorkflow';
+
+export interface EnqueueReviewGraphInput {
+  client: Client;
+  /** Task queue the worker polls for review-graph dispatches. */
+  taskQueue: string;
+  /** The programmer workflow_id that just finished. Becomes the
+   *  parent_workflow_id on every reviewer dispatch the graph fires. */
+  parent_workflow_id: string;
+  /** PR URL the apply step opened. Required — without it the graph
+   *  has no PR to review and we silently no-op. */
+  pr_url: string | undefined;
+  /** Worktree result from the programmer's activity — source of
+   *  truth for diff stats. May be undefined if the activity didn't
+   *  produce a worktree (rare; review-graph still runs but with
+   *  diff_loc=0, files_changed=0). */
+  worktree: WorktreeResult | undefined;
+  /** Backlog entry the programmer worked off. Drives tier rules
+   *  (e.g., T3 implementor → start review at R2). */
+  entry: BacklogEntry;
+  /** Repo slug, e.g. 'chitinhq/chitin'. Used by reviewer agents to
+   *  call gh CLI. */
+  repo: string;
+  /** Optional log sink (defaults to console.log). Tests inject. */
+  log?: (line: string) => void;
+}
+
+export interface EnqueueReviewGraphResult {
+  /** Whether the review-graph workflow was actually submitted. False
+   *  when pr_url was absent (PR didn't open) or submit failed. */
+  enqueued: boolean;
+  /** The review-graph workflow_id, when enqueued. */
+  workflow_id?: string;
+  /** Failure message when enqueued=false because of a submit error
+   *  (vs. enqueued=false because pr_url was absent). */
+  error?: string;
+}
+
+/**
+ * Build the review-graph input from the dispatcher's post-apply state.
+ * Pure — exported so tests can pin the field-mapping invariant
+ * without standing up a Temporal client.
+ */
+export function buildReviewGraphInput(
+  parent_workflow_id: string,
+  pr_url: string,
+  worktree: WorktreeResult | undefined,
+  entry: BacklogEntry,
+  repo: string,
+): { parent_workflow_id: string; pr_meta: PrMeta; entry: BacklogEntry; repo: string } {
+  const pr_number = extractPrNumber(pr_url);
+  const { diff_loc, files_changed } = parseDiffShortstat(worktree?.diff_shortstat ?? '');
+  return {
+    parent_workflow_id,
+    pr_meta: {
+      diff_loc,
+      files_changed,
+      // We don't enumerate the file list here — git would have to be
+      // re-invoked from a worktree that may be cleaned up. Reviewers
+      // can `gh pr diff` if they need it. Empty list = "unknown,
+      // skip path-scope-based bumps" per PrMeta docstring.
+      files: [],
+      pr_url,
+      pr_number,
+      // copilot_comment_count is undefined on first dispatch — Copilot
+      // is racing us. Reviewer prompt handles that branch.
+    },
+    entry,
+    repo,
+  };
+}
+
+/**
+ * Parse a `git diff --shortstat`-style line into (LOC, files_changed).
+ * Defensive for the empty-diff case (worktree had no change to commit
+ * but a PR opened on whatever was already pushed — rare but real).
+ */
+export function parseDiffShortstat(s: string): { diff_loc: number; files_changed: number } {
+  if (!s) return { diff_loc: 0, files_changed: 0 };
+  // Format: " 4 files changed, 123 insertions(+), 45 deletions(-)"
+  const filesMatch = s.match(/(\d+)\s+files?\s+changed/);
+  const insMatch = s.match(/(\d+)\s+insertions?/);
+  const delMatch = s.match(/(\d+)\s+deletions?/);
+  const ins = insMatch ? Number(insMatch[1]) : 0;
+  const del = delMatch ? Number(delMatch[1]) : 0;
+  return {
+    diff_loc: ins + del,
+    files_changed: filesMatch ? Number(filesMatch[1]) : 0,
+  };
+}
+
+/**
+ * Pull the numeric PR number off a github.com/<o>/<r>/pull/N URL.
+ * Returns undefined when the URL doesn't match the expected shape
+ * (defensive — caller should still enqueue with pr_number=undefined
+ * and let the reviewer-prompt builder throw the schema rejection).
+ */
+export function extractPrNumber(pr_url: string): number | undefined {
+  const m = pr_url.match(/\/pull\/(\d+)/);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
+ * Submit the review-graph workflow. Failure is logged but never
+ * propagates — the implementor's work has already shipped (PR exists);
+ * a missing review is not worse than the pre-Phase-2 baseline where
+ * Copilot was the only reviewer.
+ */
+export async function enqueueReviewGraph(
+  input: EnqueueReviewGraphInput,
+): Promise<EnqueueReviewGraphResult> {
+  const log = input.log ?? ((l: string) => console.log(l));
+
+  if (!input.pr_url) {
+    return { enqueued: false };
+  }
+
+  const reviewGraphInput = buildReviewGraphInput(
+    input.parent_workflow_id,
+    input.pr_url,
+    input.worktree,
+    input.entry,
+    input.repo,
+  );
+
+  // Reviewer chain workflow_id derives from the parent. Keep it
+  // greppable so the operator can correlate `swarm-<entry>-<ts>` to
+  // its review-graph chain.
+  const reviewGraphId = `${input.parent_workflow_id}-review-graph`;
+
+  try {
+    await input.client.workflow.start<typeof reviewGraphWorkflow>(REVIEW_GRAPH_WORKFLOW_NAME, {
+      args: [reviewGraphInput],
+      taskQueue: input.taskQueue,
+      workflowId: reviewGraphId,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        component: 'review-graph-dispatch',
+        msg: 'submit failed; PR will rely on Copilot R0 only',
+        parent_workflow_id: input.parent_workflow_id,
+        pr_url: input.pr_url,
+        error: msg,
+      }),
+    );
+    return { enqueued: false, error: msg };
+  }
+
+  log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'info',
+      component: 'review-graph-dispatch',
+      msg: 'review-graph enqueued',
+      parent_workflow_id: input.parent_workflow_id,
+      review_graph_id: reviewGraphId,
+      pr_url: input.pr_url,
+      diff_loc: reviewGraphInput.pr_meta.diff_loc,
+      files_changed: reviewGraphInput.pr_meta.files_changed,
+    }),
+  );
+
+  return { enqueued: true, workflow_id: reviewGraphId };
+}

--- a/apps/temporal-worker/src/workflow.ts
+++ b/apps/temporal-worker/src/workflow.ts
@@ -20,3 +20,9 @@ const { runAgentTurn } = proxyActivities<{
 export async function executeRequestWorkflow(req: ExecutionRequest): Promise<ActivityResult> {
   return runAgentTurn(req);
 }
+
+// Re-export the review-graph workflow so it's registered in the
+// workflowsPath bundle the worker loads. Without this, calls to
+// `client.workflow.start('reviewGraphWorkflow', ...)` would fail
+// at submit time with "workflow not found".
+export { reviewGraphWorkflow } from './review-graph-workflow.ts';

--- a/apps/temporal-worker/test/review-graph-dispatch.test.ts
+++ b/apps/temporal-worker/test/review-graph-dispatch.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildReviewGraphInput,
+  parseDiffShortstat,
+  extractPrNumber,
+  enqueueReviewGraph,
+  REVIEW_GRAPH_WORKFLOW_NAME,
+} from '../src/review-graph-dispatch.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+import type { WorktreeResult } from '../src/activity-types.ts';
+
+function makeEntry(overrides: Partial<BacklogEntry> = {}): BacklogEntry {
+  return {
+    id: 'sample-entry',
+    status: 'ready',
+    description: 'sample',
+    rawFrontmatter: '',
+    rawSection: '',
+    tier: 'T1',
+    file: 'apps/temporal-worker/src/foo.ts',
+    ...overrides,
+  };
+}
+
+function makeWorktree(overrides: Partial<WorktreeResult> = {}): WorktreeResult {
+  return {
+    path: '/tmp/wt',
+    branch: 'swarm/swarm-sample-1',
+    head_sha: 'abc1234',
+    commits_added: 1,
+    has_uncommitted_changes: false,
+    diff_shortstat: ' 3 files changed, 47 insertions(+), 12 deletions(-)',
+    ...overrides,
+  };
+}
+
+// ─── parseDiffShortstat ──────────────────────────────────────────────────
+
+describe('parseDiffShortstat', () => {
+  it('parses a typical line with insertions + deletions + files changed', () => {
+    const r = parseDiffShortstat(' 3 files changed, 47 insertions(+), 12 deletions(-)');
+    expect(r).toEqual({ diff_loc: 59, files_changed: 3 });
+  });
+
+  it('parses a line with only insertions (no deletions)', () => {
+    const r = parseDiffShortstat(' 1 file changed, 100 insertions(+)');
+    expect(r).toEqual({ diff_loc: 100, files_changed: 1 });
+  });
+
+  it('parses a line with only deletions (no insertions)', () => {
+    const r = parseDiffShortstat(' 2 files changed, 30 deletions(-)');
+    expect(r).toEqual({ diff_loc: 30, files_changed: 2 });
+  });
+
+  it('handles single-file singular phrasing ("1 file changed", "1 insertion")', () => {
+    const r = parseDiffShortstat(' 1 file changed, 1 insertion(+)');
+    expect(r).toEqual({ diff_loc: 1, files_changed: 1 });
+  });
+
+  it('returns zeros for an empty string (no diff case)', () => {
+    expect(parseDiffShortstat('')).toEqual({ diff_loc: 0, files_changed: 0 });
+  });
+
+  it('returns zeros for a malformed line that has no numbers', () => {
+    expect(parseDiffShortstat('weird placeholder')).toEqual({
+      diff_loc: 0,
+      files_changed: 0,
+    });
+  });
+});
+
+// ─── extractPrNumber ─────────────────────────────────────────────────────
+
+describe('extractPrNumber', () => {
+  it('extracts the number from a github.com PR URL', () => {
+    expect(extractPrNumber('https://github.com/chitinhq/chitin/pull/142')).toBe(142);
+    expect(extractPrNumber('https://github.com/foo/bar/pull/1')).toBe(1);
+  });
+
+  it('returns undefined for a URL without /pull/N', () => {
+    expect(extractPrNumber('https://github.com/chitinhq/chitin/issues/123')).toBeUndefined();
+  });
+
+  it('returns undefined for a non-URL string', () => {
+    expect(extractPrNumber('some text')).toBeUndefined();
+  });
+});
+
+// ─── buildReviewGraphInput ───────────────────────────────────────────────
+
+describe('buildReviewGraphInput', () => {
+  it('maps the dispatcher state into a complete ReviewGraphInput', () => {
+    const out = buildReviewGraphInput(
+      'swarm-sample-12345',
+      'https://github.com/chitinhq/chitin/pull/200',
+      makeWorktree(),
+      makeEntry(),
+      'chitinhq/chitin',
+    );
+    expect(out.parent_workflow_id).toBe('swarm-sample-12345');
+    expect(out.pr_meta.pr_number).toBe(200);
+    expect(out.pr_meta.pr_url).toBe('https://github.com/chitinhq/chitin/pull/200');
+    expect(out.pr_meta.diff_loc).toBe(59);
+    expect(out.pr_meta.files_changed).toBe(3);
+    expect(out.pr_meta.files).toEqual([]);
+    expect(out.entry.id).toBe('sample-entry');
+    expect(out.repo).toBe('chitinhq/chitin');
+    // copilot_comment_count is left undefined per the docstring (Copilot
+    // races us; the prompt's R0-pending branch handles it).
+    expect(out.pr_meta.copilot_comment_count).toBeUndefined();
+  });
+
+  it('handles missing worktree (rare; activity didn\'t produce one)', () => {
+    const out = buildReviewGraphInput(
+      'parent-1',
+      'https://github.com/o/r/pull/5',
+      undefined,
+      makeEntry(),
+      'o/r',
+    );
+    expect(out.pr_meta.diff_loc).toBe(0);
+    expect(out.pr_meta.files_changed).toBe(0);
+  });
+
+  it('leaves pr_number undefined when the URL is malformed', () => {
+    const out = buildReviewGraphInput(
+      'parent-2',
+      'https://example.com/not-a-pr',
+      makeWorktree(),
+      makeEntry(),
+      'o/r',
+    );
+    expect(out.pr_meta.pr_number).toBeUndefined();
+    expect(out.pr_meta.pr_url).toBe('https://example.com/not-a-pr');
+  });
+});
+
+// ─── enqueueReviewGraph ──────────────────────────────────────────────────
+
+interface MockClient {
+  workflow: {
+    start: ReturnType<typeof makeStartFn>;
+  };
+  __startCalls: StartCall[];
+}
+
+interface StartCall {
+  workflowName: string;
+  args: unknown[];
+  workflowId: string;
+  taskQueue: string;
+}
+
+function makeStartFn(calls: StartCall[], opts?: { rejectOn?: string }) {
+  return async (
+    workflowName: string,
+    options: { args: unknown[]; workflowId: string; taskQueue: string },
+  ) => {
+    if (opts?.rejectOn === workflowName) {
+      throw new Error('temporal submit failed (mock)');
+    }
+    calls.push({
+      workflowName,
+      args: options.args,
+      workflowId: options.workflowId,
+      taskQueue: options.taskQueue,
+    });
+    return { workflowId: options.workflowId, firstExecutionRunId: 'mock-run' };
+  };
+}
+
+function makeMockClient(opts?: { rejectOn?: string }): MockClient {
+  const calls: StartCall[] = [];
+  return {
+    workflow: { start: makeStartFn(calls, opts) },
+    __startCalls: calls,
+  };
+}
+
+describe('enqueueReviewGraph', () => {
+  it('submits the review-graph workflow when pr_url is set', async () => {
+    const client = makeMockClient();
+    const logs: string[] = [];
+    const r = await enqueueReviewGraph({
+      // The Client interface we accept matches Temporal's only on the
+      // workflow.start surface; cast through unknown for the test.
+      client: client as unknown as Parameters<typeof enqueueReviewGraph>[0]['client'],
+      taskQueue: 'chitin-worker-q',
+      parent_workflow_id: 'swarm-sample-12345',
+      pr_url: 'https://github.com/chitinhq/chitin/pull/300',
+      worktree: makeWorktree(),
+      entry: makeEntry(),
+      repo: 'chitinhq/chitin',
+      log: (l) => logs.push(l),
+    });
+    expect(r.enqueued).toBe(true);
+    expect(r.workflow_id).toBe('swarm-sample-12345-review-graph');
+    expect(client.__startCalls).toHaveLength(1);
+    expect(client.__startCalls[0].workflowName).toBe(REVIEW_GRAPH_WORKFLOW_NAME);
+    expect(client.__startCalls[0].workflowId).toBe('swarm-sample-12345-review-graph');
+    expect(client.__startCalls[0].taskQueue).toBe('chitin-worker-q');
+    // Telemetry log line on success.
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.component).toBe('review-graph-dispatch');
+    expect(parsed.msg).toBe('review-graph enqueued');
+    expect(parsed.diff_loc).toBe(59);
+  });
+
+  it('no-ops when pr_url is undefined (PR did not open)', async () => {
+    const client = makeMockClient();
+    const logs: string[] = [];
+    const r = await enqueueReviewGraph({
+      client: client as unknown as Parameters<typeof enqueueReviewGraph>[0]['client'],
+      taskQueue: 'chitin-worker-q',
+      parent_workflow_id: 'swarm-x-1',
+      pr_url: undefined,
+      worktree: makeWorktree(),
+      entry: makeEntry(),
+      repo: 'chitinhq/chitin',
+      log: (l) => logs.push(l),
+    });
+    expect(r.enqueued).toBe(false);
+    expect(r.workflow_id).toBeUndefined();
+    expect(client.__startCalls).toHaveLength(0);
+    // No log line — the no-op case is silent (next dispatcher tick
+    // gets the next pickup; no point spamming the journal).
+    expect(logs).toHaveLength(0);
+  });
+
+  it('logs warn and returns enqueued:false when temporal submit throws', async () => {
+    const client = makeMockClient({ rejectOn: REVIEW_GRAPH_WORKFLOW_NAME });
+    const logs: string[] = [];
+    const r = await enqueueReviewGraph({
+      client: client as unknown as Parameters<typeof enqueueReviewGraph>[0]['client'],
+      taskQueue: 'chitin-worker-q',
+      parent_workflow_id: 'swarm-failure-1',
+      pr_url: 'https://github.com/chitinhq/chitin/pull/400',
+      worktree: makeWorktree(),
+      entry: makeEntry(),
+      repo: 'chitinhq/chitin',
+      log: (l) => logs.push(l),
+    });
+    expect(r.enqueued).toBe(false);
+    expect(r.error).toContain('temporal submit failed');
+    // Implementor's work shipped — the warn log captures the event
+    // but NEVER propagates as a thrown error.
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.level).toBe('warn');
+    expect(parsed.component).toBe('review-graph-dispatch');
+  });
+
+  it('passes the correct args shape (ReviewGraphInput) to client.workflow.start', async () => {
+    const client = makeMockClient();
+    await enqueueReviewGraph({
+      client: client as unknown as Parameters<typeof enqueueReviewGraph>[0]['client'],
+      taskQueue: 'chitin-worker-q',
+      parent_workflow_id: 'parent-arg-shape-1',
+      pr_url: 'https://github.com/chitinhq/chitin/pull/500',
+      worktree: makeWorktree(),
+      entry: makeEntry({ id: 'arg-shape-test' }),
+      repo: 'chitinhq/chitin',
+    });
+    expect(client.__startCalls).toHaveLength(1);
+    const [arg] = client.__startCalls[0].args as [
+      {
+        parent_workflow_id: string;
+        pr_meta: { pr_number: number; pr_url: string };
+        entry: BacklogEntry;
+        repo: string;
+      },
+    ];
+    expect(arg.parent_workflow_id).toBe('parent-arg-shape-1');
+    expect(arg.pr_meta.pr_number).toBe(500);
+    expect(arg.entry.id).toBe('arg-shape-test');
+    expect(arg.repo).toBe('chitinhq/chitin');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the loop on the swarm-as-software-factory pipeline: programmer dispatch → PR opens → review-graph chain runs in parallel with the next dispatcher tick.

- New `review-graph-dispatch.ts` module: pure helpers (parseDiffShortstat, extractPrNumber, buildReviewGraphInput) + `enqueueReviewGraph(client, ...)` wrapper
- Dispatcher calls enqueueReviewGraph after notifyDispatchComplete when prUrl is set (fire-and-forget; submit failure logged but never propagates)
- workflow.ts re-exports reviewGraphWorkflow so it's registered in the worker's workflowsPath bundle
- review-graph workflow_id derives as `<parent>-review-graph` for greppable correlation

## Pipeline state after merge

```
programmer dispatch → PR opens → review-graph chain (R1→R2→R3 escalation)
                                  └── findings posted to PR by reviewer agents
                                  └── ReviewGraphResult returned (audit + telemetry)
                                  └── operator decides merge (auto-merge gatekeeper TBD)
```

## Test plan

- [x] 16 new tests covering helpers + enqueue happy/no-op/failure paths
- [x] 318/318 pass in apps/temporal-worker
- [x] typecheck clean
- [ ] First live PR after merge: verify the review-graph workflow appears in Temporal UI with id `<parent>-review-graph`

🤖 Generated with [Claude Code](https://claude.com/claude-code)