### PR TITLE
fix(emit): session_end-is-last + idempotent dedup — closes #3, #16

### DIFF
--- a/go/execution-kernel/internal/chain/chain.go
+++ b/go/execution-kernel/internal/chain/chain.go
@@ -5,6 +5,7 @@ package chain
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -12,15 +13,33 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
 
-// ChainInfo is the last-known state of a chain.
+// ChainInfo is the last-known state of a chain. The EventType /
+// LogicalHash / EmitTs fields support emit-time invariants:
+//
+//   - LastEventType: drives the session_end-is-last enforcement (#3).
+//     If it equals "session_end" and a non-session_end event tries to
+//     emit on the same chain, the emit is refused.
+//   - LastLogicalHash: drives idempotent emit (#16). A retried event
+//     whose logical content matches the chain tail's LogicalHash AND
+//     was emitted within the dedup window is treated as a duplicate.
+//   - LastEmitTs: paired with LastLogicalHash for the dedup window
+//     check. RFC3339 string (matches event.Event.Ts format).
+//
+// These fields default to "" for chains seeded before the schema
+// migration (see ALTER TABLE in OpenIndex). Empty values are equivalent
+// to "no prior info" — the invariants gracefully no-op on legacy chains.
 type ChainInfo struct {
-	ChainID  string
-	LastSeq  int64
-	LastHash string
+	ChainID         string
+	LastSeq         int64
+	LastHash        string
+	LastEventType   string
+	LastLogicalHash string
+	LastEmitTs      string
 }
 
 // Index is a kernel-owned SQLite handle for chain bookkeeping.
@@ -30,11 +49,25 @@ type Index struct {
 
 const schema = `
 CREATE TABLE IF NOT EXISTS chains (
-	chain_id  TEXT PRIMARY KEY,
-	last_seq  INTEGER NOT NULL,
-	last_hash TEXT NOT NULL
+	chain_id          TEXT PRIMARY KEY,
+	last_seq          INTEGER NOT NULL,
+	last_hash         TEXT NOT NULL,
+	last_event_type   TEXT NOT NULL DEFAULT '',
+	last_logical_hash TEXT NOT NULL DEFAULT '',
+	last_emit_ts      TEXT NOT NULL DEFAULT ''
 );
 `
+
+// migrations runs idempotent ADD COLUMN statements for DBs created before
+// the last_event_type / last_logical_hash / last_emit_ts columns existed.
+// SQLite returns a "duplicate column" error if the column is already
+// present; we swallow that specific error so re-running OpenIndex on a
+// fresh DB doesn't fail.
+var migrations = []string{
+	`ALTER TABLE chains ADD COLUMN last_event_type   TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE chains ADD COLUMN last_logical_hash TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE chains ADD COLUMN last_emit_ts      TEXT NOT NULL DEFAULT ''`,
+}
 
 func OpenIndex(path string) (*Index, error) {
 	db, err := sql.Open("sqlite", path)
@@ -56,6 +89,17 @@ func OpenIndex(path string) (*Index, error) {
 		db.Close()
 		return nil, err
 	}
+	for _, stmt := range migrations {
+		if _, err := db.Exec(stmt); err != nil {
+			// SQLite reports "duplicate column name: X" when the column
+			// is already present from a fresh-schema CREATE TABLE.
+			// Swallow that specific case; surface anything else.
+			if !strings.Contains(err.Error(), "duplicate column") {
+				db.Close()
+				return nil, err
+			}
+		}
+	}
 	return &Index{db: db}, nil
 }
 
@@ -64,9 +108,14 @@ func (i *Index) Close() error {
 }
 
 func (i *Index) Get(chainID string) (*ChainInfo, error) {
-	row := i.db.QueryRow(`SELECT chain_id, last_seq, last_hash FROM chains WHERE chain_id = ?`, chainID)
+	row := i.db.QueryRow(
+		`SELECT chain_id, last_seq, last_hash, last_event_type, last_logical_hash, last_emit_ts
+		 FROM chains WHERE chain_id = ?`, chainID)
 	var info ChainInfo
-	if err := row.Scan(&info.ChainID, &info.LastSeq, &info.LastHash); err != nil {
+	if err := row.Scan(
+		&info.ChainID, &info.LastSeq, &info.LastHash,
+		&info.LastEventType, &info.LastLogicalHash, &info.LastEmitTs,
+	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
@@ -75,12 +124,21 @@ func (i *Index) Get(chainID string) (*ChainInfo, error) {
 	return &info, nil
 }
 
-func (i *Index) Upsert(chainID string, seq int64, hash string) error {
+// Upsert writes the chain tail atomically. Used by RebuildFromJSONL when
+// reconciling from disk. The eventType/logicalHash/emitTs args may be ""
+// when the caller only knows seq+hash (legacy paths); the columns default
+// to "" so legacy callers stay correct.
+func (i *Index) Upsert(chainID string, seq int64, hash, eventType, logicalHash, emitTs string) error {
 	_, err := i.db.Exec(
-		`INSERT INTO chains (chain_id, last_seq, last_hash)
-		 VALUES (?, ?, ?)
-		 ON CONFLICT(chain_id) DO UPDATE SET last_seq = excluded.last_seq, last_hash = excluded.last_hash`,
-		chainID, seq, hash,
+		`INSERT INTO chains (chain_id, last_seq, last_hash, last_event_type, last_logical_hash, last_emit_ts)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(chain_id) DO UPDATE SET
+		   last_seq          = excluded.last_seq,
+		   last_hash         = excluded.last_hash,
+		   last_event_type   = excluded.last_event_type,
+		   last_logical_hash = excluded.last_logical_hash,
+		   last_emit_ts      = excluded.last_emit_ts`,
+		chainID, seq, hash, eventType, logicalHash, emitTs,
 	)
 	return err
 }
@@ -106,18 +164,26 @@ type EmitTx struct {
 	done    bool
 }
 
-// Commit upserts (chainID, seq, hash) and commits + releases the IMMEDIATE lock.
-func (tx *EmitTx) Commit(seq int64, hash string) error {
+// Commit upserts the chain tail and commits + releases the IMMEDIATE lock.
+// eventType / logicalHash / emitTs become the new tail's metadata used by
+// the next BeginEmit's invariant checks (session_end-is-last, idempotent
+// dedup window).
+func (tx *EmitTx) Commit(seq int64, hash, eventType, logicalHash, emitTs string) error {
 	if tx.done {
 		return nil
 	}
 	tx.done = true
 	ctx := context.Background()
 	_, err := tx.conn.ExecContext(ctx,
-		`INSERT INTO chains (chain_id, last_seq, last_hash)
-		 VALUES (?, ?, ?)
-		 ON CONFLICT(chain_id) DO UPDATE SET last_seq = excluded.last_seq, last_hash = excluded.last_hash`,
-		tx.chainID, seq, hash,
+		`INSERT INTO chains (chain_id, last_seq, last_hash, last_event_type, last_logical_hash, last_emit_ts)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(chain_id) DO UPDATE SET
+		   last_seq          = excluded.last_seq,
+		   last_hash         = excluded.last_hash,
+		   last_event_type   = excluded.last_event_type,
+		   last_logical_hash = excluded.last_logical_hash,
+		   last_emit_ts      = excluded.last_emit_ts`,
+		tx.chainID, seq, hash, eventType, logicalHash, emitTs,
 	)
 	if err != nil {
 		// Best-effort rollback before releasing the conn.
@@ -167,10 +233,14 @@ func (i *Index) BeginEmit(chainID string) (*EmitTx, error) {
 	}
 	// Read current chain state inside the transaction.
 	row := conn.QueryRowContext(ctx,
-		`SELECT chain_id, last_seq, last_hash FROM chains WHERE chain_id = ?`, chainID)
+		`SELECT chain_id, last_seq, last_hash, last_event_type, last_logical_hash, last_emit_ts
+		 FROM chains WHERE chain_id = ?`, chainID)
 	var info ChainInfo
 	var current *ChainInfo
-	if err := row.Scan(&info.ChainID, &info.LastSeq, &info.LastHash); err != nil {
+	if err := row.Scan(
+		&info.ChainID, &info.LastSeq, &info.LastHash,
+		&info.LastEventType, &info.LastLogicalHash, &info.LastEmitTs,
+	); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			_, _ = conn.ExecContext(ctx, "ROLLBACK")
 			conn.Close()
@@ -185,12 +255,21 @@ func (i *Index) BeginEmit(chainID string) (*EmitTx, error) {
 
 // jsonlEventRow holds the fields we need when scanning JSONL event lines.
 // PrevHash is a pointer so we can distinguish "not present" (unusual) from
-// "explicitly null" (chain head).
+// "explicitly null" (chain head). EventType + Ts are read so the rebuild
+// can populate the same chain-tail metadata that emit.go relies on for
+// the session_end-is-last and idempotent-dedup invariants.
+//
+// LogicalHash is recomputed from event_type + payload at rebuild time —
+// not stored on the JSONL line — so legacy events written before the
+// dedup feature still get a coherent dedup hash.
 type jsonlEventRow struct {
-	ChainID  string  `json:"chain_id"`
-	Seq      int64   `json:"seq"`
-	ThisHash string  `json:"this_hash"`
-	PrevHash *string `json:"prev_hash"`
+	ChainID   string          `json:"chain_id"`
+	Seq       int64           `json:"seq"`
+	ThisHash  string          `json:"this_hash"`
+	PrevHash  *string         `json:"prev_hash"`
+	EventType string          `json:"event_type"`
+	Ts        string          `json:"ts"`
+	Payload   json.RawMessage `json:"payload"`
 }
 
 // RebuildFromJSONL brings the index into agreement with the ground-truth JSONL
@@ -320,17 +399,49 @@ func (i *Index) RebuildFromJSONL(chitinDir string) error {
 			continue
 		}
 		last := rows[len(rows)-1]
+		// LogicalHash recomputed from canonical (event_type, payload) so
+		// the dedup-window check on next emit works even on legacy chains
+		// reconciled from JSONL.
+		logicalHash := LogicalHash(last.EventType, last.Payload)
 		if _, err := i.db.Exec(
-			`INSERT INTO chains (chain_id, last_seq, last_hash)
-			 VALUES (?, ?, ?)
+			`INSERT INTO chains (chain_id, last_seq, last_hash, last_event_type, last_logical_hash, last_emit_ts)
+			 VALUES (?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(chain_id) DO UPDATE
-			   SET last_seq  = excluded.last_seq,
-			       last_hash = excluded.last_hash
+			   SET last_seq          = excluded.last_seq,
+			       last_hash         = excluded.last_hash,
+			       last_event_type   = excluded.last_event_type,
+			       last_logical_hash = excluded.last_logical_hash,
+			       last_emit_ts      = excluded.last_emit_ts
 			   WHERE excluded.last_seq > last_seq`,
-			chainID, last.Seq, last.ThisHash,
+			chainID, last.Seq, last.ThisHash, last.EventType, logicalHash, last.Ts,
 		); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// LogicalHash returns a stable hash over (event_type, payload) — the
+// fields that uniquely identify a logical event regardless of when /
+// how many times it was emitted. Used for idempotent-emit dedup (#16):
+// retries of the same logical event yield identical LogicalHash even
+// though Ts/Seq/PrevHash/ThisHash all differ.
+//
+// Empty event_type or empty payload yield a stable empty-prefix hash;
+// callers should treat the empty string as "no logical hash available"
+// and skip the dedup check.
+func LogicalHash(eventType string, payload json.RawMessage) string {
+	if eventType == "" {
+		return ""
+	}
+	// Canonical-ish JSON: payload may already be canonical from
+	// hash.HashEvent's pipeline; if not, json.Marshal of a sorted
+	// re-decode would be more rigorous. For dedup purposes we just
+	// need byte-equal across retries, which is what the kernel-emit
+	// path produces (deterministic JSON encoding).
+	h := sha256.New()
+	h.Write([]byte(eventType))
+	h.Write([]byte{0})
+	h.Write(payload)
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/go/execution-kernel/internal/chain/chain_test.go
+++ b/go/execution-kernel/internal/chain/chain_test.go
@@ -33,7 +33,7 @@ func TestIndex_NewChainReturnsZero(t *testing.T) {
 
 func TestIndex_UpsertAndGet(t *testing.T) {
 	idx := newTempIndex(t)
-	if err := idx.Upsert("chainA", 0, "hash0"); err != nil {
+	if err := idx.Upsert("chainA", 0, "hash0", "", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	info, err := idx.Get("chainA")
@@ -44,7 +44,7 @@ func TestIndex_UpsertAndGet(t *testing.T) {
 		t.Errorf("unexpected info: %+v", info)
 	}
 
-	if err := idx.Upsert("chainA", 1, "hash1"); err != nil {
+	if err := idx.Upsert("chainA", 1, "hash1", "", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	info, _ = idx.Get("chainA")
@@ -55,8 +55,8 @@ func TestIndex_UpsertAndGet(t *testing.T) {
 
 func TestIndex_TwoChainsIndependent(t *testing.T) {
 	idx := newTempIndex(t)
-	idx.Upsert("A", 0, "ha")
-	idx.Upsert("B", 0, "hb")
+	idx.Upsert("A", 0, "ha", "", "", "")
+	idx.Upsert("B", 0, "hb", "", "", "")
 	a, _ := idx.Get("A")
 	b, _ := idx.Get("B")
 	if a.LastHash != "ha" || b.LastHash != "hb" {

--- a/go/execution-kernel/internal/emit/emit.go
+++ b/go/execution-kernel/internal/emit/emit.go
@@ -4,13 +4,28 @@ package emit
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/chain"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/hash"
 )
+
+// ErrSessionEnded is returned by Emit when the chain's tail is already
+// session_end and the new event is not also session_end. Spec §3
+// invariant — once a session has ended, no further non-session_end
+// events may land on its chain. Closes #3.
+var ErrSessionEnded = errors.New("emit: chain has session_end tail; cannot emit non-session_end event")
+
+// IdempotentDedupWindow is the time window within which a retried emit
+// (same logical content as the chain tail) is treated as a duplicate
+// and skipped without writing. 30s covers transport timeouts and
+// caller retry policies; legitimately distinct events with identical
+// content at sub-30s cadence are vanishingly rare. Closes #16.
+const IdempotentDedupWindow = 30 * time.Second
 
 // Emitter appends events to a JSONL log and updates the chain index.
 //
@@ -55,7 +70,42 @@ func (e *Emitter) Emit(ev *event.Event) error {
 	}
 	defer tx.Rollback() // no-op if Commit was called
 
+	// Compute logical hash up front — used for both invariant checks
+	// (idempotent dedup) and stamped on commit for the next emit's
+	// dedup-window check. Empty payload yields an empty logical hash,
+	// in which case dedup is skipped (caller chose not to participate).
+	logicalHash := chain.LogicalHash(ev.EventType, ev.Payload)
+
 	if tx.Current != nil {
+		// #3: session_end-is-last invariant. A non-session_end event
+		// may not land on a chain whose tail is session_end. Refuse.
+		if tx.Current.LastEventType == "session_end" && ev.EventType != "session_end" {
+			return fmt.Errorf("%w: chain=%s last_seq=%d new_event_type=%s",
+				ErrSessionEnded, ev.ChainID, tx.Current.LastSeq, ev.EventType)
+		}
+		// #16: idempotent emit. If the chain tail has identical
+		// logical content AND was emitted within the dedup window,
+		// the new emit is a retry — skip the write and return the
+		// tail's existing ThisHash so callers see the operation as
+		// successful. This catches the common timeout-retry case
+		// where the writer doesn't know whether the prior emit
+		// succeeded; a deterministic logical match within 30s is
+		// the strongest signal we have without a client-supplied
+		// idempotency key.
+		if logicalHash != "" &&
+			tx.Current.LastLogicalHash == logicalHash &&
+			withinDedupWindow(tx.Current.LastEmitTs) {
+			ev.Seq = tx.Current.LastSeq
+			prev := "" // not meaningful for the dedup-no-op path
+			if ev.Seq > 0 {
+				prev = tx.Current.LastHash // best-effort; caller may inspect
+			}
+			_ = prev // populate below if useful in future
+			ev.ThisHash = tx.Current.LastHash
+			// Don't write JSONL, don't bump seq, don't OTEL — the
+			// prior emit already did all of that. Roll back the tx.
+			return nil
+		}
 		ev.Seq = tx.Current.LastSeq + 1
 		prev := tx.Current.LastHash
 		ev.PrevHash = &prev
@@ -94,7 +144,7 @@ func (e *Emitter) Emit(ev *event.Event) error {
 		return fmt.Errorf("close log: %w", cerr)
 	}
 
-	if err := tx.Commit(ev.Seq, ev.ThisHash); err != nil {
+	if err := tx.Commit(ev.Seq, ev.ThisHash, ev.EventType, logicalHash, ev.Ts); err != nil {
 		return err
 	}
 
@@ -103,4 +153,22 @@ func (e *Emitter) Emit(ev *event.Event) error {
 	// affect canonical state. Safe when OTEL is nil (no-op).
 	e.OTEL.ProjectAndPost(ev, e.Index)
 	return nil
+}
+
+// withinDedupWindow returns true iff lastEmitTs is RFC3339-parseable
+// and within IdempotentDedupWindow of now. Empty / unparseable lastEmitTs
+// returns false (no dedup — legacy chain or no metadata available).
+func withinDedupWindow(lastEmitTs string) bool {
+	if lastEmitTs == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, lastEmitTs)
+	if err != nil {
+		// Try the nano variant the kernel sometimes uses.
+		t, err = time.Parse(time.RFC3339Nano, lastEmitTs)
+		if err != nil {
+			return false
+		}
+	}
+	return time.Since(t) <= IdempotentDedupWindow
 }

--- a/go/execution-kernel/internal/emit/invariants_test.go
+++ b/go/execution-kernel/internal/emit/invariants_test.go
@@ -1,0 +1,160 @@
+package emit
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/event"
+)
+
+// minimalEvent builds a valid v2 event of the given type / payload on
+// the given chain, with the given timestamp. Strict-enough for the
+// kernel emit path; mirrors minimalSessionStart's invariant fields.
+func minimalEvent(chainID, eventType string, seq int64, ts string, payload string) *event.Event {
+	return &event.Event{
+		SchemaVersion:    "2",
+		RunID:            "550e8400-e29b-41d4-a716-446655440000",
+		SessionID:        "550e8400-e29b-41d4-a716-446655440001",
+		Surface:          "claude-code",
+		DriverIdentity:   event.DriverIdentity{User: "u", MachineID: "m", MachineFingerprint: "a" + repeat("0", 63)},
+		AgentInstanceID:  "550e8400-e29b-41d4-a716-446655440002",
+		AgentFingerprint: "b" + repeat("0", 63),
+		EventType:        eventType,
+		ChainID:          chainID,
+		ChainType:        "session",
+		Seq:              seq,
+		Ts:               ts,
+		Labels:           map[string]string{},
+		Payload:          json.RawMessage(payload),
+	}
+}
+
+// TestEmit_SessionEndIsLast_Refuses asserts the #3 invariant: once a
+// chain has session_end as its tail, any non-session_end emit on that
+// chain returns ErrSessionEnded.
+func TestEmit_SessionEndIsLast_Refuses(t *testing.T) {
+	dir, idx := newEnv(t)
+	e := Emitter{LogPath: filepath.Join(dir, "events.jsonl"), Index: idx}
+
+	// Seed: session_start, then session_end.
+	if err := e.Emit(minimalSessionStart("chainA", 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Emit(minimalEvent("chainA", "session_end", 0,
+		"2026-05-02T12:00:00.000Z", `{"reason":"normal"}`)); err != nil {
+		t.Fatalf("seed session_end: %v", err)
+	}
+
+	// Now try to emit a pre_tool_use after session_end. Must fail.
+	bad := minimalEvent("chainA", "pre_tool_use", 0,
+		"2026-05-02T12:00:01.000Z", `{"tool_name":"Bash"}`)
+	err := e.Emit(bad)
+	if err == nil {
+		t.Fatalf("expected ErrSessionEnded, got nil — chain corrupted")
+	}
+	if !errors.Is(err, ErrSessionEnded) {
+		t.Errorf("expected ErrSessionEnded wrap, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "chainA") {
+		t.Errorf("error should identify the chain, got: %v", err)
+	}
+}
+
+// TestEmit_SessionEndIsLast_AllowsSecondSessionEnd asserts the carve-out:
+// session_end after session_end is allowed (re-emit / late observation).
+// Ensures the invariant doesn't break legitimate idempotent close paths.
+func TestEmit_SessionEndIsLast_AllowsSecondSessionEnd(t *testing.T) {
+	dir, idx := newEnv(t)
+	e := Emitter{LogPath: filepath.Join(dir, "events.jsonl"), Index: idx}
+
+	if err := e.Emit(minimalSessionStart("chainA", 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Emit(minimalEvent("chainA", "session_end", 0,
+		"2026-05-02T12:00:00.000Z", `{"reason":"normal"}`)); err != nil {
+		t.Fatal(err)
+	}
+	// Same logical content within the dedup window → idempotent skip
+	// (next test covers that). Use distinct content + future ts so this
+	// is a genuinely different session_end re-emit.
+	second := minimalEvent("chainA", "session_end", 0,
+		time.Now().UTC().Add(IdempotentDedupWindow+1*time.Second).Format(time.RFC3339Nano),
+		`{"reason":"late_observation"}`)
+	if err := e.Emit(second); err != nil {
+		t.Errorf("second session_end must be allowed (carve-out): %v", err)
+	}
+}
+
+// TestEmit_IdempotentDedup_SkipsRetryWithinWindow asserts the #16
+// invariant: a re-emit of identical logical content within the dedup
+// window is treated as a duplicate. The chain index must NOT advance
+// and the JSONL must NOT grow a duplicate line.
+func TestEmit_IdempotentDedup_SkipsRetryWithinWindow(t *testing.T) {
+	dir, idx := newEnv(t)
+	e := Emitter{LogPath: filepath.Join(dir, "events.jsonl"), Index: idx}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := e.Emit(minimalEvent("chainA", "session_start", 0, now,
+		`{"cwd":"/","client_info":{"name":"x","version":"1"},"model":{"name":"m","provider":"p"},"system_prompt_hash":"`+repeat("0", 64)+`","tool_allowlist_hash":"`+repeat("0", 64)+`","agent_version":"1"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	infoBefore, _ := idx.Get("chainA")
+	linesBefore := readLines(t, e.LogPath)
+
+	// Retry the SAME logical event with a slightly later timestamp.
+	// The retry's logical_hash matches the chain tail's, so dedup fires.
+	retry := minimalEvent("chainA", "session_start", 0,
+		time.Now().UTC().Add(1*time.Second).Format(time.RFC3339Nano),
+		`{"cwd":"/","client_info":{"name":"x","version":"1"},"model":{"name":"m","provider":"p"},"system_prompt_hash":"`+repeat("0", 64)+`","tool_allowlist_hash":"`+repeat("0", 64)+`","agent_version":"1"}`)
+	if err := e.Emit(retry); err != nil {
+		t.Fatalf("retry should succeed (no-op), got: %v", err)
+	}
+
+	infoAfter, _ := idx.Get("chainA")
+	linesAfter := readLines(t, e.LogPath)
+
+	if infoBefore.LastSeq != infoAfter.LastSeq {
+		t.Errorf("LastSeq advanced on retry: before=%d after=%d (idempotent dedup failed)",
+			infoBefore.LastSeq, infoAfter.LastSeq)
+	}
+	if len(linesBefore) != len(linesAfter) {
+		t.Errorf("JSONL grew on retry: before=%d after=%d lines (duplicate written)",
+			len(linesBefore), len(linesAfter))
+	}
+	if retry.ThisHash != infoBefore.LastHash {
+		t.Errorf("retry ThisHash should match chain tail: got %q want %q",
+			retry.ThisHash, infoBefore.LastHash)
+	}
+}
+
+// TestEmit_IdempotentDedup_DistinctContentStillEmits asserts that
+// content-different events on the same chain DO emit. Otherwise the
+// dedup logic would silently swallow legitimate distinct events with
+// happen-to-be-similar payloads.
+func TestEmit_IdempotentDedup_DistinctContentStillEmits(t *testing.T) {
+	dir, idx := newEnv(t)
+	e := Emitter{LogPath: filepath.Join(dir, "events.jsonl"), Index: idx}
+
+	if err := e.Emit(minimalSessionStart("chainA", 0)); err != nil {
+		t.Fatal(err)
+	}
+	infoAfterFirst, _ := idx.Get("chainA")
+
+	// Distinct event_type AND distinct payload — different logical hash.
+	if err := e.Emit(minimalEvent("chainA", "pre_tool_use", 0,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		`{"tool_name":"Bash","tool_input":{"command":"echo hi"}}`)); err != nil {
+		t.Fatal(err)
+	}
+	infoAfterSecond, _ := idx.Get("chainA")
+
+	if infoAfterSecond.LastSeq != infoAfterFirst.LastSeq+1 {
+		t.Errorf("distinct event must advance LastSeq: before=%d after=%d",
+			infoAfterFirst.LastSeq, infoAfterSecond.LastSeq)
+	}
+}

--- a/go/execution-kernel/internal/emit/otel_test.go
+++ b/go/execution-kernel/internal/emit/otel_test.go
@@ -175,7 +175,7 @@ func TestParentSpanIdRules(t *testing.T) {
 
 	const parentChainID = "11111111-1111-1111-1111-111111111111"
 	const parentLastHash = "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-	if err := idx.Upsert(parentChainID, 5, parentLastHash); err != nil {
+	if err := idx.Upsert(parentChainID, 5, parentLastHash, "", "", ""); err != nil {
 		t.Fatalf("seed parent chain: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Two emit-time invariants the chain index couldn't enforce because it didn't track event_type or logical content for the chain tail. Added three columns to the chains table (\`last_event_type\`, \`last_logical_hash\`, \`last_emit_ts\`) plus migrations; \`emit.go\` reads them inside the BeginEmit transaction and refuses to violate either invariant.

- **#3** — \`session_end\`-is-last. After session_end lands on a chain, any non-session_end emit returns \`ErrSessionEnded\`. A second session_end is allowed (idempotent close / late observation). Closes the spec §3 gap where late tool_results, racy SubagentStops, or buggy hook fires could append \`assistant_turn\` / \`post_tool_use\` AFTER the canonical session_end and silently corrupt replay.
- **#16** — Idempotent emit. A retried emit (same event_type + payload as the chain tail, within 30s) is treated as a duplicate: no JSONL write, no seq bump, no OTEL projection. \`ev.ThisHash\` gets set to the existing chain tail's hash so the caller sees the operation as successful. Catches the common timeout-retry case.

The dedup is conservative: 30s window, matches only on (event_type, payload). Two events with identical content emitted >30s apart are NOT deduped.

Schema migration: \`ALTER TABLE chains ADD COLUMN ... DEFAULT ''\` for each new column. \"Duplicate column name\" errors swallowed for fresh DBs. Empty defaults mean legacy chains gracefully no-op the new invariants until their first new-format emit.

Filed as follow-ups (require empirical lab work): **#21** (SubagentStop chain routing), **#22** (PreCompact dedupe — needs forced-trial of whether Claude Code fires duplicate hooks), **#4** (subagent invariants; depends on #21).

## Test plan
- [x] \`go test ./...\` clean across the kernel
- [x] 4 new tests in \`emit/invariants_test.go\` cover session_end refuses, session_end re-emit allowed, idempotent dedup skips retry, distinct content still emits
- [x] Existing chain + emit tests pass with new Upsert/Commit signatures
- [ ] CI green

Closes #3
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)