### PR TITLE
feat(analyst): swarm-dispatched analyst role + alarm-feeder reroute

### DIFF
--- a/apps/temporal-worker/src/alarm-feeder.ts
+++ b/apps/temporal-worker/src/alarm-feeder.ts
@@ -120,10 +120,12 @@ export function readLatestRollup(rollupsDir: string): RollupShape | undefined {
 
 /**
  * Render a draft `in_design` backlog entry that the existing
- * groomer + downstream chain will pick up. Uses role:researcher so
- * the resulting workflow goes through the researcher prompt
- * template (PR #143) — alarms are usually "what regressed?
- * investigate" tasks, which is researcher-shape.
+ * groomer + downstream chain will pick up. Uses `role: analyst` —
+ * alarms surface from the swarm's INTERNAL telemetry (rollup,
+ * gov-decisions, swarm_runs), and processing internal telemetry is
+ * the analyst's scope per the design's §3 row. Researcher role is
+ * for EXTERNAL signal pulls (arxiv / reddit / openclaw) — separate
+ * lane.
  */
 export function renderAlarmEntry(alarm: string, entryId: string, now: string): string {
   return [
@@ -137,14 +139,14 @@ export function renderAlarmEntry(alarm: string, entryId: string, now: string): s
     'blocks: []',
     'file: TBD',
     'references_signal: chitin-swarm-rollup alarms',
-    'role: researcher',
+    'role: analyst',
     '```',
     '',
     `Auto-filed by chitin-alarm-feeder.timer at ${now} from a swarm-rollup alarm:`,
     '',
     `> ${alarm}`,
     '',
-    'Researcher role: read the alarm + the latest swarm-rollup JSON at `~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json`; identify the root cause (recent dispatch failures, driver regressions, governance edits, etc); propose either a fix entry or `status: needs_human` if the cause is non-obvious. Operator: groom this entry once it has a real `tier` / `file:` / `estimated_loc`.',
+    'Analyst role: use `python/analysis/` to read the latest swarm-rollup JSON at `~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json` + the events-jsonl chain; identify the root cause (recent dispatch failures, driver regressions, governance edits, etc); write a markdown report to `python/analysis/out/<entry-id>.md` and emit a `<<<ANALYSIS>>>` JSON line with root_cause + recommended_action. Operator: groom this entry once it has a real `tier` / `file:` / `estimated_loc`.',
     '',
   ].join('\n');
 }

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -99,6 +99,62 @@ Synthesis rules:
 ${RESEARCHER_OUTPUT_INSTRUCTIONS}`;
 }
 
+// Analyst prompt for the BacklogEntry path. The analyst role owns
+// internal-telemetry analysis (gov-decisions chain, swarm rollups,
+// debt ledger). It's distinct from researcher (which pulls EXTERNAL
+// signals — arxiv, reddit, openclaw): analyst processes the swarm's
+// own audit trail to find regressions, debt patterns, success-rate
+// dips, and proposes either a fix entry or a needs_human escalation.
+//
+// Why a dedicated template (vs reusing programmer): the analyst is
+// expected to NOT write code. Its output is a finding + recommended
+// action, parsed via `<<<ANALYSIS>>>` so the apply step records a
+// markdown report rather than expecting a code commit. An empty
+// worktree on success is the EXPECTED outcome.
+function buildAnalystEntryPrompt(entry: BacklogEntry): string {
+  return `You are playing the analyst role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3 for the role's scope.
+
+Your toolkit is \`python/analysis/\`: a typed library of loaders + reports against chitin's canonical event chain. The lib already produces three streams:
+
+  - \`analysis.decisions\` — per-rule deny/allow analysis of governance decisions
+  - \`analysis.debt\` — debt-ledger loader + reporting
+  - \`analysis.swarm_health\` — daily rollup (bucket-B rate, success-by-tier, alarms[])
+  - \`analysis.swarm_runs\` — per-run records (driver, tier, exit_code, duration_ms)
+
+Source data:
+  - \`~/.cache/chitin/.../events-*.jsonl\` — gov-decisions chain (canonical)
+  - \`~/.cache/chitin/swarm-state/dispatched/<entry-id>.json\` — dispatch markers
+  - \`~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json\` — daily rollup
+  - \`tmp/result-swarm-*.json\` — workflow result envelopes
+  - \`docs/debt-ledger.md\` — operator-curated + auto-curated debt
+
+ENTRY ID: ${entry.id}
+ROLE: analyst
+
+ENTRY DETAIL:
+${entry.description}
+
+What good output looks like:
+- Run an existing analysis module (\`python -m analysis.swarm_health\` etc.) OR author a one-off Python query against the chain JSONL.
+- Surface the smallest set of facts that explain WHY the entry was filed (root cause, not symptoms).
+- Recommend a concrete next action: a fix-shape backlog entry, a tier-rule change, a debt-ledger promotion, or \`status: needs_human\` if the cause is non-obvious.
+
+Output rules:
+- Write your findings to \`python/analysis/out/${entry.id}.md\` (the apply step picks up files in this directory). Use the existing analysis writers in \`python/analysis/writers.py\` so format stays consistent across runs.
+- Empty worktree on completion is EXPECTED for the analyst role — your output is the markdown report under \`out/\`, not a code change. The apply step understands this.
+- Do NOT modify code under \`apps/\`, \`go/\`, or \`libs/\`. Pure analysis is your scope; if the analysis surfaces a code change, that's a follow-up backlog entry.
+- Do NOT modify chitin.yaml or anything under .chitin/ — governance is human-only.
+- If you cannot reproduce the regression or the rollup data is missing, exit cleanly with a stub report saying so. Better silent than guessed.
+
+At the END of your run, emit EXACTLY ONE JSON object on a single line, prefixed with the literal token \`<<<ANALYSIS>>>\` and nothing else after the closing brace on that line:
+
+<<<ANALYSIS>>>{"root_cause":"<one sentence>","recommended_action":"file-fix-entry"|"needs_human"|"no-action","report_path":"python/analysis/out/${entry.id}.md","confidence":"high"|"medium"|"low"}
+
+If you couldn't determine a root cause, emit:
+
+<<<ANALYSIS>>>{"root_cause":"unable to determine","recommended_action":"needs_human","report_path":"python/analysis/out/${entry.id}.md","confidence":"low"}`;
+}
+
 // Stub for the remaining non-programmer roles. Future entries replace
 // these with real per-role prompts (reviewer reads the PR's diff; qa
 // runs validation suites; etc.). For now the stub frames the role and
@@ -144,7 +200,9 @@ const ROLE_PROMPTS: Record<Role, RolePromptBuilder> = {
   qa: (entry) => buildStubPrompt('qa', entry),
   gatekeeper: (entry) => buildStubPrompt('gatekeeper', entry),
   'tech-writer': (entry) => buildStubPrompt('tech-writer', entry),
-  analyst: (entry) => buildStubPrompt('analyst', entry),
+  // Analyst uses its dedicated entry-level template. Internal-telemetry
+  // analysis distinct from researcher's external-signal pulls.
+  analyst: buildAnalystEntryPrompt,
   refactorer: (entry) => buildStubPrompt('refactorer', entry),
   'debt-curator': (entry) => buildStubPrompt('debt-curator', entry),
 };
@@ -184,4 +242,5 @@ export const __test__ = {
   ROLE_VOCAB,
   buildStubPrompt,
   buildResearcherEntryPrompt,
+  buildAnalystEntryPrompt,
 };

--- a/apps/temporal-worker/test/alarm-feeder.test.ts
+++ b/apps/temporal-worker/test/alarm-feeder.test.ts
@@ -92,14 +92,14 @@ describe('readLatestRollup', () => {
 // ─── renderAlarmEntry ────────────────────────────────────────────────────
 
 describe('renderAlarmEntry', () => {
-  it("renders an in_design backlog entry with role:researcher", () => {
+  it("renders an in_design backlog entry with role:analyst (internal-telemetry lane)", () => {
     const out = renderAlarmEntry(
       'BUCKET-B REGRESSION: 1/19 runs contaminated',
       'investigate-bucket-b-regression',
       '2026-05-02T18:00:00Z',
     );
     expect(out).toContain('### `investigate-bucket-b-regression`');
-    expect(out).toContain('role: researcher');
+    expect(out).toContain('role: analyst');
     expect(out).toContain('status: in_design');
     expect(out).toContain('BUCKET-B REGRESSION');
     expect(out).toContain('chitin-alarm-feeder.timer');
@@ -182,7 +182,7 @@ describe('runAlarmFeeder', () => {
     const md = readFileSync(backlogPath, 'utf8');
     expect(md).toContain('### `investigate-bucket-b-regression`');
     expect(md).toContain('### `investigate-success-rate-drop`');
-    expect(md).toContain('role: researcher');
+    expect(md).toContain('role: analyst');
     // Telemetry shape
     const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
     expect(parsed.component).toBe('alarm-feeder');

--- a/apps/temporal-worker/test/role-prompts.test.ts
+++ b/apps/temporal-worker/test/role-prompts.test.ts
@@ -111,6 +111,21 @@ describe('buildPromptForEntry', () => {
     }
   });
 
+  it('routes role: analyst to the dedicated analyst prompt (internal-telemetry lane)', () => {
+    const dispatched = buildPromptForEntry(makeEntry({ id: 'a-test', role: 'analyst' }));
+    expect(dispatched).toContain('analyst role');
+    expect(dispatched).toContain('a-test');
+    // The analyst prompt mandates the structured-output marker.
+    expect(dispatched).toContain('<<<ANALYSIS>>>');
+    // Names the python/analysis toolkit the role's job is to use.
+    expect(dispatched).toContain('python/analysis');
+    // Does NOT borrow programmer preamble — analyst output is reports,
+    // not commits.
+    expect(dispatched).not.toContain('TOOL DISPATCHES count');
+    // Names the report path convention so the apply step's lookup works.
+    expect(dispatched).toContain('python/analysis/out/a-test.md');
+  });
+
   it('falls back to programmer prompt when role is unknown (defensive)', () => {
     const fallback = buildPromptForEntry(makeEntry({ file: 'x.ts', role: 'time-traveler' }));
     expect(fallback).toContain('TOOL DISPATCHES count');  // programmer template signature


### PR DESCRIPTION
## Summary

Closes the analyst-role gap from §3. Python lib was already in production for the operator-driven path; this adds the swarm-dispatched path so an entry with \`role: analyst\` flows through a dedicated prompt template.

**Two halves:**
1. \`buildAnalystEntryPrompt\` — frames the agent with \`python/analysis/\` toolkit, names canonical data sources, mandates \`<<<ANALYSIS>>>\` structured emit, declares empty-worktree-on-success EXPECTED (analyst output is a markdown report under \`python/analysis/out/<entry-id>.md\`, not a code commit).
2. **alarm-feeder reroute** — drafted entries use \`role: analyst\` instead of \`role: researcher\`. Lane distinction: researcher = external signal pulls, analyst = internal telemetry processing.

## Pipeline state

\`\`\`
rollup → alarms[] → alarm-feeder files in_design role:analyst
                    ↓
                  groomer classifies → dispatcher fires
                    ↓
                  analyst workflow uses python/analysis to find root cause
                    ↓
                  python/analysis/out/<entry-id>.md report
                    ↓
                  review-graph (light review) → operator/auto-merge
\`\`\`

## Test plan

- [x] 506/506 pass in apps/temporal-worker; typecheck clean
- [x] Dedicated analyst routing test (verifies prompt mentions python/analysis, has <<<ANALYSIS>>> marker, names report path)
- [ ] After merge: deploy + restart worker. Next alarm-feeder tick will file entries with role:analyst (the existing investigate-bucket-b-regression entry stays as-is on disk; the change only affects future drafts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)