### PR TITLE
test: shared TS↔Go fixtures + schema-drift gate — closes #7, #15, #17

### DIFF
--- a/go/execution-kernel/internal/event/parity_test.go
+++ b/go/execution-kernel/internal/event/parity_test.go
@@ -1,0 +1,111 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestEvent_FixtureRoundTripPreservesAllKeys is the Go side of the
+// schema-drift gate (#17). The shared fixture
+// libs/contracts/tests/envelope.golden.json is the contract; this
+// test decodes it into Event and asserts ToMap's output contains
+// every key from the fixture.
+//
+// What this catches:
+//
+//	zod adds a field but Go's Event struct doesn't get it
+//	  → JSON-decode of the fixture leaves Event.X = zero-value,
+//	    ToMap doesn't emit X, round-trip key set is missing X.
+//
+//	Go adds a field but zod schema doesn't include it
+//	  → fixture would have to be updated to include the new field
+//	    for THIS test to pass; the TS-side parity test would then
+//	    fail because zod doesn't know about it.
+//
+// In both cases the drift becomes a CI failure on one side or the
+// other, forcing an explicit cross-language coordination.
+func TestEvent_FixtureRoundTripPreservesAllKeys(t *testing.T) {
+	repoRoot, err := findRepoRootForEvent()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	fixturePath := filepath.Join(repoRoot, "libs", "contracts", "tests", "envelope.golden.json")
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	// Step 1: snapshot the fixture's key set.
+	var fixtureMap map[string]any
+	if err := json.Unmarshal(raw, &fixtureMap); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	fixtureKeys := keys(fixtureMap)
+
+	// Step 2: decode into Event, re-emit via ToMap.
+	var ev Event
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		t.Fatalf("decode into Event: %v", err)
+	}
+	emitted, err := ev.ToMap()
+	if err != nil {
+		t.Fatalf("ToMap: %v", err)
+	}
+	emittedKeys := keys(emitted)
+
+	// Step 3: every key the fixture has must appear in the round-tripped
+	// output. Extras in the round-trip are also a sign of drift (Go
+	// emitting a field zod doesn't know about) — fail on those too.
+	missing := setDiff(fixtureKeys, emittedKeys)
+	extra := setDiff(emittedKeys, fixtureKeys)
+	if len(missing) > 0 {
+		t.Errorf("Event.ToMap dropped fixture keys (Go-side drift): %v", missing)
+	}
+	if len(extra) > 0 {
+		t.Errorf("Event.ToMap emitted keys not in fixture (Go added fields without zod update): %v", extra)
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func setDiff(a, b []string) []string {
+	bSet := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		bSet[x] = struct{}{}
+	}
+	var out []string
+	for _, x := range a {
+		if _, ok := bSet[x]; !ok {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+func findRepoRootForEvent() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(cwd, "libs", "contracts", "tests", "envelope.golden.json")); err == nil {
+			return cwd, nil
+		}
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			return "", fmt.Errorf("envelope.golden.json not found walking up from cwd")
+		}
+		cwd = parent
+	}
+}

--- a/go/execution-kernel/internal/hash/hash_test.go
+++ b/go/execution-kernel/internal/hash/hash_test.go
@@ -2,6 +2,10 @@ package hash
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -67,29 +71,66 @@ func TestHashEvent_ExcludesThisHash(t *testing.T) {
 	}
 }
 
+// TestCanonicalJSON_EventGolden asserts byte-equality against a SHARED
+// fixture at libs/contracts/tests/canonical.golden.{json,txt} that the
+// TS canonicalJSON implementation also reads. Closes #7 + #15: the two
+// implementations can no longer drift silently on opposite-side test
+// suites — a divergence on either side fails its own goldensuite.
+//
+// Fixture source-of-truth lives under libs/contracts/tests/ because
+// the contracts library is the cross-language schema home; the Go and
+// TS test suites both load from there.
 func TestCanonicalJSON_EventGolden(t *testing.T) {
-	event := map[string]any{
-		"schema_version":  "2",
-		"run_id":          "550e8400-e29b-41d4-a716-446655440000",
-		"session_id":      "550e8400-e29b-41d4-a716-446655440001",
-		"surface":         "claude-code",
-		"seq":             0.0,
-		"event_type":      "session_start",
-		"chain_type":      "session",
-		"parent_chain_id": nil,
-		"prev_hash":       nil,
-		"labels":          map[string]any{},
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	inputBytes, err := os.ReadFile(filepath.Join(repoRoot, "libs", "contracts", "tests", "canonical.golden.json"))
+	if err != nil {
+		t.Fatalf("read input fixture: %v", err)
+	}
+	wantBytes, err := os.ReadFile(filepath.Join(repoRoot, "libs", "contracts", "tests", "canonical.golden.txt"))
+	if err != nil {
+		t.Fatalf("read want fixture: %v", err)
+	}
+	want := strings.TrimRight(string(wantBytes), "\n")
+
+	var event map[string]any
+	if err := json.Unmarshal(inputBytes, &event); err != nil {
+		t.Fatalf("parse input fixture: %v", err)
 	}
 	got, err := CanonicalJSON(event)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `{"chain_type":"session","event_type":"session_start","labels":{},"parent_chain_id":null,"prev_hash":null,"run_id":"550e8400-e29b-41d4-a716-446655440000","schema_version":"2","seq":0,"session_id":"550e8400-e29b-41d4-a716-446655440001","surface":"claude-code"}`
 	if got != want {
-		t.Errorf("golden canonical JSON mismatch:\ngot:  %s\nwant: %s", got, want)
+		t.Errorf("golden canonical JSON mismatch (Go side):\ngot:  %s\nwant: %s", got, want)
 	}
 	var rt map[string]any
 	if err := json.Unmarshal([]byte(got), &rt); err != nil {
 		t.Fatalf("canonical JSON did not parse: %v", err)
+	}
+}
+
+// findRepoRoot walks up from the test's working dir until it finds a
+// directory containing both `libs/contracts` and `go/execution-kernel`.
+// Used by the shared-fixture goldensuite so the test works regardless
+// of `go test` cwd.
+func findRepoRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(cwd, "libs", "contracts")); err == nil {
+			if _, err := os.Stat(filepath.Join(cwd, "go", "execution-kernel")); err == nil {
+				return cwd, nil
+			}
+		}
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			return "", fmt.Errorf("repo root not found walking up from cwd")
+		}
+		cwd = parent
 	}
 }

--- a/libs/contracts/tests/canonical.golden.json
+++ b/libs/contracts/tests/canonical.golden.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "2",
+  "run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "session_id": "550e8400-e29b-41d4-a716-446655440001",
+  "surface": "claude-code",
+  "seq": 0,
+  "event_type": "session_start",
+  "chain_type": "session",
+  "parent_chain_id": null,
+  "prev_hash": null,
+  "labels": {}
+}

--- a/libs/contracts/tests/canonical.golden.txt
+++ b/libs/contracts/tests/canonical.golden.txt
@@ -1,0 +1,1 @@
+{"chain_type":"session","event_type":"session_start","labels":{},"parent_chain_id":null,"prev_hash":null,"run_id":"550e8400-e29b-41d4-a716-446655440000","schema_version":"2","seq":0,"session_id":"550e8400-e29b-41d4-a716-446655440001","surface":"claude-code"}

--- a/libs/contracts/tests/envelope-parity.test.ts
+++ b/libs/contracts/tests/envelope-parity.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { EnvelopeSchema } from '../src/envelope.schema';
+
+// Schema-drift gate (closes #17). The shared fixture
+// libs/contracts/tests/envelope.golden.json has every v2 envelope field
+// populated. This test asserts:
+//
+//   1. zod parses the fixture without errors (zod.Envelope == fixture shape).
+//   2. The fixture's key set matches EnvelopeSchema's key set + 'payload'.
+//
+// The Go side (go/execution-kernel/internal/event/event_parity_test.go)
+// has a mirrored test that decodes the same fixture into Event and
+// asserts ToMap's output preserves the key set. A field added to zod
+// without the matching Go change fails the Go test; a field added to
+// Go without the zod change fails the TS test.
+
+describe('Envelope schema drift gate', () => {
+  const fixture = JSON.parse(
+    readFileSync(join(__dirname, 'envelope.golden.json'), 'utf8'),
+  );
+
+  it('zod parses the shared envelope fixture without error', () => {
+    // Strip payload (the schema is envelope-only; payload has its own
+    // discriminated schemas keyed by event_type).
+    const { payload: _payload, ...envelope } = fixture;
+    const parsed = EnvelopeSchema.parse(envelope);
+    expect(parsed.schema_version).toBe('2');
+  });
+
+  it('fixture key set matches the EnvelopeSchema key set + payload', () => {
+    const fixtureKeys = new Set(Object.keys(fixture));
+    // envelope-side keys (everything except payload)
+    const fixtureEnvelopeKeys = new Set(
+      [...fixtureKeys].filter((k) => k !== 'payload'),
+    );
+
+    const schemaKeys = new Set(Object.keys(EnvelopeSchema.shape));
+
+    // No extras in fixture
+    const fixtureOnly = [...fixtureEnvelopeKeys].filter(
+      (k) => !schemaKeys.has(k),
+    );
+    expect(fixtureOnly).toEqual([]);
+    // No missing in fixture
+    const schemaOnly = [...schemaKeys].filter(
+      (k) => !fixtureEnvelopeKeys.has(k),
+    );
+    expect(schemaOnly).toEqual([]);
+    // Fixture must include payload (Event has payload too)
+    expect(fixtureKeys.has('payload')).toBe(true);
+  });
+});

--- a/libs/contracts/tests/envelope.golden.json
+++ b/libs/contracts/tests/envelope.golden.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "2",
+  "run_id": "550e8400-e29b-41d4-a716-446655440000",
+  "session_id": "550e8400-e29b-41d4-a716-446655440001",
+  "surface": "claude-code",
+  "driver_identity": {
+    "user": "jared",
+    "machine_id": "test-box",
+    "machine_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "agent_instance_id": "550e8400-e29b-41d4-a716-446655440002",
+  "parent_agent_id": null,
+  "agent_fingerprint": "0000000000000000000000000000000000000000000000000000000000000001",
+  "event_type": "session_start",
+  "chain_id": "550e8400-e29b-41d4-a716-446655440001",
+  "chain_type": "session",
+  "parent_chain_id": null,
+  "seq": 0,
+  "prev_hash": null,
+  "this_hash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+  "ts": "2026-05-02T22:00:00.000Z",
+  "labels": {"env": "test"},
+  "payload": {}
+}

--- a/libs/contracts/tests/hash.test.ts
+++ b/libs/contracts/tests/hash.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { canonicalJSON, sha256Hex, hashEvent } from '../src/hash';
 
@@ -20,6 +22,19 @@ describe('canonicalJSON', () => {
 
   it('handles nulls', () => {
     expect(canonicalJSON({ a: null })).toBe('{"a":null}');
+  });
+
+  // Cross-language goldensuite: closes #7 + #15. Reads the same fixture
+  // pair the Go test reads (canonical.golden.json + canonical.golden.txt)
+  // and asserts byte-equal canonicalJSON output. A divergence on either
+  // side fails its own goldensuite — the two implementations can no
+  // longer drift silently while both pass their local sort/whitespace
+  // structural checks.
+  it('byte-equals the shared golden fixture (parity with Go)', () => {
+    const fixtureDir = __dirname;
+    const input = JSON.parse(readFileSync(join(fixtureDir, 'canonical.golden.json'), 'utf8'));
+    const want = readFileSync(join(fixtureDir, 'canonical.golden.txt'), 'utf8').replace(/\n+$/, '');
+    expect(canonicalJSON(input)).toBe(want);
   });
 });
 


### PR DESCRIPTION
## Summary

Three contract-drift issues fixed via shared fixtures both Go and TS reference.

- **#7 + #15** — Canonical-JSON parity. Shared \`canonical.golden.json\` (input) + \`canonical.golden.txt\` (expected output). Go and TS tests both load + byte-equal-assert. Silent drift on either side fails its own goldensuite.
- **#17** — Schema-drift gate (cheap interim per issue's option 2). Shared \`envelope.golden.json\` with every v2 envelope field populated. TS test asserts zod parses fixture + key sets match. Go test asserts \`Event.ToMap\` round-trip preserves all keys (no missing, no extra).

Drift cases the schema-drift gate catches:
- zod adds field, Go doesn't → Go test fails (missing key in round-trip)
- Go adds field, zod doesn't → TS test fails (zod doesn't know the key)

Both force explicit cross-language coordination. Option 1 (regenerate Go from zod) is the long-term fix; this gate prevents silent regressions until then.

## Test plan
- [x] \`go test ./...\` clean (Go side reads shared fixtures)
- [x] \`pnpm exec vitest run libs/contracts/\` 110/110 pass (TS side reads same fixtures)
- [x] Both \`canonical.golden.json/txt\` and \`envelope.golden.json\` are committed in libs/contracts/tests/
- [ ] CI green
- [ ] Manual drift drill: add a field to zod, confirm Go test fails

Closes #7
Closes #15
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)