### PR TITLE
fix(normalize): map modern Claude Code tools to closed-enum actions

### DIFF
--- a/go/execution-kernel/internal/driver/claudecode/normalize.go
+++ b/go/execution-kernel/internal/driver/claudecode/normalize.go
@@ -31,11 +31,36 @@ func SetWarnSink(w io.Writer) { warnSink = w }
 //	Edit, Write, NotebookEdit           → file.write
 //	Read                                → file.read
 //	WebFetch, WebSearch                 → http.request
-//	Task                                → delegate.task
+//	Task, Agent, Skill                  → delegate.task (subagent dispatch
+//	                                      + skill invocation are the same
+//	                                      shape: cede a tool budget to a
+//	                                      subordinate agent)
+//	TaskCreate, TaskUpdate              → file.write target="task-state"
+//	TaskGet, TaskList, TaskOutput,
+//	  ToolSearch, AskUserQuestion       → file.read (browse-shape; no
+//	                                      external side effect)
+//	TaskStop                            → delegate.task (terminating an
+//	                                      earlier delegation; same shape)
+//	Monitor                             → shell.exec (spawns subprocess)
+//	EnterPlanMode, ExitPlanMode         → file.read (mode toggle, no side
+//	                                      effect on the host)
+//	EnterWorktree, ExitWorktree         → git.worktree.add / .remove
+//	PushNotification, RemoteTrigger     → http.request (external send)
+//	CronCreate                          → file.write target="cron"
+//	CronDelete                          → file.delete target="cron"
+//	CronList, ScheduleWakeup            → file.read / file.write (schedule
+//	                                      state change is write-shape)
 //	Glob, Grep, LS                      → file.read (browse-shaped, default-allow)
 //	TodoWrite                           → file.write target="todo"
 //	                                      (matches existing gov.Normalize convention)
 //	<unknown>                           → ActUnknown (fail-closed at policy)
+//
+// Issue #69: closed-enum coverage gap. Pre-fix, modern Claude Code
+// tools (Agent, Skill, TaskCreate-family, etc.) all fell to ActUnknown
+// → fail-closed → blocked under enforce mode, forcing operators to
+// monitor mode globally. Now each name has a deliberate mapping; new
+// tools added by Anthropic still hit ActUnknown (correct fail-closed
+// behavior), but the common ones don't surprise the operator.
 //
 // The Glob/Grep/LS/TodoWrite resolution follows the plan's leaning
 // recommendation: read-shaped browse tools default-allow rather than
@@ -88,17 +113,128 @@ func Normalize(in HookInput) (gov.Action, error) {
 			Path:   in.Cwd,
 		}, nil
 
-	case "Task":
-		// Task = subagent delegation. Use the description (human-readable
-		// goal) as the Target since policy rules and audit-log readers
-		// want the intent, not the verbose subagent_type or prompt.
+	case "Task", "Agent", "Skill":
+		// Subagent delegation OR skill invocation. Both cede a tool
+		// budget to a subordinate agent — same policy shape. Target
+		// is the human-readable intent (description / subagent_type /
+		// skill name) so audit-log readers see what the agent meant
+		// to do, not the verbose prompt.
 		target := stringField(in.ToolInput, "description")
 		if target == "" {
 			target = stringField(in.ToolInput, "subagent_type")
 		}
+		if target == "" {
+			target = stringField(in.ToolInput, "skill")
+		}
 		return gov.Action{
 			Type:   gov.ActDelegateTask,
 			Target: target,
+			Path:   in.Cwd,
+		}, nil
+
+	case "TaskStop":
+		// Terminating an earlier delegation — same delegate-task
+		// policy shape. Target is the task id being stopped.
+		return gov.Action{
+			Type:   gov.ActDelegateTask,
+			Target: stringField(in.ToolInput, "task_id"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "TaskCreate", "TaskUpdate":
+		// Mutate a task-list entry. file.write target="task-state"
+		// matches the convention TodoWrite uses (single-target write
+		// the operator can scope-allow with one rule).
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "task-state",
+			Path:   in.Cwd,
+		}, nil
+
+	case "TaskGet", "TaskList", "TaskOutput", "ToolSearch", "AskUserQuestion":
+		// Browse-shape; no external side effect. Default-allow under
+		// the existing read policy.
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: in.ToolName,
+			Path:   in.Cwd,
+		}, nil
+
+	case "Monitor":
+		// Spawns a subprocess + streams events. shell.exec shape so
+		// the operator can scope-allow with the existing exec rules.
+		return gov.Action{
+			Type:   gov.ActShellExec,
+			Target: stringField(in.ToolInput, "command"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "EnterPlanMode", "ExitPlanMode":
+		// Mode toggle — no host-visible side effect. Browse-shape.
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: in.ToolName,
+			Path:   in.Cwd,
+		}, nil
+
+	case "EnterWorktree":
+		return gov.Action{
+			Type:   gov.ActGitWorktreeAdd,
+			Target: stringField(in.ToolInput, "branch"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "ExitWorktree":
+		return gov.Action{
+			Type:   gov.ActGitWorktreeRemove,
+			Target: stringField(in.ToolInput, "path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "PushNotification", "RemoteTrigger":
+		// Outbound network — http.request shape. Operator can
+		// allowlist by target host through the existing net rules.
+		target := stringField(in.ToolInput, "url")
+		if target == "" {
+			target = stringField(in.ToolInput, "endpoint")
+		}
+		if target == "" {
+			target = in.ToolName
+		}
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: target,
+			Path:   in.Cwd,
+		}, nil
+
+	case "CronCreate":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "cron",
+			Path:   in.Cwd,
+		}, nil
+
+	case "CronDelete":
+		return gov.Action{
+			Type:   gov.ActFileDelete,
+			Target: "cron",
+			Path:   in.Cwd,
+		}, nil
+
+	case "CronList":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: "cron",
+			Path:   in.Cwd,
+		}, nil
+
+	case "ScheduleWakeup":
+		// Schedules a future agent-loop iteration — write-shape state
+		// mutation. Target = the wakeup id (delaySeconds + reason
+		// could go in payload but Target is the policy hook).
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "schedule-wakeup",
 			Path:   in.Cwd,
 		}, nil
 

--- a/go/execution-kernel/internal/driver/claudecode/normalize_test.go
+++ b/go/execution-kernel/internal/driver/claudecode/normalize_test.go
@@ -13,14 +13,27 @@ import (
 // default-deny path catches them.
 func TestNormalize_AllDocumentedToolsProduceNonEmptyType(t *testing.T) {
 	tools := []string{
+		// Original tool set
 		"Bash", "Edit", "Write", "NotebookEdit",
 		"Read", "WebFetch", "WebSearch", "Task",
 		"Glob", "Grep", "LS", "TodoWrite",
+		// Modern Claude Code tools (issue #69 — pre-fix these all
+		// fell to ActUnknown → fail-closed → blocked under enforce
+		// mode).
+		"Agent", "Skill", "TaskStop",
+		"TaskCreate", "TaskUpdate",
+		"TaskGet", "TaskList", "TaskOutput", "ToolSearch", "AskUserQuestion",
+		"Monitor",
+		"EnterPlanMode", "ExitPlanMode",
+		"EnterWorktree", "ExitWorktree",
+		"PushNotification", "RemoteTrigger",
+		"CronCreate", "CronDelete", "CronList",
+		"ScheduleWakeup",
 	}
 	for _, name := range tools {
 		in := HookInput{
 			ToolName:  name,
-			ToolInput: map[string]any{"command": "x", "file_path": "/x", "url": "https://x", "query": "x", "pattern": "*", "path": "/x", "description": "x", "notebook_path": "/x.ipynb"},
+			ToolInput: map[string]any{"command": "x", "file_path": "/x", "url": "https://x", "query": "x", "pattern": "*", "path": "/x", "description": "x", "notebook_path": "/x.ipynb", "subagent_type": "x", "skill": "x", "task_id": "t1", "branch": "main", "endpoint": "/x"},
 			Cwd:       "/cwd",
 		}
 		a, err := Normalize(in)
@@ -34,6 +47,79 @@ func TestNormalize_AllDocumentedToolsProduceNonEmptyType(t *testing.T) {
 		if a.Type == gov.ActUnknown {
 			t.Errorf("%s: must not produce ActUnknown (documented tool)", name)
 		}
+	}
+}
+
+// TestNormalize_ModernClaudeCodeToolMappings pins the per-tool action
+// type for the modern Claude Code surface. Closes issue #69 — the
+// pre-fix denial under `mode: enforce` was the headline operator pain.
+func TestNormalize_ModernClaudeCodeToolMappings(t *testing.T) {
+	cases := []struct {
+		name      string
+		toolName  string
+		toolInput map[string]any
+		wantType  gov.ActionType
+	}{
+		{"Agent maps to delegate.task", "Agent", map[string]any{"description": "search the codebase", "subagent_type": "general-purpose"}, gov.ActDelegateTask},
+		{"Skill maps to delegate.task", "Skill", map[string]any{"skill": "graphify"}, gov.ActDelegateTask},
+		{"TaskStop maps to delegate.task", "TaskStop", map[string]any{"task_id": "t1"}, gov.ActDelegateTask},
+		{"TaskCreate maps to file.write target=task-state", "TaskCreate", map[string]any{}, gov.ActFileWrite},
+		{"TaskUpdate maps to file.write target=task-state", "TaskUpdate", map[string]any{}, gov.ActFileWrite},
+		{"TaskGet maps to file.read", "TaskGet", map[string]any{}, gov.ActFileRead},
+		{"TaskList maps to file.read", "TaskList", map[string]any{}, gov.ActFileRead},
+		{"TaskOutput maps to file.read", "TaskOutput", map[string]any{}, gov.ActFileRead},
+		{"ToolSearch maps to file.read", "ToolSearch", map[string]any{"query": "x"}, gov.ActFileRead},
+		{"AskUserQuestion maps to file.read", "AskUserQuestion", map[string]any{}, gov.ActFileRead},
+		{"Monitor maps to shell.exec", "Monitor", map[string]any{"command": "tail -f log"}, gov.ActShellExec},
+		{"EnterPlanMode maps to file.read", "EnterPlanMode", map[string]any{}, gov.ActFileRead},
+		{"ExitPlanMode maps to file.read", "ExitPlanMode", map[string]any{}, gov.ActFileRead},
+		{"EnterWorktree maps to git.worktree.add", "EnterWorktree", map[string]any{"branch": "feat/x"}, gov.ActGitWorktreeAdd},
+		{"ExitWorktree maps to git.worktree.remove", "ExitWorktree", map[string]any{"path": "/wt"}, gov.ActGitWorktreeRemove},
+		{"PushNotification maps to http.request", "PushNotification", map[string]any{"endpoint": "https://x"}, gov.ActHTTPRequest},
+		{"RemoteTrigger maps to http.request", "RemoteTrigger", map[string]any{"url": "https://x"}, gov.ActHTTPRequest},
+		{"CronCreate maps to file.write target=cron", "CronCreate", map[string]any{}, gov.ActFileWrite},
+		{"CronDelete maps to file.delete target=cron", "CronDelete", map[string]any{}, gov.ActFileDelete},
+		{"CronList maps to file.read target=cron", "CronList", map[string]any{}, gov.ActFileRead},
+		{"ScheduleWakeup maps to file.write", "ScheduleWakeup", map[string]any{}, gov.ActFileWrite},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := Normalize(HookInput{ToolName: tc.toolName, ToolInput: tc.toolInput, Cwd: "/cwd"})
+			if err != nil {
+				t.Fatalf("Normalize: %v", err)
+			}
+			if a.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", a.Type, tc.wantType)
+			}
+		})
+	}
+}
+
+// TestNormalize_AgentSkillFallbackTargetExtraction pins the target-
+// extraction precedence for Agent/Skill: description > subagent_type >
+// skill. The Target is the field policy rules + audit-log readers
+// see, so order matters when multiple are present.
+func TestNormalize_AgentSkillFallbackTargetExtraction(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolInput  map[string]any
+		wantTarget string
+	}{
+		{"description wins over subagent_type", map[string]any{"description": "search", "subagent_type": "general-purpose"}, "search"},
+		{"subagent_type wins over skill", map[string]any{"subagent_type": "general-purpose", "skill": "graphify"}, "general-purpose"},
+		{"skill alone", map[string]any{"skill": "graphify"}, "graphify"},
+		{"empty everything → empty target", map[string]any{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := Normalize(HookInput{ToolName: "Agent", ToolInput: tc.toolInput, Cwd: "/cwd"})
+			if err != nil {
+				t.Fatalf("Normalize: %v", err)
+			}
+			if a.Target != tc.wantTarget {
+				t.Errorf("Target = %q, want %q", a.Target, tc.wantTarget)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #69. Modern Claude Code tools (Agent, Skill, TaskCreate-family, ToolSearch, Monitor, etc.) all fell to ActUnknown → fail-closed → blocked under \`mode: enforce\`. Operators were forced to \`mode: monitor\` globally to use any subagent/skill workflow.

**21 tool name → action mappings added.** All semantic — Agent/Skill = delegate.task (subagent dispatch is the same shape as Task), TaskCreate/Update = file.write target=task-state, browse-shape tools (TaskGet, ToolSearch, AskUserQuestion) = file.read, Monitor = shell.exec, EnterWorktree/ExitWorktree = git.worktree.add/.remove, etc.

Genuinely-unknown future tools still fail-closed (correct behavior — operator extends the switch when new tools land).

## Test plan

- [x] 21+ new test cases pin the per-tool mappings
- [x] \`go test ./...\` clean
- [ ] After merge: any spawned Claude Code agent under \`mode: enforce\` should now pass the gate (rather than fail at the closed-enum check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)