### PR TITLE
fix(driver/copilot): hygiene cluster — closes #53, #54, #55, #56, #57

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
+++ b/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
@@ -18,7 +18,12 @@ import (
 //	1 — runtime error (session failed after startup)
 //	2 — startup error or usage error
 func cmdDriveCopilot(args []string) int {
-	fs := flag.NewFlagSet("drive copilot", flag.ExitOnError)
+	// ContinueOnError so parse failures hit the documented exit-code map
+	// (return 2) instead of os.Exit'ing past it. Tests can then observe
+	// the return value, and any future change to the exit-code map for
+	// usage errors stays in one place.
+	fs := flag.NewFlagSet("drive copilot", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
 	cwd := fs.String("cwd", ".", "policy scope working directory")
 	interactive := fs.Bool("interactive", false, "launch REPL-style interactive session")
 	preflight := fs.Bool("preflight", false, "run startup validations and exit without starting session")

--- a/go/execution-kernel/internal/driver/copilot/driver.go
+++ b/go/execution-kernel/internal/driver/copilot/driver.go
@@ -39,6 +39,13 @@ type PreflightOpts struct {
 // terminates it (lockdown is correct operation, not an error).
 // Returns non-nil for startup failures, SDK errors, or timeouts.
 func Run(ctx context.Context, prompt string, opts RunOpts) error {
+	// Wrap ctx so lockdown / error branches can cancel the SendAndWait
+	// goroutine explicitly rather than relying on session.Disconnect's
+	// implicit cleanup (issue #57: SDK contract doesn't guarantee
+	// Disconnect unblocks a parked SendAndWait).
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// 1. Load policy (chitin.yaml search from cwd upward).
 	policy, _, err := gov.LoadWithInheritance(opts.Cwd)
 	if err != nil {
@@ -46,7 +53,10 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 	}
 
 	// 2. Open Counter (SQLite escalation state in ~/.chitin/gov.db).
-	chitinDir := defaultChitinDir()
+	chitinDir, err := defaultChitinDir()
+	if err != nil {
+		return fmt.Errorf("chitin dir: %w", err)
+	}
 	if err := os.MkdirAll(chitinDir, 0755); err != nil {
 		return fmt.Errorf("chitin dir: %w", err)
 	}
@@ -71,7 +81,7 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 	}
 	defer client.Close()
 
-	if err := client.Start(ctx); err != nil {
+	if err := client.Start(runCtx); err != nil {
 		return fmt.Errorf("client start: %w", err)
 	}
 
@@ -88,19 +98,24 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 		LockdownCh: lockdownCh,
 	}
 
-	// 6. Create session with handler registered.
-	// Model: "gpt-4.1" is required for reliable tool-use in headless ACP mode.
-	// The spike's Rung 4 confirmed this model calls the shell tool in response
-	// to shell-action prompts; the default model applies its own safety filters
-	// and declines tool calls for risky prompts (rm -rf, curl|bash) without
-	// ever firing OnPermissionRequest, which bypasses chitin governance entirely.
-	// AvailableTools: nil = all built-in tools remain available so the model
-	// can call shell, file-read, file-write, and other Copilot built-ins.
+	// 6. Resolve model and verify it's on the Copilot CLI's whitelist BEFORE
+	// session create. Issue #53: the default fallback applies pre-filters
+	// that decline risky tool calls without firing OnPermissionRequest,
+	// silently bypassing chitin governance. If the requested model is
+	// missing from ListModels output, fail loud so the operator notices
+	// vs. silently routing through the default model.
 	model := opts.Model
 	if model == "" {
 		model = "gpt-4.1"
 	}
-	session, err := client.SDKClient().CreateSession(ctx, &copilotsdk.SessionConfig{
+	if err := verifyModelAvailable(runCtx, client.SDKClient(), model); err != nil {
+		return fmt.Errorf("model %q not available on this Copilot CLI: %w", model, err)
+	}
+
+	// 7. Create session with handler registered.
+	// AvailableTools: nil = all built-in tools remain available so the model
+	// can call shell, file-read, file-write, and other Copilot built-ins.
+	session, err := client.SDKClient().CreateSession(runCtx, &copilotsdk.SessionConfig{
 		Model:               model,
 		OnPermissionRequest: handler.OnPermissionRequest,
 	})
@@ -109,7 +124,7 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 	}
 	defer session.Disconnect() //nolint:errcheck
 
-	// 7. Subscribe to the event stream so model text, tool calls, and tool
+	// 8. Subscribe to the event stream so model text, tool calls, and tool
 	// results reach stdout. Without this, SendAndWait returns silently and
 	// the operator sees nothing — governance still runs, but the demo story
 	// ("model tried X; tool returned Y") is invisible. Registered before
@@ -119,9 +134,9 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 	})
 	defer unsubscribe()
 
-	// 8. Dispatch.
+	// 9. Dispatch.
 	if opts.Interactive {
-		return runInteractive(ctx, session, lockdownCh)
+		return runInteractive(runCtx, cancel, session, lockdownCh)
 	}
 
 	// Run the prompt via SendAndWait. While it blocks, the permission
@@ -133,13 +148,15 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 	}
 	sendDone := make(chan sendResult, 1)
 	go func() {
-		evt, err := session.SendAndWait(ctx, copilotsdk.MessageOptions{Prompt: prompt})
+		evt, err := session.SendAndWait(runCtx, copilotsdk.MessageOptions{Prompt: prompt})
 		sendDone <- sendResult{evt, err}
 	}()
 
 	select {
 	case lde := <-lockdownCh:
-		// Lockdown fired during the session — terminate cleanly.
+		// Lockdown fired during the session — cancel runCtx so SendAndWait
+		// unblocks promptly, then terminate cleanly.
+		cancel()
 		printLockdownSummary(lde)
 		return nil
 
@@ -156,6 +173,36 @@ func Run(ctx context.Context, prompt string, opts RunOpts) error {
 		}
 		return nil
 	}
+}
+
+// verifyModelAvailable calls ListModels and checks that the requested
+// model id is in the result. Returns nil iff the id is present.
+//
+// Issue #53: when a Copilot CLI release drops a model from its whitelist
+// (or the SDK substitutes a fallback that ALSO pre-filters tool calls),
+// chitin governance silently no-ops on those events. Failing loud at
+// session start gives the operator a clear signal vs. an audit log
+// showing zero events for a session that actually executed tools.
+func verifyModelAvailable(ctx context.Context, sdk *copilotsdk.Client, model string) error {
+	models, err := sdk.ListModels(ctx)
+	if err != nil {
+		// ListModels failure is recoverable — proceed with session create
+		// and let CreateSession surface a real error if the model is bad.
+		// Logging only, no return: we'd rather tolerate a transient list
+		// failure than block the session for a network blip.
+		fmt.Fprintf(os.Stderr, "warning: model whitelist check skipped: %v\n", err)
+		return nil
+	}
+	for _, m := range models {
+		if m.ID == model {
+			return nil
+		}
+	}
+	available := make([]string, 0, len(models))
+	for _, m := range models {
+		available = append(available, m.ID)
+	}
+	return fmt.Errorf("not in available set %v", available)
 }
 
 // Preflight runs 5 startup validations in order.
@@ -189,7 +236,11 @@ func Preflight(opts PreflightOpts) (string, error) {
 	sb.WriteString("  [OK]   policy load\n")
 
 	// 4. ~/.chitin/ writable (create dir + probe file).
-	chitinDir := defaultChitinDir()
+	chitinDir, err := defaultChitinDir()
+	if err != nil {
+		sb.WriteString(fmt.Sprintf("  [FAIL] resolve ~/.chitin/: %v\n", err))
+		return sb.String(), fmt.Errorf("resolve ~/.chitin/: %w", err)
+	}
 	if err := os.MkdirAll(chitinDir, 0755); err != nil {
 		sb.WriteString(fmt.Sprintf("  [FAIL] ~/.chitin/ writable: %v\n", err))
 		return sb.String(), fmt.Errorf("~/.chitin/ writable: %w", err)
@@ -219,9 +270,21 @@ func Preflight(opts PreflightOpts) (string, error) {
 }
 
 // defaultChitinDir returns ~/.chitin, the runtime state directory.
-func defaultChitinDir() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".chitin")
+//
+// Issue #54: previously swallowed os.UserHomeDir errors and resolved to
+// relative ".chitin" when HOME was unset (CI containers, restrictive
+// sandboxes). gov.db then landed in CWD without warning, breaking
+// audit-log durability across runs. Returns the error so callers can
+// fail-loud at startup.
+func defaultChitinDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	if home == "" {
+		return "", fmt.Errorf("resolve home dir: empty (HOME unset?)")
+	}
+	return filepath.Join(home, ".chitin"), nil
 }
 
 func printLockdownSummary(lde *LockdownError) {
@@ -236,7 +299,10 @@ func printLockdownSummary(lde *LockdownError) {
 // Invariant: every non-empty, non-command line is dispatched exactly once.
 // SDK errors surface to stderr but do not kill the loop — only /quit, /exit,
 // EOF, ctx cancellation, or a lockdown signal terminates the REPL.
-func runInteractive(ctx context.Context, session *copilotsdk.Session, lockdownCh <-chan *LockdownError) error {
+//
+// cancel cancels ctx — call before lockdown / EOF returns so the
+// in-flight SendAndWait goroutine unblocks promptly (issue #57).
+func runInteractive(ctx context.Context, cancel context.CancelFunc, session *copilotsdk.Session, lockdownCh <-chan *LockdownError) error {
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Fprintln(os.Stderr, "chitin/copilot interactive mode. Type /quit or /exit to leave; Ctrl-D for EOF.")
 	for {
@@ -266,6 +332,7 @@ func runInteractive(ctx context.Context, session *copilotsdk.Session, lockdownCh
 
 		select {
 		case lde := <-lockdownCh:
+			cancel()
 			printLockdownSummary(lde)
 			return nil
 		case sendErr := <-sendDone:

--- a/go/execution-kernel/internal/driver/copilot/handler.go
+++ b/go/execution-kernel/internal/driver/copilot/handler.go
@@ -45,6 +45,10 @@ func (e *LockdownError) Error() string {
 //
 // Wire-up: assign Handler.OnPermissionRequest as the OnPermissionRequest
 // field in copilotsdk.SessionConfig or copilotsdk.ClientOptions.
+//
+// The SDK calls OnPermissionRequest synchronously per the documented
+// contract ("Called synchronously by the SDK before each tool execution"),
+// so denials counts as a plain int — no atomic / mutex needed.
 type Handler struct {
 	Gate    Gate
 	Agent   string // "copilot-cli" for this driver
@@ -58,6 +62,13 @@ type Handler struct {
 	// the session cleanly. A capacity-1 buffered channel is recommended so the
 	// send never blocks (lockdown fires at most once per session).
 	LockdownCh chan<- *LockdownError
+
+	// denials counts non-lockdown denies seen by this Handler instance.
+	// Surfaced into LockdownError.Count when lockdown fires so the
+	// printLockdownSummary line ("denials=N") matches what the operator
+	// just watched. 0 when lockdown was detected from a pre-existing
+	// persisted state (no denies seen this session).
+	denials int
 }
 
 // OnPermissionRequest is the SDK PermissionHandlerFunc callback. Called
@@ -107,7 +118,7 @@ func (h *Handler) OnPermissionRequest(
 	}
 
 	if decision.RuleID == "lockdown" {
-		lde := &LockdownError{Agent: h.Agent}
+		lde := &LockdownError{Agent: h.Agent, Count: h.denials}
 		if h.LockdownCh != nil {
 			select {
 			case h.LockdownCh <- lde:
@@ -124,6 +135,7 @@ func (h *Handler) OnPermissionRequest(
 	// Regular deny — "user-not-available" invites the model to attempt a
 	// variation, which drives the escalation counter toward lockdown when
 	// the model keeps firing at the same rule.
+	h.denials++
 	return copilotsdk.PermissionRequestResult{
 		Kind: copilotsdk.PermissionRequestResultKind("user-not-available"),
 	}, nil

--- a/go/execution-kernel/internal/driver/copilot/handler_test.go
+++ b/go/execution-kernel/internal/driver/copilot/handler_test.go
@@ -22,6 +22,9 @@ const (
 
 // captureStderr redirects os.Stderr for the duration of fn and returns the bytes written.
 // Used to assert Verbose decision logging without coupling tests to log framing.
+//
+// Restores os.Stderr and closes the read-end via defer so a panic in fn or
+// io.Copy doesn't leak fds across the test suite (issue #56).
 func captureStderr(t *testing.T, fn func()) []byte {
 	t.Helper()
 	orig := os.Stderr
@@ -30,6 +33,9 @@ func captureStderr(t *testing.T, fn func()) []byte {
 		t.Fatalf("pipe: %v", err)
 	}
 	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+	defer r.Close()
+
 	done := make(chan []byte, 1)
 	go func() {
 		var buf bytes.Buffer
@@ -38,7 +44,6 @@ func captureStderr(t *testing.T, fn func()) []byte {
 	}()
 	fn()
 	_ = w.Close()
-	os.Stderr = orig
 	return <-done
 }
 
@@ -83,10 +88,11 @@ func TestHandler_Allow(t *testing.T) {
 	}
 }
 
-func TestHandler_GuideDenyRejectsAndLogsDecision(t *testing.T) {
-	// Wire kind flips to "reject" with nil error. Guide text travels via the
-	// Verbose decision log on stderr, not via the handler's error return —
-	// the Go SDK drops handler errors before they reach the wire.
+func TestHandler_GuideDenyReturnsRetryableAndLogsDecision(t *testing.T) {
+	// Wire kind is "user-not-available" (retryable: invites the model to try
+	// a variation, which drives the escalation counter). Guide text travels
+	// via the Verbose decision log on stderr, not via the handler's error
+	// return — the Go SDK drops handler errors before they reach the wire.
 	h := &Handler{
 		Gate: &mockGate{decision: gov.Decision{
 			Allowed:          false,
@@ -189,6 +195,49 @@ func TestHandler_LockdownSignalsChannelAndReturnsReject(t *testing.T) {
 	default:
 		t.Fatal("expected *LockdownError on LockdownCh, channel was empty")
 	}
+}
+
+func TestHandler_LockdownCountReflectsPriorDenials(t *testing.T) {
+	// Issue #54: LockdownError.Count must carry the per-handler denial
+	// total so printLockdownSummary's "denials=N" matches what the
+	// operator just watched. Mock gate denies for the first 3 calls,
+	// then locks down on the 4th — final Count must be 3.
+	gate := &countingGate{denyCount: 3}
+	lockdownCh := make(chan *LockdownError, 1)
+	h := &Handler{
+		Gate:       gate,
+		Agent:      "copilot-cli",
+		Cwd:        "/work",
+		LockdownCh: lockdownCh,
+	}
+	req := copilotsdk.PermissionRequest{
+		Kind: copilotsdk.PermissionRequestKindShell, FullCommandText: strPtr("rm -rf /"),
+	}
+	for i := 0; i < 4; i++ {
+		_, _ = h.OnPermissionRequest(req, copilotsdk.PermissionInvocation{})
+	}
+	select {
+	case lde := <-lockdownCh:
+		if lde.Count != 3 {
+			t.Errorf("LockdownError.Count: got %d, want 3 (3 prior denials before lockdown)", lde.Count)
+		}
+	default:
+		t.Fatal("expected lockdown signal on channel")
+	}
+}
+
+// countingGate denies for the first denyCount calls, then locks down.
+type countingGate struct {
+	denyCount int
+	calls     int
+}
+
+func (g *countingGate) Evaluate(a gov.Action, agent string, _ *gov.BudgetEnvelope) gov.Decision {
+	g.calls++
+	if g.calls > g.denyCount {
+		return gov.Decision{Allowed: false, Mode: "enforce", RuleID: "lockdown", Agent: agent}
+	}
+	return gov.Decision{Allowed: false, Mode: "guide", RuleID: "no-rm", Reason: "denied"}
 }
 
 func TestHandler_LockdownWithNilChannelDoesNotPanic(t *testing.T) {

--- a/go/execution-kernel/internal/gov/decision_test.go
+++ b/go/execution-kernel/internal/gov/decision_test.go
@@ -72,16 +72,20 @@ func TestWriteLog_AppendsOneJSONLine(t *testing.T) {
 
 func TestDecision_JSONL_CarriesAgent(t *testing.T) {
 	dir := t.TempDir()
+	// Capture now once: a separate time.Now() at filename-construction time
+	// can land on the next UTC date when the test runs within ~1s of midnight,
+	// flaking the assertion (issue #56).
+	now := time.Now().UTC()
 	d := Decision{
 		Allowed: true,
 		Agent:   "copilot-cli",
 		Action:  Action{Type: "shell.exec", Target: "ls /tmp"},
-		Ts:      time.Now().UTC().Format(time.RFC3339),
+		Ts:      now.Format(time.RFC3339),
 	}
 	if err := WriteLog(d, dir); err != nil {
 		t.Fatalf("WriteLog: %v", err)
 	}
-	path := filepath.Join(dir, "gov-decisions-"+time.Now().UTC().Format("2006-01-02")+".jsonl")
+	path := filepath.Join(dir, "gov-decisions-"+now.Format("2006-01-02")+".jsonl")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read log: %v", err)


### PR DESCRIPTION
## Summary

Five mechanical post-PR-#51 hygiene fixes in `driver/copilot` and `gov`.

- **#53** — Verify model is on Copilot CLI's whitelist before `CreateSession`. `ListModels` is consulted; missing model fails loud with the available set instead of silently substituting (the default model pre-filters risky tool calls without firing `OnPermissionRequest`, bypassing governance).
- **#54** — `defaultChitinDir` now returns `(string, error)`; callers fail loud when `HOME` is unset rather than silently writing to relative `.chitin`. `LockdownError.Count` populated from a per-`Handler` denial counter so `printLockdownSummary`'s `denials=N` line matches what the operator watched.
- **#55** — `drive_copilot.go` uses `flag.ContinueOnError` + `fs.SetOutput(os.Stderr)` so parse failures honor the documented exit-code map (`return 2`) instead of `os.Exit`'ing past it.
- **#56** — Test hygiene: `captureStderr` defers restore + `r.Close`; `TestHandler_GuideDenyRejectsAndLogsDecision` renamed to `...ReturnsRetryableAndLogsDecision` (matches the actual `user-not-available` assertion); `TestDecision_JSONL_CarriesAgent` captures `now` once to remove the UTC-midnight cross-day flake.
- **#57** — `Run` wraps ctx in `context.WithCancel`; lockdown branch calls `cancel()` before `printLockdownSummary` so the in-flight `SendAndWait` goroutine unblocks promptly. `runInteractive` accepts the cancel and does the same.

Tests added: `TestHandler_LockdownCountReflectsPriorDenials` (3 prior denies before lockdown → Count=3).

## Test plan
- [x] go test ./... clean across the kernel
- [ ] CI green
- [ ] Operator smoke: chitin-kernel drive copilot --preflight still reports preflight OK
- [ ] Operator smoke: typo model id should now fail loud at session start

Closes #53
Closes #54
Closes #55
Closes #56
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)