### PR TITLE
docs: post-swarm-factory ship updates + per-app READMEs + backlog audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Chitin
 
-**Execution kernel for AI coding agents.** Every tool call across Claude Code, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript). MIT licensed.
+**Execution kernel for AI coding agents.** Every tool call across Claude Code, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript + Python). MIT licensed.
 
 > Principle: real execution before policy. Policy before automation. Automation gated by the same kernel.
 
-## Phase 1 — Claude Code capture→replay on a local workstation
+## Where chitin is today
+
+- **Kernel + governance** — Go binary fires on every PreToolUse hook, evaluates `chitin.yaml`, writes a hash-linked JSONL chain. Gate decisions are auditable; chain integrity is SHA-256-verified.
+- **OTEL emit (F4, 2026-05-02)** — kernel projects every chain event onto an OTLP/HTTP JSON span after the canonical write succeeds. One-way bridge: chain authoritative, OTEL non-authoritative. Opt-in via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+- **Autonomous swarm runtime** — Temporal-backed dispatcher + worker that picks ready backlog entries, dispatches role-typed agents (programmer, reviewer, researcher, analyst, …), runs the §5 review-tier escalation chain (R1→R2→R3→operator), and (with `CHITIN_GATEKEEPER_AUTO_MERGE=1`) auto-merges PRs that pass the §6 gate matrix. The factory's design lives in [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md).
+- **Self-feeding telemetry loop** — periodic scripts (researcher, lessons, debt-curator, groomer, alarm-feeder, stale-doc detector) keep the backlog hydrated from external signals + internal alarms; the analyst role runs deterministic Python recipes against the chain to investigate regressions automatically.
+
+## Quick start
 
 ```bash
 pnpm install
@@ -14,15 +21,37 @@ pnpm exec nx run cli:build
 # Run a Claude Code session...
 ./dist/apps/cli/main.js events list
 ./dist/apps/cli/main.js replay <run_id>
+./dist/apps/cli/main.js health
 ```
+
+To run the autonomous swarm on your own rig, see [`infra/systemd/README.md`](./infra/systemd/README.md).
 
 ## Architecture
 
-- `apps/cli` — operator CLI (`chitin init | events list | events tail | replay`)
-- `libs/contracts` — canonical event schema (zod); Go types generated from this
-- `libs/telemetry` — JSONL tailer, SQLite indexer, replay streamer
-- `libs/adapters/claude-code` — monitor-only PreToolUse hook receiver (thin TS, exec's the Go kernel)
-- `go/execution-kernel` — canon, normalize, emit, hook. Only layer allowed side effects.
+```
+.
+├── apps/
+│   ├── cli/                          # operator CLI (`chitin`)
+│   ├── temporal-worker/              # autonomous swarm runtime + cron-fired scripts
+│   └── openclaw-plugin-governance/   # openclaw integration: chitin gates every openclaw tool call
+├── libs/
+│   ├── contracts/                    # canonical schemas (event chain, ExecutionRequest, envelope)
+│   └── telemetry/                    # JSONL tailer + SQLite indexer + replay streamer
+├── go/execution-kernel/              # the Go kernel — only layer allowed side effects
+├── python/analysis/                  # decisions / debt / souls streams + daily rollup + analyst recipes
+└── infra/systemd/                    # user-mode systemd units for the swarm
+```
+
+| Package | What it owns |
+|---------|--------------|
+| `apps/cli` | Operator CLI (`init`, `events list/tail/tree`, `replay`, `health`, `ledger`, `review`, `install`). [README](./apps/cli/README.md) |
+| `apps/temporal-worker` | Dispatcher, review-graph workflow, gatekeeper, role-typed prompts, all cron scripts. [README](./apps/temporal-worker/README.md) |
+| `apps/openclaw-plugin-governance` | openclaw plugin that wires chitin's policy gate into openclaw's tool-call lifecycle. [README](./apps/openclaw-plugin-governance/README.md) |
+| `libs/contracts` | Canonical schemas every chitin component agrees on. [README](./libs/contracts/README.md) |
+| `libs/telemetry` | Read-side of the event chain. [README](./libs/telemetry/README.md) |
+| `go/execution-kernel` | The Go kernel binary — `canon`, `normalize`, `emit`, `gov`, `hook`, `health`. The only layer allowed side effects. |
+| `python/analysis` | Decisions / debt / souls / swarm-runs / swarm-health / daily rollup + the analyst-role investigation recipe. |
+| `infra/systemd` | User-mode systemd units (worker + 7 cron timers). [README](./infra/systemd/README.md) |
 
 ## Where chitin writes data
 
@@ -49,16 +78,27 @@ For diagnostics, run `chitin health` — it reports on the resolved dir and exit
 - **Nx** — orchestrator (project graph, affected, module boundaries)
 - **Vite+** (`vp`) — TypeScript test/lint/format/build (Vitest, Oxlint, Oxfmt, Rolldown, tsgo)
 - **Go 1.22+** — execution kernel, run via `nx:run-commands`
+- **uv + pytest** — Python analysis lib (`python/analysis/`)
+- **Temporal** — workflow durability for the autonomous swarm
 
 ## Docs
 
-- [`docs/thesis.md`](./docs/thesis.md)
-- [`docs/operating-model.md`](./docs/operating-model.md)
-- [`docs/architecture.md`](./docs/architecture.md)
-- [`docs/event-model.md`](./docs/event-model.md)
+Core:
+- [`docs/thesis.md`](./docs/thesis.md) — what chitin is + isn't
+- [`docs/operating-model.md`](./docs/operating-model.md) — how chitin runs against an agent surface
+- [`docs/architecture.md`](./docs/architecture.md) — three-plane model (Temporal control / OpenClaw execution / Chitin enforcement)
+- [`docs/event-model.md`](./docs/event-model.md) — canonical event chain + OTEL projection
 - [`docs/toolchain.md`](./docs/toolchain.md)
 - [`docs/roadmap.md`](./docs/roadmap.md)
-- [`docs/archive-map.md`](./docs/archive-map.md)
+
+Autonomous swarm (factory model):
+- [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md) — the full §3-§9 station-taxonomy + review-tier escalation + auto-merge gates
+- [`docs/swarm-backlog.md`](./docs/swarm-backlog.md) — what the swarm picks up next
+- [`docs/swarm-lessons.md`](./docs/swarm-lessons.md) — auto-distilled lessons prepended to programmer prompts
+- [`docs/debt-ledger.md`](./docs/debt-ledger.md) — operator-curated + auto-curated debt
+- [`infra/systemd/README.md`](./infra/systemd/README.md) — install + operate the worker + 7 cron timers
+
+Archive: [`docs/archive-map.md`](./docs/archive-map.md)
 
 ## License
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,54 @@
+# `apps/cli` — `chitin` CLI
+
+Operator-facing CLI for chitin: wire surfaces, inspect events,
+replay runs, install the kernel, run health checks, audit the debt
+ledger, run review passes.
+
+```bash
+pnpm install
+pnpm exec tsx apps/cli/src/main.ts <command>
+# Or via the bin once installed:
+chitin <command>
+```
+
+## Subcommands
+
+| Command | What it does |
+|---------|--------------|
+| `init claude-code [--workspace <dir>]` | Wire the PreToolUse hook for Claude Code in the given workspace. One-shot install. |
+| `events list [--surface <s>] [--run <id>] [--limit N]` | Print rows from the captured event chain. |
+| `events tail [--surface <s>] [--run <id>]` | Stream events as they're appended (like `tail -f`). |
+| `events tree [--run <id>]` | Render the event chain as a parent-child tree. |
+| `replay <run-id>` | Re-run a captured run from the chain. |
+| `run …` | Submit a one-off agent turn (programmer-shape). See `--help`. |
+| `install` | Build + symlink the chitin-kernel binary into `~/.local/bin`. |
+| `health` | Run the kernel's health check (chain integrity, marker counts, etc). |
+| `ledger` | Audit `docs/debt-ledger.md` — counts open/claimed/shipped + filters. |
+| `review <pr-number>` | Manually run the review-graph workflow against a PR (operator-facing equivalent of the auto-enqueued path in `dispatcher.ts`). |
+
+Each subcommand is one file under `src/commands/`. Add a new
+subcommand by:
+
+1. Writing `src/commands/<name>.ts` with a `register<Name>` (or
+   `<name>Command`) export.
+2. Wiring it into `src/main.ts`.
+3. Adding a vitest case under `tests/`.
+
+## Layer
+
+`@chitin/cli` is the operator surface. It's NOT used by the swarm
+worker (that's `apps/temporal-worker`). Both compose against the
+same kernel + libs.
+
+## Test suite
+
+```bash
+pnpm exec vitest run apps/cli/tests
+```
+
+## Related
+
+- `apps/temporal-worker/README.md` — the autonomous swarm runtime
+- `go/execution-kernel/cmd/chitin-kernel/` — the Go kernel binary
+  the CLI wraps
+- `libs/contracts/README.md` — the schemas the CLI consumes

--- a/apps/temporal-worker/README.md
+++ b/apps/temporal-worker/README.md
@@ -1,0 +1,106 @@
+# `apps/temporal-worker`
+
+Chitin's autonomous swarm runtime — Temporal worker + dispatcher +
+the suite of cron-fired scripts that close the §3 station-taxonomy
+loop from `docs/design/2026-05-02-swarm-as-software-factory.md`.
+
+## What's here
+
+### Long-running
+
+| File | Role |
+|------|------|
+| `src/worker.ts` | Temporal worker. Polls `chitin-worker-q`, runs activities (`runAgentTurn`, `runGatekeeperNotify`). Loaded by `chitin-worker.service`. |
+| `src/workflow.ts` | Workflow registry — re-exports `executeRequestWorkflow` + `reviewGraphWorkflow` so the worker's webpack bundle picks them up. |
+| `src/activity.ts` | The activity that spawns an agent in a worktree, runs it, captures the result envelope. |
+| `src/review-graph-workflow.ts` | The §5 review-tier escalation chain. Dispatches reviewers R1→R2→R3, calls the gatekeeper notify activity at the end. |
+
+### Cron-fired scripts (one per timer; pattern: deterministic, idempotent, telemetry-emitting, no Temporal)
+
+| Script | Timer | Job |
+|--------|-------|-----|
+| `src/dispatcher.ts` | `chitin-dispatcher.timer` (every 5 min) | Read backlog, pick next ready entry, submit one programmer workflow, run apply step, enqueue review-graph. |
+| `src/researcher.ts` | `chitin-researcher.timer` (every 4h) | Pull external signals (arxiv / Reddit / HN / openclaw / ollama), dedup against `docs/roadmap.md`, append candidates. |
+| `src/lessons.ts` | `chitin-lessons.timer` (daily) | Scan merged swarm/* PRs, distill one-sentence lessons, append to `docs/swarm-lessons.md`. The dispatcher prepends recent lessons to programmer prompts. Heuristic v1 + LLM-backed v2 (off by default; flip via `CHITIN_LESSONS_USE_LLM=1`). |
+| `src/debt-curator.ts` | `chitin-debt-curator.timer` (daily) | Scan repo for TODO/FIXME/HACK/XXX markers, dedup, file `docs/debt-ledger.md` entries at severity:'low'. |
+| `src/groomer.ts` | `chitin-groomer.timer` (daily) | Read roadmap candidates, draft up to N (default 1) `in_design` backlog entries from arxiv-source candidates. The existing `groom-pass.ts` (Copilot-driven) takes them to `ready`. |
+| `src/alarm-feeder.ts` | `chitin-alarm-feeder.timer` (daily) | Read latest rollup `alarms[]`, dedup, draft `in_design` entries with `role: analyst`. Closes §7 telemetry → backlog flywheel. |
+| `src/stale-doc-detector.ts` | `chitin-stale-doc-detector.timer` (daily) | Scan `docs/**/*.md` for project-relative path refs that no longer exist; file ledger entries. Tech-writer's debt-detection half. |
+| `src/groom-pass.ts` | (manual / on-demand) | Copilot-driven grooming pass — promotes `in_design` → `ready` by classifying tier / file scope / estimated_loc. |
+
+### Role registry + prompts
+
+| File | Purpose |
+|------|---------|
+| `src/role-prompts.ts` | Role → prompt-builder registry. Routes `BacklogEntry.role` (programmer / researcher / reviewer / analyst / …) to the right template. |
+| `src/researcher-prompts.ts` | Researcher prompt + `<<<CANDIDATES>>>`-marked structured emit + parser. |
+| `src/reviewer-prompts.ts` | Adversarial reviewer prompt template (R1/R2/R3 tones) + `<<<REVIEW>>>`-marked emit + parser. |
+| `src/gatekeeper.ts` | Slack digest + §6 auto-merge gates (CI green, bucket-B rate, 🔴 findings, T5-path, scope-intersect, driver-success-rate). Opt-in via `CHITIN_GATEKEEPER_AUTO_MERGE=1`. |
+
+### Dispatcher integration
+
+| File | Purpose |
+|------|---------|
+| `src/review-graph-dispatch.ts` | After PR opens, the dispatcher calls `enqueueReviewGraph` to fire `reviewGraphWorkflow` as a separate top-level workflow. Fire-and-forget — the next dispatcher tick is free to pick a new entry. |
+| `src/grooming/parse-backlog.ts` | Parser for `docs/swarm-backlog.md`. |
+| `src/grooming/apply-workflow-result.ts` | Apply step: push branch, open PR, revert known artifacts (e.g., `.claude/settings.json` overwrite). |
+
+## Pipeline at a glance
+
+```
+chitin-researcher.timer (4h) → docs/roadmap.md candidates
+                                ↓
+chitin-groomer.timer (24h) → docs/swarm-backlog.md in_design entries (arxiv source-allowlist)
+                                ↓
+groom-pass.ts (Copilot-driven, on-demand) → ready entries
+                                ↓
+chitin-dispatcher.timer (5m) → programmer workflow → activity → PR
+                                ↓
+                                + enqueue reviewGraphWorkflow
+                                ↓
+review-graph (R1→R2→R3 escalation + parse-failure handling) → ReviewGraphResult
+                                ↓
+gatekeeper notify activity:
+  ├─ all 6 §6 gates pass + CHITIN_GATEKEEPER_AUTO_MERGE=1 → gh pr merge
+  └─ otherwise → Slack digest, operator decides
+
+chitin-swarm-rollup.timer (24h) → ~/.cache/chitin/swarm-rollups/<date>.json
+                                ↓
+chitin-alarm-feeder.timer (24h) → role:analyst investigate-* in_design entries
+                                ↓
+analyst workflow → python -m analysis.investigate (deterministic recipe) → markdown report
+
+chitin-lessons.timer (24h)        → docs/swarm-lessons.md → prepended to programmer prompts
+chitin-debt-curator.timer (24h)   → docs/debt-ledger.md  (TODO/FIXME scan)
+chitin-stale-doc-detector.timer (24h) → docs/debt-ledger.md (broken doc refs)
+```
+
+## Flags + env
+
+| Variable | Effect |
+|----------|--------|
+| `CHITIN_REPO_ROOT` | Repo root (defaults to cwd). Used by every script. |
+| `CHITIN_SLACK_WEBHOOK_URL` | Slack webhook for dispatcher events + gatekeeper digests. Empty = no-op. |
+| `CHITIN_LESSONS_USE_LLM` | `1` = lessons distilled via `claude -p haiku-4-5` (reflective). Off = heuristic title-strip. |
+| `CHITIN_GATEKEEPER_AUTO_MERGE` | `1` = gatekeeper actually `gh pr merge`s on green. Off = notify-only. |
+| `CHITIN_RESEARCHER_CAP` | Max candidates per researcher tick (default 5). |
+| `CHITIN_GROOMER_CAP` / `CHITIN_GROOMER_SOURCES` | Groomer cap (default 1) / source allowlist (default `arxiv`). |
+| `CHITIN_DEBT_CURATOR_CAP` | Default 20. |
+| `CHITIN_LESSONS_SCAN_LIMIT` | Default 30 PRs back. |
+| `CHITIN_ALARM_FEEDER_CAP` | Default 1. |
+| `CHITIN_STALE_DOC_CAP` | Default 10. |
+
+## Test suite
+
+```bash
+pnpm exec vitest run apps/temporal-worker
+```
+
+500+ tests. Each cron script has its own `*.test.ts` covering pure
+logic + the runner's happy / dedup / cap / no-op / error-containment
+paths.
+
+## Systemd units
+
+See `infra/systemd/README.md` for unit installation, env-file setup,
+and operate / pause / hard-stop runbooks.

--- a/apps/temporal-worker/src/stale-doc-detector.ts
+++ b/apps/temporal-worker/src/stale-doc-detector.ts
@@ -80,10 +80,13 @@ const SCAN_PREFIXES = [
 // One ref candidate per regex match. The match is the longest
 // prefix-anchored path-shaped substring on the line. We post-process
 // to drop trailing markdown / punctuation that snuck in.
+//
+// Note: forward-slashes don't need escaping inside `new RegExp(...)`
+// — only inside `/.../`-literals, where they delimit the pattern.
+// SCAN_PREFIXES is a hardcoded constant of lowercase-alpha + slash;
+// no regex metacharacters to escape.
 const REF_RE = new RegExp(
-  '(?:' +
-    SCAN_PREFIXES.map((p) => p.replace(/\//g, '\\/')).join('|') +
-    ')[A-Za-z0-9_./@\\-]+',
+  '(?:' + SCAN_PREFIXES.join('|') + ')[A-Za-z0-9_./@\\-]+',
   'g',
 );
 

--- a/docs/design/2026-05-02-swarm-as-software-factory.md
+++ b/docs/design/2026-05-02-swarm-as-software-factory.md
@@ -71,23 +71,24 @@ off any node when telemetry says "this needs cleanup."
 ## 3. Station taxonomy
 
 Eleven roles, one row each. Most map onto existing in_design entries
-or well-known SoTA patterns. **Today** = current chitin state.
+or well-known SoTA patterns. **Today** = current chitin state
+(refreshed 2026-05-02 after the autonomous-swarm ship).
 **Reference** = the SoTA work we should mine before re-deriving the
 prompt and tool-set.
 
 | Role | Owns | Today | Reference patterns |
 |------|------|-------|--------------------|
-| `researcher` | Pull external signals (arxiv, Reddit, X, openclaw upstream, ollama releases). Open candidate entries in `roadmap.md`. | Manual (operator + this assistant) | NotebookLM ingestion, awesome-openclaw-agents registry, dev.to community mining |
-| `product` | Turn raw signals into 1-paragraph problem statements with success criteria. | Manual | MetaGPT's PM role; LangChain agentic-engineering writeups |
-| `groomer` | Tier-classify entries; size; identify file scope; mark blockers; verify against schema. | Slice 7 has a partial groomer (Copilot GPT-4.1 with `chitin-groom-pass.ts`) | Lobster's deterministic YAML-first pattern (ggondim) |
-| `architect` | Write `docs/design/<entry-id>.md` ADRs: context / options / decision / tradeoffs. | Mixed into implementation today | MetaGPT architect role; AutoCodeRover patch-context |
-| `programmer` | Read entry's `file:`, edit, commit, push branch. The current swarm worker. | **In production.** | SWE-agent, Live-SWE-agent's tool-registry pattern |
-| `reviewer` | Tier-escalating review (R0-R3, see §5). | R0 (Copilot bot) automated; R3 (Opus) manual via operator | Anthropic's plan/code/review pattern |
-| `qa` | Generate or run E2E tests against shipped diffs; smoke-test. | Unit tests exist; no E2E generation | Cursor's test-author flow; Playwright codegen agent |
-| `gatekeeper` | Read CI + reviews + telemetry; decide self-merge or escalate. | Manual (operator) | This is novel — we're defining it |
-| `tech-writer` | Update wiki + ADRs + runbooks from merged work. Maintain `lessons-learned`. | Partial via operator-driven fix passes | Wiki pipeline; NotebookLM artifact generation |
-| `analyst` | The Python analysis lib. Daily rollup (PR #127). Author new queries on demand. | **In production.** | LangSmith / Helicone / Phoenix patterns |
-| `refactorer` + `debt-curator` | Surface duplication / dead code / hot-path debt. Maintain `docs/debt-ledger.md`. | Doesn't exist | Zoncolan-style static analysis; AutoFlake-style mechanical cleanup |
+| `researcher` | Pull external signals (arxiv, Reddit, X, openclaw upstream, ollama releases). Open candidate entries in `roadmap.md`. | **In production.** `chitin-researcher.timer` fires every 4h via `apps/temporal-worker/src/researcher.ts` (#147); 5-source dedupe + cap. Per-role prompt template at `researcher-prompts.ts` (#143). | NotebookLM ingestion, awesome-openclaw-agents registry, dev.to community mining |
+| `product` | Turn raw signals into 1-paragraph problem statements with success criteria. | Filed as in_design backlog entry `product-role-prompt-template` (#161). | MetaGPT's PM role; LangChain agentic-engineering writeups |
+| `groomer` | Tier-classify entries; size; identify file scope; mark blockers; verify against schema. | **Two-half production.** Candidate-promoter (`chitin-groomer.timer`, #157) drips arxiv candidates → in_design entries; existing `groom-pass.ts` (Copilot-driven) classifies in_design → ready. | Lobster's deterministic YAML-first pattern (ggondim) |
+| `architect` | Write `docs/design/<entry-id>.md` ADRs: context / options / decision / tradeoffs. | Filed as in_design backlog entry `architect-role-prompt-template` (#161). | MetaGPT architect role; AutoCodeRover patch-context |
+| `programmer` | Read entry's `file:`, edit, commit, push branch. The current swarm worker. | **In production.** Slice 7 dispatcher + Phase-1 role registry; lessons prepended from `swarm-lessons.md` (#152, #156). | SWE-agent, Live-SWE-agent's tool-registry pattern |
+| `reviewer` | Tier-escalating review (R0-R3, see §5). | **In production.** R1→R2→R3 escalation chain in `reviewGraphWorkflow` (#140); adversarial prompt template `reviewer-prompts.ts`. R0 = Copilot bot (server-side, passive). R0-wait integration filed as `r0-copilot-wait-on-review-graph-kickoff` (#161). | Anthropic's plan/code/review pattern |
+| `qa` | Generate or run E2E tests against shipped diffs; smoke-test. | Filed as in_design backlog entry `qa-automation-from-merged-diff` (#161). | Cursor's test-author flow; Playwright codegen agent |
+| `gatekeeper` | Read CI + reviews + telemetry; decide self-merge or escalate. | **In production.** Slack digest (#149) + 6-gate auto-merge (#158, #159). All §6 gates wired: action=approve, t5_shape=false, CI green, no 🔴 findings, no T5-path touch, scope-intersection, bucket-B rate=0, driver-success ≥70%. Off by default; opt-in via `CHITIN_GATEKEEPER_AUTO_MERGE=1`. | This was novel — we defined it |
+| `tech-writer` | Update wiki + ADRs + runbooks from merged work. Maintain `lessons-learned`. | **Two halves shipped.** Lessons-learned sidecar (`chitin-lessons.timer`, #152, #156) + stale-doc detector (`chitin-stale-doc-detector.timer`, #165). Wiki / runbook auto-update is a follow-up. | Wiki pipeline; NotebookLM artifact generation |
+| `analyst` | The Python analysis lib. Daily rollup (PR #127). Author new queries on demand. | **In production + recipe-driven.** `python/analysis/` for ad-hoc + daily rollup; swarm-dispatched analyst role (#163) routes alarm-feeder entries to `python/analysis/investigate.py` (#164) — deterministic pre-canned investigations of bucket-B / low-success / qwen-idle alarm kinds. | LangSmith / Helicone / Phoenix patterns |
+| `refactorer` + `debt-curator` | Surface duplication / dead code / hot-path debt. Maintain `docs/debt-ledger.md`. | **In production.** TODO/FIXME/HACK/XXX marker scanner (`chitin-debt-curator.timer`, #153, hotfix #155); stricter regex + path excludes after live first-run noise. Duplication / dead-code detection is post-v1. | Zoncolan-style static analysis; AutoFlake-style mechanical cleanup |
 
 The taxonomy isn't a hierarchy — it's a *registry*. A backlog entry
 at any point can name `role: researcher` or `role: qa` and the

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -76,7 +76,7 @@ Reserved (not yet wired): `policy_decided`, `rewritten`, `denied`, `chain_verify
 
 ## OTEL projection (one-way bridge)
 
-When OTEL emit is enabled (F4, ships before 2026-05-07), the kernel projects events onto OTEL spans **after** the chain write succeeds. The chain is authoritative; OTEL is non-authoritative.
+When OTEL emit is enabled (F4, **shipped 2026-05-02** in `go/execution-kernel/internal/emit/otel.go` — opt-in via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`), the kernel projects events onto OTEL spans **after** the chain write succeeds. The chain is authoritative; OTEL is non-authoritative.
 
 ```
 event chain (canonical)         OTEL span (projection)
@@ -98,7 +98,7 @@ decision.decision     ──────►  attribute: decision.type
 - No policy on OTEL. All policy decisions derive from the chain or kernel-observed data.
 - Kernel survives OTEL failure. If OTEL emit fails, kernel write must still succeed.
 
-F4 ships 4 event types only (`session_start`, `pre_tool_use`, `decision`, `post_tool_use`) over OTLP HTTP JSON. Full `gen_ai.*` semconv compliance, OTLP-grpc, batching, and multi-exporter support are post-talk.
+F4 v1 ships 4 event types only (`session_start`, `pre_tool_use`, `decision`, `post_tool_use`) over OTLP HTTP JSON, sync after chain commit (kernel runs as a short-lived CLI per emit; daemon-mode async is deferred). Full `gen_ai.*` semconv compliance, OTLP-grpc, batching, and multi-exporter support are post-talk.
 
 ## Surface neutrality
 

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -1970,3 +1970,94 @@ Auto-filed by chitin-alarm-feeder.timer at 2026-05-02T19:46:35.246Z from a swarm
 > BUCKET-B REGRESSION: 1/19 runs contaminated (5.3%) — PR #123 preflight may have regressed
 
 Researcher role: read the alarm + the latest swarm-rollup JSON at `~/.cache/chitin/swarm-rollups/<YYYY-MM-DD>.json`; identify the root cause (recent dispatch failures, driver regressions, governance edits, etc); propose either a fix entry or `status: needs_human` if the cause is non-obvious. Operator: groom this entry once it has a real `tier` / `file:` / `estimated_loc`.
+
+### `nx-affected-in-ci`
+
+```yaml
+id: nx-affected-in-ci
+tier: T1
+status: ready
+estimated_loc: 80
+blocks: []
+file: .github/workflows/ci.yml, nx.json
+references_design: nx affected docs / chitin's existing nx.json
+role: programmer
+```
+
+CI doesn't use `nx affected`. `nx.json` is configured with the
+TypeScript plugin (typecheck / build targets), but `.github/workflows/
+ci.yml` runs `pnpm exec vitest run` against EVERYTHING on every PR,
+plus `go test ./...` on every PR. Docs-only PRs trigger full test
+suites; the marginal CI cost compounds across the 30+ PRs we ship a
+day.
+
+Scope:
+
+1. CI workflow: replace bare `pnpm exec vitest run` with
+   `pnpm exec nx affected -t test --base=origin/main` (or with
+   `nx run-many` if affected detection isn't worth the complexity
+   on this size repo).
+2. Same for typecheck + lint targets if Nx isn't already routing
+   those.
+3. Keep `go test ./...` as-is unless someone files a separate entry
+   to add Nx-Go integration.
+4. Verify on a docs-only PR: should skip TS test step entirely.
+
+Trade-off: Nx affected requires correct project boundaries (which
+this repo has via `nx.json` + `package.json` per package). The
+cost is one PR with 80-ish LOC of CI changes; the gain is faster
+CI on routine PRs and a real "Nx-shaped" workflow that matches the
+nx.json config we already wrote.
+
+## Audit log: shipped entries (2026-05-02 ship session)
+
+Many entries below this line have status: ready or in_design but
+their work is actually merged. Rather than touching every entry's
+status field (low-leverage edit), we record the shipped audit here
+so the backlog itself stays small to scan. The dispatcher's
+existing "skip — origin branch exists" check already prevents
+re-dispatch of these.
+
+| Entry id | Status field | Actual state | Shipped in |
+|----------|--------------|--------------|------------|
+| `dispatcher-respect-blocks-field` | ready | shipped | #144 |
+| `review-graph-executor` | ready | shipped | #140 |
+| `tech-debt-ledger` | ready | shipped | #137 |
+| `debt-ledger-analysis-loader` | ready | shipped | #142 |
+| `researcher-role-prompt-template` | ready | shipped | #143 |
+| `chitin-researcher-systemd-units` | ready | shipped | #145 |
+| `external-signal-fetchers` | ready | shipped | #147 |
+| `analysis-swarm-runs-loader` | ready | shipped | #126 |
+| `swarm-daily-rollup-healthcheck` | ready | shipped | #127 |
+| `dispatcher-preflight-scrub-claude-settings-backup` | ready | shipped | (live in `dispatcher.ts` preflight + apply revert) |
+| `normalize-decision-params-truthiness` | ready | shipped | #101 |
+| `workflow-name-drift-test` | ready | shipped | (origin branch) |
+| `dispatcher-prompt-relative-path-prefix` | ready | shipped | #105 |
+| `dispatcher-prompt-scope-discipline` | ready | shipped | #106 |
+| `activity-include-hook-events-flag` | ready | shipped | #108 |
+| `repo-regex-tighten` | ready | shipped | #103 |
+| `read-vs-read_file-file_path-alias` | ready | shipped | #113 |
+| `wall-timeout-sigkill-propagation` | ready | shipped | #114 (+ rerun in #123) |
+| `cron-subagents-image-granular-targets` | ready | shipped | #116 |
+| `task-validate-command-pre-activity-gate` | ready | shipped | #117 |
+| `chitin-install-slice-3-agents` | ready | shipped | #118 |
+| `openclaw-tool-coverage-audit` | ready | shipped | #119 |
+| `rename-local-cloud-driver-misnomer` | ready | shipped | #120 |
+| `lessons-learned-sidecar` | in_design | shipped | #152 + #156 |
+| `agent-adversarial-review-pass` | completed | already correct | #134 |
+| `role-typed-backlog-entries` | completed | already correct | (Phase 1) |
+| `external-signal-collector` | (SUPERSEDED) | already correct | superseded by 3 split entries |
+
+Entries newly filed in this session (in_design, awaiting groomer):
+
+- `product-role-prompt-template` (#161)
+- `architect-role-prompt-template` (#161)
+- `qa-automation-from-merged-diff` (#161)
+- `r0-copilot-wait-on-review-graph-kickoff` (#161)
+- `investigate-bucket-b-regression` (#162, auto-filed by alarm-feeder)
+- `nx-affected-in-ci` (this commit)
+
+Operator action item: the dispatcher's branch + marker checks already
+keep these from re-dispatching. If you want a clean visual scan of
+"what's left", filter the file by `status: ready` lines that are NOT
+in the table above.

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -1,3 +1,51 @@
-# contracts
+# `@chitin/contracts`
 
-This library was generated with [Nx](https://nx.dev).
+The schemas every chitin component agrees on. If two layers disagree
+about an envelope, event, or execution-request shape — they disagree
+because of code drift, not contract drift; this package is the
+single point of truth.
+
+## Schemas
+
+| File | Purpose |
+|------|---------|
+| `src/envelope.schema.ts` | The result envelope every workflow + activity produces (`tmp/result-*.json` shape). What the apply step + analyst recipes consume. |
+| `src/event.schema.ts` | Canonical event shape on the chain (`session_start`, `pre_tool_use`, `decision`, `post_tool_use`, etc.). Hash-linked + surface-neutral. |
+| `src/event.types.ts` | TypeScript types projected from the event schema; `EventType` enum + payload unions. |
+| `src/execution-request.schema.ts` | `ExecutionRequest` — the typed dispatch contract: `{role, tier, allowed_drivers, bounds, parent_workflow_id, step_index, …}`. The dispatcher constructs these; the worker validates. |
+| `src/payloads.schema.ts` | Per-event-type payload schemas referenced from `event.schema.ts`. |
+| `src/hash.ts` | `hashEvent(map)` — the deterministic SHA-256 over canonical-keyed event JSON. Owns chain integrity. **Uses `node:crypto`** — must NOT be imported as a value from workflow code (Temporal's webpack bundler can't resolve `node:` imports). Workflow-side code uses type-only imports. |
+| `src/chitindir-resolve.ts` | Resolves `~/.cache/chitin/<workspace>/` — the per-workspace state dir. Uses `node:fs`/`os`/`path`; same workflow-bundler caveat as `hash.ts`. |
+
+## Workflow-bundle caveat
+
+Temporal's workflow webpack bundle traces imports from `apps/
+temporal-worker/src/workflow.ts`. Anything VALUE-imported there
+(directly or transitively) goes into the bundle. `@chitin/contracts/
+index.ts` re-exports `hash.ts` + `chitindir-resolve.ts`, both of
+which import from `node:*` — which the bundler refuses.
+
+Workflow-side files therefore use **type-only imports**:
+
+```ts
+import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
+```
+
+Activity-side and CLI-side files can value-import freely.
+
+## Test suite
+
+```bash
+pnpm exec vitest run libs/contracts
+```
+
+Schema round-trip tests + `hash.ts` determinism tests. Each schema
+has a paired `tests/<name>.schema.test.ts`.
+
+## Related
+
+- `apps/temporal-worker/src/review-graph-workflow.ts` — illustrative
+  consumer of the type-only import pattern (hotfix #150 added the
+  workflow-bundler note).
+- `go/execution-kernel/internal/event/` — the Go-side mirror of the
+  event schema; chitin-kernel writes events the TS schemas validate.

--- a/libs/telemetry/README.md
+++ b/libs/telemetry/README.md
@@ -1,3 +1,47 @@
-# telemetry
+# `@chitin/telemetry`
 
-This library was generated with [Nx](https://nx.dev).
+The query-side of chitin's event chain. Reads the canonical JSONL
+log + the SQLite chain index to answer questions about what happened
+across runs.
+
+If `@chitin/contracts` defines the chain's *shape*, this lib defines
+how to *consume* it.
+
+## Modules
+
+| File | Purpose |
+|------|---------|
+| `src/sqlite-indexer.ts` | The SQLite-backed index that mirrors the JSONL chain. Built lazily; the kernel writes events to JSONL and updates the index in the same transaction (chain.go). This module is the read-side. |
+| `src/ensure-indexed.ts` | Idempotent "make sure the index is current" — call before any query. Cheap when up-to-date. |
+| `src/jsonl-tailer.ts` | Streaming reader for `events-*.jsonl`. Used by the CLI's `events tail` command. |
+| `src/replay.ts` | Replay a captured run from the chain — produces the same execution-request that originally fired. Underpins `chitin replay <run-id>`. |
+| `src/schema.sql` | Schema for the SQLite index. Bundled at build; the indexer applies it on first read. |
+| `src/index.ts` | Public exports. |
+
+## Chain semantics (read side)
+
+- The JSONL log is **canonical**. Every consumer must tolerate
+  reading raw JSONL even if the SQLite index is missing.
+- The index is a **derived view** — building it is fast (re-scans
+  JSONL); losing it is a recoverable corruption, not data loss.
+- `replay` is **deterministic**: same chain → same emitted
+  execution-request. The chain's hash linkage is the audit-grade
+  guarantee.
+
+## Test suite
+
+```bash
+pnpm exec vitest run libs/telemetry
+```
+
+Coverage focuses on round-trips between JSONL and the SQLite index
++ replay determinism.
+
+## Related
+
+- `go/execution-kernel/internal/chain/` — the Go-side write path
+  (kernel emits events; this lib reads them).
+- `python/analysis/loaders.py` — the Python-side reader for the
+  same JSONL chain. Two languages, one canonical format.
+- `apps/cli/src/commands/events-list.ts` / `events-tail.ts` — CLI
+  consumers of this lib.


### PR DESCRIPTION
## Summary

After ~30 PRs in one session, several docs went stale. This batch refreshes them + adds the per-app/lib READMEs that didn't exist (or were Nx-stub placeholders) + files a backlog audit.

**What changed:**
- **\`docs/event-model.md\`** — F4 marked shipped 2026-05-02 (was "ships before 2026-05-07")
- **\`docs/design/.../swarm-as-software-factory.md §3\`** — refreshed all 11 station-taxonomy rows; 8 in production, 3 in_design with citations
- **\`docs/swarm-backlog.md\`** — added audit table for 26 shipped-but-not-status-updated entries + filed \`nx-affected-in-ci\` (nx.json exists but CI runs vitest against everything)
- **\`apps/temporal-worker/README.md\`** — NEW. Pipeline diagram, cron-script inventory, env matrix
- **\`apps/cli/README.md\`** — NEW. Subcommand inventory
- **\`libs/contracts/README.md\`** — replaced Nx-stub with schema inventory + workflow-bundle caveat
- **\`libs/telemetry/README.md\`** — replaced Nx-stub with module inventory

**Deliberately not done:** per-entry status field updates (audit table is the source of truth instead — 25+ tiny edits would just generate merge-conflict risk).

## Test plan

- [x] 674/674 tests pass; typecheck clean
- [x] Renders in markdown previewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)