### PR TITLE
feat(gatekeeper): terminal-state Slack digest closes the review-graph chain

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -593,6 +593,11 @@ function findMatchingOpenBrace(s: string, end: number): number {
   return -1;
 }
 
+// Re-export runGatekeeperNotify so the worker registers it as an
+// activity. Workflows can't make HTTP calls; reviewGraphWorkflow
+// proxies this for the terminal-state Slack digest.
+export { runGatekeeperNotify } from './gatekeeper.ts';
+
 export const __test__ = {
   parseToolSummary,
   planInvocation,

--- a/apps/temporal-worker/src/gatekeeper.ts
+++ b/apps/temporal-worker/src/gatekeeper.ts
@@ -1,0 +1,191 @@
+// Gatekeeper notify (Phase 2 step 4 — bare visibility layer).
+//
+// What it is:
+//   The terminal step the reviewGraphWorkflow calls after the
+//   escalation loop returns. Takes the ReviewGraphResult + PR
+//   metadata, posts a Slack digest, returns a structured outcome
+//   the workflow can include in its return value for telemetry.
+//
+// What it is NOT (yet):
+//   Auto-merge. The factory design's §6 gatekeeper has an auto-merge
+//   path on `action='approve' AND CI green`, but auto-merging the
+//   swarm's own work is the highest-risk capability we'd ship — it
+//   needs a soak window first. v1 is "post the digest, let the
+//   operator decide." Auto-merge lands behind a CHITIN_GATEKEEPER_
+//   AUTO_MERGE flag in a follow-up entry once we have telemetry on
+//   the review-graph's false-approve rate.
+//
+// Why this is an activity (vs a workflow step or pure function):
+//   Slack lives outside Temporal. Workflows can't make HTTP calls
+//   directly — they need an activity to do it deterministically (the
+//   workflow replays from history; HTTP results are not replay-safe).
+//   Pure-function would work for shaping the digest; we keep that
+//   half pure (`buildGatekeeperDigest`) and wrap it in
+//   `runGatekeeperNotify` for the HTTP boundary.
+
+import type { ReviewGraphAction, ReviewGraphResult } from './review-graph-workflow.ts';
+import type { PrMeta } from './review-graph.ts';
+
+export interface GatekeeperInput {
+  result: ReviewGraphResult;
+  pr_meta: PrMeta;
+  /** Repo slug — purely audit context for the digest header. */
+  repo: string;
+  /** Backlog entry id — same. */
+  entry_id: string;
+}
+
+export interface GatekeeperOutcome {
+  action: ReviewGraphAction;
+  notified: boolean;
+  /** When notified=false: reason. When notified=true: whether the
+   *  Slack post itself returned ok (best-effort; failures don't
+   *  propagate, only get logged). */
+  reason: string;
+  digest: string;
+}
+
+const ACTION_EMOJI: Record<ReviewGraphAction, string> = {
+  approve: '✅',
+  'request-changes': '🟡',
+  'escalate-to-operator': '🚨',
+  'parse-failure-at-r4': '⚠️',
+};
+
+const ACTION_HEADLINE: Record<ReviewGraphAction, string> = {
+  approve: 'review chain approved',
+  'request-changes': 'reviewer requested changes',
+  'escalate-to-operator': 'review chain escalated to operator',
+  'parse-failure-at-r4': 'review chain parse-failure cascade — every tier emit failed to parse',
+};
+
+/**
+ * Build a markdown digest for the operator. Pure — exported so tests
+ * can pin the format invariant without mocking the HTTP boundary.
+ */
+export function buildGatekeeperDigest(input: GatekeeperInput): string {
+  const { result, pr_meta, entry_id, repo } = input;
+  const emoji = ACTION_EMOJI[result.action];
+  const headline = ACTION_HEADLINE[result.action];
+
+  const findingsSection = renderFindings(result);
+  const tiersSection = renderTierLog(result);
+
+  const prLine = pr_meta.pr_url ? `<${pr_meta.pr_url}|#${pr_meta.pr_number ?? '?'}>` : '(no PR url)';
+
+  // Slack mrkdwn tolerates github-flavored markdown for the most
+  // common cases; we deliberately stay simple so the same digest
+  // renders identically when piped to journalctl.
+  return [
+    `${emoji} *${headline}*`,
+    `repo \`${repo}\`  •  entry \`${entry_id}\`  •  PR ${prLine}`,
+    `final_tier=${result.final_tier}  •  diff=${pr_meta.diff_loc} LOC across ${pr_meta.files_changed} file(s)`,
+    result.t5_shape ? '⚠️  t5_shape detected — gatekeeper escalates regardless of action' : '',
+    findingsSection,
+    tiersSection,
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+}
+
+function renderFindings(result: ReviewGraphResult): string {
+  const findings = result.output?.findings ?? [];
+  if (findings.length === 0) {
+    return result.action === 'approve'
+      ? 'no findings — chain approved cleanly'
+      : 'no structured findings emitted';
+  }
+  // Cap at 8 to keep Slack rendering reasonable; full audit lives in
+  // the temporal UI.
+  const head = findings.slice(0, 8);
+  const lines = head.map((f) => {
+    const loc = f.line ? `${f.file}:${f.line}` : f.file;
+    return `  - ${f.severity} ${loc} (${f.category}): ${f.summary}`;
+  });
+  if (findings.length > head.length) {
+    lines.push(`  - … +${findings.length - head.length} more (see Temporal UI for full set)`);
+  }
+  return ['Findings:', ...lines].join('\n');
+}
+
+function renderTierLog(result: ReviewGraphResult): string {
+  if (result.tier_log.length === 0) return '';
+  const lines = result.tier_log.map((entry) => {
+    const status = entry.parsed ? 'parsed' : 'parse-fail';
+    const decision = entry.output?.decision ?? '—';
+    return `  - ${entry.tier}: ${status}  decision=${decision}`;
+  });
+  return ['Tier log:', ...lines].join('\n');
+}
+
+/**
+ * Post the gatekeeper digest to Slack. Failure is logged but never
+ * propagates — visibility is best-effort, never a workflow blocker.
+ *
+ * Activity-shaped: this is what reviewGraphWorkflow proxies. Slack
+ * env-var lookup happens inside the function (vs. at module load) so
+ * tests can drive a deterministic outcome regardless of the host's
+ * env.
+ */
+export async function runGatekeeperNotify(input: GatekeeperInput): Promise<GatekeeperOutcome> {
+  const digest = buildGatekeeperDigest(input);
+  const webhook = process.env.CHITIN_SLACK_WEBHOOK_URL?.trim();
+
+  if (!webhook) {
+    return {
+      action: input.result.action,
+      notified: false,
+      reason: 'CHITIN_SLACK_WEBHOOK_URL unset — digest emitted to journal only',
+      digest,
+    };
+  }
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 3000);
+  try {
+    const resp = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        text: digest,
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: digest },
+          },
+        ],
+      }),
+      signal: ctrl.signal,
+    });
+    if (!resp.ok) {
+      return {
+        action: input.result.action,
+        notified: false,
+        reason: `slack post non-ok status=${resp.status}`,
+        digest,
+      };
+    }
+    return {
+      action: input.result.action,
+      notified: true,
+      reason: 'posted',
+      digest,
+    };
+  } catch (err) {
+    return {
+      action: input.result.action,
+      notified: false,
+      reason: `slack post failed: ${err instanceof Error ? err.message : String(err)}`,
+      digest,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export const __test__ = {
+  ACTION_EMOJI,
+  ACTION_HEADLINE,
+  renderFindings,
+  renderTierLog,
+};

--- a/apps/temporal-worker/src/review-graph-workflow.ts
+++ b/apps/temporal-worker/src/review-graph-workflow.ts
@@ -21,7 +21,7 @@
 // workflow itself so it's reviewable in isolation; the dispatcher edit
 // is the next step.
 
-import { executeChild } from '@temporalio/workflow';
+import { executeChild, proxyActivities } from '@temporalio/workflow';
 import {
   ExecutionRequestSchema,
   type ExecutionRequest,
@@ -404,22 +404,63 @@ function formatParseFailureForNextTier(
 
 // ─── Temporal wrapper ──────────────────────────────────────────────────────
 
+// Activity proxy for the gatekeeper Slack digest. 30s is generous
+// for an HTTP POST + 3s internal timeout; activity itself is
+// best-effort and never throws on Slack failure.
+const { runGatekeeperNotify } = proxyActivities<{
+  runGatekeeperNotify(input: {
+    result: ReviewGraphResult;
+    pr_meta: ReviewGraphInput['pr_meta'];
+    repo: string;
+    entry_id: string;
+  }): Promise<{
+    action: ReviewGraphAction;
+    notified: boolean;
+    reason: string;
+    digest: string;
+  }>;
+}>({
+  startToCloseTimeout: '30 seconds',
+  retry: { maximumAttempts: 1 },
+});
+
 /**
  * The Temporal workflow chitin's review-graph runs as. Thin shell —
  * dispatches each reviewer via `executeChild(executeRequestWorkflow,
- * ...)` and delegates loop logic to runReviewGraphLoop.
+ * ...)` and delegates loop logic to runReviewGraphLoop. After the
+ * loop terminates, fires the gatekeeper notify activity so the
+ * operator gets a Slack digest of the chain's terminal state.
  *
  * Register in worker.ts's workflowsPath module (workflow.ts re-export)
  * before the dispatcher can call `client.workflow.start(...)` with
  * this name.
  */
 export async function reviewGraphWorkflow(input: ReviewGraphInput): Promise<ReviewGraphResult> {
-  return runReviewGraphLoop(input, async (req) => {
+  const result = await runReviewGraphLoop(input, async (req) => {
     return await executeChild<typeof executeRequestWorkflow>('executeRequestWorkflow', {
       args: [req],
       workflowId: req.workflow_id,
     });
   });
+
+  // Fire-and-don't-fail the gatekeeper notify. A Slack outage shouldn't
+  // make the workflow look failed — the chain's audit trail is already
+  // captured in `result`. Errors here are silently swallowed; the
+  // activity itself returns notified=false rather than throwing.
+  try {
+    await runGatekeeperNotify({
+      result,
+      pr_meta: input.pr_meta,
+      repo: input.repo,
+      entry_id: input.entry.id,
+    });
+  } catch {
+    // Activity layer already swallows HTTP errors. This catch covers
+    // the rarer case where Temporal itself rejects the activity call
+    // (worker offline, etc.). The workflow still returns its result.
+  }
+
+  return result;
 }
 
 export const __test__ = {

--- a/apps/temporal-worker/test/gatekeeper.test.ts
+++ b/apps/temporal-worker/test/gatekeeper.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildGatekeeperDigest,
+  runGatekeeperNotify,
+  __test__,
+  type GatekeeperInput,
+} from '../src/gatekeeper.ts';
+import type { ReviewGraphResult } from '../src/review-graph-workflow.ts';
+import type { PrMeta, ReviewerOutput, ReviewerFinding } from '../src/review-graph.ts';
+
+const { ACTION_EMOJI, ACTION_HEADLINE } = __test__;
+
+function makeOutput(overrides: Partial<ReviewerOutput> = {}): ReviewerOutput {
+  return {
+    decision: 'approve',
+    confidence: 'high',
+    findings: [],
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<ReviewGraphResult> = {}): ReviewGraphResult {
+  return {
+    final_tier: 'R1',
+    action: 'approve',
+    output: makeOutput(),
+    t5_shape: false,
+    tier_log: [{ tier: 'R1', parsed: true, output: makeOutput() }],
+    ...overrides,
+  };
+}
+
+function makePrMeta(overrides: Partial<PrMeta> = {}): PrMeta {
+  return {
+    diff_loc: 47,
+    files_changed: 3,
+    files: [],
+    pr_url: 'https://github.com/chitinhq/chitin/pull/200',
+    pr_number: 200,
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<GatekeeperInput> = {}): GatekeeperInput {
+  return {
+    result: makeResult(),
+    pr_meta: makePrMeta(),
+    repo: 'chitinhq/chitin',
+    entry_id: 'sample-entry',
+    ...overrides,
+  };
+}
+
+// ─── buildGatekeeperDigest ──────────────────────────────────────────────
+
+describe('buildGatekeeperDigest', () => {
+  it('renders the approve emoji + headline + repo + entry + PR link', () => {
+    const out = buildGatekeeperDigest(makeInput());
+    expect(out).toContain(ACTION_EMOJI.approve);
+    expect(out).toContain(ACTION_HEADLINE.approve);
+    expect(out).toContain('chitinhq/chitin');
+    expect(out).toContain('sample-entry');
+    expect(out).toContain('#200');
+    expect(out).toContain('https://github.com/chitinhq/chitin/pull/200');
+  });
+
+  it('renders different emoji for each action', () => {
+    expect(buildGatekeeperDigest(makeInput({ result: makeResult({ action: 'approve' }) }))).toContain('✅');
+    expect(buildGatekeeperDigest(makeInput({ result: makeResult({ action: 'request-changes' }) }))).toContain('🟡');
+    expect(buildGatekeeperDigest(makeInput({ result: makeResult({ action: 'escalate-to-operator' }) }))).toContain('🚨');
+    expect(buildGatekeeperDigest(makeInput({ result: makeResult({ action: 'parse-failure-at-r4' }) }))).toContain('⚠️');
+  });
+
+  it('flags t5_shape with the explicit override notice', () => {
+    const out = buildGatekeeperDigest(makeInput({ result: makeResult({ t5_shape: true }) }));
+    expect(out).toContain('t5_shape detected');
+  });
+
+  it('reports diff_loc and files_changed in the header', () => {
+    const out = buildGatekeeperDigest(
+      makeInput({ pr_meta: makePrMeta({ diff_loc: 829, files_changed: 4 }) }),
+    );
+    expect(out).toContain('diff=829 LOC');
+    expect(out).toContain('4 file(s)');
+  });
+
+  it('renders findings as bullets with severity + location + summary', () => {
+    const findings: ReviewerFinding[] = [
+      { severity: '🔴', file: 'a.ts', line: 42, category: 'bug', summary: 'broken logic' },
+      { severity: '🟡', file: 'b.ts', category: 'design', summary: 'rename' },
+    ];
+    const out = buildGatekeeperDigest(
+      makeInput({
+        result: makeResult({
+          action: 'request-changes',
+          output: makeOutput({ decision: 'request_changes', findings }),
+        }),
+      }),
+    );
+    expect(out).toContain('🔴 a.ts:42');
+    expect(out).toContain('broken logic');
+    expect(out).toContain('🟡 b.ts');
+  });
+
+  it('says "no findings" on a clean approve', () => {
+    const out = buildGatekeeperDigest(makeInput()); // approve + empty
+    expect(out).toContain('no findings');
+  });
+
+  it('caps findings at 8 + adds "more" line for excess', () => {
+    const findings: ReviewerFinding[] = Array.from({ length: 12 }, (_, i) => ({
+      severity: '🟡' as const,
+      file: `f${i}.ts`,
+      category: 'design' as const,
+      summary: `nit ${i}`,
+    }));
+    const out = buildGatekeeperDigest(
+      makeInput({
+        result: makeResult({
+          action: 'request-changes',
+          output: makeOutput({ decision: 'request_changes', findings }),
+        }),
+      }),
+    );
+    expect(out).toContain('f0.ts');
+    expect(out).toContain('f7.ts');
+    expect(out).not.toContain('f9.ts');
+    expect(out).toContain('+4 more');
+  });
+
+  it('includes a tier log section listing each visited tier', () => {
+    const tier_log: ReviewGraphResult['tier_log'] = [
+      { tier: 'R1', parsed: true, output: makeOutput({ decision: 'escalate' }) },
+      { tier: 'R2', parsed: true, output: makeOutput({ decision: 'escalate' }) },
+      { tier: 'R3', parsed: false, error: 'no <<<REVIEW>>> marker' },
+    ];
+    const out = buildGatekeeperDigest(
+      makeInput({
+        result: makeResult({ final_tier: 'R3', action: 'parse-failure-at-r4', tier_log }),
+      }),
+    );
+    expect(out).toContain('R1: parsed');
+    expect(out).toContain('R2: parsed');
+    expect(out).toContain('R3: parse-fail');
+  });
+
+  it('handles the missing-PR-url edge case (rare; fallback message)', () => {
+    const out = buildGatekeeperDigest(
+      makeInput({ pr_meta: { ...makePrMeta(), pr_url: undefined, pr_number: undefined } }),
+    );
+    expect(out).toContain('(no PR url)');
+  });
+});
+
+// ─── runGatekeeperNotify ────────────────────────────────────────────────
+
+describe('runGatekeeperNotify', () => {
+  let realFetch: typeof globalThis.fetch;
+  let realWebhook: string | undefined;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+    realWebhook = process.env.CHITIN_SLACK_WEBHOOK_URL;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (realWebhook === undefined) delete process.env.CHITIN_SLACK_WEBHOOK_URL;
+    else process.env.CHITIN_SLACK_WEBHOOK_URL = realWebhook;
+  });
+
+  it('returns notified:false when the webhook is unset (no fetch call)', async () => {
+    delete process.env.CHITIN_SLACK_WEBHOOK_URL;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      return new Response('ok', { status: 200 });
+    }) as typeof globalThis.fetch;
+    const r = await runGatekeeperNotify(makeInput());
+    expect(r.notified).toBe(false);
+    expect(r.reason).toContain('unset');
+    expect(r.digest).toContain('sample-entry');
+    expect(fetchCalls).toBe(0);
+  });
+
+  it('posts to slack and returns notified:true on 200', async () => {
+    process.env.CHITIN_SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
+    const captured: { url: string; body: string }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      captured.push({ url: String(url), body: String(init?.body ?? '') });
+      return new Response('ok', { status: 200 });
+    }) as typeof globalThis.fetch;
+    const r = await runGatekeeperNotify(makeInput());
+    expect(r.notified).toBe(true);
+    expect(r.reason).toBe('posted');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toContain('hooks.slack.com');
+    expect(captured[0].body).toContain('sample-entry');
+  });
+
+  it('returns notified:false on non-2xx without throwing', async () => {
+    process.env.CHITIN_SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
+    globalThis.fetch = (async () => new Response('rate limited', { status: 429 })) as typeof globalThis.fetch;
+    const r = await runGatekeeperNotify(makeInput());
+    expect(r.notified).toBe(false);
+    expect(r.reason).toContain('429');
+  });
+
+  it('returns notified:false when fetch rejects (network failure)', async () => {
+    process.env.CHITIN_SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
+    globalThis.fetch = (async () => {
+      throw new Error('connection refused');
+    }) as typeof globalThis.fetch;
+    const r = await runGatekeeperNotify(makeInput());
+    expect(r.notified).toBe(false);
+    expect(r.reason).toContain('connection refused');
+  });
+
+  it('returns the digest on every code path (so journal gets it even when slack misses)', async () => {
+    delete process.env.CHITIN_SLACK_WEBHOOK_URL;
+    const r = await runGatekeeperNotify(makeInput());
+    expect(r.digest.length).toBeGreaterThan(0);
+    expect(r.digest).toContain('sample-entry');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 step 4 — the bare visibility layer. After reviewGraphWorkflow's loop terminates, fires a gatekeeper notify activity that posts a Slack digest of the chain's terminal state for the operator.

- Pure \`buildGatekeeperDigest\` shapes operator-facing digest (per-action emoji + headline, capped findings, tier log, t5_shape override notice)
- \`runGatekeeperNotify\` activity posts to Slack via \`CHITIN_SLACK_WEBHOOK_URL\` (no-op when unset; HTTP errors swallowed)
- Workflow proxies the activity at 30s timeout, try/catch ensures Slack outage never makes workflow look failed

**What this does NOT do (intentional):** auto-merge on approve. Auto-merging the swarm's own work needs a soak window first to measure the review-graph's false-approve rate. Auto-merge lands behind a \`CHITIN_GATEKEEPER_AUTO_MERGE\` flag in a follow-up entry once we have that telemetry.

## Pipeline state after merge

\`\`\`
programmer → PR → review-graph → reviewers → ReviewGraphResult →
  gatekeeper digest to Slack → operator merges or fixes
                               (auto-merge is a follow-up)
\`\`\`

## Test plan

- [x] 14 new tests covering digest rendering + notify activity
- [x] 354/354 pass in apps/temporal-worker
- [x] typecheck clean
- [ ] First post-merge live PR: verify Slack receives the digest with the action emoji + finding bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)