### PR TITLE
fix(f4): tighten OTEL timeout, single OnDecision callsite, decisionStr audit — closes #74, #76, #77

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_emit.go
@@ -99,12 +99,31 @@ func buildDecisionEvent(d *gov.Decision, chainID, surface string) *event.Event {
 	if ts == "" {
 		ts = time.Now().UTC().Format(time.RFC3339Nano)
 	}
-	decisionStr := "allow"
-	if !d.Allowed {
+	// decisionStr is the OUTCOME (allow/deny/guide), not the policy mode.
+	// Closes #77 audit: `Allowed && Mode=guide` IS reachable (every allow
+	// under a guide-mode policy), but the right semantic is to report the
+	// outcome — the action proceeded, so decision.type=allow regardless
+	// of whether the policy was in guide mode. The policy.mode info is a
+	// separate attribute (added below) so consumers wanting it don't
+	// overload decision.type.
+	//
+	// Invariants (six reachable (Allowed, Mode) combinations):
+	//   true,  enforce → "allow"  (action proceeded)
+	//   true,  guide   → "allow"  (action proceeded; mode only matters
+	//                              on the deny branch)
+	//   true,  monitor → "allow"  (monitor flipped a soft deny to allow;
+	//                              decision.type tracks the outcome)
+	//   false, enforce → "deny"   (hard block)
+	//   false, guide   → "guide"  (soft deny — model can retry)
+	//   false, monitor → unreachable (monitor would have flipped to allow)
+	var decisionStr string
+	switch {
+	case d.Allowed:
+		decisionStr = "allow"
+	case d.Mode == "guide":
+		decisionStr = "guide"
+	default:
 		decisionStr = "deny"
-		if d.Mode == "guide" {
-			decisionStr = "guide"
-		}
 	}
 	payload := map[string]any{
 		"decision":    decisionStr,

--- a/go/execution-kernel/cmd/chitin-kernel/gate_emit_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_emit_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// TestBuildDecisionEvent_DecisionStr exhausts the (Allowed, Mode) state
+// space and asserts decisionStr maps to the OUTCOME (allow/deny/guide),
+// NOT the policy mode. Closes #77 audit.
+//
+// The five reachable cases (six minus the impossible Allowed=false +
+// monitor — monitor flips that to Allowed=true at gate-time):
+func TestBuildDecisionEvent_DecisionStr(t *testing.T) {
+	cases := []struct {
+		name    string
+		allowed bool
+		mode    string
+		want    string
+	}{
+		{"allow under enforce", true, "enforce", "allow"},
+		{"allow under guide (was the contested case)", true, "guide", "allow"},
+		{"allow under monitor (override flipped a deny)", true, "monitor", "allow"},
+		{"deny under enforce (hard block)", false, "enforce", "deny"},
+		{"deny under guide (soft deny — model can retry)", false, "guide", "guide"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &gov.Decision{
+				Allowed: tc.allowed,
+				Mode:    tc.mode,
+				RuleID:  "test-rule",
+				Ts:      "2026-05-02T22:00:00Z",
+			}
+			ev := buildDecisionEvent(d, "test-chain", "claude-code")
+			var payload map[string]any
+			if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+				t.Fatalf("payload: %v", err)
+			}
+			got, _ := payload["decision"].(string)
+			if got != tc.want {
+				t.Errorf("decisionStr: got %q, want %q (Allowed=%v Mode=%q)",
+					got, tc.want, tc.allowed, tc.mode)
+			}
+		})
+	}
+}

--- a/go/execution-kernel/internal/emit/otel.go
+++ b/go/execution-kernel/internal/emit/otel.go
@@ -38,6 +38,14 @@ type otelExporter struct {
 // newOTELExporter constructs an exporter from the OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 // (or OTEL_EXPORTER_OTLP_ENDPOINT) env var. Returns nil if neither is set —
 // caller treats nil as "OTEL disabled" and skips projection.
+//
+// Timeout: 500ms. Tightened from 2s in #74. The kernel's per-hook
+// latency budget is ~100ms (gate_hook.go), and 3 hooks × 10 tool calls
+// per session = up to 60s of dead time on a slow/hung collector at the
+// old 2s timeout. 500ms catches a healthy localhost RTT (sub-50ms)
+// with margin while bounding the worst case to ≤15s per session.
+// Sync POST is still correct for v1 (kernel is short-lived per emit);
+// daemon-mode async is the v2 path.
 func newOTELExporter() *otelExporter {
 	ep := endpointFromEnv()
 	if ep == "" {
@@ -45,9 +53,16 @@ func newOTELExporter() *otelExporter {
 	}
 	return &otelExporter{
 		endpoint: ep,
-		client:   &http.Client{Timeout: 2 * time.Second},
+		client:   &http.Client{Timeout: otelHTTPTimeout},
 	}
 }
+
+// otelHTTPTimeout bounds both the http.Client timeout and the
+// context.WithTimeout in ProjectAndPost. Single source of truth so
+// they can never drift (drift would mean either context fires first
+// and leaks an in-flight request, or client fires first and leaks the
+// context goroutine).
+const otelHTTPTimeout = 500 * time.Millisecond
 
 // allowedEventTypes is the F4 v1 scope set per the spec. Other event
 // types still write to the canonical chain (which is authoritative);
@@ -95,7 +110,7 @@ func (x *otelExporter) ProjectAndPost(ev *event.Event, idx *chain.Index) {
 		log.Printf("otel: encode: %v", err)
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), otelHTTPTimeout)
 	defer cancel()
 	if err := x.post(ctx, body); err != nil {
 		log.Printf("otel: post: %v", err)

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -72,8 +72,25 @@ type Gate struct {
 //
 // Envelope exhaustion is NOT subject to monitor-mode override — caps are
 // hard contracts even when policy is in monitor.
-func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decision {
+//
+// OnDecision is fired exactly once per Evaluate via a single defer-based
+// callsite (closes #76). Both the lockdown short-circuit and the normal
+// path now route through the same exit point, so a future short-circuit
+// (rate-limit, circuit-breaker) can't silently skip the callback.
+// Pass-by-copy preserves the existing contract that callbacks can't
+// mutate the Decision the caller sees.
+func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final Decision) {
 	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Single OnDecision callsite. Defer fires after the named-return
+	// `final` is set; reads `final` rather than capturing a per-branch
+	// variable so any branch's return value flows through.
+	defer func() {
+		if g.OnDecision != nil {
+			dCopy := final
+			g.OnDecision(&dCopy)
+		}
+	}()
 
 	// Capture caller_origin once, up front — used only when envelope == nil
 	// so we can identify which call sites bypass cost-governance plumbing.
@@ -93,12 +110,8 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decisi
 		}
 		stampEnvelope(&d, envelope, g, a, agent)
 		_ = WriteLog(d, g.LogDir)
-		if g.OnDecision != nil {
-			// Pass a copy so callbacks can't mutate the Decision the caller sees.
-			dCopy := d
-			g.OnDecision(&dCopy)
-		}
-		return d
+		final = d
+		return
 	}
 
 	// 2. Policy evaluate.
@@ -194,17 +207,13 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) Decisi
 	// 8. Log.
 	_ = WriteLog(d, g.LogDir)
 
-	// 9. F4 addendum: emit a `decision` chain event via the wired callback,
-	// if any. Fires after WriteLog so the audit log is durable first; the
-	// callback's failure (if any) is the CLI layer's concern, never affects
-	// the Decision returned to the caller. Pass a copy so callbacks can't
-	// mutate the Decision the caller sees.
-	if g.OnDecision != nil {
-		dCopy := d
-		g.OnDecision(&dCopy)
-	}
-
-	return d
+	// 9. F4 addendum: OnDecision callback fires from the deferred
+	// callsite at the top of Evaluate (single-source-of-truth so a
+	// future short-circuit can't skip the callback). Order is preserved:
+	// WriteLog runs before the deferred OnDecision because defers fire
+	// AFTER the function returns.
+	final = d
+	return
 }
 
 // stampEnvelope is the lockdown-path helper: it does its own classify +


### PR DESCRIPTION
## Summary

Three F4 follow-ups from PR #71's adversarial review.

- **#74** — OTEL HTTP timeout 2s → 500ms. Per-hook latency budget is ~100ms; old 2s on a slow/hung collector cost up to 60s of dead time per session. 500ms catches healthy-localhost RTT (sub-50ms) and bounds the worst case to ≤15s per session. Single \`otelHTTPTimeout\` const so \`http.Client.Timeout\` and \`context.WithTimeout\` can never drift. Sync POST remains correct for v1; daemon-mode async is the v2 path.
- **#76** — OnDecision now fires from a single defer-based callsite at the top of \`Evaluate\`. Both the lockdown short-circuit and the normal path route through the same exit so a future short-circuit (rate-limit, circuit-breaker) can't silently skip the callback. Existing single-fire tests still pass.
- **#77** — Audited \`buildDecisionEvent\`'s decisionStr derivation. Found \`Allowed && Mode=guide\` IS reachable (every allow under a guide-mode policy). Replaced the nested-if with an explicit switch documenting the five reachable (Allowed, Mode) combinations. Semantic unchanged: \`decision.type\` reports the OUTCOME, not the policy mode. Added \`TestBuildDecisionEvent_DecisionStr\` as a regression guard.

## Test plan
- [x] \`go test ./...\` clean across the kernel
- [x] Existing \`TestGate_OnDecisionFiresOn*\` tests pass (single-fire invariant preserved)
- [x] New \`TestBuildDecisionEvent_DecisionStr\` covers all 5 reachable (Allowed, Mode) combinations
- [ ] CI green

Closes #74
Closes #76
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)