### PR TITLE
feat(groomer): candidate-promoter v1 — closes the work-source autonomy gap

### DIFF
--- a/apps/temporal-worker/src/groomer.ts
+++ b/apps/temporal-worker/src/groomer.ts
@@ -1,0 +1,267 @@
+// Groomer-as-candidate-promoter (v1).
+//
+// Closes the autonomy gap that "swarm runs out of work without
+// operator." The researcher already drops candidates into
+// docs/roadmap.md's "Candidates from external signal" section; an
+// operator was the only path from there to the backlog. Now a daily
+// timer reads the candidates, dedups against existing backlog
+// entries, drafts an `in_design` entry per qualifying candidate,
+// and the existing chitin-groom-pass.ts workflow picks it up to
+// classify (tier, size, file scope) into a `ready` entry.
+//
+// Conservative gating in v1 (turn the dial up later if it's too
+// quiet, down if it's too noisy):
+//
+//   - Source filter: only `arxiv` candidates promote auto. Reddit
+//     and HN are noisier — operator manually tags those if wanted.
+//     openclaw / ollama releases default to operator-curated too,
+//     since "version bumped" usually doesn't translate to a
+//     swarm-actionable entry without operator interpretation.
+//   - Cap: at most 1 promotion per run.
+//   - The drafted entry's status is `in_design`, NOT `ready` — the
+//     existing groomer (groom-pass.ts) is the next step. v1 promotes
+//     into the design queue; tier-classification + scope-naming is
+//     the next role's job.
+//
+// What an "ageRequirement" would buy: insulation from rumored
+// papers that get retracted within 24h. v1 skips this — arxiv IDs
+// are stable, the source is curated. Add if a flapping candidate
+// shows up.
+
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface RoadmapCandidate {
+  source: string;
+  id: string;
+  url: string;
+  summary: string;
+}
+
+export interface GroomerOptions {
+  roadmapPath: string;
+  backlogPath: string;
+  cap: number;
+  /** ISO-8601 timestamp injected by runner. */
+  now: string;
+  /** Source-allowlist. Candidates from sources outside this set are
+   *  skipped — operator manually promotes those. v1 default is
+   *  ['arxiv'] for high-signal-only autopromotion. */
+  promotableSources: string[];
+  log?: (line: string) => void;
+}
+
+export interface GroomerResult {
+  total_candidates: number;
+  filtered_to_promotable: number;
+  promoted: number;
+  duplicates_skipped: number;
+}
+
+// ─── Roadmap candidate parsing ───────────────────────────────────────────
+
+const CANDIDATES_HEADING = '## Candidates from external signal';
+
+// One candidate row format (matches researcher.ts's appendCandidates):
+//   - [<source>] [<id>](url) — <summary>
+// We accept whitespace variations and trailing operator notes.
+const CANDIDATE_ROW_RE =
+  /^- \[([^\]]+)\] \[([^\]]+)\]\(([^)]+)\)\s*[—\-]\s*(.+?)\s*$/;
+
+/**
+ * Parse the roadmap.md candidates section. Returns rows in their
+ * declared order (newest-at-bottom per researcher's convention).
+ * Tolerant of operator hand-edits — non-matching lines preserved
+ * elsewhere; only the bullet rows count.
+ */
+export function parseRoadmapCandidates(text: string): RoadmapCandidate[] {
+  const start = text.indexOf(CANDIDATES_HEADING);
+  if (start < 0) return [];
+  const after = text.slice(start + CANDIDATES_HEADING.length);
+  const sectionEnd = after.search(/\n## /);
+  const body = sectionEnd >= 0 ? after.slice(0, sectionEnd) : after;
+  const out: RoadmapCandidate[] = [];
+  for (const line of body.split('\n')) {
+    const m = line.match(CANDIDATE_ROW_RE);
+    if (m) {
+      out.push({ source: m[1], id: m[2], url: m[3], summary: m[4] });
+    }
+  }
+  return out;
+}
+
+// ─── Backlog id parsing ──────────────────────────────────────────────────
+
+// Matches any `### \`id\`` heading in swarm-backlog.md.
+const BACKLOG_ID_RE = /^### `([^`]+)`/gm;
+
+export function parseBacklogIds(text: string): Set<string> {
+  const ids = new Set<string>();
+  for (const match of text.matchAll(BACKLOG_ID_RE)) {
+    ids.add(match[1]);
+  }
+  return ids;
+}
+
+// ─── Drafted entry shape ─────────────────────────────────────────────────
+
+/**
+ * Turn a candidate id into a backlog-entry-shaped slug. arxiv IDs
+ * have dots and 'v' suffixes; we slugify to fit the
+ * `### \`<id>\`` style without introducing collisions.
+ */
+export function candidateToEntryId(c: RoadmapCandidate): string {
+  const slug = c.id
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  return `${c.source}-${slug}-investigate`;
+}
+
+/**
+ * Render a draft `in_design` backlog entry that the existing
+ * groom-pass.ts flow can classify. Keeps the entry minimal — the
+ * groomer agent's job is to fill in tier, file: scope, estimated_loc,
+ * blocks. All we provide is the seed.
+ */
+export function renderDraftEntry(c: RoadmapCandidate, entryId: string, now: string): string {
+  return [
+    `### \`${entryId}\``,
+    '',
+    '```yaml',
+    `id: ${entryId}`,
+    'tier: TBD',
+    'status: in_design',
+    'estimated_loc: TBD',
+    'blocks: []',
+    'file: TBD',
+    `references_signal: ${c.url}`,
+    'role: programmer',
+    '```',
+    '',
+    `Auto-promoted by chitin-groomer.timer at ${now} from \`docs/roadmap.md\` candidate:`,
+    '',
+    `> [${c.source}] [${c.id}](${c.url}) — ${c.summary}`,
+    '',
+    'Next step (groomer role): replace `tier: TBD`, `estimated_loc: TBD`, and `file: TBD` with concrete values; classify the work shape (programmer / researcher / refactorer); flip `status` to `ready` when the entry is dispatcher-shaped.',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Append a rendered draft entry to swarm-backlog.md. Inserts at the
+ * end of the document (operator's chronological convention; the
+ * existing groomer reads any in_design entry regardless of position).
+ */
+export function appendBacklogEntry(text: string, rendered: string): string {
+  const trimmed = text.replace(/\s+$/, '');
+  return `${trimmed}\n\n${rendered}`;
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────
+
+/**
+ * Run one groomer tick. Read roadmap candidates, dedup against
+ * backlog, filter by source allowlist, draft up to `cap` new
+ * `in_design` entries, append. Idempotent — re-runs on the same
+ * input produce zero promotions.
+ */
+export async function runGroomer(opts: GroomerOptions): Promise<GroomerResult> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+
+  const roadmap = await readFile(opts.roadmapPath, 'utf8').catch(() => '');
+  const backlog = await readFile(opts.backlogPath, 'utf8').catch(() => '');
+
+  const candidates = parseRoadmapCandidates(roadmap);
+  const knownIds = parseBacklogIds(backlog);
+
+  const allowedSources = new Set(opts.promotableSources);
+  const promotable = candidates.filter((c) => allowedSources.has(c.source));
+
+  let nextBacklog = backlog;
+  let promoted = 0;
+  let duplicates_skipped = 0;
+  for (const c of promotable) {
+    if (promoted >= opts.cap) break;
+    const entryId = candidateToEntryId(c);
+    if (knownIds.has(entryId)) {
+      duplicates_skipped++;
+      continue;
+    }
+    const rendered = renderDraftEntry(c, entryId, opts.now);
+    nextBacklog = appendBacklogEntry(nextBacklog, rendered);
+    knownIds.add(entryId); // guard against in-run duplicates from the same id
+    promoted++;
+  }
+
+  if (promoted > 0) {
+    await writeFile(opts.backlogPath, nextBacklog, 'utf8');
+  }
+
+  const result: GroomerResult = {
+    total_candidates: candidates.length,
+    filtered_to_promotable: promotable.length,
+    promoted,
+    duplicates_skipped,
+  };
+
+  log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      component: 'groomer',
+      ...result,
+    }),
+  );
+
+  return result;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────
+
+const DEFAULT_ROADMAP_PATH = resolve(process.cwd(), 'docs/roadmap.md');
+const DEFAULT_BACKLOG_PATH = resolve(process.cwd(), 'docs/swarm-backlog.md');
+const DEFAULT_CAP = 1;
+const DEFAULT_PROMOTABLE_SOURCES = ['arxiv'];
+
+async function main(): Promise<void> {
+  const cap = Number(process.env.CHITIN_GROOMER_CAP ?? String(DEFAULT_CAP));
+  const sources = (process.env.CHITIN_GROOMER_SOURCES ?? DEFAULT_PROMOTABLE_SOURCES.join(','))
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  await runGroomer({
+    roadmapPath: DEFAULT_ROADMAP_PATH,
+    backlogPath: DEFAULT_BACKLOG_PATH,
+    cap,
+    now: new Date().toISOString(),
+    promotableSources: sources,
+  });
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        component: 'groomer',
+        msg: 'groomer tick fatal',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    process.exit(1);
+  });
+}
+
+export const __test__ = {
+  CANDIDATES_HEADING,
+  CANDIDATE_ROW_RE,
+  BACKLOG_ID_RE,
+  DEFAULT_PROMOTABLE_SOURCES,
+  DEFAULT_CAP,
+};

--- a/apps/temporal-worker/test/groomer.test.ts
+++ b/apps/temporal-worker/test/groomer.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendBacklogEntry,
+  candidateToEntryId,
+  parseBacklogIds,
+  parseRoadmapCandidates,
+  renderDraftEntry,
+  runGroomer,
+  __test__,
+  type RoadmapCandidate,
+} from '../src/groomer.ts';
+
+const { CANDIDATES_HEADING, DEFAULT_CAP, DEFAULT_PROMOTABLE_SOURCES } = __test__;
+
+function makeCand(overrides: Partial<RoadmapCandidate> = {}): RoadmapCandidate {
+  return {
+    source: 'arxiv',
+    id: '2511.13646v3',
+    url: 'https://arxiv.org/abs/2511.13646v3',
+    summary: 'Live-SWE-agent v3: tool-registry pattern + benchmark loop',
+    ...overrides,
+  };
+}
+
+// ─── parseRoadmapCandidates ──────────────────────────────────────────────
+
+describe('parseRoadmapCandidates', () => {
+  it('returns empty when the section is missing', () => {
+    expect(parseRoadmapCandidates('# Roadmap\n\nIntro\n')).toEqual([]);
+  });
+
+  it('returns empty when the section exists but has no rows', () => {
+    expect(parseRoadmapCandidates(`${CANDIDATES_HEADING}\n\n(none yet)\n`)).toEqual([]);
+  });
+
+  it('parses well-formed candidate rows', () => {
+    const md = `${CANDIDATES_HEADING}\n\n- [arxiv] [2511.13646v3](https://arxiv.org/abs/2511.13646v3) — Live-SWE-agent v3\n- [reddit] [1abc](https://reddit.com/r/x/1abc) — qwen3 thread\n`;
+    const cs = parseRoadmapCandidates(md);
+    expect(cs).toHaveLength(2);
+    expect(cs[0]).toEqual({
+      source: 'arxiv',
+      id: '2511.13646v3',
+      url: 'https://arxiv.org/abs/2511.13646v3',
+      summary: 'Live-SWE-agent v3',
+    });
+    expect(cs[1].source).toBe('reddit');
+  });
+
+  it('stops at the next ## heading (does not bleed into adjacent sections)', () => {
+    const md = `${CANDIDATES_HEADING}\n\n- [arxiv] [a-1](u) — note\n\n## Other section\n\n- [arxiv] [bait](u) — should not appear\n`;
+    const cs = parseRoadmapCandidates(md);
+    expect(cs).toHaveLength(1);
+    expect(cs[0].id).toBe('a-1');
+  });
+
+  it('handles ids with dots and slashes (gh release tag form)', () => {
+    const md = `${CANDIDATES_HEADING}\n\n- [gh:openclaw/openclaw] [openclaw/openclaw@v0.4.2](https://example.com) — release\n`;
+    const cs = parseRoadmapCandidates(md);
+    expect(cs[0].id).toBe('openclaw/openclaw@v0.4.2');
+  });
+});
+
+// ─── parseBacklogIds ─────────────────────────────────────────────────────
+
+describe('parseBacklogIds', () => {
+  it('extracts ids from `### \\`<id>\\`` headings', () => {
+    const md = `# Backlog\n\n### \`role-typed-backlog-entries\`\n\nblah\n\n### \`debt-ledger-analysis-loader\`\n\n`;
+    expect(parseBacklogIds(md)).toEqual(
+      new Set(['role-typed-backlog-entries', 'debt-ledger-analysis-loader']),
+    );
+  });
+
+  it('returns empty when no headings match', () => {
+    expect(parseBacklogIds('# Backlog\n\nIntro\n')).toEqual(new Set());
+  });
+});
+
+// ─── candidateToEntryId ──────────────────────────────────────────────────
+
+describe('candidateToEntryId', () => {
+  it('slugifies arxiv ids cleanly', () => {
+    expect(candidateToEntryId(makeCand({ source: 'arxiv', id: '2511.13646v3' }))).toBe(
+      'arxiv-2511-13646v3-investigate',
+    );
+  });
+
+  it('slugifies reddit-style ids', () => {
+    expect(candidateToEntryId(makeCand({ source: 'reddit', id: '1t1n6o8' }))).toBe(
+      'reddit-1t1n6o8-investigate',
+    );
+  });
+
+  it('caps the slug length to keep entry ids tractable', () => {
+    const id = 'a'.repeat(200);
+    expect(candidateToEntryId(makeCand({ id })).length).toBeLessThan(80);
+  });
+
+  it("two different candidates produce different entry ids", () => {
+    expect(candidateToEntryId(makeCand({ id: 'a' }))).not.toBe(
+      candidateToEntryId(makeCand({ id: 'b' })),
+    );
+  });
+});
+
+// ─── renderDraftEntry ────────────────────────────────────────────────────
+
+describe('renderDraftEntry', () => {
+  it('produces a complete `in_design` backlog entry', () => {
+    const out = renderDraftEntry(makeCand(), 'arxiv-x-investigate', '2026-05-02T18:00:00Z');
+    expect(out).toContain('### `arxiv-x-investigate`');
+    expect(out).toContain('status: in_design');
+    expect(out).toContain('tier: TBD');
+    expect(out).toContain('file: TBD');
+    expect(out).toContain('Live-SWE-agent v3');  // summary survives
+    expect(out).toContain('arxiv-x-investigate');
+  });
+
+  it('embeds the source URL as references_signal', () => {
+    const out = renderDraftEntry(
+      makeCand({ url: 'https://arxiv.org/abs/foo' }),
+      'arxiv-foo-investigate',
+      '2026-05-02T18:00:00Z',
+    );
+    expect(out).toContain('references_signal: https://arxiv.org/abs/foo');
+  });
+
+  it('names the next-step expectation (operator/groomer fills tier/file/loc)', () => {
+    const out = renderDraftEntry(makeCand(), 'arxiv-x-investigate', '2026-05-02T18:00:00Z');
+    expect(out.toLowerCase()).toContain('next step');
+    expect(out.toLowerCase()).toContain('groomer');
+  });
+});
+
+// ─── appendBacklogEntry ──────────────────────────────────────────────────
+
+describe('appendBacklogEntry', () => {
+  it('appends rendered entry at the end of the doc', () => {
+    const md = '# Backlog\n\n### `existing-entry`\n\nblah\n';
+    const rendered = '### `new-entry`\n\nfresh\n';
+    const out = appendBacklogEntry(md, rendered);
+    expect(out).toContain('existing-entry');
+    expect(out).toContain('new-entry');
+    expect(out.indexOf('new-entry')).toBeGreaterThan(out.indexOf('existing-entry'));
+  });
+});
+
+// ─── runGroomer ──────────────────────────────────────────────────────────
+
+describe('runGroomer', () => {
+  let scratch: string;
+  let roadmapPath: string;
+  let backlogPath: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'groomer-test-'));
+    roadmapPath = join(scratch, 'roadmap.md');
+    backlogPath = join(scratch, 'swarm-backlog.md');
+    logs = [];
+    writeFileSync(backlogPath, '# Swarm Backlog\n\n## Entries\n\n', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("does nothing when roadmap has no candidates", async () => {
+    writeFileSync(roadmapPath, '# Roadmap\n\nintro\n', 'utf8');
+    const r = await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l) => logs.push(l),
+    });
+    expect(r.promoted).toBe(0);
+    expect(r.total_candidates).toBe(0);
+    // Backlog file untouched.
+    expect(readFileSync(backlogPath, 'utf8')).toContain('## Entries');
+  });
+
+  it('promotes an arxiv candidate to an in_design backlog entry', async () => {
+    writeFileSync(
+      roadmapPath,
+      `${CANDIDATES_HEADING}\n\n- [arxiv] [2511.13646v3](https://arxiv.org/abs/2511.13646v3) — Live-SWE-agent v3\n`,
+      'utf8',
+    );
+    const r = await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l) => logs.push(l),
+    });
+    expect(r.promoted).toBe(1);
+    const md = readFileSync(backlogPath, 'utf8');
+    expect(md).toContain('### `arxiv-2511-13646v3-investigate`');
+    expect(md).toContain('status: in_design');
+    // Telemetry shape
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.component).toBe('groomer');
+    expect(parsed.promoted).toBe(1);
+  });
+
+  it('skips reddit candidates by default (source allowlist)', async () => {
+    writeFileSync(
+      roadmapPath,
+      `${CANDIDATES_HEADING}\n\n- [reddit] [1xxx](https://reddit.com/r/x/1xxx) — qwen3 thread\n`,
+      'utf8',
+    );
+    const r = await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l) => logs.push(l),
+    });
+    expect(r.total_candidates).toBe(1);
+    expect(r.filtered_to_promotable).toBe(0);
+    expect(r.promoted).toBe(0);
+  });
+
+  it('respects the source allowlist when expanded by env', async () => {
+    writeFileSync(
+      roadmapPath,
+      `${CANDIDATES_HEADING}\n\n- [reddit] [1xxx](https://reddit.com/r/x/1xxx) — qwen3 thread\n`,
+      'utf8',
+    );
+    const r = await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv', 'reddit'],
+      log: (l) => logs.push(l),
+    });
+    expect(r.promoted).toBe(1);
+  });
+
+  it('dedups against existing backlog entries', async () => {
+    writeFileSync(
+      roadmapPath,
+      `${CANDIDATES_HEADING}\n\n- [arxiv] [foo](https://x) — bar\n`,
+      'utf8',
+    );
+    writeFileSync(
+      backlogPath,
+      '# Backlog\n\n### `arxiv-foo-investigate`\n\nalready promoted\n',
+      'utf8',
+    );
+    const r = await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l) => logs.push(l),
+    });
+    expect(r.promoted).toBe(0);
+    expect(r.duplicates_skipped).toBe(1);
+  });
+
+  it('caps promotions per run', async () => {
+    const rows = Array.from(
+      { length: 10 },
+      (_, i) => `- [arxiv] [paper-${i}](https://arxiv.org/abs/paper-${i}) — paper ${i}`,
+    ).join('\n');
+    writeFileSync(roadmapPath, `${CANDIDATES_HEADING}\n\n${rows}\n`, 'utf8');
+    const r = await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 3,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l) => logs.push(l),
+    });
+    expect(r.promoted).toBe(3);
+    const md = readFileSync(backlogPath, 'utf8');
+    expect((md.match(/status: in_design/g) ?? []).length).toBe(3);
+  });
+
+  it('does not touch the backlog file when nothing was promoted', async () => {
+    writeFileSync(roadmapPath, `${CANDIDATES_HEADING}\n\n`, 'utf8');
+    const before = readFileSync(backlogPath, 'utf8');
+    await runGroomer({
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l) => logs.push(l),
+    });
+    expect(readFileSync(backlogPath, 'utf8')).toBe(before);
+  });
+
+  it("idempotent on a second run — same candidates produce zero new entries", async () => {
+    writeFileSync(
+      roadmapPath,
+      `${CANDIDATES_HEADING}\n\n- [arxiv] [foo](https://x) — bar\n`,
+      'utf8',
+    );
+    const opts = {
+      roadmapPath,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      promotableSources: ['arxiv'],
+      log: (l: string) => logs.push(l),
+    };
+    const r1 = await runGroomer(opts);
+    expect(r1.promoted).toBe(1);
+    const r2 = await runGroomer(opts);
+    expect(r2.promoted).toBe(0);
+    expect(r2.duplicates_skipped).toBe(1);
+  });
+});
+
+// ─── default constants sanity ────────────────────────────────────────────
+
+describe('defaults', () => {
+  it("DEFAULT_PROMOTABLE_SOURCES is a conservative allowlist (arxiv only)", () => {
+    expect(DEFAULT_PROMOTABLE_SOURCES).toEqual(['arxiv']);
+  });
+
+  it('DEFAULT_CAP is 1 (drip-feed, not flood)', () => {
+    expect(DEFAULT_CAP).toBe(1);
+  });
+});

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -14,6 +14,8 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 | `chitin-researcher.timer` | timer | Fires the researcher every 4 hours. |
 | `chitin-swarm-rollup.service` | oneshot | Daily swarm-health rollup: derives metrics from `tmp/result-swarm-*.json` + dispatcher journalctl, posts a digest to Slack. |
 | `chitin-swarm-rollup.timer` | timer | Fires the rollup once per day. |
+| `chitin-groomer.service` | oneshot | Daily groomer: reads roadmap candidates, drafts up to N (default 1) `in_design` backlog entries from arxiv-source candidates. The existing groom-pass.ts then classifies tier/file/loc. |
+| `chitin-groomer.timer` | timer | Fires the groomer once per day. |
 | `chitin-lessons.service` | oneshot | Daily lessons-learned extractor: scans merged swarm/* PRs, distills a one-sentence lesson per, appends to `docs/swarm-lessons.md`. The dispatcher prepends recent lessons to programmer prompts. |
 | `chitin-lessons.timer` | timer | Fires the lessons extractor once per day. |
 | `chitin-debt-curator.service` | oneshot | Daily debt-curator scan: greps the repo for TODO/FIXME/HACK/XXX markers, dedups, appends new finds to `docs/debt-ledger.md` at severity:'low' (operator promotes). |
@@ -31,6 +33,7 @@ systemctl --user enable --now chitin-researcher.timer
 systemctl --user enable --now chitin-swarm-rollup.timer
 systemctl --user enable --now chitin-lessons.timer
 systemctl --user enable --now chitin-debt-curator.timer
+systemctl --user enable --now chitin-groomer.timer
 ```
 
 To survive logout (start at boot):
@@ -49,6 +52,7 @@ journalctl --user -u chitin-researcher -f
 journalctl --user -u chitin-swarm-rollup -f
 journalctl --user -u chitin-lessons -f
 journalctl --user -u chitin-debt-curator -f
+journalctl --user -u chitin-groomer -f
 
 # Status
 systemctl --user status chitin-worker

--- a/infra/systemd/chitin-groomer.service
+++ b/infra/systemd/chitin-groomer.service
@@ -1,0 +1,21 @@
+# One-shot service fired by chitin-groomer.timer.
+# Reads docs/roadmap.md "Candidates from external signal", dedups
+# against docs/swarm-backlog.md, drafts up to N (default 1)
+# `in_design` entries from arxiv-source candidates. The existing
+# groom-pass.ts (Copilot-driven) takes those in_design entries the
+# rest of the way to `ready`.
+
+[Unit]
+Description=Chitin swarm groomer (candidate promoter)
+After=chitin-worker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/groomer.ts
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/infra/systemd/chitin-groomer.timer
+++ b/infra/systemd/chitin-groomer.timer
@@ -1,0 +1,17 @@
+# Timer for chitin-groomer.service.
+# Daily — drips at most 1 candidate from arxiv into the backlog per
+# day (cap configurable via CHITIN_GROOMER_CAP env). Persistent so a
+# missed tick from a powered-off rig fires on the next boot. 1h boot
+# offset stages it after rollup / lessons / debt-curator.
+
+[Unit]
+Description=Chitin swarm groomer timer
+
+[Timer]
+OnUnitActiveSec=24h
+OnBootSec=1h
+Persistent=true
+Unit=chitin-groomer.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Researcher already drops candidates into \`roadmap.md\`; this closes the last manual step. A daily timer reads candidates, dedups against backlog, drafts \`in_design\` entries from arxiv-source candidates. The existing \`groom-pass.ts\` (Copilot-driven) classifies them the rest of the way to \`ready\`.

**Conservative gating v1:**
- Source allowlist: default \`['arxiv']\` (\`CHITIN_GROOMER_SOURCES\` env to expand)
- Cap: default 1/run (\`CHITIN_GROOMER_CAP\` env)
- Drafted entries land as \`in_design\`, not \`ready\` — the existing groomer classifies tier/file/loc

**Pipeline state with this:**
\`\`\`
researcher (4h) → roadmap.md candidates
                    ↓
groomer (24h, this PR) → in_design backlog entries
                    ↓
groom-pass.ts (operator/cron) → ready backlog entries
                    ↓
chitin-dispatcher (5min) → programmer workflow
                    ↓
review-graph + gatekeeper → operator merges
\`\`\`

## Test plan

- [x] 25 tests covering parsing/dedup/cap/idempotency; 438/438 in temporal-worker
- [x] Typecheck clean
- [ ] After merge: \`systemctl --user enable --now chitin-groomer.timer\` + first manual run; verify the existing 5 reddit qwen3 candidates get filtered out (source allowlist) and the next arxiv candidate gets drafted

🤖 Generated with [Claude Code](https://claude.com/claude-code)