### PR TITLE
feat(lessons): tech-writer role v1 — lessons-learned sidecar + prompt injection

### DIFF
--- a/apps/temporal-worker/src/lessons.ts
+++ b/apps/temporal-worker/src/lessons.ts
@@ -1,0 +1,354 @@
+// Lessons-learned sidecar — the tech-writer role's first deliverable.
+//
+// Purpose: every merged swarm PR teaches the next worker something
+// (about the codebase, about chitin's own patterns, about prior bugs
+// avoided). Without a sidecar, that knowledge dies in PR descriptions
+// nobody reads. With it, the dispatcher prepends the most-recent N
+// lessons to every programmer prompt, so the next swarm worker
+// starts where the last one finished.
+//
+// Two halves:
+//
+// 1. `runLessonsExtractor` — scheduled periodically via
+//    chitin-lessons.timer. Lists merged swarm PRs, dedups against the
+//    sidecar, distills a one-sentence lesson per PR (heuristic in v1;
+//    LLM swap point baked in), appends to docs/swarm-lessons.md.
+//
+// 2. `getRecentLessons` — pure, called by role-prompts.ts at programmer-
+//    prompt-build time. Returns the most recent N entries as a string
+//    block to prepend.
+//
+// Why a script, not a workflow: this is deterministic file I/O over
+// `gh` output. The swarm's other periodic scripts (researcher.ts,
+// swarm-rollup) follow the same systemd-fired-script pattern. Running
+// it as a Temporal workflow would buy nothing — there's no
+// retry/wall-timeout shape worth Temporal's overhead. Pattern matches
+// researcher.ts deliberately so a future operator reads them
+// together.
+//
+// Heuristic vs LLM tradeoff for v1: heuristic only. Title + first
+// body paragraph + a couple of file/diff signals. LLM distillation
+// (claude-code-headless extracting a *real* lesson from the diff +
+// commit messages) is a follow-up entry — when/if heuristic-quality
+// proves insufficient. Heuristic ships now because it's deterministic,
+// dep-free, and can't accidentally leak secrets through an LLM call.
+
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface MergedPr {
+  number: number;
+  title: string;
+  body: string;
+  mergedAt: string; // ISO-8601
+  url: string;
+  /** Branch that landed (e.g., `swarm/swarm-foo-12345`). Empty when
+   *  the gh API didn't return it (rare). */
+  headRefName: string;
+}
+
+export interface LessonEntry {
+  pr_number: number;
+  date: string; // YYYY-MM-DD
+  lesson: string; // one sentence
+}
+
+export interface LessonsExtractorOptions {
+  lessonsPath: string;
+  /** Limits the gh PR scan window. v1 default = 30 PRs back. */
+  scanLimit: number;
+  /** Distillation function. Tests inject a deterministic mock; live
+   *  uses the heuristic. Future LLM-backed version swaps in here. */
+  distill: (pr: MergedPr) => string;
+  /** PR fetcher. Tests inject; live uses the gh CLI wrapper. */
+  fetchMergedPrs: (limit: number) => Promise<MergedPr[]>;
+  log?: (line: string) => void;
+}
+
+export interface LessonsExtractorResult {
+  total_scanned: number;
+  new_entries: number;
+  duplicates_skipped: number;
+}
+
+// ─── Lessons file format ─────────────────────────────────────────────────
+
+const LESSONS_HEADER = `# Swarm lessons learned
+
+One-sentence lesson per merged swarm PR. The dispatcher prepends the
+most recent N entries to every programmer prompt — so the next swarm
+worker starts with what the last one learned.
+
+Format: \`- YYYY-MM-DD #<pr-number> — <lesson>\`. Newest first.
+
+Curated by:
+- chitin-lessons.timer (periodic) — heuristic distillation from PR
+  title + body + diff stat
+- operator (manual) — high-leverage corrections that the heuristic
+  missed; preserved across runs (the extractor only appends, never
+  rewrites existing entries)
+
+`;
+
+const ENTRY_RE = /^- (\d{4}-\d{2}-\d{2}) #(\d+) — (.+)$/;
+
+/**
+ * Parse the lessons file into structured entries. Tolerant of
+ * operator hand-edits — anything that doesn't match the row regex
+ * is preserved verbatim (we only manipulate the bullet list, not the
+ * surrounding doc).
+ */
+export function parseLessons(text: string): LessonEntry[] {
+  const entries: LessonEntry[] = [];
+  for (const line of text.split('\n')) {
+    const m = line.match(ENTRY_RE);
+    if (m) {
+      entries.push({ date: m[1], pr_number: Number(m[2]), lesson: m[3].trim() });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Append `newEntries` to the file's bullet list. Newest-first order.
+ * Preserves the doc's prose (header, footnotes) verbatim — we only
+ * touch the bullet list. If the file is empty / missing the header,
+ * we create the canonical structure.
+ */
+export function appendLessons(text: string, newEntries: LessonEntry[]): string {
+  if (newEntries.length === 0) return text;
+  const newRows = newEntries
+    .map((e) => `- ${e.date} #${e.pr_number} — ${e.lesson}`)
+    .join('\n');
+
+  if (!text || !text.includes('#')) {
+    return `${LESSONS_HEADER}${newRows}\n`;
+  }
+
+  // Find the first existing entry row; insert new rows before it
+  // (newest first). If no entries yet, append at the end of the
+  // file's prose.
+  const lines = text.split('\n');
+  const firstEntryIdx = lines.findIndex((l) => ENTRY_RE.test(l));
+  if (firstEntryIdx < 0) {
+    const trimmed = text.replace(/\s+$/, '');
+    return `${trimmed}\n\n${newRows}\n`;
+  }
+  return [...lines.slice(0, firstEntryIdx), newRows, ...lines.slice(firstEntryIdx)].join('\n');
+}
+
+// ─── Heuristic lesson extractor ──────────────────────────────────────────
+
+/**
+ * Deterministic v1 distillation. Given a merged PR, produce a one-
+ * sentence lesson. Strategy:
+ *
+ *   1. If the PR body has a "## Lesson" or "## Why" section, take its
+ *      first sentence.
+ *   2. Otherwise: PR title (stripped of conventional-commit prefixes)
+ *      + " (PR body trim)" if the body's first sentence adds value.
+ *   3. Cap at ~200 chars.
+ *
+ * Heuristic by design — see the file header for the rationale. Errors
+ * fall through to a minimal "merged" stub rather than throwing,
+ * because the periodic extractor must never crash the timer tick on
+ * one weird PR.
+ */
+export function extractLessonHeuristic(pr: MergedPr): string {
+  try {
+    // Look for a "## Lesson" or "## Why" section in the body.
+    const sectionRe = /^##+\s+(Lesson|Why|Insight)s?\s*\n+([\s\S]*?)(?=\n##+\s|$)/im;
+    const sectionMatch = pr.body.match(sectionRe);
+    if (sectionMatch) {
+      const body = sectionMatch[2].trim();
+      const firstSentence = body.split(/(?<=[.!?])\s+/)[0];
+      return capLength(firstSentence, 220);
+    }
+    // Fall back to PR title with conventional-commit prefix stripped.
+    const cleanedTitle = pr.title.replace(/^(\w+)(?:\([^)]+\))?:\s*/, '').trim();
+    if (cleanedTitle) return capLength(cleanedTitle, 220);
+    // Title missing entirely (rare, but encountered in CI test
+    // fixtures) — emit a stub so the row still contributes to the
+    // dedup set.
+    return capLength(`merged PR #${pr.number}`, 220);
+  } catch {
+    return capLength(pr.title || `merged PR #${pr.number}`, 220);
+  }
+}
+
+function capLength(s: string, max: number): string {
+  const trimmed = s.trim().replace(/\s+/g, ' ');
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+// ─── PR fetcher (live) ───────────────────────────────────────────────────
+
+interface GhPrJsonRow {
+  number: number;
+  title: string;
+  body: string;
+  mergedAt: string;
+  url: string;
+  headRefName: string;
+}
+
+/**
+ * Live PR fetcher. Uses `gh pr list` filtered to merged + branch
+ * prefix `swarm/`. Returns rows newest-first. Failure throws —
+ * runLessonsExtractor catches.
+ */
+export async function fetchMergedSwarmPrs(limit: number): Promise<MergedPr[]> {
+  const out = execFileSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--state',
+      'merged',
+      '--search',
+      'head:swarm/',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,body,mergedAt,url,headRefName',
+    ],
+    { encoding: 'utf8' },
+  );
+  const rows = JSON.parse(out) as GhPrJsonRow[];
+  return rows.map((r) => ({
+    number: r.number,
+    title: r.title,
+    body: r.body ?? '',
+    mergedAt: r.mergedAt,
+    url: r.url,
+    headRefName: r.headRefName ?? '',
+  }));
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────
+
+/**
+ * Run one extractor tick. Reads the lessons file, fetches recent
+ * merged swarm PRs, dedups by pr_number, distills new ones, appends.
+ * Idempotent: re-runs on the same input produce zero new entries.
+ */
+export async function runLessonsExtractor(
+  opts: LessonsExtractorOptions,
+): Promise<LessonsExtractorResult> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+
+  const text = await readFile(opts.lessonsPath, 'utf8').catch(() => '');
+  const existing = parseLessons(text);
+  const knownPrs = new Set(existing.map((e) => e.pr_number));
+
+  const merged = await opts.fetchMergedPrs(opts.scanLimit);
+
+  const newEntries: LessonEntry[] = [];
+  let duplicates_skipped = 0;
+  for (const pr of merged) {
+    if (knownPrs.has(pr.number)) {
+      duplicates_skipped++;
+      continue;
+    }
+    const lesson = opts.distill(pr).trim();
+    if (!lesson) continue;
+    newEntries.push({
+      pr_number: pr.number,
+      date: pr.mergedAt.slice(0, 10),
+      lesson,
+    });
+  }
+
+  if (newEntries.length > 0) {
+    // Sort newest-first so they land at the top of the bullet list.
+    newEntries.sort((a, b) => b.pr_number - a.pr_number);
+    const updated = appendLessons(text, newEntries);
+    await writeFile(opts.lessonsPath, updated, 'utf8');
+  }
+
+  const result: LessonsExtractorResult = {
+    total_scanned: merged.length,
+    new_entries: newEntries.length,
+    duplicates_skipped,
+  };
+
+  log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      component: 'lessons-extractor',
+      ...result,
+    }),
+  );
+
+  return result;
+}
+
+// ─── Prompt-injection helper ─────────────────────────────────────────────
+
+/**
+ * Read the lessons file and return the most-recent `n` entries as a
+ * markdown bullet block suitable for prepending to a programmer
+ * prompt. Returns the empty string when there are no lessons yet
+ * (the prompt builder skips the section in that case rather than
+ * showing an empty heading).
+ *
+ * Sync by design — called from buildProgrammerPrompt at every
+ * dispatcher dispatch. Async would force the prompt builder up the
+ * call chain to be async too. The file is small (a few KB at steady
+ * state), so a sync read is cheaper than the refactor.
+ */
+export function getRecentLessonsSync(lessonsPath: string, n: number): string {
+  let text = '';
+  try {
+    text = readFileSync(lessonsPath, 'utf8');
+  } catch {
+    return '';
+  }
+  if (!text) return '';
+  const entries = parseLessons(text);
+  if (entries.length === 0) return '';
+  const head = entries.slice(0, n);
+  return head.map((e) => `- #${e.pr_number}: ${e.lesson}`).join('\n');
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────
+
+const DEFAULT_LESSONS_PATH = resolve(process.cwd(), 'docs/swarm-lessons.md');
+
+async function main(): Promise<void> {
+  const limit = Number(process.env.CHITIN_LESSONS_SCAN_LIMIT ?? '30');
+  await runLessonsExtractor({
+    lessonsPath: DEFAULT_LESSONS_PATH,
+    scanLimit: limit,
+    distill: extractLessonHeuristic,
+    fetchMergedPrs: fetchMergedSwarmPrs,
+  });
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        component: 'lessons-extractor',
+        msg: 'lessons tick fatal',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    process.exit(1);
+  });
+}
+
+export const __test__ = {
+  LESSONS_HEADER,
+  ENTRY_RE,
+  capLength,
+  DEFAULT_LESSONS_PATH,
+};

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -11,9 +11,18 @@
 // doesn't crash when they're picked, but the actual per-role prompt
 // engineering lands in follow-up entries (one per role).
 
+import { resolve } from 'node:path';
 import type { Role } from '@chitin/contracts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 import { RESEARCHER_OUTPUT_INSTRUCTIONS } from './researcher-prompts.ts';
+import { getRecentLessonsSync } from './lessons.ts';
+
+// How many of the most-recent lessons to prepend to a programmer
+// prompt. Picked low enough that the overhead per dispatch is small,
+// high enough that the recent-history pattern (last week's swarm
+// activity) is visible to the next worker.
+const LESSONS_PROMPT_HEAD = 12;
+const LESSONS_PATH = resolve(process.cwd(), 'docs/swarm-lessons.md');
 
 export type RolePromptBuilder = (entry: BacklogEntry) => string;
 
@@ -29,7 +38,19 @@ function buildProgrammerPrompt(entry: BacklogEntry): string {
     targetFile = 'the file named in the entry';
   }
 
-  return `You are a swarm worker executing one backlog entry. Output text is ignored — only TOOL DISPATCHES count. If you finish without dispatching tools, the work is lost.
+  // Recent lessons prepended so the next swarm worker starts with
+  // what the last N already learned. Empty string when the file is
+  // missing or empty (first-tick state) — the section is skipped
+  // rather than rendering an empty heading.
+  const lessonsBlock = getRecentLessonsSync(LESSONS_PATH, LESSONS_PROMPT_HEAD);
+  const lessonsHeader = lessonsBlock
+    ? `RECENT LESSONS (most recent first — apply these before writing code; ignore irrelevant ones):
+${lessonsBlock}
+
+`
+    : '';
+
+  return `${lessonsHeader}You are a swarm worker executing one backlog entry. Output text is ignored — only TOOL DISPATCHES count. If you finish without dispatching tools, the work is lost.
 
 ENTRY ID: ${entry.id}
 TARGET FILE: ${targetFile}

--- a/apps/temporal-worker/test/lessons.test.ts
+++ b/apps/temporal-worker/test/lessons.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendLessons,
+  extractLessonHeuristic,
+  getRecentLessonsSync,
+  parseLessons,
+  runLessonsExtractor,
+  __test__,
+  type MergedPr,
+} from '../src/lessons.ts';
+
+const { ENTRY_RE, capLength, LESSONS_HEADER } = __test__;
+
+function makePr(overrides: Partial<MergedPr> = {}): MergedPr {
+  return {
+    number: 100,
+    title: 'feat(foo): add the bar',
+    body: '## Summary\n\nDoes the thing.\n',
+    mergedAt: '2026-05-02T12:00:00Z',
+    url: 'https://github.com/chitinhq/chitin/pull/100',
+    headRefName: 'swarm/swarm-foo-1',
+    ...overrides,
+  };
+}
+
+// ─── parseLessons ─────────────────────────────────────────────────────────
+
+describe('parseLessons', () => {
+  it('returns empty array when text has no entries', () => {
+    expect(parseLessons('# Header\n\nNo bullets yet.\n')).toEqual([]);
+  });
+
+  it('extracts well-formed bullet rows', () => {
+    const md = `# Lessons\n\n- 2026-05-02 #150 — fix bundler to drop runtime ExecutionRequestSchema\n- 2026-05-01 #142 — PyYAML auto-converts ISO-8601 timestamps to datetime\n`;
+    expect(parseLessons(md)).toEqual([
+      { date: '2026-05-02', pr_number: 150, lesson: 'fix bundler to drop runtime ExecutionRequestSchema' },
+      { date: '2026-05-01', pr_number: 142, lesson: 'PyYAML auto-converts ISO-8601 timestamps to datetime' },
+    ]);
+  });
+
+  it('ignores non-matching lines (operator hand-edits)', () => {
+    const md = `- 2026-05-02 #150 — real lesson\nrandom note\n- nonsense\n- 2026-05-01 #142 — another lesson\n`;
+    expect(parseLessons(md)).toHaveLength(2);
+  });
+});
+
+// ─── appendLessons ────────────────────────────────────────────────────────
+
+describe('appendLessons', () => {
+  it('returns input unchanged when newEntries is empty', () => {
+    const md = '# x\n';
+    expect(appendLessons(md, [])).toBe(md);
+  });
+
+  it('creates the canonical header when input is empty', () => {
+    const out = appendLessons('', [
+      { date: '2026-05-02', pr_number: 150, lesson: 'do not import contracts barrel from workflow' },
+    ]);
+    expect(out).toContain('# Swarm lessons learned');
+    expect(out).toContain('- 2026-05-02 #150 — do not import contracts barrel');
+  });
+
+  it('inserts new rows BEFORE existing entries (newest-first)', () => {
+    const md = `${LESSONS_HEADER}- 2026-05-01 #100 — older\n`;
+    const out = appendLessons(md, [
+      { date: '2026-05-02', pr_number: 150, lesson: 'newer' },
+    ]);
+    const newerIdx = out.indexOf('#150');
+    const olderIdx = out.indexOf('#100');
+    expect(newerIdx).toBeLessThan(olderIdx);
+    // Header is preserved.
+    expect(out).toContain('# Swarm lessons learned');
+  });
+
+  it('preserves operator hand-edits in surrounding prose', () => {
+    const md = `# Swarm lessons learned\n\nOperator edited prose here — keep it!\n\n- 2026-05-01 #100 — older\n`;
+    const out = appendLessons(md, [
+      { date: '2026-05-02', pr_number: 150, lesson: 'newer' },
+    ]);
+    expect(out).toContain('Operator edited prose here — keep it!');
+    expect(out).toContain('#100');
+    expect(out).toContain('#150');
+  });
+});
+
+// ─── extractLessonHeuristic ──────────────────────────────────────────────
+
+describe('extractLessonHeuristic', () => {
+  it("strips conventional-commit prefix from PR title", () => {
+    expect(extractLessonHeuristic(makePr({ title: 'feat(dispatcher): add blocks-respect logic' }))).toBe(
+      'add blocks-respect logic',
+    );
+    expect(extractLessonHeuristic(makePr({ title: 'fix: regex tighten' }))).toBe('regex tighten');
+  });
+
+  it("preserves a title that doesn't have a prefix", () => {
+    expect(extractLessonHeuristic(makePr({ title: 'plain title' }))).toBe('plain title');
+  });
+
+  it('uses the "## Lesson" body section when present', () => {
+    const pr = makePr({
+      body: `## Summary\n\nblah\n\n## Lesson\n\nNever import barrel from workflow code — pulls node:crypto.\n\n## Test plan\n\n...\n`,
+    });
+    expect(extractLessonHeuristic(pr)).toContain('Never import barrel');
+  });
+
+  it('uses the "## Why" section as a fallback', () => {
+    const pr = makePr({
+      body: `## Summary\n\nblah\n\n## Why\n\nThe bundler can't reach node:fs from a workflow. Fixed by deduplicating the import.\n`,
+    });
+    expect(extractLessonHeuristic(pr)).toContain("bundler can't reach node:fs");
+  });
+
+  it('caps at ~220 chars with ellipsis', () => {
+    const longLesson = 'x'.repeat(400);
+    const pr = makePr({ body: `## Lesson\n\n${longLesson}\n` });
+    const out = extractLessonHeuristic(pr);
+    expect(out.length).toBeLessThanOrEqual(220);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('falls back gracefully on bizarre input rather than throwing', () => {
+    const pr = makePr({ title: '', body: '' });
+    expect(extractLessonHeuristic(pr)).toBeTruthy();
+  });
+});
+
+// ─── runLessonsExtractor ─────────────────────────────────────────────────
+
+describe('runLessonsExtractor', () => {
+  let scratch: string;
+  let lessonsPath: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'lessons-test-'));
+    lessonsPath = join(scratch, 'swarm-lessons.md');
+    logs = [];
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('appends new entries when the file is missing on first run', async () => {
+    const r = await runLessonsExtractor({
+      lessonsPath,
+      scanLimit: 5,
+      distill: extractLessonHeuristic,
+      fetchMergedPrs: async () => [
+        makePr({ number: 100, title: 'feat: alpha', mergedAt: '2026-05-02T10:00:00Z' }),
+        makePr({ number: 99, title: 'fix: beta', mergedAt: '2026-05-01T10:00:00Z' }),
+      ],
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(2);
+    expect(r.duplicates_skipped).toBe(0);
+    expect(r.total_scanned).toBe(2);
+    const text = readFileSync(lessonsPath, 'utf8');
+    expect(text).toContain('#100');
+    expect(text).toContain('#99');
+    // Telemetry log line
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.component).toBe('lessons-extractor');
+    expect(parsed.new_entries).toBe(2);
+  });
+
+  it('dedups against existing entries (idempotent re-runs add 0)', async () => {
+    writeFileSync(
+      lessonsPath,
+      `${LESSONS_HEADER}- 2026-05-02 #100 — alpha\n- 2026-05-01 #99 — beta\n`,
+      'utf8',
+    );
+    const r = await runLessonsExtractor({
+      lessonsPath,
+      scanLimit: 5,
+      distill: extractLessonHeuristic,
+      fetchMergedPrs: async () => [
+        makePr({ number: 100, title: 'feat: alpha' }),
+        makePr({ number: 99, title: 'fix: beta' }),
+      ],
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(0);
+    expect(r.duplicates_skipped).toBe(2);
+  });
+
+  it('appends new entries above existing ones (newest first)', async () => {
+    writeFileSync(
+      lessonsPath,
+      `${LESSONS_HEADER}- 2026-05-01 #99 — beta\n`,
+      'utf8',
+    );
+    await runLessonsExtractor({
+      lessonsPath,
+      scanLimit: 5,
+      distill: extractLessonHeuristic,
+      fetchMergedPrs: async () => [
+        makePr({ number: 100, title: 'feat: alpha new', mergedAt: '2026-05-02T12:00:00Z' }),
+      ],
+      log: (l) => logs.push(l),
+    });
+    const text = readFileSync(lessonsPath, 'utf8');
+    const newerIdx = text.indexOf('#100');
+    const olderIdx = text.indexOf('#99');
+    expect(newerIdx).toBeLessThan(olderIdx);
+  });
+
+  it('uses the injected distill function (LLM swap point)', async () => {
+    let distillCalls = 0;
+    await runLessonsExtractor({
+      lessonsPath,
+      scanLimit: 5,
+      distill: (pr) => {
+        distillCalls++;
+        return `LLM-distilled lesson for #${pr.number}`;
+      },
+      fetchMergedPrs: async () => [makePr({ number: 100 })],
+      log: (l) => logs.push(l),
+    });
+    expect(distillCalls).toBe(1);
+    const text = readFileSync(lessonsPath, 'utf8');
+    expect(text).toContain('LLM-distilled lesson for #100');
+  });
+
+  it('skips empty distillations rather than writing blank rows', async () => {
+    const r = await runLessonsExtractor({
+      lessonsPath,
+      scanLimit: 5,
+      distill: () => '',  // distillation returned nothing usable
+      fetchMergedPrs: async () => [makePr({ number: 100 })],
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(0);
+    // No file should be created when nothing landed.
+    expect(() => readFileSync(lessonsPath, 'utf8')).toThrow();
+  });
+
+  it('does not touch the file when there is nothing new', async () => {
+    writeFileSync(lessonsPath, `${LESSONS_HEADER}- 2026-05-01 #99 — beta\n`, 'utf8');
+    const before = readFileSync(lessonsPath, 'utf8');
+    await runLessonsExtractor({
+      lessonsPath,
+      scanLimit: 5,
+      distill: extractLessonHeuristic,
+      fetchMergedPrs: async () => [makePr({ number: 99, title: 'fix: beta' })],
+      log: (l) => logs.push(l),
+    });
+    expect(readFileSync(lessonsPath, 'utf8')).toBe(before);
+  });
+});
+
+// ─── getRecentLessonsSync ────────────────────────────────────────────────
+
+describe('getRecentLessonsSync', () => {
+  let scratch: string;
+  let lessonsPath: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'lessons-sync-test-'));
+    lessonsPath = join(scratch, 'swarm-lessons.md');
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('returns empty string when the file is missing', () => {
+    expect(getRecentLessonsSync(lessonsPath, 5)).toBe('');
+  });
+
+  it('returns empty string when the file has no entries', () => {
+    writeFileSync(lessonsPath, '# header\n\nno entries yet\n', 'utf8');
+    expect(getRecentLessonsSync(lessonsPath, 5)).toBe('');
+  });
+
+  it('returns the top N entries as a bullet block', () => {
+    writeFileSync(
+      lessonsPath,
+      `${LESSONS_HEADER}- 2026-05-02 #150 — fix bundler\n- 2026-05-02 #149 — gatekeeper notify\n- 2026-05-01 #100 — older\n`,
+      'utf8',
+    );
+    const out = getRecentLessonsSync(lessonsPath, 2);
+    expect(out).toContain('#150');
+    expect(out).toContain('#149');
+    expect(out).not.toContain('#100');
+  });
+
+  it('returns all entries when n exceeds the file length', () => {
+    writeFileSync(
+      lessonsPath,
+      `${LESSONS_HEADER}- 2026-05-02 #150 — only entry\n`,
+      'utf8',
+    );
+    const out = getRecentLessonsSync(lessonsPath, 100);
+    expect(out).toContain('#150');
+    // Output is a single bullet, not padded with blanks.
+    expect(out.split('\n')).toHaveLength(1);
+  });
+});
+
+// ─── ENTRY_RE / capLength sanity ─────────────────────────────────────────
+
+describe('ENTRY_RE', () => {
+  it('matches a well-formed row', () => {
+    const m = '- 2026-05-02 #150 — alpha'.match(ENTRY_RE);
+    expect(m).not.toBeNull();
+    if (m) {
+      expect(m[1]).toBe('2026-05-02');
+      expect(m[2]).toBe('150');
+      expect(m[3]).toBe('alpha');
+    }
+  });
+
+  it('rejects a row with the wrong shape', () => {
+    expect('- 2026-05-02 alpha'.match(ENTRY_RE)).toBeNull();
+    expect('- #150 alpha'.match(ENTRY_RE)).toBeNull();
+  });
+});
+
+describe('capLength', () => {
+  it('passes through short strings', () => {
+    expect(capLength('short', 100)).toBe('short');
+  });
+
+  it('trims to max with ellipsis when over', () => {
+    expect(capLength('x'.repeat(300), 100)).toHaveLength(100);
+    expect(capLength('x'.repeat(300), 100).endsWith('…')).toBe(true);
+  });
+
+  it('collapses internal whitespace runs', () => {
+    expect(capLength('a   b\n\tc', 100)).toBe('a b c');
+  });
+});

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -14,6 +14,8 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 | `chitin-researcher.timer` | timer | Fires the researcher every 4 hours. |
 | `chitin-swarm-rollup.service` | oneshot | Daily swarm-health rollup: derives metrics from `tmp/result-swarm-*.json` + dispatcher journalctl, posts a digest to Slack. |
 | `chitin-swarm-rollup.timer` | timer | Fires the rollup once per day. |
+| `chitin-lessons.service` | oneshot | Daily lessons-learned extractor: scans merged swarm/* PRs, distills a one-sentence lesson per, appends to `docs/swarm-lessons.md`. The dispatcher prepends recent lessons to programmer prompts. |
+| `chitin-lessons.timer` | timer | Fires the lessons extractor once per day. |
 
 ## Install
 
@@ -25,6 +27,7 @@ systemctl --user enable --now chitin-worker
 systemctl --user enable --now chitin-dispatcher.timer
 systemctl --user enable --now chitin-researcher.timer
 systemctl --user enable --now chitin-swarm-rollup.timer
+systemctl --user enable --now chitin-lessons.timer
 ```
 
 To survive logout (start at boot):
@@ -41,6 +44,7 @@ journalctl --user -u chitin-worker -f
 journalctl --user -u chitin-dispatcher -f
 journalctl --user -u chitin-researcher -f
 journalctl --user -u chitin-swarm-rollup -f
+journalctl --user -u chitin-lessons -f
 
 # Status
 systemctl --user status chitin-worker

--- a/infra/systemd/chitin-lessons.service
+++ b/infra/systemd/chitin-lessons.service
@@ -1,0 +1,27 @@
+# One-shot service fired by chitin-lessons.timer.
+# Scans recently-merged swarm/* PRs, distills a one-sentence lesson per
+# (heuristic in v1; LLM swap point in lessons.ts), appends to
+# docs/swarm-lessons.md. Idempotent — re-runs add 0 entries when the
+# scan window hasn't surfaced anything new. The dispatcher reads the
+# file at programmer-prompt-build time and prepends the most recent
+# N entries so the next swarm worker starts where the last one left.
+
+[Unit]
+Description=Chitin swarm lessons-learned extractor
+# Worker not required (this is a pure gh-CLI + file-IO script), but
+# if the worker is restarting we'd rather not race it for the
+# repo's working tree.
+After=chitin-worker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+# Routes through pnpm exec tsx, matching dispatcher / researcher.
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/lessons.ts
+StandardOutput=journal
+StandardError=journal
+# 60s is generous for a `gh pr list` of 30 + a markdown rewrite.
+TimeoutStartSec=60

--- a/infra/systemd/chitin-lessons.timer
+++ b/infra/systemd/chitin-lessons.timer
@@ -1,0 +1,21 @@
+# Timer for chitin-lessons.service.
+# Daily — fires once a day, persistent so a missed tick from a powered-
+# off rig fires on the next boot. The cadence is daily because lessons
+# only meaningfully change on PR-merge events, and a daily extractor
+# tick produces a tight digest the dispatcher can lean on. If the
+# operator wants near-realtime lessons (rare), CHITIN_LESSONS_SCAN_LIMIT
+# + a manual `systemctl --user start chitin-lessons.service` works.
+
+[Unit]
+Description=Chitin swarm lessons-learned timer
+
+[Timer]
+# Fire once per day. OnBootSec offsets so a fresh boot doesn't hammer
+# the gh API alongside the daily-rollup tick.
+OnUnitActiveSec=24h
+OnBootSec=30min
+Persistent=true
+Unit=chitin-lessons.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Closes the §3 tech-writer role gap from the swarm-as-software-factory design. Without this, the swarm can't compound its own learning — every PR teaches the next worker nothing because the knowledge dies in PR descriptions.

**Two halves:**

1. **Extractor** (\`lessons.ts\`):
   - Lists merged \`swarm/*\` PRs via \`gh\`, dedups against \`docs/swarm-lessons.md\` by pr_number, distills a one-sentence lesson per (heuristic v1: prefers \`## Lesson\`/\`## Why\` body sections, falls back to conventional-commit-stripped title)
   - Fired by \`chitin-lessons.timer\` daily
   - LLM swap point baked in via the \`distill\` callback

2. **Prompt injection** (\`role-prompts.ts\`):
   - \`buildProgrammerPrompt\` now prepends a RECENT LESSONS block (top 12 entries) read sync from the file
   - Empty file = section omitted

## Why heuristic-only for v1

Deterministic, dep-free, can't leak secrets through an LLM call. LLM-backed distillation lands as a follow-up entry once we have telemetry on heuristic quality.

## Test plan

- [x] 28 new tests covering extractor + injection halves; 382/382 pass
- [x] Typecheck clean
- [ ] After merge: \`systemctl --user enable --now chitin-lessons.timer\` + \`systemctl --user start chitin-lessons.service\` for first run; verify entries land in \`docs/swarm-lessons.md\` and the next dispatcher tick's programmer prompt includes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)