### PR TITLE
feat(swarm): implementor-side escalation + strategic harness roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # nx affected needs the base ref's history to compute the
+          # diff. GitHub's shallow checkout doesn't fetch origin/main,
+          # so without this `git diff origin/main HEAD` fails with
+          # "ambiguous argument 'origin/main'". fetch-depth: 0 fetches
+          # full history; standard nx repo setup uses this.
+          fetch-depth: 0
 
       - uses: ./.github/actions/observe
 

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -31,7 +31,7 @@ import { Connection, Client } from '@temporalio/client';
 import { ExecutionRequestSchema } from '@chitin/contracts';
 import type { DriverId, Tier } from '@chitin/contracts';
 import { execFileSync, execSync } from 'node:child_process';
-import { mkdirSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -194,31 +194,140 @@ async function findRunningSwarmWorkflow(client: Client): Promise<string | null> 
   return null;
 }
 
-function entryHasDispatchMarker(entryId: string): boolean {
-  const path = resolve(STATE_DIR, `${entryId}.json`);
-  return existsSync(path);
+// Implementor-side escalation: tier ladder mirrors review-graph's
+// R1→R2→R3→operator escalation. A failed dispatch (commits=0) gets
+// re-attempted at one tier higher; after exhausting T4, the marker
+// stays stuck and the operator picks up.
+//
+// The "junior dev" intuition: if a junior can't ship the work +
+// tests pass cleanly, escalate to senior. Don't throw away the
+// effort — but DO escalate before another junior tries the same
+// thing again.
+const TIER_LADDER: Tier[] = ['T0', 'T1', 'T2', 'T3', 'T4'];
+
+interface MarkerOutcome {
+  exit_code: number;
+  commits_added: number;
+  completed_at: string;
 }
 
-function writeDispatchMarker(entryId: string, workflowId: string, tier: Tier, driver: DriverId) {
+interface DispatchMarker {
+  entry_id: string;
+  workflow_id: string;
+  tier: Tier;
+  driver: DriverId;
+  dispatched_at: string;
+  /** Last completed result. Written by `recordDispatchOutcome` after
+   *  the workflow returns. Absent until then — caller must treat
+   *  marker-without-outcome as "still in flight, do not re-dispatch". */
+  last_result?: MarkerOutcome;
+  /** Tier ladder visited so far. The junior-dev escalation rule:
+   *  re-dispatch at the next-up tier, log every attempt. */
+  tier_attempts?: Tier[];
+}
+
+function readDispatchMarker(entryId: string): DispatchMarker | null {
+  const path = resolve(STATE_DIR, `${entryId}.json`);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as DispatchMarker;
+  } catch {
+    return null;
+  }
+}
+
+function entryHasDispatchMarker(entryId: string): boolean {
+  return readDispatchMarker(entryId) !== null;
+}
+
+function writeDispatchMarker(
+  entryId: string,
+  workflowId: string,
+  tier: Tier,
+  driver: DriverId,
+  prior?: DispatchMarker | null,
+) {
   mkdirSync(STATE_DIR, { recursive: true });
   const path = resolve(STATE_DIR, `${entryId}.json`);
-  writeFileSync(
-    path,
-    JSON.stringify(
-      {
-        entry_id: entryId,
-        workflow_id: workflowId,
-        tier,
-        driver,
-        dispatched_at: new Date().toISOString(),
-      },
-      null,
-      2,
-    ),
-  );
+  const tier_attempts: Tier[] = prior?.tier_attempts ?? (prior ? [prior.tier] : []);
+  if (!tier_attempts.includes(tier)) tier_attempts.push(tier);
+  const marker: DispatchMarker = {
+    entry_id: entryId,
+    workflow_id: workflowId,
+    tier,
+    driver,
+    dispatched_at: new Date().toISOString(),
+    tier_attempts,
+  };
+  writeFileSync(path, JSON.stringify(marker, null, 2));
 }
 
-function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
+/**
+ * Update the marker with the workflow's terminal outcome. Called
+ * after `handle.result()` returns. Idempotent re-writes are safe.
+ */
+function recordDispatchOutcome(
+  entryId: string,
+  result: { exit_code: number; commits_added: number },
+) {
+  const marker = readDispatchMarker(entryId);
+  if (!marker) return; // marker missing — don't synthesize one
+  marker.last_result = {
+    exit_code: result.exit_code,
+    commits_added: result.commits_added,
+    completed_at: new Date().toISOString(),
+  };
+  const path = resolve(STATE_DIR, `${entryId}.json`);
+  writeFileSync(path, JSON.stringify(marker, null, 2));
+}
+
+/**
+ * Implementor-side escalation rule. Reads the marker; decides
+ * whether the entry is re-dispatchable at a higher tier.
+ *
+ * Returns:
+ *   { kind: 'no-marker' }              — first dispatch, no escalation
+ *   { kind: 'in-flight' }              — workflow still running; skip
+ *   { kind: 'shipped' }                — commits made; chain handles it
+ *   { kind: 'exhausted' }              — last tier was T4; operator-only
+ *   { kind: 'escalate', nextTier: T }  — re-dispatch at nextTier
+ *
+ * The "shipped" case covers the user's "junior dev" point: if the
+ * agent committed work — even if tests then failed — the work is
+ * REAL, the reviewer chain catches the rest. Don't re-dispatch on
+ * top of an already-pushed branch.
+ */
+export function classifyDispatchEscalation(marker: DispatchMarker | null): {
+  kind: 'no-marker' | 'in-flight' | 'shipped' | 'exhausted' | 'escalate';
+  nextTier?: Tier;
+} {
+  if (!marker) return { kind: 'no-marker' };
+  if (!marker.last_result) return { kind: 'in-flight' };
+  if (marker.last_result.commits_added > 0) return { kind: 'shipped' };
+  // commits=0 → the work was lost. Escalate to the next-up tier.
+  const visited = new Set(marker.tier_attempts ?? [marker.tier]);
+  const lastTier = marker.tier_attempts?.[marker.tier_attempts.length - 1] ?? marker.tier;
+  const lastIdx = TIER_LADDER.indexOf(lastTier);
+  // Find the next tier we haven't tried; cap at T4.
+  for (let i = lastIdx + 1; i < TIER_LADDER.length; i++) {
+    const candidate = TIER_LADDER[i];
+    if (!visited.has(candidate)) return { kind: 'escalate', nextTier: candidate };
+  }
+  return { kind: 'exhausted' };
+}
+
+interface PickedEntry {
+  entry: BacklogEntry;
+  /** Tier to dispatch at. Equals entry.tier on first dispatch; one
+   *  step UP the ladder when re-dispatching after a commits=0 outcome
+   *  (junior-dev escalation rule). */
+  effectiveTier: Tier;
+  /** Prior marker, if escalating. Caller passes to writeDispatchMarker
+   *  so tier_attempts accumulates. */
+  priorMarker: DispatchMarker | null;
+}
+
+function pickEntryToDispatch(entries: BacklogEntry[]): PickedEntry | null {
   // One fetch per tick — entryHasOriginBranch reads cached refs after
   // this. Without the hoist, an N-entry × K-blocker scan would do N×K
   // network round trips per tick.
@@ -243,13 +352,32 @@ function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
       log('info', 'skip entry: swarm/<id> branch exists on origin', { entry_id: entry.id });
       continue;
     }
-    if (entryHasDispatchMarker(entry.id)) {
-      log('info', 'skip entry: dispatch marker present (operator must rm to retry)', {
+
+    // Implementor-side escalation: read the marker, decide whether
+    // a prior failed run is re-dispatchable at a higher tier.
+    const marker = readDispatchMarker(entry.id);
+    const escalation = classifyDispatchEscalation(marker);
+    if (escalation.kind === 'in-flight') {
+      log('info', 'skip entry: dispatch marker present, last run still in flight', {
         entry_id: entry.id,
-        marker: resolve(STATE_DIR, `${entry.id}.json`),
       });
       continue;
     }
+    if (escalation.kind === 'shipped') {
+      log('info', 'skip entry: prior run committed work — review chain handles the rest', {
+        entry_id: entry.id,
+        commits: marker?.last_result?.commits_added,
+      });
+      continue;
+    }
+    if (escalation.kind === 'exhausted') {
+      log('info', 'skip entry: tier ladder exhausted (T4 attempted) — operator-only now', {
+        entry_id: entry.id,
+        tier_attempts: marker?.tier_attempts,
+      });
+      continue;
+    }
+
     const unmetBlocker = findUnmetBlocker(entry, entryHasOriginBranch);
     if (unmetBlocker !== undefined) {
       log('info', 'skip entry: blocked-by', {
@@ -258,7 +386,19 @@ function pickEntryToDispatch(entries: BacklogEntry[]): BacklogEntry | null {
       });
       continue;
     }
-    return entry;
+
+    let effectiveTier = entry.tier as Tier;
+    if (escalation.kind === 'escalate' && escalation.nextTier) {
+      effectiveTier = escalation.nextTier;
+      log('info', 'escalating entry to next tier (prior run produced no commits)', {
+        entry_id: entry.id,
+        prior_tier: marker?.tier,
+        next_tier: effectiveTier,
+        tier_attempts: marker?.tier_attempts,
+      });
+    }
+
+    return { entry, effectiveTier, priorMarker: marker };
   }
   return null;
 }
@@ -377,13 +517,14 @@ async function main() {
     }
 
     const entries = parseBacklog(BACKLOG_PATH);
-    const entry = pickEntryToDispatch(entries);
-    if (!entry) {
+    const picked = pickEntryToDispatch(entries);
+    if (!picked) {
       log('info', 'no ready entry to dispatch this tick');
       await notifyTickIdle('no ready entry to dispatch');
       return;
     }
-    const tier = entry.tier as Tier;
+    const { entry, effectiveTier, priorMarker } = picked;
+    const tier = effectiveTier;
     const driver = TIER_DRIVER[tier];
     const wallTimeout = TIER_WALL_TIMEOUT_S[tier];
     const maxToolCalls = TIER_MAX_TOOL_CALLS[tier];
@@ -430,10 +571,12 @@ async function main() {
     });
 
     // Write the marker BEFORE submit. If submit fails, marker still
-    // present → operator's intent is "this entry was attempted; don't
-    // auto-retry." Manual rm to retry. This is intentionally pessimistic:
-    // the swarm doesn't quietly retry without operator review.
-    writeDispatchMarker(entry.id, workflowId, tier, driver);
+    // present → next tick reads it via the escalation classifier.
+    // The new escalation logic supersedes the previous "operator must
+    // rm to retry" rule: a failed dispatch (commits=0) auto-escalates
+    // one tier up; only T4-exhausted entries stay stuck for operator
+    // pickup. priorMarker carries the tier_attempts ladder forward.
+    writeDispatchMarker(entry.id, workflowId, tier, driver, priorMarker);
 
     let handle;
     try {
@@ -459,8 +602,19 @@ async function main() {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await notifyDispatchError({ entry_id: entry.id, workflow_id: workflowId, stage: 'workflow', error: msg });
+      // Record outcome so the next tick's escalation classifier knows
+      // the run terminated. exit_code=-1 + commits=0 is the SIGKILL
+      // signature; commits=0 alone signals re-dispatchable.
+      recordDispatchOutcome(entry.id, { exit_code: -1, commits_added: 0 });
       throw err;
     }
+    // Record terminal outcome on the marker so the next dispatcher
+    // tick's escalation classifier sees commits=N and decides shipped/
+    // re-dispatch correctly.
+    recordDispatchOutcome(entry.id, {
+      exit_code: result.exit_code,
+      commits_added: result.worktree?.commits_added ?? 0,
+    });
     mkdirSync(TMP_DIR, { recursive: true });
     const envelopePath = resolve(TMP_DIR, `result-${workflowId}.json`);
     writeFileSync(

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -55,7 +55,14 @@ ${lessonsBlock}
 ENTRY ID: ${entry.id}
 TARGET FILE: ${targetFile}
 
-YOUR FIRST ACTION: dispatch the \`read\` tool on ${targetFile}. Do not respond with text first. Read the file, understand the change required, then dispatch \`edit\` or \`write\` to make the change. Run \`exec\` if tests are needed. Finally dispatch \`exec\` with a git command to commit your work (e.g., git add -A && git commit -m "..."), so the apply pipeline can push the branch.
+WORKFLOW (in order):
+
+1. \`read\` ${targetFile}. Understand the change required.
+2. \`edit\` or \`write\` to make the change.
+3. **Commit immediately**: \`exec\` with \`git add -A && git commit -m "<entry-id>: one-line summary"\`. Commit your work BEFORE running tests. The apply pipeline only pushes committed work; uncommitted changes are dropped.
+4. (Optional) \`exec\` to run tests. Test failures are diagnostic — they go in your stdout for the reviewer to inspect, NOT a reason to discard your work. If tests fail, you may attempt a fix-up commit, but do not exit without at least one commit.
+
+If you finish without committing, the work is lost. If tests fail after your commit, that's a signal for the reviewer chain — your job is to produce work the reviewer can evaluate, not to ship perfectly-tested work in one shot. The review-graph (R1→R2→R3) catches what you couldn't.
 
 ENTRY DETAIL (frontmatter + description):
 ${entry.description}
@@ -66,7 +73,7 @@ CONSTRAINTS:
 - Forbid editing files not named in the entry's \`file\` field, and instruct the agent to \`read\` ONLY the target file before editing.
 - If you decide the entry is misclassified or requires human judgment, exit without committing — empty worktrees are not pushed.
 
-REMEMBER: chat replies do nothing. Tool calls are the only thing that produces work. Start by reading ${targetFile} now.`;
+REMEMBER: chat replies do nothing. Tool calls are the only thing that produces work. Commit BEFORE testing. Start by reading ${targetFile} now.`;
 }
 
 // Researcher prompt for the BacklogEntry path. The richer runner-level

--- a/apps/temporal-worker/test/dispatcher-escalation.test.ts
+++ b/apps/temporal-worker/test/dispatcher-escalation.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { classifyDispatchEscalation } from '../src/dispatcher.ts';
+import type { DriverId, Tier } from '@chitin/contracts';
+
+interface MarkerOutcome {
+  exit_code: number;
+  commits_added: number;
+  completed_at: string;
+}
+
+interface DispatchMarker {
+  entry_id: string;
+  workflow_id: string;
+  tier: Tier;
+  driver: DriverId;
+  dispatched_at: string;
+  last_result?: MarkerOutcome;
+  tier_attempts?: Tier[];
+}
+
+function makeMarker(overrides: Partial<DispatchMarker> = {}): DispatchMarker {
+  return {
+    entry_id: 'sample',
+    workflow_id: 'swarm-sample-1',
+    tier: 'T1',
+    driver: 'copilot',
+    dispatched_at: '2026-05-02T18:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeOutcome(overrides: Partial<MarkerOutcome> = {}): MarkerOutcome {
+  return { exit_code: 0, commits_added: 1, completed_at: '2026-05-02T18:05:00Z', ...overrides };
+}
+
+// ─── No marker ───────────────────────────────────────────────────────────
+
+describe('classifyDispatchEscalation — no marker', () => {
+  it('returns no-marker when marker is null (first dispatch)', () => {
+    expect(classifyDispatchEscalation(null)).toEqual({ kind: 'no-marker' });
+  });
+});
+
+// ─── In-flight ───────────────────────────────────────────────────────────
+
+describe('classifyDispatchEscalation — in-flight', () => {
+  it('returns in-flight when marker exists but last_result is missing', () => {
+    expect(classifyDispatchEscalation(makeMarker())).toEqual({ kind: 'in-flight' });
+  });
+});
+
+// ─── Shipped ─────────────────────────────────────────────────────────────
+
+describe('classifyDispatchEscalation — shipped', () => {
+  it('returns shipped when commits_added > 0 (work landed; chain handles rest)', () => {
+    expect(
+      classifyDispatchEscalation(makeMarker({ last_result: makeOutcome({ commits_added: 1 }) })),
+    ).toEqual({ kind: 'shipped' });
+  });
+
+  it('returns shipped even when exit_code != 0 — commits trump exit code', () => {
+    // The "junior dev committed code, then tests failed" case. The work
+    // is real; reviewer chain catches the test failure.
+    expect(
+      classifyDispatchEscalation(
+        makeMarker({ last_result: makeOutcome({ exit_code: 1, commits_added: 2 }) }),
+      ),
+    ).toEqual({ kind: 'shipped' });
+  });
+});
+
+// ─── Escalate ────────────────────────────────────────────────────────────
+
+describe('classifyDispatchEscalation — escalate', () => {
+  it('escalates T1 → T2 when commits=0 and only T1 attempted', () => {
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T1',
+        last_result: makeOutcome({ exit_code: 1, commits_added: 0 }),
+      }),
+    );
+    expect(r).toEqual({ kind: 'escalate', nextTier: 'T2' });
+  });
+
+  it('escalates T2 → T3 when prior tier_attempts is [T1, T2]', () => {
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T2',
+        tier_attempts: ['T1', 'T2'],
+        last_result: makeOutcome({ commits_added: 0 }),
+      }),
+    );
+    expect(r).toEqual({ kind: 'escalate', nextTier: 'T3' });
+  });
+
+  it('escalates on SIGKILL outcome (exit_code=-1) when commits=0', () => {
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T1',
+        last_result: makeOutcome({ exit_code: -1, commits_added: 0 }),
+      }),
+    );
+    expect(r).toEqual({ kind: 'escalate', nextTier: 'T2' });
+  });
+
+  it('skips already-tried tiers when picking next (e.g., T1, T3 tried → next is T2 NOT T2 again)', () => {
+    // Edge case: tier_attempts is non-monotonic. Should pick the lowest
+    // un-tried tier above the most recent one.
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T3',
+        tier_attempts: ['T1', 'T3'],
+        last_result: makeOutcome({ commits_added: 0 }),
+      }),
+    );
+    // After T3, the next-up un-tried tier is T4.
+    expect(r).toEqual({ kind: 'escalate', nextTier: 'T4' });
+  });
+});
+
+// ─── Exhausted ───────────────────────────────────────────────────────────
+
+describe('classifyDispatchEscalation — exhausted', () => {
+  it('returns exhausted after T4 was the last attempt + still no commits', () => {
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T4',
+        tier_attempts: ['T1', 'T2', 'T3', 'T4'],
+        last_result: makeOutcome({ commits_added: 0 }),
+      }),
+    );
+    expect(r).toEqual({ kind: 'exhausted' });
+  });
+
+  it('returns exhausted when every tier was visited (operator-only now)', () => {
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T4',
+        tier_attempts: ['T0', 'T1', 'T2', 'T3', 'T4'],
+        last_result: makeOutcome({ commits_added: 0 }),
+      }),
+    );
+    expect(r).toEqual({ kind: 'exhausted' });
+  });
+});
+
+// ─── Sanity ───────────────────────────────────────────────────────────────
+
+describe('classifyDispatchEscalation — sanity', () => {
+  it("never returns escalate when commits > 0", () => {
+    // Determinism: shipped trumps escalation regardless of tier ladder.
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T1',
+        tier_attempts: ['T1'],
+        last_result: makeOutcome({ exit_code: 1, commits_added: 1 }),
+      }),
+    );
+    expect(r.kind).toBe('shipped');
+  });
+
+  it('treats tier as the marker.tier when tier_attempts is missing (legacy markers)', () => {
+    // Markers from before the escalation feature have no tier_attempts;
+    // we should still classify them via marker.tier.
+    const r = classifyDispatchEscalation(
+      makeMarker({
+        tier: 'T2',
+        tier_attempts: undefined,
+        last_result: makeOutcome({ commits_added: 0 }),
+      }),
+    );
+    expect(r).toEqual({ kind: 'escalate', nextTier: 'T3' });
+  });
+});

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -2061,3 +2061,90 @@ Operator action item: the dispatcher's branch + marker checks already
 keep these from re-dispatching. If you want a clean visual scan of
 "what's left", filter the file by `status: ready` lines that are NOT
 in the table above.
+
+## Strategic roadmap entries (filed 2026-05-02)
+
+These are not bite-sized backlog entries — they're substrate-level
+investments where the OUTCOME is "lower-tier agents succeed at tasks
+they'd otherwise need higher-tier (more expensive) agents for." The
+positioning bet: chitin's edge isn't smarter agents, it's a better
+HARNESS that makes cheaper agents succeed. Devin and Cursor make the
+agent better. Chitin makes the substrate better — the determinism,
+the tools, the memory, the recipes — so a copilot-tier agent solves
+problems an Opus-tier agent used to need.
+
+Each entry below is a roadmap seed: it should be groomed into smaller
+scopes before the swarm can claim them.
+
+### `agent-harness-substrate-roadmap`
+
+```yaml
+id: agent-harness-substrate-roadmap
+tier: T5
+status: in_design
+estimated_loc: TBD
+blocks: []
+file: TBD (multiple — substrate-level work spans apps/, libs/, kernel)
+references_design: docs/design/2026-05-02-swarm-as-software-factory.md (positioning) + this commit's PR description
+role: architect
+```
+
+The strategic roadmap for "make lower-tier agents win." The
+operating bet: success rate of a tier-N agent is dominated by
+the harness it has, not the model. Concrete substrates worth
+investing in (each becomes its own scope-down entry once an
+architect prioritizes):
+
+1. **Pre-canned recipe library** (extending `analysis.investigate`)
+   - The analyst recipe pattern (#164) generalizes. Every role can
+     have a recipe library: `qa.replay-failed-test`,
+     `architect.draft-adr-from-entry`, `groomer.classify-tier`,
+     `programmer.scaffold-test-file`. Same shape: deterministic CLI,
+     structured emit, agent reports the result. The agent's job
+     collapses from "figure out what to do" to "pick the right
+     recipe and run it."
+
+2. **Shared memory layer** (ClaudeMem-shape OR a chitin-native
+   equivalent)
+   - Today the only cross-run memory is `swarm-lessons.md` (text
+     prepended to programmer prompts). That's lossy + LLM-distilled.
+     A typed memory store (key-value or vector or graph) lets:
+     - Reviewers cite past similar bugs by id
+     - Programmers retrieve the EXACT prior diff that matched the
+       current entry's pattern
+     - Analysts reuse cached analysis results within a window
+   - Open question: build it OR adopt? ClaudeMem exists but coupling
+     chitin to it has lock-in risk. A chitin-native event-chain-
+     backed memory might be the right substrate (the chain is
+     already a memory; the missing piece is the typed retrieval API).
+
+3. **MCP tool servers for the swarm's own workflows**
+   - Right now agents have shell + edit + read. They could have
+     typed MCP tools: `chitin.entry.read("<id>")`,
+     `chitin.lesson.cite("<lesson-id>")`,
+     `chitin.recipe.run("analyst.investigate", {...})`,
+     `chitin.gov.gate.test(<command>)`. Typed tools turn the
+     agent's prompt from "figure out the right shell command" into
+     "call the typed function." Determinism goes up, success rate
+     goes up.
+
+4. **Better entry shape**
+   - Today `BacklogEntry` is mostly free-form prose under a yaml
+     header. Higher-determinism shape would include:
+     `acceptance_criteria: ["test X passes", "no rule rendered changes"]`,
+     `read_first: ["./apps/foo.ts", "./docs/design/..."]`,
+     `prompt_examples: ["see how it was done in #142"]`. Closer to
+     a Lobster-style YAML-first task definition.
+
+5. **Implementor-side escalation telemetry**
+   - The escalation feature shipped in this PR fires re-dispatch on
+     commits=0. We need an observation pass after some soak: which
+     entries are NEVER cleared by escalation? Those are the entries
+     where ALL tiers (T1-T4) fail — meaning the entry itself is
+     malformed, not the agent. The pattern matters: groomers should
+     learn to spot those entry shapes before dispatch.
+
+The architect role (when shipped) is the right home for this entry.
+Operator: when picking up, decompose into 5+ T1-T2 scope-down
+entries with concrete files + LOC estimates. Each substrate piece
+ships independently; the "substrate" is the union, not a monolith.


### PR DESCRIPTION
## Summary

Two halves: the immediate tactical fix that mirrors the review-graph's R1→R2→R3→operator pattern on the implementor side, plus the strategic seed for the substrate work.

### Tactical — implementor-side escalation

Failed dispatch (commits=0) auto-escalates one tier up instead of leaving the marker stuck forever:

- **Programmer prompt** reordered: \`read → edit → commit → (optional) test\`. Commit is #3 of 4 now, BEFORE tests. Test failures are diagnostic for the reviewer chain, not a reason to discard work.
- **Marker outcome tracking**: after \`handle.result()\` returns (or throws on SIGKILL), marker gets \`last_result: {exit_code, commits_added}\`.
- **\`classifyDispatchEscalation\`** (pure, exported, table-tested): \`no-marker\` / \`in-flight\` / \`shipped\` (commits>0 trumps exit code) / \`escalate\` (next tier) / \`exhausted\` (T4-saturated).
- **Dispatcher wiring**: re-dispatch fires at the escalated tier; \`tier_attempts\` ladder accumulates in the marker.

### Strategic — \`agent-harness-substrate-roadmap\` (T5 in_design)

Captures Jared's positioning bet: chitin's edge isn't smarter agents, it's a better HARNESS that makes cheaper agents succeed. Five sub-areas seeded:
1. Pre-canned recipe library (analyst-investigate generalized)
2. Shared memory layer (ClaudeMem-shape OR chitin-native)
3. MCP tool servers for swarm-internal workflows
4. Better entry shape (Lobster-style YAML-first acceptance_criteria)
5. Implementor-side escalation telemetry (observation pass)

## Test plan

- [x] 12 new tests covering every classifier kind; 549/549 in temporal-worker
- [x] Typecheck clean
- [ ] After merge: worker restart picks up the new code; first failed dispatch will exercise the escalation path

🤖 Generated with [Claude Code](https://claude.com/claude-code)