### PR TITLE
feat(analyst): pre-canned investigation recipe — determinism-first analyst

### DIFF
--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -112,21 +112,16 @@ ${RESEARCHER_OUTPUT_INSTRUCTIONS}`;
 // markdown report rather than expecting a code commit. An empty
 // worktree on success is the EXPECTED outcome.
 function buildAnalystEntryPrompt(entry: BacklogEntry): string {
-  return `You are playing the analyst role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3 for the role's scope.
+  // Pull the alarm signal out of the entry description so the agent
+  // can hand it directly to the recipe. The alarm-feeder formats
+  // entries with `> <alarm text>` as a blockquote line; if a
+  // different upstream filed this entry, the agent reads the
+  // description for context.
+  const alarmHint = '<extract the alarm string from the ENTRY DETAIL — typically a blockquote line under "Auto-filed by chitin-alarm-feeder.timer">';
 
-Your toolkit is \`python/analysis/\`: a typed library of loaders + reports against chitin's canonical event chain. The lib already produces three streams:
+  return `You are playing the analyst role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3.
 
-  - \`analysis.decisions\` — per-rule deny/allow analysis of governance decisions
-  - \`analysis.debt\` — debt-ledger loader + reporting
-  - \`analysis.swarm_health\` — daily rollup (bucket-B rate, success-by-tier, alarms[])
-  - \`analysis.swarm_runs\` — per-run records (driver, tier, exit_code, duration_ms)
-
-Source data:
-  - \`~/.cache/chitin/.../events-*.jsonl\` — gov-decisions chain (canonical)
-  - \`~/.cache/chitin/swarm-state/dispatched/<entry-id>.json\` — dispatch markers
-  - \`~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json\` — daily rollup
-  - \`tmp/result-swarm-*.json\` — workflow result envelopes
-  - \`docs/debt-ledger.md\` — operator-curated + auto-curated debt
+The investigation is fully recipe-driven. The recipe owns the analysis (deterministic: same alarm + same data → same finding); your job is to invoke it and report the result. Do NOT author bespoke Python — chitin's determinism-first model means the recipe is the contract.
 
 ENTRY ID: ${entry.id}
 ROLE: analyst
@@ -134,25 +129,28 @@ ROLE: analyst
 ENTRY DETAIL:
 ${entry.description}
 
-What good output looks like:
-- Run an existing analysis module (\`python -m analysis.swarm_health\` etc.) OR author a one-off Python query against the chain JSONL.
-- Surface the smallest set of facts that explain WHY the entry was filed (root cause, not symptoms).
-- Recommend a concrete next action: a fix-shape backlog entry, a tier-rule change, a debt-ledger promotion, or \`status: needs_human\` if the cause is non-obvious.
+YOUR ENTIRE WORKFLOW (3 tool calls):
 
-Output rules:
-- Write your findings to \`python/analysis/out/${entry.id}.md\` (the apply step picks up files in this directory). Use the existing analysis writers in \`python/analysis/writers.py\` so format stays consistent across runs.
-- Empty worktree on completion is EXPECTED for the analyst role — your output is the markdown report under \`out/\`, not a code change. The apply step understands this.
-- Do NOT modify code under \`apps/\`, \`go/\`, or \`libs/\`. Pure analysis is your scope; if the analysis surfaces a code change, that's a follow-up backlog entry.
-- Do NOT modify chitin.yaml or anything under .chitin/ — governance is human-only.
-- If you cannot reproduce the regression or the rollup data is missing, exit cleanly with a stub report saying so. Better silent than guessed.
+1. Extract the alarm string from ENTRY DETAIL above (look for a \`> <alarm text>\` blockquote, typically on a line right after "Auto-filed by chitin-alarm-feeder.timer").
 
-At the END of your run, emit EXACTLY ONE JSON object on a single line, prefixed with the literal token \`<<<ANALYSIS>>>\` and nothing else after the closing brace on that line:
+2. Dispatch the \`exec\` tool to run the investigation recipe:
+   \`\`\`
+   cd python && python3 -m analysis.investigate --entry "${entry.id}" --alarm "<the alarm string from step 1>"
+   \`\`\`
+   The recipe writes a markdown report to \`python/analysis/out/${entry.id}.md\` + a JSON sidecar to \`python/analysis/out/${entry.id}.json\`, and prints a \`<<<ANALYSIS>>>{...}\` line on stdout.
 
-<<<ANALYSIS>>>{"root_cause":"<one sentence>","recommended_action":"file-fix-entry"|"needs_human"|"no-action","report_path":"python/analysis/out/${entry.id}.md","confidence":"high"|"medium"|"low"}
+3. The last line of stdout from step 2 IS your structured emit. Echo it as your final reply (the marker line must appear in your output for the runner's parser to find it).
 
-If you couldn't determine a root cause, emit:
+That's it. The recipe handles every alarm kind it knows (bucket-B, low-success, qwen-idle); unknown kinds fall back to needs_human with a stub report. New alarm kinds are added by extending \`analysis.investigate.ALARM_HANDLERS\` — that's a separate backlog entry for the operator, not your job here.
 
-<<<ANALYSIS>>>{"root_cause":"unable to determine","recommended_action":"needs_human","report_path":"python/analysis/out/${entry.id}.md","confidence":"low"}`;
+CONSTRAINTS:
+- The agent's stdout must include the \`<<<ANALYSIS>>>\` line from the recipe. The runner's parser keys on it.
+- Do NOT author Python yourself. If the recipe doesn't recognize the alarm kind, it writes a needs_human stub — that's the correct behavior. File a separate backlog entry to teach the recipe later.
+- Do NOT modify code under \`apps/\`, \`go/\`, or \`libs/\`. Pure analysis is your scope.
+- Do NOT modify chitin.yaml or anything under .chitin/.
+- Empty worktree on completion is EXPECTED — your output is the markdown report under \`python/analysis/out/\` (which the apply step commits + pushes if it's a tracked path) and the marker-line on stdout (which the runner reads for the chain).
+
+Reference: \`python/analysis/investigate.py\` is the recipe source. Read it before extending; the alarm kinds it handles + the Finding shape are pinned by tests in \`tests/test_investigate.py\`.`;
 }
 
 // Stub for the remaining non-programmer roles. Future entries replace

--- a/apps/temporal-worker/test/role-prompts.test.ts
+++ b/apps/temporal-worker/test/role-prompts.test.ts
@@ -117,8 +117,9 @@ describe('buildPromptForEntry', () => {
     expect(dispatched).toContain('a-test');
     // The analyst prompt mandates the structured-output marker.
     expect(dispatched).toContain('<<<ANALYSIS>>>');
-    // Names the python/analysis toolkit the role's job is to use.
-    expect(dispatched).toContain('python/analysis');
+    // Names the recipe-driven invocation — the determinism-first model.
+    expect(dispatched).toContain('python3 -m analysis.investigate');
+    expect(dispatched).toContain('--entry "a-test"');
     // Does NOT borrow programmer preamble — analyst output is reports,
     // not commits.
     expect(dispatched).not.toContain('TOOL DISPATCHES count');

--- a/python/analysis/investigate.py
+++ b/python/analysis/investigate.py
@@ -1,0 +1,342 @@
+"""Pre-canned investigation recipe for the swarm-dispatched analyst role.
+
+Maps an alarm string from the swarm-rollup onto the right analysis
+loaders + extracts a deterministic root-cause + recommended-action.
+The agent's job collapses to:
+
+    python3 -m analysis.investigate --entry <id> --alarm "<text>"
+
+…and reading the JSON sidecar to emit the analyst prompt's
+`<<<ANALYSIS>>>` line. No LLM judgment in the analysis path —
+same alarm + same data always produce the same finding. That's the
+determinism-first model: the recipe owns the analysis, the agent
+just reports.
+
+Why this is a recipe (not the agent's free-form Python):
+  - Reproducible: re-running on yesterday's chain produces identical
+    output. Caught regressions are caught the same way every time.
+  - Reviewable: the recipe's logic is in tests, not buried in an
+    LLM prompt.
+  - Cheap: no token cost for the analysis itself (only for the
+    agent reading + reporting).
+  - Auditable: any swarm investigation lands a markdown report under
+    python/analysis/out/<entry-id>.md the operator can grep.
+
+v1 alarm kinds (extend by adding to ALARM_HANDLERS):
+  - BUCKET-B REGRESSION: ... → bucket-b investigator
+  - LOW SUCCESS: driver=X NN% → success-rate investigator
+  - LOW SUCCESS: tier=TX NN% → tier success-rate investigator
+  - QWEN IDLE: ... → local-qwen routing investigator
+  - (default fallback) → unknown-alarm investigator (writes a
+    summary report + recommends needs_human)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+
+# ─── Result schema ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Finding:
+    """The structured output of an investigation. Mirrors the analyst
+    prompt's `<<<ANALYSIS>>>` JSON contract verbatim — the agent
+    reads this from the JSON sidecar and emits it as the line."""
+
+    root_cause: str
+    recommended_action: str  # 'file-fix-entry' | 'needs_human' | 'no-action'
+    report_path: str
+    confidence: str  # 'high' | 'medium' | 'low'
+
+
+@dataclass(frozen=True)
+class InvestigationContext:
+    entry_id: str
+    alarm: str
+    out_dir: Path
+    """Directory for the markdown report. Default: python/analysis/out/."""
+
+
+# ─── Alarm classification ──────────────────────────────────────────────────
+
+
+def classify_alarm(alarm: str) -> str:
+    """Return the canonical kind of an alarm, or 'unknown'.
+
+    The kind is the leading uppercase phrase before the first colon,
+    normalized — same as the alarm-feeder's signature. Two
+    independent code paths derive the same kind so dedup works
+    end-to-end (alarm-feeder files an entry by kind, investigator
+    matches the same kind).
+    """
+    head = alarm.split(":", 1)[0].strip().lower()
+    return re.sub(r"[^a-z0-9]+", "-", head).strip("-") or "unknown"
+
+
+# ─── Per-alarm investigators ───────────────────────────────────────────────
+
+
+def investigate_bucket_b_regression(ctx: InvestigationContext) -> Finding:
+    """Bucket-B = PR title-vs-diff mismatch (a swarm worker pushed work
+    that doesn't match the entry's declared file: scope). PR #123
+    fixed the auto-commit path that caused 4 PRs of contamination on
+    2026-05-02; rate > 0% means a regression of that fix."""
+    health = _latest_health()
+    bb_count = health.get("bucket_b_count", 0)
+    bb_rate = health.get("bucket_b_rate", 0.0)
+    write_markdown(
+        ctx.out_dir / f"{ctx.entry_id}.md",
+        title=f"Investigation: bucket-B regression",
+        sections=[
+            ("Alarm", ctx.alarm),
+            (
+                "Current rate",
+                f"{bb_count} contaminated runs out of {health.get('total_runs', 0)} "
+                f"(rate {bb_rate:.1%}) in the last rollup window.",
+            ),
+            (
+                "Likely cause",
+                "PR #123's apply-step revertWorktreeSettingsArtifact may have regressed, OR "
+                "writeWorktreeClaudeSettings is being invoked at an unexpected lifecycle "
+                "point. Inspect recent dispatcher / activity / apply-step diffs vs PR #123.",
+            ),
+            (
+                "Recommended next step",
+                "File a fix-shape backlog entry against `apps/temporal-worker/src/` to "
+                "re-verify the apply-step revert. Operator should manually merge the next "
+                "swarm PR until rate returns to 0%.",
+            ),
+        ],
+    )
+    return Finding(
+        root_cause=(
+            f"Bucket-B contamination rate {bb_rate:.1%} ({bb_count} runs) — "
+            "apply-step revert may have regressed since PR #123."
+        ),
+        recommended_action="file-fix-entry",
+        report_path=str(ctx.out_dir / f"{ctx.entry_id}.md"),
+        confidence="high" if bb_count >= 2 else "medium",
+    )
+
+
+def investigate_low_success(ctx: InvestigationContext) -> Finding:
+    """LOW SUCCESS alarms cite either a driver or a tier with success
+    rate < threshold. The right action depends on whether the dip is
+    transient (<5 runs) or sustained."""
+    m = re.search(r"(driver|tier)=([A-Za-z0-9-]+).*?(\d+)%\s*\((\d+)/(\d+)\)", ctx.alarm)
+    if not m:
+        return _fallback_finding(
+            ctx,
+            reason="LOW SUCCESS alarm did not match expected shape",
+        )
+    dim, dim_value, _pct, success_n, total_n = m.group(1), m.group(2), m.group(3), int(m.group(4)), int(m.group(5))
+    confidence = "high" if total_n >= 10 else "medium" if total_n >= 5 else "low"
+    health = _latest_health()
+    write_markdown(
+        ctx.out_dir / f"{ctx.entry_id}.md",
+        title=f"Investigation: low success rate ({dim}={dim_value})",
+        sections=[
+            ("Alarm", ctx.alarm),
+            (
+                "Sample size",
+                f"{success_n}/{total_n} runs in the last window. "
+                f"Confidence: {confidence} (≥10 runs = high, 5–9 = medium, <5 = low).",
+            ),
+            (
+                "Cohort breakdown",
+                json.dumps(
+                    health.get(f"success_by_{dim}", {}).get(dim_value, {}),
+                    indent=2,
+                ),
+            ),
+            (
+                "Likely cause categories",
+                "1. Wall-timeout / SIGKILL on the agent (slow model);\n"
+                "2. Apply-step push failing (worktree dirty, branch protected);\n"
+                "3. Driver-specific regression (model API change, prompt drift);\n"
+                "4. Backlog entries got harder (T3+ work skewing recent dispatches).",
+            ),
+            (
+                "Recommended next step",
+                "If confidence high: file a fix-shape entry against the failing dimension's "
+                "code path (driver wrapper or tier-specific prompt). If low: needs_human — "
+                "operator decides whether to re-run a few entries and observe.",
+            ),
+        ],
+    )
+    return Finding(
+        root_cause=(
+            f"{dim}={dim_value} success rate is {success_n}/{total_n} — "
+            "regression localized to that path."
+        ),
+        recommended_action="file-fix-entry" if confidence == "high" else "needs_human",
+        report_path=str(ctx.out_dir / f"{ctx.entry_id}.md"),
+        confidence=confidence,
+    )
+
+
+def investigate_qwen_idle(ctx: InvestigationContext) -> Finding:
+    """QWEN IDLE = T0 traffic routed to copilot instead of local-qwen.
+    This is operator-mediated (the dispatcher's TIER_DRIVER map was
+    flipped after slice 7-tuning surfaced qwen3-coder instability).
+    Flipping back is gated on the qwen-stream regression being fixed."""
+    write_markdown(
+        ctx.out_dir / f"{ctx.entry_id}.md",
+        title="Investigation: qwen3 (3090) idle",
+        sections=[
+            ("Alarm", ctx.alarm),
+            (
+                "Current state",
+                "T0 routing in dispatcher.ts is `'copilot'`, not `'local-qwen'`. "
+                "Comment in the file documents the temp routing decision after "
+                "slice 7-tuning surfaced qwen3-coder ollama-stream instability + "
+                "scope drift. The 3090 sits idle until the upstream issue is "
+                "resolved.",
+            ),
+            (
+                "Recommended next step",
+                "needs_human — operator decides whether to flip T0 back to "
+                "local-qwen now (and tolerate flakiness) or wait for the "
+                "qwen-ollama-stream-instability backlog entry to ship a fix.",
+            ),
+        ],
+    )
+    return Finding(
+        root_cause=(
+            "T0 routing flipped to copilot pending qwen-ollama-stream-instability fix; "
+            "3090 idle by design until that lands."
+        ),
+        recommended_action="needs_human",
+        report_path=str(ctx.out_dir / f"{ctx.entry_id}.md"),
+        confidence="high",
+    )
+
+
+def _fallback_finding(ctx: InvestigationContext, *, reason: str) -> Finding:
+    """Default investigator for alarm kinds without a dedicated handler.
+    Writes a summary report so the operator has a starting point."""
+    write_markdown(
+        ctx.out_dir / f"{ctx.entry_id}.md",
+        title=f"Investigation: unknown alarm kind",
+        sections=[
+            ("Alarm", ctx.alarm),
+            ("Reason", reason),
+            (
+                "Recommended next step",
+                "needs_human — operator should classify this alarm kind and add a dedicated "
+                "investigator to `analysis/investigate.py` so future occurrences land "
+                "automatically.",
+            ),
+        ],
+    )
+    return Finding(
+        root_cause=f"unknown alarm kind ({reason})",
+        recommended_action="needs_human",
+        report_path=str(ctx.out_dir / f"{ctx.entry_id}.md"),
+        confidence="low",
+    )
+
+
+# ─── Routing ──────────────────────────────────────────────────────────────
+
+
+ALARM_HANDLERS: dict[str, Callable[[InvestigationContext], Finding]] = {
+    "bucket-b-regression": investigate_bucket_b_regression,
+    "low-success": investigate_low_success,
+    "qwen-idle": investigate_qwen_idle,
+}
+
+
+def investigate(ctx: InvestigationContext) -> Finding:
+    """Dispatch on alarm kind. Unknown kinds get the fallback."""
+    kind = classify_alarm(ctx.alarm)
+    handler = ALARM_HANDLERS.get(kind)
+    if handler is None:
+        return _fallback_finding(ctx, reason=f"no handler for kind '{kind}'")
+    return handler(ctx)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _latest_health(rollup_dir: Path | None = None) -> dict:
+    """Read the most-recent rollup JSON. Same source the gatekeeper
+    consults — keeps the investigator and the gate seeing identical
+    numbers (no recompute drift). Returns {} when the rollup dir is
+    absent or unreadable; callers MUST tolerate empty data."""
+    if rollup_dir is None:
+        rollup_dir = Path(os.path.expanduser("~/.cache/chitin/swarm-rollups"))
+    try:
+        names = sorted(p.name for p in rollup_dir.iterdir() if p.suffix == ".json")
+    except (FileNotFoundError, NotADirectoryError):
+        return {}
+    if not names:
+        return {}
+    try:
+        return json.loads((rollup_dir / names[-1]).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def write_markdown(path: Path, *, title: str, sections: list[tuple[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    parts = [f"# {title}", ""]
+    parts.append(f"_Generated by `analysis.investigate` at {datetime.now(tz=timezone.utc).isoformat()}._")
+    parts.append("")
+    for heading, body in sections:
+        parts.append(f"## {heading}")
+        parts.append("")
+        parts.append(body)
+        parts.append("")
+    path.write_text("\n".join(parts), encoding="utf-8")
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="analysis.investigate")
+    p.add_argument("--entry", required=True, help="Backlog entry id (used as the report filename slug).")
+    p.add_argument("--alarm", required=True, help="The alarm string verbatim from the rollup.")
+    p.add_argument(
+        "--out-dir",
+        default=str(Path(__file__).parent / "out"),
+        help="Directory for the markdown report. Default: python/analysis/out/.",
+    )
+    p.add_argument(
+        "--json-sidecar",
+        action="store_true",
+        default=True,
+        help="Also write {out-dir}/{entry-id}.json with the structured Finding (default on).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ctx = InvestigationContext(
+        entry_id=args.entry,
+        alarm=args.alarm,
+        out_dir=Path(args.out_dir),
+    )
+    finding = investigate(ctx)
+    sidecar = ctx.out_dir / f"{ctx.entry_id}.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(asdict(finding), indent=2) + "\n", encoding="utf-8")
+    # Emit the agent-facing line on stdout so the analyst prompt's
+    # `<<<ANALYSIS>>>` extract works without re-reading the file.
+    print(f"<<<ANALYSIS>>>{json.dumps(asdict(finding))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/tests/test_investigate.py
+++ b/python/analysis/tests/test_investigate.py
@@ -1,0 +1,224 @@
+"""Tests for analysis.investigate — pre-canned alarm investigation recipe.
+
+Pinned: the agent-facing JSON line + the markdown report shape are
+contracts the analyst prompt depends on. Same alarm + same data must
+always yield the same finding.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from analysis.investigate import (
+    Finding,
+    InvestigationContext,
+    classify_alarm,
+    investigate,
+    investigate_bucket_b_regression,
+    investigate_low_success,
+    investigate_qwen_idle,
+    main,
+)
+
+
+# ─── classify_alarm ────────────────────────────────────────────────────────
+
+
+def test_classify_alarm_extracts_kind_from_leading_phrase():
+    assert classify_alarm("BUCKET-B REGRESSION: 1/19 contaminated (5.3%)") == "bucket-b-regression"
+    assert classify_alarm("LOW SUCCESS: driver=copilot 56% (5/9)") == "low-success"
+    assert classify_alarm("QWEN IDLE: 100% T0 routed away") == "qwen-idle"
+
+
+def test_classify_alarm_is_rate_invariant():
+    """Two BUCKET-B alarms with different metrics map to the same kind
+    so the alarm-feeder + investigator agree on dedup."""
+    assert classify_alarm("BUCKET-B REGRESSION: 1/19 (5%)") == classify_alarm("BUCKET-B REGRESSION: 7/40 (18%)")
+
+
+def test_classify_alarm_handles_no_colon():
+    """Defensive: alarms without a colon still produce a kind."""
+    out = classify_alarm("PLAIN ALARM no colon")
+    assert out == "plain-alarm-no-colon"
+
+
+def test_classify_alarm_empty_input_is_unknown():
+    assert classify_alarm("") == "unknown"
+
+
+# ─── investigate (top-level dispatch) ──────────────────────────────────────
+
+
+def _ctx(tmp_path: Path, alarm: str, entry: str = "investigate-test") -> InvestigationContext:
+    return InvestigationContext(entry_id=entry, alarm=alarm, out_dir=tmp_path)
+
+
+def test_dispatches_bucket_b_to_dedicated_handler(tmp_path: Path):
+    finding = investigate(_ctx(tmp_path, "BUCKET-B REGRESSION: 0/19 contaminated (0%)"))
+    assert finding.recommended_action == "file-fix-entry"
+    assert "bucket-b" in (tmp_path / "investigate-test.md").read_text().lower() or \
+           "bucket-B" in (tmp_path / "investigate-test.md").read_text()
+
+
+def test_dispatches_low_success_to_dedicated_handler(tmp_path: Path):
+    finding = investigate(_ctx(tmp_path, "LOW SUCCESS: driver=copilot 56% (5/9)"))
+    # 5/9 = medium confidence (≥5, <10)
+    assert finding.confidence == "medium"
+    assert "driver=copilot" in (tmp_path / "investigate-test.md").read_text()
+
+
+def test_dispatches_qwen_idle_to_dedicated_handler(tmp_path: Path):
+    finding = investigate(_ctx(tmp_path, "QWEN IDLE: 100% T0 routed away"))
+    assert finding.recommended_action == "needs_human"
+    assert "3090" in (tmp_path / "investigate-test.md").read_text()
+
+
+def test_unknown_alarm_kind_falls_back_to_needs_human(tmp_path: Path):
+    finding = investigate(_ctx(tmp_path, "UNKNOWN_ALARM_KIND: something"))
+    assert finding.recommended_action == "needs_human"
+    assert finding.confidence == "low"
+    # Fallback report mentions the missing handler.
+    assert "no handler" in (tmp_path / "investigate-test.md").read_text().lower()
+
+
+# ─── investigate_low_success ───────────────────────────────────────────────
+
+
+def test_low_success_high_confidence_when_n_ge_10(tmp_path: Path):
+    finding = investigate_low_success(_ctx(tmp_path, "LOW SUCCESS: tier=T2 60% (6/10)"))
+    assert finding.confidence == "high"
+    assert finding.recommended_action == "file-fix-entry"
+
+
+def test_low_success_low_confidence_when_n_lt_5(tmp_path: Path):
+    finding = investigate_low_success(_ctx(tmp_path, "LOW SUCCESS: tier=T0 50% (1/2)"))
+    assert finding.confidence == "low"
+    assert finding.recommended_action == "needs_human"
+
+
+def test_low_success_medium_confidence_when_n_in_5_to_9(tmp_path: Path):
+    finding = investigate_low_success(_ctx(tmp_path, "LOW SUCCESS: driver=qwen 71% (5/7)"))
+    assert finding.confidence == "medium"
+    assert finding.recommended_action == "needs_human"  # medium → still operator
+
+
+def test_low_success_malformed_alarm_falls_back(tmp_path: Path):
+    """If the alarm doesn't match the expected shape, use the fallback."""
+    finding = investigate_low_success(_ctx(tmp_path, "LOW SUCCESS: garbled"))
+    assert finding.recommended_action == "needs_human"
+
+
+# ─── investigate_bucket_b_regression ──────────────────────────────────────
+
+
+def test_bucket_b_writes_a_report_and_returns_high_when_count_ge_2(tmp_path: Path):
+    finding = investigate_bucket_b_regression(_ctx(tmp_path, "BUCKET-B REGRESSION: 3/40 (7.5%)"))
+    # confidence is data-driven (reads latest rollup); on a host without rollup
+    # data, count is 0 → medium. Just assert the report landed.
+    report = tmp_path / "investigate-test.md"
+    assert report.exists()
+    assert "Investigation: bucket-B regression" in report.read_text()
+    assert finding.recommended_action == "file-fix-entry"
+
+
+# ─── main / CLI / JSON sidecar ─────────────────────────────────────────────
+
+
+def test_main_writes_json_sidecar_and_prints_analysis_marker(tmp_path: Path, capsys):
+    rc = main(
+        [
+            "--entry",
+            "test-entry",
+            "--alarm",
+            "QWEN IDLE: 100%",
+            "--out-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    sidecar = tmp_path / "test-entry.json"
+    report = tmp_path / "test-entry.md"
+    assert sidecar.exists()
+    assert report.exists()
+    payload = json.loads(sidecar.read_text())
+    assert set(payload.keys()) == {"root_cause", "recommended_action", "report_path", "confidence"}
+    assert payload["recommended_action"] == "needs_human"
+    captured = capsys.readouterr()
+    # The agent reads the <<<ANALYSIS>>> marker line directly off stdout.
+    assert "<<<ANALYSIS>>>" in captured.out
+    marker_line = captured.out.split("<<<ANALYSIS>>>", 1)[1].split("\n", 1)[0]
+    parsed_marker = json.loads(marker_line)
+    assert parsed_marker == payload
+
+
+def test_main_handles_unknown_alarm_kind_gracefully(tmp_path: Path, capsys):
+    rc = main(
+        [
+            "--entry",
+            "weird-entry",
+            "--alarm",
+            "WEIRD ALARM TYPE: x",
+            "--out-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    sidecar = tmp_path / "weird-entry.json"
+    payload = json.loads(sidecar.read_text())
+    assert payload["recommended_action"] == "needs_human"
+    assert payload["confidence"] == "low"
+
+
+# ─── Determinism ───────────────────────────────────────────────────────────
+
+
+def test_same_alarm_produces_same_finding(tmp_path: Path):
+    """Determinism contract: re-running on the same input yields
+    byte-identical sidecar JSON modulo the report-path field. The
+    timestamp in the markdown changes, but the structured Finding
+    must not."""
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    finding_a = investigate(_ctx(a_dir, "QWEN IDLE: 100%", entry="x"))
+    finding_b = investigate(_ctx(b_dir, "QWEN IDLE: 100%", entry="x"))
+    # Strip the dir-specific report_path before comparing.
+    assert (
+        finding_a.root_cause,
+        finding_a.recommended_action,
+        finding_a.confidence,
+    ) == (
+        finding_b.root_cause,
+        finding_b.recommended_action,
+        finding_b.confidence,
+    )
+
+
+def test_finding_is_serializable_json(tmp_path: Path):
+    """The Finding must round-trip through JSON cleanly (the agent
+    reads the JSON sidecar)."""
+    finding = investigate(_ctx(tmp_path, "QWEN IDLE: 100%"))
+    from dataclasses import asdict
+
+    raw = json.dumps(asdict(finding))
+    reconstituted = json.loads(raw)
+    assert reconstituted["root_cause"] == finding.root_cause
+    assert reconstituted["recommended_action"] == finding.recommended_action
+
+
+# ─── Sanity ────────────────────────────────────────────────────────────────
+
+
+def test_finding_recommended_action_is_one_of_three_canonical_values(tmp_path: Path):
+    """The analyst prompt's <<<ANALYSIS>>> contract enumerates three
+    actions; the recipe must never emit anything else."""
+    canonical = {"file-fix-entry", "needs_human", "no-action"}
+    for alarm in [
+        "BUCKET-B REGRESSION: 0/0 (0%)",
+        "LOW SUCCESS: tier=T1 50% (5/10)",
+        "QWEN IDLE: 100%",
+        "UNKNOWN: x",
+    ]:
+        finding = investigate(_ctx(tmp_path, alarm, entry=f"e-{hash(alarm)}"))
+        assert finding.recommended_action in canonical


### PR DESCRIPTION
## Summary

Closes the analyst-uses-the-Python-lib gap. Before #163 the analyst prompt told the agent "use python/analysis" and trusted it to figure out imports, args, output format. After: a deterministic CLI recipe owns the analysis; the agent's job collapses to one tool call + echo the result.

**\`python/analysis/investigate.py\`** — pre-canned alarm investigator:
- \`python3 -m analysis.investigate --entry <id> --alarm "<text>"\`
- Routes by alarm kind (signature-derived):
  - \`bucket-b-regression\` → reads latest rollup, reports current rate, recommends file-fix-entry
  - \`low-success\` → confidence by sample size (≥10 high, 5-9 medium, <5 low)
  - \`qwen-idle\` → needs_human
  - unknown → fallback stub + needs_human
- Writes report markdown + JSON sidecar + emits \`<<<ANALYSIS>>>\` marker line on stdout
- Reads the latest rollup JSON (no recompute drift vs gatekeeper)

**Analyst prompt rewrite** — 3 tool calls (extract alarm → exec recipe → echo marker), no agent-authored Python.

## Why this matters

The analyst is the first swarm role where the LLM's freedom is INVERTED — not "give the agent tools and trust it" but "the recipe produces the answer; the agent reports it." Determinism-first model in code, applied to a role traditionally LLM-heavy.

## Test plan

- [x] 18 new Python tests; 142/142 in python/analysis
- [x] 506/506 in apps/temporal-worker; typecheck clean
- [x] Live verified on the rig with the existing 2026-05-02 bucket-B alarm
- [ ] After merge: next alarm-feeder tick will file an analyst entry; first dispatched analyst workflow exercises the full chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)