### PR TITLE
docs(roadmap): first researcher tick output — 5 reddit qwen3 candidates

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,3 +104,11 @@ A1 (agent framework builders) → A2 (platform/infra) → A4 (security/complianc
 ## Phase 0 — archive predecessors (complete)
 
 Renamed `chitinhq/chitin → chitinhq/chitin-archive` at `v1.0.0`; archived every other v1 repo in the org; created the new public MIT `chitinhq/chitin` monorepo. Hermes (the predecessor driver) was killed as a chitin component on 2026-04-23 — chitin is governance around openclaw + Claude Code, not a tick loop. See [`archive-map.md`](./archive-map.md) for what was extracted vs left behind.
+
+## Candidates from external signal
+
+- [reddit] [1t1n6o8](https://reddit.com/r/LocalLLaMA/comments/1t1n6o8/we_are_finally_there_qwen3627b_agentic_search_957/) — We are finally there: Qwen3.6-27B + agentic search; 95.7% SimpleQA on a single 3090, fully local
+- [reddit] [1t19iil](https://reddit.com/r/LocalLLaMA/comments/1t19iil/been_using_qwen3627bq8_k_xl_vscode_rtx_6000_pro/) — Been using Qwen-3.6-27B-q8_k_xl + VSCode + RTX 6000 Pro As Daily Driver
+- [reddit] [1t1judm](https://reddit.com/r/LocalLLaMA/comments/1t1judm/qwen3627b_at_72_toks_on_rtx_3090_on_windows_using/) — Qwen3.6-27B at 72 tok/s on RTX 3090 on Windows using native vLLM (no WSL, no Docker), portable launcher and installer
+- [reddit] [1t1jc1d](https://reddit.com/r/LocalLLaMA/comments/1t1jc1d/have_qwen_said_anything_about_further_qwen_36/) — Have Qwen said anything about further Qwen 3.6 models?
+- [reddit] [1t1a8gf](https://reddit.com/r/LocalLLaMA/comments/1t1a8gf/qwen3627bnvfp4_images/) — Qwen3.6-27B-NVFP4 - images


### PR DESCRIPTION
## Summary

The systemd researcher.timer fired its first tick at 14:42:17 EDT today, immediately after \`chitin.env\` was installed with \`CHITIN_SLACK_WEBHOOK_URL\` and the timer was enabled.

Pipeline telemetry (verbatim from journalctl):
\`\`\`
{"component":"researcher","candidates_opened":5,"sources_scanned":5,"duplicates_skipped":0,"fetcher_errors":[]}
\`\`\`

5 reddit candidates landed in the "Candidates from external signal" section — all qwen3-related, matching the keyword filter (\`agent\` / \`swarm\` / \`qwen\`).

## Why commit live output

This captures the first run's output explicitly rather than relying on the next researcher tick (in 4 hours) to re-fetch — reddit's top-of-day window is mutable, so capturing now keeps the operational evidence stable for review.

## Test plan

- [x] Operator reviews each candidate
- [ ] Promote to backlog entries any that warrant attention (the qwen3 perf threads are dispatcher-relevant given chitin's T0 routing question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)