### PR TITLE
fix(f4): three OTEL emit bugs from PR #71's adversarial review

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -2148,3 +2148,70 @@ The architect role (when shipped) is the right home for this entry.
 Operator: when picking up, decompose into 5+ T1-T2 scope-down
 entries with concrete files + LOC estimates. Each substrate piece
 ships independently; the "substrate" is the union, not a monolith.
+
+### `agent-identification-fingerprinting-v2`
+
+```yaml
+id: agent-identification-fingerprinting-v2
+tier: T3
+status: in_design
+estimated_loc: TBD
+blocks: []
+file: TBD (libs/adapters/claude-code/src/hook-context.ts, go/execution-kernel/internal/event/event.go, plus copilot + openclaw adapters)
+references_design: docs/event-model.md (existing fingerprint surface) + GitHub issue #9
+role: architect
+```
+
+The current fingerprinting surface is plumbed but shallow. Real
+"this agent uniquely identifies as <X> with capabilities <Y>" doesn't
+exist yet, which limits:
+
+- **Per-agent telemetry slicing** — today every claude-code hook produces
+  the same `agent_fingerprint` regardless of model / token budget /
+  extension surface. Can't slice success rates by agent capability.
+- **Cross-session continuity** — `agent_instance_id` is `randomUUID()`
+  per HOOK CALL. Same Claude Code session emits dozens of different
+  instance IDs. Should be stable per-session at minimum.
+- **Provenance audit** — auto-merge gates can't prove "this PR was
+  produced by an agent with capability set X" because the fingerprint
+  doesn't encode the capability surface.
+
+Today's surface (verbatim from `libs/adapters/claude-code/src/hook-context.ts`):
+- `machine_fingerprint = sha256(hostname + uid + 'chitin-machine-fingerprint-v2')`
+  — partially-stable but doesn't use systemd machine-id (issue #9
+  names this exact gap).
+- `agent_fingerprint = sha256({surface, machine, version})` — same value
+  for every claude-code hook on this machine; useless for slicing.
+- `agent_instance_id = randomUUID()` — fresh every hook.
+
+What v2 should look like:
+
+1. **Stable machine_fingerprint** — derive from `/etc/machine-id`
+   (Linux) or `system_profiler` UUID (mac); fallback to current
+   sha256 only when the canonical source is missing. Closes issue #9.
+
+2. **Capability-encoding agent_fingerprint** — sha256 of:
+   ```
+   {surface, model_name, model_version, allowed_tools[], extension_pack[],
+    chitin_kernel_version}
+   ```
+   Stable across runs of "the same configured agent"; differs when
+   any capability dimension changes.
+
+3. **Session-stable agent_instance_id** — first hook in a session
+   generates the UUID; subsequent hooks read it from session_state.json
+   (already exists in `<repo>/.chitin/`) instead of generating fresh.
+
+4. **OTEL projection update** — the F4 projector adds
+   `agent.fingerprint` and `machine.fingerprint` attributes (currently
+   only `agent.id`). Required for downstream observability tools
+   (mission-control etc.) to slice by fingerprint.
+
+5. **Cross-surface parity** — copilot-cli + openclaw adapters need
+   the same logic. Today only claude-code is wired; the others
+   inherit empty fingerprint fields.
+
+Why T3: capability-encoding requires reading model metadata from
+each driver (claude-code, copilot, openclaw) — non-trivial cross-
+surface work. Decompose into per-surface entries when an architect
+prioritizes.

--- a/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/emit"
@@ -85,7 +86,19 @@ func (e *decisionEmitter) emitDecision(d *gov.Decision) {
 // payload carries the fields F4's projectToSpan can pick up (decision,
 // tool.name via action_type) plus the audit-relevant fields (rule_id,
 // reason, suggestion, corrected_command).
+//
+// Closes issue #75: stamps a defensive ts when d.Ts is empty (zero-
+// value Decision OR a code path that forgot to stamp). The chain JSONL
+// can't be retroactively patched, so the only safe move is to write
+// SOMETHING here — the event timestamps the moment we wrote it, which
+// is correct-modulo-the-bug-that-caused-Ts-to-be-empty. Without this,
+// the event lands on the chain with ts="" and silently drops at OTEL
+// projection time.
 func buildDecisionEvent(d *gov.Decision, chainID, surface string) *event.Event {
+	ts := d.Ts
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339Nano)
+	}
 	decisionStr := "allow"
 	if !d.Allowed {
 		decisionStr = "deny"
@@ -127,7 +140,7 @@ func buildDecisionEvent(d *gov.Decision, chainID, surface string) *event.Event {
 		EventType:       "decision",
 		ChainID:         chainID,
 		ChainType:       "session",
-		Ts:              d.Ts,
+		Ts:              ts,
 		Labels:          map[string]string{},
 		Payload:         payloadJSON,
 	}

--- a/go/execution-kernel/internal/emit/otel.go
+++ b/go/execution-kernel/internal/emit/otel.go
@@ -49,6 +49,19 @@ func newOTELExporter() *otelExporter {
 	}
 }
 
+// allowedEventTypes is the F4 v1 scope set per the spec. Other event
+// types still write to the canonical chain (which is authoritative);
+// they just don't project to OTEL until the spec extends. Closes
+// issue #72: emitting `assistant_turn`, `compaction`, `intended_*`,
+// etc. as spans was unintended scope creep + would surprise downstream
+// OTEL consumers expecting only the 4 documented types.
+var allowedEventTypes = map[string]bool{
+	"session_start":  true,
+	"pre_tool_use":   true,
+	"decision":       true,
+	"post_tool_use":  true,
+}
+
 // ProjectAndPost projects ev to a span and POSTs it to the configured collector.
 // Errors are logged and dropped — never propagated to the kernel write path.
 // Safe to call when x is nil (no-op).
@@ -59,8 +72,17 @@ func newOTELExporter() *otelExporter {
 // chain commit preserves the failure invariant — chain state is durable before
 // the network call begins. Latency cost: one round-trip per emit, capped at
 // 2s by the http.Client timeout. v2 (daemon-mode kernel) can revisit async.
+//
+// Event-type filter: only the 4 in-scope F4 v1 event types project. Other
+// types are silently skipped (they're still on the canonical chain). See
+// allowedEventTypes for the set; extend the spec + this map together when
+// the OTEL surface grows.
 func (x *otelExporter) ProjectAndPost(ev *event.Event, idx *chain.Index) {
 	if x == nil {
+		return
+	}
+	if !allowedEventTypes[ev.EventType] {
+		// Out-of-scope event type. Chain still has it; OTEL doesn't.
 		return
 	}
 	span, err := projectToSpan(ev, idx)
@@ -83,9 +105,19 @@ func (x *otelExporter) ProjectAndPost(ev *event.Event, idx *chain.Index) {
 // projectToSpan maps a canonical event onto an OTLP/HTTP JSON span.
 // Caller is responsible for ev being non-nil.
 func projectToSpan(ev *event.Event, idx *chain.Index) (otlpSpan, error) {
+	traceID := traceIDFromChainID(ev.ChainID)
+	if traceID == "" {
+		return otlpSpan{}, fmt.Errorf("invalid chain_id for traceId: %q (must produce 32 hex chars)", ev.ChainID)
+	}
 	parent, err := parentSpanID(ev, idx)
 	if err != nil {
 		return otlpSpan{}, fmt.Errorf("parent span id: %w", err)
+	}
+	if ev.Ts == "" {
+		// Closes issue #75: an empty Ts upstream silently dropped the
+		// span via the time.Parse error. Now: explicit error so the
+		// log line names the missing field rather than the parse fail.
+		return otlpSpan{}, fmt.Errorf("event has empty ts (this_hash=%s, type=%s)", ev.ThisHash, ev.EventType)
 	}
 	nano, err := tsToUnixNano(ev.Ts)
 	if err != nil {
@@ -117,7 +149,7 @@ func projectToSpan(ev *event.Event, idx *chain.Index) (otlpSpan, error) {
 	}
 
 	return otlpSpan{
-		TraceID:           traceIDFromChainID(ev.ChainID),
+		TraceID:           traceID,
 		SpanID:            spanIDFromHash(ev.ThisHash),
 		ParentSpanID:      parent,
 		Name:              ev.EventType,
@@ -149,9 +181,30 @@ func parentSpanID(ev *event.Event, idx *chain.Index) (string, error) {
 }
 
 // traceIDFromChainID encodes a UUID chain_id as a 32-hex-char traceId by
-// stripping hyphens. OTLP/HTTP JSON traceId is a case-insensitive hex string.
+// stripping hyphens. OTLP/HTTP+JSON traceId MUST be exactly 32 lowercase
+// hex chars (16 bytes). Returns empty string when input doesn't conform —
+// caller treats empty as "skip projection" rather than emitting a malformed
+// span.
+//
+// Closes issue #73: the prior implementation accepted any input and
+// emitted whatever-it-stripped as the traceId, silently corrupting OTLP
+// payloads when chain_ids weren't UUID-shape (e.g., the SP-2
+// `otel:<trace>:<span>:` chain_ids that flow through here from openclaw
+// ingestion). Validation prevents the bad-data-leaks-into-spans class.
 func traceIDFromChainID(id string) string {
-	return strings.ReplaceAll(id, "-", "")
+	stripped := strings.ReplaceAll(id, "-", "")
+	if len(stripped) != 32 {
+		return ""
+	}
+	for i := 0; i < len(stripped); i++ {
+		c := stripped[i]
+		isLowerHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+		isUpperHex := c >= 'A' && c <= 'F'
+		if !isLowerHex && !isUpperHex {
+			return ""
+		}
+	}
+	return strings.ToLower(stripped)
 }
 
 // spanIDFromHash takes the first 16 hex chars of a SHA-256 chain hash.

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
@@ -437,3 +438,101 @@ func TestKernelSurvivesOTELFailure(t *testing.T) {
 		t.Errorf("chain index not updated: %+v want seq=0 hash=%q", info, ev.ThisHash)
 	}
 }
+
+// ─── Fixes for issues #72 / #73 / #75 (PR #170) ────────────────────────
+
+// TestProjectAndPost_FiltersOutOfScopeEventTypes pins the F4 v1 scope
+// (issue #72): events outside the 4-type allowlist (session_start,
+// pre_tool_use, decision, post_tool_use) MUST NOT project to OTEL spans.
+// Chain still has them; OTEL doesnt.
+func TestProjectAndPost_FiltersOutOfScopeEventTypes(t *testing.T) {
+	idx := openTestIndex(t)
+	hits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	x := &otelExporter{endpoint: server.URL, client: &http.Client{Timeout: 2 * time.Second}}
+
+	for _, et := range []string{"assistant_turn", "compaction", "session_end", "user_prompt", "intended_tool_use", "post_compact"} {
+		ev := &event.Event{
+			EventType: et, ChainID: "550e8400-e29b-41d4-a716-446655440000", ThisHash: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			AgentInstanceID: "agent-1", Ts: "2026-04-30T01:39:37.647Z",
+			Payload: json.RawMessage(`{}`),
+		}
+		x.ProjectAndPost(ev, idx)
+	}
+	if hits != 0 {
+		t.Fatalf("out-of-scope event types projected to OTEL: got %d hits, want 0", hits)
+	}
+}
+
+// TestTraceIDFromChainID_ValidationRules pins the OTLP traceId format
+// requirement (issue #73): exactly 32 lowercase hex chars after stripping
+// hyphens. Anything else returns "" — caller treats empty as drop.
+func TestTraceIDFromChainID_ValidationRules(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"valid uuid", "550e8400-e29b-41d4-a716-446655440000", "550e8400e29b41d4a716446655440000"},
+		{"valid uuid uppercase normalized", "550E8400-E29B-41D4-A716-446655440000", "550e8400e29b41d4a716446655440000"},
+		{"sp2 otel chain_id rejected", "otel:01010101010101010101010101010101:0101010101010101", ""},
+		{"too short rejected", "abc-def", ""},
+		{"non-hex rejected", "zzzzzzzz-e29b-41d4-a716-446655440000", ""},
+		{"empty rejected", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := traceIDFromChainID(tc.in)
+			if got != tc.want {
+				t.Errorf("traceIDFromChainID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProjectToSpan_RejectsEmptyTs pins the empty-ts guard (issue #75).
+// Decision events with empty Ts must error explicitly so the log line
+// names the missing field.
+func TestProjectToSpan_RejectsEmptyTs(t *testing.T) {
+	idx := openTestIndex(t)
+	ev := &event.Event{
+		EventType: "decision", ChainID: "550e8400-e29b-41d4-a716-446655440000",
+		ThisHash: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		AgentInstanceID: "agent-1", Ts: "", // EMPTY
+		Payload: json.RawMessage(`{}`),
+	}
+	_, err := projectToSpan(ev, idx)
+	if err == nil {
+		t.Fatalf("expected error for empty ts, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty ts") {
+		t.Errorf("error should name empty ts: %v", err)
+	}
+}
+
+// TestProjectToSpan_RejectsInvalidChainID pins the trace-id validation
+// (issue #73 at the projector level): the new validation in
+// traceIDFromChainID returns "" for non-UUID input; projectToSpan must
+// surface that as an explicit error.
+func TestProjectToSpan_RejectsInvalidChainID(t *testing.T) {
+	idx := openTestIndex(t)
+	ev := &event.Event{
+		EventType: "session_start", ChainID: "otel:01010101010101010101010101010101:0101",
+		ThisHash: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		AgentInstanceID: "agent-1", Ts: "2026-04-30T01:39:37.647Z",
+		Payload: json.RawMessage(`{}`),
+	}
+	_, err := projectToSpan(ev, idx)
+	if err == nil {
+		t.Fatalf("expected error for non-UUID chain_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid chain_id") {
+		t.Errorf("error should name chain_id: %v", err)
+	}
+}
+


### PR DESCRIPTION
Closes:
- #72 ProjectAndPost emits every event_type, not just the 4 in scope
- #73 traceIDFromChainID accepts non-UUID input → malformed traceIds
- #75 empty decision.Ts silently drops OTEL projection

Verified each against shipped \`otel.go\` + \`gate_emit.go\` before fixing.

**Fixes:**
1. \`allowedEventTypes\` allowlist; out-of-scope events early-return (chain still has them, OTEL doesn't)
2. \`traceIDFromChainID\` returns \"\" for non-32-hex input; projectToSpan surfaces as explicit error
3. \`buildDecisionEvent\` defensively stamps \`time.Now()\` when \`d.Ts\` empty; projectToSpan errors explicitly on empty Ts

Plus filed **\`agent-identification-fingerprinting-v2\`** as in_design backlog entry — captures Jared's parallel ask: current fingerprinting (machine_fingerprint, agent_fingerprint, agent_instance_id) is plumbed but shallow.

## Test plan

- [x] \`go test ./...\` clean across the kernel
- [x] 4 new tests pin each fix
- [ ] After merge: live OTEL emit will only project the 4 in-scope event types; SP-2 chain_ids no longer corrupt payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)