### PR TITLE
feat(alarm-feeder): §7 telemetry → backlog flywheel

### DIFF
--- a/apps/temporal-worker/src/alarm-feeder.ts
+++ b/apps/temporal-worker/src/alarm-feeder.ts
@@ -1,0 +1,245 @@
+// §7 telemetry → backlog flywheel.
+//
+// The daily rollup (chitin-swarm-rollup.timer) writes
+// ~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json including an
+// `alarms` array — natural-language strings the rollup detector
+// fires when something regresses (bucket-B re-appears, success-rate
+// dips, dispatch volume craters, etc).
+//
+// Today: alarms post to Slack and live in the rollup JSON. Operator
+// reads, decides, files an investigation entry by hand.
+//
+// This module: closes that loop. A daily timer reads the latest
+// rollup, dedups alarms against existing investigate-* backlog
+// entries, drafts an in_design entry per new alarm with
+// role:researcher (so the existing groomer + downstream chain can
+// pick it up). Cap is conservative (default 1/day) — alarm bursts
+// shouldn't flood the backlog.
+//
+// Pattern matches researcher.ts / lessons.ts / debt-curator.ts /
+// groomer.ts: cron-fired script, idempotent, telemetry log line,
+// no Temporal involvement. The rollup is a flat-file boundary; this
+// module reads it.
+
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile } from 'node:fs/promises';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { homedir } from 'node:os';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface AlarmFeederOptions {
+  rollupsDir: string;
+  backlogPath: string;
+  cap: number;
+  /** ISO-8601 timestamp injected by runner. */
+  now: string;
+  log?: (line: string) => void;
+}
+
+export interface AlarmFeederResult {
+  total_alarms: number;
+  new_entries: number;
+  duplicates_skipped: number;
+  rollup_present: boolean;
+}
+
+interface RollupShape {
+  alarms?: string[];
+  // The other fields are read by the gatekeeper; we only need alarms.
+}
+
+// ─── Alarm signature → entry id ──────────────────────────────────────────
+
+/**
+ * Derive a stable id from an alarm string. We don't want a small
+ * wording change ("5.3%" → "6.1%") to file a new entry, so the
+ * signature is the FIRST WORDS of the alarm before any metric — the
+ * "kind" of alarm, not the specific numbers.
+ *
+ * Examples:
+ *   "BUCKET-B REGRESSION: 1/19 runs contaminated (5.3%) — PR #123 ..."
+ *     → "bucket-b-regression"
+ *   "SUCCESS RATE DROP: claude-code-headless tier T2 fell to 60% ..."
+ *     → "success-rate-drop"
+ */
+export function alarmSignature(alarm: string): string {
+  // Take the leading uppercase phrase up to the first colon, normalize.
+  const colonIdx = alarm.indexOf(':');
+  const head = colonIdx >= 0 ? alarm.slice(0, colonIdx) : alarm.slice(0, 60);
+  return head
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+export function alarmEntryId(signature: string): string {
+  return `investigate-${signature}`;
+}
+
+// ─── Backlog id parsing (mirror of groomer.ts) ───────────────────────────
+
+const BACKLOG_ID_RE = /^### `([^`]+)`/gm;
+
+export function parseBacklogIds(text: string): Set<string> {
+  const ids = new Set<string>();
+  for (const match of text.matchAll(BACKLOG_ID_RE)) {
+    ids.add(match[1]);
+  }
+  return ids;
+}
+
+// ─── Rollup reading ──────────────────────────────────────────────────────
+
+/**
+ * Read the most-recent rollup JSON from `rollupsDir`. Returns
+ * { rollup: RollupShape } when found, { rollup: undefined } when
+ * absent or unreadable. Tests inject a tmpdir with synthetic JSON.
+ */
+export function readLatestRollup(rollupsDir: string): RollupShape | undefined {
+  let names: string[];
+  try {
+    names = readdirSync(rollupsDir).filter((n) => n.endsWith('.json'));
+  } catch {
+    return undefined;
+  }
+  if (names.length === 0) return undefined;
+  names.sort();
+  const latest = names[names.length - 1];
+  try {
+    const raw = readFileSync(resolve(rollupsDir, latest), 'utf8');
+    return JSON.parse(raw) as RollupShape;
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── Drafted entry shape ─────────────────────────────────────────────────
+
+/**
+ * Render a draft `in_design` backlog entry that the existing
+ * groomer + downstream chain will pick up. Uses role:researcher so
+ * the resulting workflow goes through the researcher prompt
+ * template (PR #143) — alarms are usually "what regressed?
+ * investigate" tasks, which is researcher-shape.
+ */
+export function renderAlarmEntry(alarm: string, entryId: string, now: string): string {
+  return [
+    `### \`${entryId}\``,
+    '',
+    '```yaml',
+    `id: ${entryId}`,
+    'tier: TBD',
+    'status: in_design',
+    'estimated_loc: TBD',
+    'blocks: []',
+    'file: TBD',
+    'references_signal: chitin-swarm-rollup alarms',
+    'role: researcher',
+    '```',
+    '',
+    `Auto-filed by chitin-alarm-feeder.timer at ${now} from a swarm-rollup alarm:`,
+    '',
+    `> ${alarm}`,
+    '',
+    'Researcher role: read the alarm + the latest swarm-rollup JSON at `~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json`; identify the root cause (recent dispatch failures, driver regressions, governance edits, etc); propose either a fix entry or `status: needs_human` if the cause is non-obvious. Operator: groom this entry once it has a real `tier` / `file:` / `estimated_loc`.',
+    '',
+  ].join('\n');
+}
+
+export function appendBacklogEntry(text: string, rendered: string): string {
+  const trimmed = text.replace(/\s+$/, '');
+  return `${trimmed}\n\n${rendered}`;
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────
+
+export async function runAlarmFeeder(
+  opts: AlarmFeederOptions,
+): Promise<AlarmFeederResult> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+
+  const rollup = readLatestRollup(opts.rollupsDir);
+  const alarms = rollup?.alarms ?? [];
+
+  const backlog = await readFile(opts.backlogPath, 'utf8').catch(() => '');
+  const knownIds = parseBacklogIds(backlog);
+
+  let next = backlog;
+  let newEntries = 0;
+  let duplicates_skipped = 0;
+  const seenInRun = new Set<string>();
+  for (const alarm of alarms) {
+    if (newEntries >= opts.cap) break;
+    const sig = alarmSignature(alarm);
+    if (!sig) continue;
+    const entryId = alarmEntryId(sig);
+    if (knownIds.has(entryId) || seenInRun.has(entryId)) {
+      duplicates_skipped++;
+      continue;
+    }
+    seenInRun.add(entryId);
+    next = appendBacklogEntry(next, renderAlarmEntry(alarm, entryId, opts.now));
+    newEntries++;
+  }
+
+  if (newEntries > 0) {
+    await writeFile(opts.backlogPath, next, 'utf8');
+  }
+
+  const result: AlarmFeederResult = {
+    total_alarms: alarms.length,
+    new_entries: newEntries,
+    duplicates_skipped,
+    rollup_present: rollup !== undefined,
+  };
+
+  log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      component: 'alarm-feeder',
+      ...result,
+    }),
+  );
+
+  return result;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────
+
+const DEFAULT_ROLLUPS_DIR = resolve(homedir(), '.cache/chitin/swarm-rollups');
+const DEFAULT_BACKLOG_PATH = resolve(process.cwd(), 'docs/swarm-backlog.md');
+const DEFAULT_CAP = 1;
+
+async function main(): Promise<void> {
+  const cap = Number(process.env.CHITIN_ALARM_FEEDER_CAP ?? String(DEFAULT_CAP));
+  await runAlarmFeeder({
+    rollupsDir: DEFAULT_ROLLUPS_DIR,
+    backlogPath: DEFAULT_BACKLOG_PATH,
+    cap,
+    now: new Date().toISOString(),
+  });
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        component: 'alarm-feeder',
+        msg: 'alarm-feeder tick fatal',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    process.exit(1);
+  });
+}
+
+export const __test__ = {
+  BACKLOG_ID_RE,
+  DEFAULT_CAP,
+};

--- a/apps/temporal-worker/test/alarm-feeder.test.ts
+++ b/apps/temporal-worker/test/alarm-feeder.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  alarmEntryId,
+  alarmSignature,
+  appendBacklogEntry,
+  parseBacklogIds,
+  readLatestRollup,
+  renderAlarmEntry,
+  runAlarmFeeder,
+} from '../src/alarm-feeder.ts';
+
+// ─── alarmSignature ──────────────────────────────────────────────────────
+
+describe('alarmSignature', () => {
+  it('extracts a stable kind-id from the leading phrase before colon', () => {
+    expect(alarmSignature('BUCKET-B REGRESSION: 1/19 runs contaminated (5.3%)')).toBe(
+      'bucket-b-regression',
+    );
+    expect(alarmSignature('SUCCESS RATE DROP: claude-code-headless tier T2 fell to 60%')).toBe(
+      'success-rate-drop',
+    );
+  });
+
+  it('numbers in the middle do not change the signature (rate variations dedup)', () => {
+    expect(alarmSignature('BUCKET-B REGRESSION: 1/19 runs contaminated (5.3%)')).toBe(
+      alarmSignature('BUCKET-B REGRESSION: 2/30 runs contaminated (6.7%)'),
+    );
+  });
+
+  it("falls back to the first 60 chars when no colon is present", () => {
+    const sig = alarmSignature('Plain alarm with no colon delimiter');
+    expect(sig).toBe('plain-alarm-with-no-colon-delimiter');
+  });
+});
+
+describe('alarmEntryId', () => {
+  it("prefixes signature with 'investigate-'", () => {
+    expect(alarmEntryId('bucket-b-regression')).toBe('investigate-bucket-b-regression');
+  });
+});
+
+// ─── parseBacklogIds ─────────────────────────────────────────────────────
+
+describe('parseBacklogIds', () => {
+  it("extracts ids from `### \\`<id>\\`` headings", () => {
+    const md = "# Backlog\n\n### `entry-one`\n\n### `entry-two`\n";
+    expect(parseBacklogIds(md)).toEqual(new Set(['entry-one', 'entry-two']));
+  });
+
+  it("returns empty for backlog without ### headings", () => {
+    expect(parseBacklogIds('# Backlog\n\nintro\n')).toEqual(new Set());
+  });
+});
+
+// ─── readLatestRollup ────────────────────────────────────────────────────
+
+describe('readLatestRollup', () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'alarm-feeder-rollup-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("returns undefined when the rollup dir is missing", () => {
+    expect(readLatestRollup(join(scratch, 'nope'))).toBeUndefined();
+  });
+
+  it("returns undefined when no rollup files exist", () => {
+    expect(readLatestRollup(scratch)).toBeUndefined();
+  });
+
+  it("reads alarms from the lex-newest JSON", () => {
+    writeFileSync(join(scratch, '2026-04-30.json'), JSON.stringify({ alarms: ['old'] }), 'utf8');
+    writeFileSync(join(scratch, '2026-05-02.json'), JSON.stringify({ alarms: ['new', 'fresh'] }), 'utf8');
+    const r = readLatestRollup(scratch);
+    expect(r?.alarms).toEqual(['new', 'fresh']);
+  });
+
+  it("returns undefined on malformed JSON (does not throw)", () => {
+    writeFileSync(join(scratch, '2026-05-02.json'), 'not json', 'utf8');
+    expect(readLatestRollup(scratch)).toBeUndefined();
+  });
+});
+
+// ─── renderAlarmEntry ────────────────────────────────────────────────────
+
+describe('renderAlarmEntry', () => {
+  it("renders an in_design backlog entry with role:researcher", () => {
+    const out = renderAlarmEntry(
+      'BUCKET-B REGRESSION: 1/19 runs contaminated',
+      'investigate-bucket-b-regression',
+      '2026-05-02T18:00:00Z',
+    );
+    expect(out).toContain('### `investigate-bucket-b-regression`');
+    expect(out).toContain('role: researcher');
+    expect(out).toContain('status: in_design');
+    expect(out).toContain('BUCKET-B REGRESSION');
+    expect(out).toContain('chitin-alarm-feeder.timer');
+  });
+});
+
+// ─── runAlarmFeeder ──────────────────────────────────────────────────────
+
+describe('runAlarmFeeder', () => {
+  let scratch: string;
+  let backlogPath: string;
+  let rollupsDir: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'alarm-feeder-test-'));
+    rollupsDir = join(scratch, 'rollups');
+    backlogPath = join(scratch, 'swarm-backlog.md');
+    logs = [];
+    writeFileSync(backlogPath, '# Swarm Backlog\n\n## Entries\n\n', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  function writeRollup(name: string, alarms: string[]) {
+    try {
+      mkdtempSync(rollupsDir);
+    } catch {
+      // dir might exist; handled by node fs
+    }
+    // Ensure dir exists.
+    const fs = require('node:fs') as typeof import('node:fs');
+    fs.mkdirSync(rollupsDir, { recursive: true });
+    writeFileSync(join(rollupsDir, name), JSON.stringify({ alarms }), 'utf8');
+  }
+
+  it("does nothing when the rollup directory doesn't exist", async () => {
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.rollup_present).toBe(false);
+    expect(r.new_entries).toBe(0);
+    expect(r.total_alarms).toBe(0);
+    expect(readFileSync(backlogPath, 'utf8')).toContain('## Entries');
+  });
+
+  it("does nothing when the rollup has no alarms", async () => {
+    writeRollup('2026-05-02.json', []);
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.rollup_present).toBe(true);
+    expect(r.new_entries).toBe(0);
+    expect(r.total_alarms).toBe(0);
+  });
+
+  it("files a backlog entry per new alarm", async () => {
+    writeRollup('2026-05-02.json', [
+      'BUCKET-B REGRESSION: 1/19 runs contaminated (5.3%)',
+      'SUCCESS RATE DROP: copilot tier T2 fell to 50%',
+    ]);
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(2);
+    const md = readFileSync(backlogPath, 'utf8');
+    expect(md).toContain('### `investigate-bucket-b-regression`');
+    expect(md).toContain('### `investigate-success-rate-drop`');
+    expect(md).toContain('role: researcher');
+    // Telemetry shape
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.component).toBe('alarm-feeder');
+    expect(parsed.new_entries).toBe(2);
+  });
+
+  it("dedups against existing backlog entries (idempotent re-runs)", async () => {
+    writeRollup('2026-05-02.json', ['BUCKET-B REGRESSION: 1/19 contaminated']);
+    writeFileSync(
+      backlogPath,
+      "# Backlog\n\n### `investigate-bucket-b-regression`\n\nalready filed\n",
+      'utf8',
+    );
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(0);
+    expect(r.duplicates_skipped).toBe(1);
+  });
+
+  it("dedups within a run when two alarms share the same kind-signature", async () => {
+    writeRollup('2026-05-02.json', [
+      'BUCKET-B REGRESSION: 1/19 contaminated (5%)',
+      'BUCKET-B REGRESSION: 2/30 contaminated (7%)',
+    ]);
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(1);
+    expect(r.duplicates_skipped).toBe(1);
+  });
+
+  it("caps entries written per run", async () => {
+    writeRollup('2026-05-02.json', [
+      'ALARM ONE: x',
+      'ALARM TWO: y',
+      'ALARM THREE: z',
+      'ALARM FOUR: w',
+    ]);
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 2,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(2);
+  });
+
+  it("doesn't touch the backlog when nothing was filed", async () => {
+    writeRollup('2026-05-02.json', []);
+    const before = readFileSync(backlogPath, 'utf8');
+    await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(readFileSync(backlogPath, 'utf8')).toBe(before);
+  });
+});
+
+// ─── appendBacklogEntry sanity ───────────────────────────────────────────
+
+describe('appendBacklogEntry', () => {
+  it("appends rendered entry at the end", () => {
+    const md = '# x\n\n### `existing`\n\nblah\n';
+    const out = appendBacklogEntry(md, '### `new`\n\nfresh\n');
+    expect(out).toContain('existing');
+    expect(out).toContain('new');
+    expect(out.indexOf('new')).toBeGreaterThan(out.indexOf('existing'));
+  });
+});

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -20,6 +20,8 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 | `chitin-lessons.timer` | timer | Fires the lessons extractor once per day. |
 | `chitin-debt-curator.service` | oneshot | Daily debt-curator scan: greps the repo for TODO/FIXME/HACK/XXX markers, dedups, appends new finds to `docs/debt-ledger.md` at severity:'low' (operator promotes). |
 | `chitin-debt-curator.timer` | timer | Fires the debt-curator once per day. |
+| `chitin-alarm-feeder.service` | oneshot | Daily alarm-feeder: reads rollup `alarms[]`, dedups against existing `investigate-*` backlog entries, drafts in_design entries with role:researcher. Closes §7 telemetry → backlog flywheel. |
+| `chitin-alarm-feeder.timer` | timer | Fires the alarm-feeder once per day. |
 
 ## Install
 
@@ -33,6 +35,7 @@ systemctl --user enable --now chitin-researcher.timer
 systemctl --user enable --now chitin-swarm-rollup.timer
 systemctl --user enable --now chitin-lessons.timer
 systemctl --user enable --now chitin-debt-curator.timer
+systemctl --user enable --now chitin-alarm-feeder.timer
 systemctl --user enable --now chitin-groomer.timer
 ```
 
@@ -52,6 +55,7 @@ journalctl --user -u chitin-researcher -f
 journalctl --user -u chitin-swarm-rollup -f
 journalctl --user -u chitin-lessons -f
 journalctl --user -u chitin-debt-curator -f
+journalctl --user -u chitin-alarm-feeder -f
 journalctl --user -u chitin-groomer -f
 
 # Status

--- a/infra/systemd/chitin-alarm-feeder.service
+++ b/infra/systemd/chitin-alarm-feeder.service
@@ -1,0 +1,21 @@
+# One-shot service fired by chitin-alarm-feeder.timer.
+# Reads the latest swarm-rollup JSON, dedups alarms against existing
+# investigate-* backlog entries, drafts up to N (default 1) in_design
+# entries with role:researcher per new alarm. Closes §7's "alarm
+# fires → researcher investigates" loop.
+
+[Unit]
+Description=Chitin swarm alarm-feeder (rollup → backlog flywheel)
+# Order after the rollup so it reads the freshest JSON.
+After=chitin-swarm-rollup.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/alarm-feeder.ts
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/infra/systemd/chitin-alarm-feeder.timer
+++ b/infra/systemd/chitin-alarm-feeder.timer
@@ -1,0 +1,16 @@
+# Timer for chitin-alarm-feeder.service.
+# Daily — fires after the rollup has settled (90min boot offset
+# stages it after rollup/lessons/debt-curator/groomer). Persistent
+# so a missed tick from a powered-off rig fires on the next boot.
+
+[Unit]
+Description=Chitin swarm alarm-feeder timer
+
+[Timer]
+OnUnitActiveSec=24h
+OnBootSec=90min
+Persistent=true
+Unit=chitin-alarm-feeder.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Closes §7 of the design doc. The rollup writes \`alarms[]\` to its JSON; today operator reads + files investigation entries by hand. This: a daily timer reads the latest rollup, dedups alarms against existing \`investigate-*\` entries (by kind-signature so rate-shift doesn't refile), drafts \`in_design\` entries with \`role:researcher\` per new alarm. Existing groomer + dispatcher chain takes them the rest of the way.

**Pipeline state with this:**

\`\`\`
rollup (24h) → alarms[] in JSON
                ↓
alarm-feeder (24h, this PR) → in_design investigate-* entries
                ↓
groomer (existing) → tier-classify → ready
                ↓
dispatcher → researcher workflow (researcher prompts from #143)
                ↓
PR opens → review-graph → gatekeeper → operator/auto-merge
\`\`\`

## Test plan

- [x] 19 tests covering signature, parsing, runner happy/dedup/cap/empty paths; 488/488 in temporal-worker
- [x] Typecheck clean
- [ ] After merge: \`systemctl --user enable --now chitin-alarm-feeder.timer\`. First tick will see the existing bucket-B alarm in the 2026-05-01 rollup and file the first investigate entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)