### PR TITLE
feat(stale-doc-detector): tech-writer's debt-detection half

### DIFF
--- a/apps/temporal-worker/src/stale-doc-detector.ts
+++ b/apps/temporal-worker/src/stale-doc-detector.ts
@@ -1,0 +1,388 @@
+// Stale-doc detector — tech-writer role's debt-detection half.
+//
+// Purpose: every time a swarm PR renames or deletes a file, every doc
+// that referenced that path goes stale silently. Operator notices
+// when they grep for the old path and find nothing useful, often
+// weeks later. With a daily scan, those refs get filed to debt-ledger
+// the moment they break.
+//
+// What we scan: every `docs/**/*.md` file. Every reference of the
+// shape `apps/...`, `libs/...`, `go/...`, `python/...`, `infra/...`,
+// `scripts/...`, `tests/...` (the project-relative path families).
+// We resolve each reference against the working tree; if it doesn't
+// exist, we file an entry.
+//
+// What we DON'T scan: external URLs (different concern, different
+// fix), bare filenames (too lossy), references inside code blocks
+// (the operator may quote a deleted path intentionally as a
+// historical artifact). The scope is operator-facing prose paths.
+//
+// Pattern matches researcher.ts / lessons.ts / debt-curator.ts /
+// groomer.ts / alarm-feeder.ts: cron-fired, idempotent, telemetry log
+// line, no Temporal involvement.
+
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync, readdirSync } from 'node:fs';
+import { resolve, relative } from 'node:path';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface StaleRef {
+  /** Doc file containing the broken ref. */
+  doc: string;
+  /** 1-based line number in the doc. */
+  line: number;
+  /** The path the doc references. */
+  ref: string;
+  /** A short snippet of context (~60 chars) so the operator sees the
+   *  surrounding prose. */
+  context: string;
+}
+
+export interface DetectorOptions {
+  repoRoot: string;
+  /** Where to look for docs. Default: 'docs'. */
+  docsRoot: string;
+  /** Where to write the debt entries. */
+  ledgerPath: string;
+  cap: number;
+  /** ISO-8601 timestamp injected by runner. */
+  now: string;
+  log?: (line: string) => void;
+}
+
+export interface DetectorResult {
+  total_refs_scanned: number;
+  stale_refs: number;
+  new_entries: number;
+  duplicates_skipped: number;
+}
+
+// ─── Reference extraction ────────────────────────────────────────────────
+
+// The path families we scan for. We restrict to project-relative
+// paths so we don't false-positive on URLs, package names, or shell
+// arguments. Each entry is a path PREFIX; matches start with the
+// prefix and run until a delimiter (whitespace, `)`, `'`, `"`, `,`,
+// `;`, end of line).
+const SCAN_PREFIXES = [
+  'apps/',
+  'libs/',
+  'go/',
+  'python/',
+  'infra/',
+  'scripts/',
+  'tests/',
+  'docs/',
+];
+
+// One ref candidate per regex match. The match is the longest
+// prefix-anchored path-shaped substring on the line. We post-process
+// to drop trailing markdown / punctuation that snuck in.
+const REF_RE = new RegExp(
+  '(?:' +
+    SCAN_PREFIXES.map((p) => p.replace(/\//g, '\\/')).join('|') +
+    ')[A-Za-z0-9_./@\\-]+',
+  'g',
+);
+
+// Strip trailing punctuation that the regex might capture (markdown
+// renderers tolerate "see apps/foo.ts." but the period isn't part of
+// the path).
+function trimRefPunctuation(s: string): string {
+  return s.replace(/[.,;:!?)\]]+$/, '');
+}
+
+/**
+ * Extract every project-relative path reference from the doc text.
+ * Returns raw matches (one entry per occurrence). Caller dedups +
+ * resolves against the filesystem.
+ *
+ * Two skip rules:
+ *   1. Lines inside yaml-fenced blocks — those are config (e.g.,
+ *      debt-ledger entries with `file: docs/x.md`), not prose. The
+ *      detector would otherwise ingest its own previous output.
+ *   2. Matches whose match-position follows a `://` on the same line
+ *      — those are URL path components, not project-relative paths.
+ *      Different concern, different fix.
+ */
+export function extractRefs(text: string): { ref: string; line: number; context: string }[] {
+  const out: { ref: string; line: number; context: string }[] = [];
+  const lines = text.split('\n');
+  let inYamlFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim().startsWith('```')) {
+      // Toggle fenced-block state. Both opening (```yaml) and closing
+      // (```) lines hit this branch, so the toggle is symmetric.
+      const fenceOpen = line.trim().match(/^```\w*/);
+      if (fenceOpen && !inYamlFence) {
+        inYamlFence = true;
+        continue;
+      }
+      if (inYamlFence) {
+        inYamlFence = false;
+        continue;
+      }
+    }
+    if (inYamlFence) continue;
+
+    REF_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = REF_RE.exec(line)) !== null) {
+      // URL detection: if the match position is preceded by `://` on
+      // the same line (https://, http://, file://, etc.), skip.
+      const before = line.slice(0, m.index);
+      if (/:\/\//.test(before)) continue;
+
+      // Cross-repo path detection: `gh api repos/<owner>/<repo>/contents/<path>`
+      // and `github.com/<owner>/<repo>/blob/<branch>/<path>` are the
+      // two common shapes. The path after `contents/` or `blob/<ref>/`
+      // is RELATIVE TO THE OTHER REPO, not chitin. Live first run on
+      // 2026-05-02 caught 100+ such false positives in
+      // docs/observations/research/ where notes reference openclaw +
+      // ollama paths via gh api curl examples.
+      if (/repos\/[\w.-]+\/[\w.-]+\/contents\/$/.test(before)) continue;
+      if (/github\.com\/[\w.-]+\/[\w.-]+\/blob\/[\w.-]+\/$/.test(before)) continue;
+
+      const raw = m[0];
+      const ref = trimRefPunctuation(raw);
+      if (!ref) continue;
+      // Strip optional `:line` or `:line-line` suffix that markdown
+      // notation appends (we only resolve the path, not line numbers).
+      const pathPart = ref.replace(/:\d+(-\d+)?$/, '').replace(/#.*$/, '');
+      out.push({
+        ref: pathPart,
+        line: i + 1,
+        context: shortContext(line),
+      });
+    }
+  }
+  return out;
+}
+
+function shortContext(line: string): string {
+  const trimmed = line.trim().replace(/\s+/g, ' ');
+  return trimmed.length > 80 ? `${trimmed.slice(0, 79)}…` : trimmed;
+}
+
+// ─── Filesystem resolution ────────────────────────────────────────────────
+
+/**
+ * Does the repo-relative path exist on disk? Empty/blank → false
+ * (no ref to check). The detector treats absent as "stale", but the
+ * resolver itself is just a cache around fs.existsSync.
+ */
+export function refExists(repoRoot: string, ref: string): boolean {
+  if (!ref) return false;
+  // Normalize: strip any trailing slash so existsSync agrees on dirs.
+  const normalized = ref.replace(/\/+$/, '');
+  return existsSync(resolve(repoRoot, normalized));
+}
+
+/**
+ * Walk `docsRoot` recursively, returning every .md file (repo-relative).
+ */
+export function walkDocs(repoRoot: string, docsRoot: string): string[] {
+  const out: string[] = [];
+  const stack = [resolve(repoRoot, docsRoot)];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = resolve(dir, ent.name);
+      if (ent.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (ent.isFile() && ent.name.endsWith('.md')) {
+        out.push(relative(repoRoot, full));
+      }
+    }
+  }
+  return out.sort();
+}
+
+// ─── Debt ledger integration (mirrors debt-curator.ts shape) ─────────────
+
+const ENTRY_BLOCK_RE = /```yaml\s*([\s\S]*?)```/g;
+const ID_FIELD_RE = /^id:\s*(.+)$/m;
+
+export function parseLedgerIds(text: string): Set<string> {
+  const ids = new Set<string>();
+  for (const match of text.matchAll(ENTRY_BLOCK_RE)) {
+    const block = match[1];
+    const idMatch = block.match(ID_FIELD_RE);
+    if (idMatch) ids.add(idMatch[1].trim());
+  }
+  return ids;
+}
+
+/**
+ * Stable id from a stale ref: `stale-doc-<doc-slug>-<ref-slug>-<sha8>`.
+ * Same input → same id (idempotent dedup across runs).
+ */
+export function staleRefId(stale: StaleRef): string {
+  const canonical = `${stale.doc}|${stale.ref}|${stale.context}`;
+  let hash = 5381;
+  for (let i = 0; i < canonical.length; i++) {
+    hash = ((hash << 5) + hash + canonical.charCodeAt(i)) | 0;
+  }
+  const sha = (hash >>> 0).toString(16).padStart(8, '0').slice(0, 8);
+  const docSlug = stale.doc
+    .replace(/\..+$/, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 30);
+  const refSlug = stale.ref
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 30);
+  return `stale-doc-${docSlug}-${refSlug}-${sha}`;
+}
+
+export function renderEntry(stale: StaleRef, id: string, now: string): string {
+  return [
+    '---',
+    '',
+    '```yaml',
+    `id: ${id}`,
+    `discovered_at: ${now}`,
+    'discovered_by: swarm',
+    'severity: low',
+    'category: doc-debt',
+    `file: ${stale.doc}`,
+    'status: open',
+    'shipped_in:',
+    'description: |',
+    `  Stale doc reference detected at ${stale.doc}:${stale.line}.`,
+    `  Reference: ${stale.ref} (no longer exists in the working tree).`,
+    `  Context: ${stale.context}`,
+    `  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.`,
+    '```',
+    '',
+  ].join('\n');
+}
+
+export function appendEntries(text: string, rendered: string[]): string {
+  if (rendered.length === 0) return text;
+  const trimmed = text.replace(/\s+$/, '');
+  return `${trimmed}\n\n${rendered.join('\n')}`;
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────
+
+export async function runStaleDocDetector(opts: DetectorOptions): Promise<DetectorResult> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+
+  const docs = walkDocs(opts.repoRoot, opts.docsRoot);
+
+  const stale: StaleRef[] = [];
+  let total_refs_scanned = 0;
+  for (const doc of docs) {
+    let text: string;
+    try {
+      text = await readFile(resolve(opts.repoRoot, doc), 'utf8');
+    } catch {
+      continue;
+    }
+    const refs = extractRefs(text);
+    total_refs_scanned += refs.length;
+    for (const r of refs) {
+      if (!refExists(opts.repoRoot, r.ref)) {
+        stale.push({ doc, line: r.line, ref: r.ref, context: r.context });
+      }
+    }
+  }
+
+  // Dedup against existing ledger entries.
+  const ledgerText = await readFile(opts.ledgerPath, 'utf8').catch(() => '');
+  const knownIds = parseLedgerIds(ledgerText);
+
+  const renderedEntries: string[] = [];
+  let duplicates_skipped = 0;
+  const seenInRun = new Set<string>();
+  for (const s of stale) {
+    if (renderedEntries.length >= opts.cap) break;
+    const id = staleRefId(s);
+    if (knownIds.has(id) || seenInRun.has(id)) {
+      duplicates_skipped++;
+      continue;
+    }
+    seenInRun.add(id);
+    renderedEntries.push(renderEntry(s, id, opts.now));
+  }
+
+  if (renderedEntries.length > 0) {
+    const updated = appendEntries(ledgerText, renderedEntries);
+    await writeFile(opts.ledgerPath, updated, 'utf8');
+  }
+
+  const result: DetectorResult = {
+    total_refs_scanned,
+    stale_refs: stale.length,
+    new_entries: renderedEntries.length,
+    duplicates_skipped,
+  };
+
+  log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      component: 'stale-doc-detector',
+      ...result,
+    }),
+  );
+
+  return result;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────
+
+const DEFAULT_REPO_ROOT = process.env.CHITIN_REPO_ROOT ?? process.cwd();
+const DEFAULT_DOCS_ROOT = 'docs';
+const DEFAULT_LEDGER_PATH = resolve(DEFAULT_REPO_ROOT, 'docs/debt-ledger.md');
+const DEFAULT_CAP = 10;
+
+async function main(): Promise<void> {
+  const cap = Number(process.env.CHITIN_STALE_DOC_CAP ?? String(DEFAULT_CAP));
+  await runStaleDocDetector({
+    repoRoot: DEFAULT_REPO_ROOT,
+    docsRoot: DEFAULT_DOCS_ROOT,
+    ledgerPath: DEFAULT_LEDGER_PATH,
+    cap,
+    now: new Date().toISOString(),
+  });
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        component: 'stale-doc-detector',
+        msg: 'stale-doc-detector tick fatal',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    process.exit(1);
+  });
+}
+
+export const __test__ = {
+  REF_RE,
+  SCAN_PREFIXES,
+  ENTRY_BLOCK_RE,
+  ID_FIELD_RE,
+  shortContext,
+  trimRefPunctuation,
+  DEFAULT_CAP,
+};
+

--- a/apps/temporal-worker/test/stale-doc-detector.test.ts
+++ b/apps/temporal-worker/test/stale-doc-detector.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendEntries,
+  extractRefs,
+  parseLedgerIds,
+  refExists,
+  renderEntry,
+  runStaleDocDetector,
+  staleRefId,
+  walkDocs,
+  __test__,
+  type StaleRef,
+} from '../src/stale-doc-detector.ts';
+
+const { SCAN_PREFIXES, shortContext, trimRefPunctuation } = __test__;
+
+// ─── extractRefs ──────────────────────────────────────────────────────────
+
+describe('extractRefs', () => {
+  it('extracts a single ref from a line', () => {
+    const refs = extractRefs('See `apps/temporal-worker/src/foo.ts` for the impl.\n');
+    expect(refs).toHaveLength(1);
+    expect(refs[0].ref).toBe('apps/temporal-worker/src/foo.ts');
+    expect(refs[0].line).toBe(1);
+  });
+
+  it("extracts every supported prefix family", () => {
+    const text = `
+See:
+- apps/foo.ts
+- libs/bar.ts
+- go/baz.go
+- python/qux.py
+- infra/systemd/x.service
+- scripts/y.sh
+- tests/z.test.ts
+- docs/w.md
+`;
+    const refs = extractRefs(text);
+    const found = refs.map((r) => r.ref);
+    for (const prefix of SCAN_PREFIXES) {
+      expect(found.some((f) => f.startsWith(prefix))).toBe(true);
+    }
+  });
+
+  it("does NOT match URLs (different concern)", () => {
+    const refs = extractRefs('See https://github.com/owner/apps/foo.ts for context.\n');
+    expect(refs).toHaveLength(0);
+  });
+
+  it("does NOT match gh-api cross-repo path refs", () => {
+    const refs = extractRefs(
+      '`gh api repos/openclaw/openclaw/contents/docs/concepts/agent-workspace.md`\n',
+    );
+    expect(refs).toHaveLength(0);
+  });
+
+  it("does NOT match github.com/owner/repo/blob/<ref>/<path> shapes", () => {
+    const refs = extractRefs(
+      'See github.com/openclaw/openclaw/blob/main/docs/concepts/foo.md for context.\n',
+    );
+    expect(refs).toHaveLength(0);
+  });
+
+  it("does NOT match bare filenames (too lossy)", () => {
+    const refs = extractRefs('See foo.ts and bar.go.\n');
+    expect(refs).toHaveLength(0);
+  });
+
+  it('trims trailing markdown / sentence punctuation', () => {
+    expect(extractRefs('See apps/foo.ts.\n')[0].ref).toBe('apps/foo.ts');
+    expect(extractRefs('At apps/foo.ts, then ...\n')[0].ref).toBe('apps/foo.ts');
+    expect(extractRefs('In `apps/foo.ts`)\n')[0].ref).toBe('apps/foo.ts');
+  });
+
+  it('strips :line and :line-range suffixes (we only resolve the path)', () => {
+    expect(extractRefs('apps/foo.ts:42 has the bug\n')[0].ref).toBe('apps/foo.ts');
+    expect(extractRefs('apps/foo.ts:42-50 covers it\n')[0].ref).toBe('apps/foo.ts');
+  });
+
+  it("strips #anchor suffixes (markdown linkage)", () => {
+    expect(extractRefs('docs/foo.md#section-name\n')[0].ref).toBe('docs/foo.md');
+  });
+
+  it('captures the line number (1-based)', () => {
+    const refs = extractRefs('a\nb\napps/x.ts on line 3\n');
+    expect(refs[0].line).toBe(3);
+  });
+
+  it('captures a short context excerpt', () => {
+    const refs = extractRefs('See `apps/foo.ts` for the auto-merge impl.\n');
+    expect(refs[0].context).toContain('apps/foo.ts');
+    expect(refs[0].context.length).toBeLessThanOrEqual(80);
+  });
+
+  it('handles multiple refs on the same line', () => {
+    const refs = extractRefs('Both apps/a.ts and libs/b.ts changed.\n');
+    expect(refs).toHaveLength(2);
+    expect(refs[0].ref).toBe('apps/a.ts');
+    expect(refs[1].ref).toBe('libs/b.ts');
+  });
+});
+
+// ─── refExists ────────────────────────────────────────────────────────────
+
+describe('refExists', () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'stale-doc-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('returns true for an existing file', () => {
+    writeFileSync(join(scratch, 'foo.ts'), '');
+    expect(refExists(scratch, 'foo.ts')).toBe(true);
+  });
+
+  it('returns false for a non-existent file', () => {
+    expect(refExists(scratch, 'nope.ts')).toBe(false);
+  });
+
+  it('returns true for an existing directory', () => {
+    mkdirSync(join(scratch, 'apps'));
+    expect(refExists(scratch, 'apps/')).toBe(true);
+    expect(refExists(scratch, 'apps')).toBe(true);
+  });
+
+  it('returns false for empty / blank ref', () => {
+    expect(refExists(scratch, '')).toBe(false);
+  });
+});
+
+// ─── walkDocs ─────────────────────────────────────────────────────────────
+
+describe('walkDocs', () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'stale-doc-walk-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('returns empty when the docs root is missing', () => {
+    expect(walkDocs(scratch, 'no-such-docs')).toEqual([]);
+  });
+
+  it('returns markdown files under the docs root, recursively', () => {
+    mkdirSync(join(scratch, 'docs/sub'), { recursive: true });
+    writeFileSync(join(scratch, 'docs/a.md'), '');
+    writeFileSync(join(scratch, 'docs/sub/b.md'), '');
+    writeFileSync(join(scratch, 'docs/c.txt'), ''); // not markdown
+    const out = walkDocs(scratch, 'docs');
+    expect(out).toContain('docs/a.md');
+    expect(out).toContain('docs/sub/b.md');
+    expect(out).not.toContain('docs/c.txt');
+  });
+});
+
+// ─── ledger integration ──────────────────────────────────────────────────
+
+describe('parseLedgerIds', () => {
+  it("extracts ids from yaml-fenced entries", () => {
+    const md = `# Ledger\n\n\`\`\`yaml\nid: stale-doc-foo-1\nseverity: low\n\`\`\`\n\n\`\`\`yaml\nid: stale-doc-bar-2\n\`\`\`\n`;
+    expect(parseLedgerIds(md)).toEqual(new Set(['stale-doc-foo-1', 'stale-doc-bar-2']));
+  });
+
+  it('returns empty for ledger without ids', () => {
+    expect(parseLedgerIds('# Ledger\n\nintro\n')).toEqual(new Set());
+  });
+});
+
+describe('staleRefId', () => {
+  function makeStale(overrides: Partial<StaleRef> = {}): StaleRef {
+    return {
+      doc: 'docs/x.md',
+      line: 5,
+      ref: 'apps/foo.ts',
+      context: 'See apps/foo.ts',
+      ...overrides,
+    };
+  }
+
+  it('produces stable ids — same input = same id', () => {
+    const a = makeStale();
+    expect(staleRefId(a)).toBe(staleRefId(a));
+  });
+
+  it('produces different ids for different doc/ref/context', () => {
+    const base = makeStale();
+    expect(staleRefId(base)).not.toBe(staleRefId({ ...base, doc: 'docs/y.md' }));
+    expect(staleRefId(base)).not.toBe(staleRefId({ ...base, ref: 'apps/bar.ts' }));
+    expect(staleRefId(base)).not.toBe(staleRefId({ ...base, context: 'different' }));
+  });
+
+  it("matches the canonical id format `stale-doc-<docslug>-<refslug>-<sha8>`", () => {
+    expect(staleRefId(makeStale())).toMatch(/^stale-doc-[a-z0-9-]+-[a-f0-9]{8}$/);
+  });
+});
+
+describe('renderEntry', () => {
+  it('renders a yaml-fenced entry with category:doc-debt + severity:low', () => {
+    const out = renderEntry(
+      { doc: 'docs/a.md', line: 5, ref: 'apps/gone.ts', context: 'see apps/gone.ts' },
+      'stale-doc-x',
+      '2026-05-02T18:00:00Z',
+    );
+    expect(out).toContain('id: stale-doc-x');
+    expect(out).toContain('category: doc-debt');
+    expect(out).toContain('severity: low');
+    expect(out).toContain('docs/a.md');
+    expect(out).toContain('apps/gone.ts');
+  });
+});
+
+// ─── runStaleDocDetector ─────────────────────────────────────────────────
+
+describe('runStaleDocDetector', () => {
+  let scratch: string;
+  let ledgerPath: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'stale-doc-runner-test-'));
+    mkdirSync(join(scratch, 'docs'));
+    mkdirSync(join(scratch, 'apps'));
+    ledgerPath = join(scratch, 'docs/debt-ledger.md');
+    writeFileSync(ledgerPath, '# Debt Ledger\n\nintro\n', 'utf8');
+    logs = [];
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('files an entry per stale ref it finds', async () => {
+    writeFileSync(
+      join(scratch, 'docs/a.md'),
+      'The fresh ref is `apps/exists.ts`.\nA broken ref: `apps/gone.ts`.\n',
+      'utf8',
+    );
+    writeFileSync(join(scratch, 'apps/exists.ts'), '');
+
+    const r = await runStaleDocDetector({
+      repoRoot: scratch,
+      docsRoot: 'docs',
+      ledgerPath,
+      cap: 10,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.stale_refs).toBe(1);
+    expect(r.new_entries).toBe(1);
+    const md = readFileSync(ledgerPath, 'utf8');
+    // The stale ref's path appears in the entry; the existing ref's
+    // path does not (split across two lines so the context excerpts
+    // don't bleed).
+    expect(md).toMatch(/Reference: apps\/gone\.ts/);
+    expect(md).not.toMatch(/Reference: apps\/exists\.ts/);
+  });
+
+  it('idempotent — re-run on same input adds zero', async () => {
+    writeFileSync(join(scratch, 'docs/a.md'), 'See `apps/gone.ts`\n', 'utf8');
+    const opts = {
+      repoRoot: scratch,
+      docsRoot: 'docs',
+      ledgerPath,
+      cap: 10,
+      now: '2026-05-02T18:00:00Z',
+      log: (l: string) => logs.push(l),
+    };
+    const r1 = await runStaleDocDetector(opts);
+    const r2 = await runStaleDocDetector(opts);
+    expect(r1.new_entries).toBe(1);
+    expect(r2.new_entries).toBe(0);
+    expect(r2.duplicates_skipped).toBe(1);
+  });
+
+  it('caps entries written per run', async () => {
+    const refs = Array.from({ length: 50 }, (_, i) => `\`apps/gone-${i}.ts\``);
+    writeFileSync(join(scratch, 'docs/a.md'), refs.join('\n') + '\n', 'utf8');
+
+    const r = await runStaleDocDetector({
+      repoRoot: scratch,
+      docsRoot: 'docs',
+      ledgerPath,
+      cap: 5,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(5);
+    expect(r.stale_refs).toBe(50);
+  });
+
+  it("does not touch the ledger when nothing is stale", async () => {
+    mkdirSync(join(scratch, 'apps/sub'), { recursive: true });
+    writeFileSync(join(scratch, 'apps/foo.ts'), '');
+    writeFileSync(join(scratch, 'docs/a.md'), 'See `apps/foo.ts`.\n', 'utf8');
+
+    const before = readFileSync(ledgerPath, 'utf8');
+    const r = await runStaleDocDetector({
+      repoRoot: scratch,
+      docsRoot: 'docs',
+      ledgerPath,
+      cap: 10,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(r.new_entries).toBe(0);
+    expect(readFileSync(ledgerPath, 'utf8')).toBe(before);
+  });
+
+  it("emits the canonical telemetry log line", async () => {
+    writeFileSync(join(scratch, 'docs/a.md'), 'See `apps/gone.ts`\n', 'utf8');
+    await runStaleDocDetector({
+      repoRoot: scratch,
+      docsRoot: 'docs',
+      ledgerPath,
+      cap: 10,
+      now: '2026-05-02T18:00:00Z',
+      log: (l) => logs.push(l),
+    });
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.component).toBe('stale-doc-detector');
+    expect(parsed.new_entries).toBe(1);
+    expect(parsed.stale_refs).toBe(1);
+  });
+});
+
+// ─── helpers (sanity) ────────────────────────────────────────────────────
+
+describe('helpers', () => {
+  it('shortContext caps at 80 chars with ellipsis', () => {
+    const out = shortContext('x'.repeat(200));
+    expect(out.length).toBeLessThanOrEqual(80);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('trimRefPunctuation strips trailing punctuation only', () => {
+    expect(trimRefPunctuation('apps/foo.ts.')).toBe('apps/foo.ts');
+    expect(trimRefPunctuation('apps/foo.ts,')).toBe('apps/foo.ts');
+    expect(trimRefPunctuation('apps/foo.ts')).toBe('apps/foo.ts');
+    expect(trimRefPunctuation('apps/foo.ts).')).toBe('apps/foo.ts');
+  });
+});

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -22,6 +22,8 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 | `chitin-debt-curator.timer` | timer | Fires the debt-curator once per day. |
 | `chitin-alarm-feeder.service` | oneshot | Daily alarm-feeder: reads rollup `alarms[]`, dedups against existing `investigate-*` backlog entries, drafts in_design entries with role:researcher. Closes §7 telemetry → backlog flywheel. |
 | `chitin-alarm-feeder.timer` | timer | Fires the alarm-feeder once per day. |
+| `chitin-stale-doc-detector.service` | oneshot | Daily stale-doc detector: scans `docs/**/*.md` for project-relative path refs that no longer exist in the working tree, files debt-ledger entries at severity:'low'. Tech-writer's debt-detection half. |
+| `chitin-stale-doc-detector.timer` | timer | Fires the stale-doc detector once per day. |
 
 ## Install
 
@@ -36,6 +38,7 @@ systemctl --user enable --now chitin-swarm-rollup.timer
 systemctl --user enable --now chitin-lessons.timer
 systemctl --user enable --now chitin-debt-curator.timer
 systemctl --user enable --now chitin-alarm-feeder.timer
+systemctl --user enable --now chitin-stale-doc-detector.timer
 systemctl --user enable --now chitin-groomer.timer
 ```
 
@@ -56,6 +59,7 @@ journalctl --user -u chitin-swarm-rollup -f
 journalctl --user -u chitin-lessons -f
 journalctl --user -u chitin-debt-curator -f
 journalctl --user -u chitin-alarm-feeder -f
+journalctl --user -u chitin-stale-doc-detector -f
 journalctl --user -u chitin-groomer -f
 
 # Status

--- a/infra/systemd/chitin-stale-doc-detector.service
+++ b/infra/systemd/chitin-stale-doc-detector.service
@@ -1,0 +1,22 @@
+# One-shot service fired by chitin-stale-doc-detector.timer.
+# Scans every docs/**/*.md for project-relative path references
+# (apps/, libs/, go/, python/, infra/, scripts/, tests/, docs/);
+# resolves each against the working tree; files debt-ledger entries
+# at severity:'low' for refs that no longer exist. Tech-writer
+# role's debt-detection half — operator promotes / fixes / dismisses.
+# Idempotent — re-runs add 0 entries when no new refs went stale.
+
+[Unit]
+Description=Chitin swarm stale-doc detector
+After=chitin-worker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=CHITIN_REPO_ROOT=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/stale-doc-detector.ts
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/infra/systemd/chitin-stale-doc-detector.timer
+++ b/infra/systemd/chitin-stale-doc-detector.timer
@@ -1,0 +1,18 @@
+# Timer for chitin-stale-doc-detector.service.
+# Daily — doc references go stale on PR-merge events; daily cadence
+# catches them within 24h. Persistent so a missed tick from a
+# powered-off rig fires on the next boot. 105min boot offset stages
+# it after the rest of the daily lineup (rollup / lessons /
+# debt-curator / groomer / alarm-feeder).
+
+[Unit]
+Description=Chitin swarm stale-doc detector timer
+
+[Timer]
+OnUnitActiveSec=24h
+OnBootSec=105min
+Persistent=true
+Unit=chitin-stale-doc-detector.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Closes the doc-debt detection gap. PR-merge events that rename / delete files leave doc refs stale silently. With this in, those refs get filed to \`docs/debt-ledger.md\` within 24h.

Pattern matches researcher / lessons / debt-curator / groomer / alarm-feeder / analyst recipe: cron-fired, deterministic, idempotent, telemetry log line, no Temporal.

**Skip rules caught on live first run:**
- URLs (\`://\` precedes match)
- Cross-repo gh-api refs (\`repos/<o>/<r>/contents/...\`)
- Cross-repo github.com URLs (\`github.com/<o>/<r>/blob/...\`)
- Yaml-fenced blocks — without this skip, the detector ingests its own prior output

## Live first-run evidence

167 stale refs out of 1167 scanned across chitin's docs/ tree:
- Real: \`libs/governance\` (refactored away), \`chitindir-resolve.test.ts\` (planned but never created)
- Intentionally historical: \`archive-map.md\` describes the OLD layout by design (operator dismisses these)

Cap at 10/run keeps the ledger from drowning while operator triages.

## Test plan

- [x] 31 new tests; 537/537 in apps/temporal-worker; typecheck clean
- [ ] After merge: \`systemctl --user enable --now chitin-stale-doc-detector.timer\` + first manual run

🤖 Generated with [Claude Code](https://claude.com/claude-code)