### PR TITLE
swarm: nx-affected-in-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,10 @@ jobs:
         run: pnpm exec nx run execution-kernel:build
 
       - name: Vitest (TS suites)
-        run: pnpm exec vitest run
+        run: pnpm exec nx affected -t test --base=origin/main
 
-      - name: Oxlint
-        run: pnpm exec oxlint . || true  # warnings only for phase-1
+      - name: Typecheck (Nx affected)
+        run: pnpm exec nx affected -t typecheck --base=origin/main
+
+      - name: Lint (Nx affected)
+        run: pnpm exec nx affected -t lint --base=origin/main || true  # warnings only for phase-1


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `nx-affected-in-ci`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-nx-affected-in-ci-1777754749776`

## Entry context

CI doesn't use `nx affected`. `nx.json` is configured with the
TypeScript plugin (typecheck / build targets), but `.github/workflows/
ci.yml` runs `pnpm exec vitest run` against EVERYTHING on every PR,
plus `go test ./...` on every PR. Docs-only PRs trigger full test
suites; the marginal CI cost compounds across the 30+ PRs we ship a
day.

Scope:

1. CI workflow: replace bare `pnpm exec vitest run` with
   `pnpm exec nx affected -t test --base=origin/main` (or with
   `nx run-many` if affected detection isn't worth the complexity
   on this size repo).
2. Same for typecheck + lint targets if Nx isn't already routing
   those.
3. Keep `go test ./...` as-is unless someone files a separate entry
   to add Nx-Go integration.
4. Verify on a docs-only PR: should skip TS test step entirely.

Trade-off: Nx affected requires correct project boundaries (which
this repo has via `nx.json` + `package.json` per package). The
cost is one PR with 80-ish LOC of CI changes; the gain is faster
CI on routine PRs and a real "Nx-shaped" workflow that matches the
nx.json config we already wrote.


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-nx-affected-in-ci-1777754749776`
Branch: `swarm/swarm-nx-affected-in-ci-1777754749776`
Head: `21c98a6f`
Diff: `1 file changed, 6 insertions(+), 3 deletions(-)`
Commits: 1