### PR TITLE
fix(ts): SQLite WAL + machine_fingerprint coherence + temp-dir cleanup — closes #5, #8, #9

### DIFF
--- a/apps/cli/src/ctx.ts
+++ b/apps/cli/src/ctx.ts
@@ -32,8 +32,14 @@ const KERNEL_BIN_ENV = 'CHITIN_KERNEL_BINARY';
 export function buildAdapterContext(input: AdapterContextInput): AdapterContext {
   const user = input.user ?? userInfo().username;
   const machineID = input.machineID ?? hostname();
+  // Closes #9: derive machine_fingerprint from the RESOLVED machineID,
+  // not raw hostname(). When the caller passes machineID (tests,
+  // container setups, hostname-translation envs), the prior code
+  // hashed the un-translated hostname — so driver_identity.machine_id
+  // and driver_identity.machine_fingerprint could disagree, forcing
+  // analytics to choose between two views of the same machine.
   const machineFingerprint = sha256Hex(
-    `${hostname()}|${userInfo().uid}|chitin-machine-fingerprint-v2`,
+    `${machineID}|${userInfo().uid}|chitin-machine-fingerprint-v2`,
   );
   const agentFingerprint = sha256Hex(
     JSON.stringify({

--- a/libs/contracts/tests/chitindir-resolve.test.ts
+++ b/libs/contracts/tests/chitindir-resolve.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, statSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { describe, it, expect, afterEach } from 'vitest';
@@ -7,12 +7,23 @@ import { resolveChitinDir } from '../src/chitindir-resolve';
 describe('resolveChitinDir', () => {
   const originalHome = process.env.HOME;
 
+  // #8: track temp dirs and rm them in afterEach so /tmp doesn't
+  // accumulate across CI runs.
+  const tempDirs: string[] = [];
+  function tempDir(prefix: string): string {
+    const d = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(d);
+    return d;
+  }
+
   afterEach(() => {
     process.env.HOME = originalHome;
+    for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+    tempDirs.length = 0;
   });
 
   it('finds an existing .chitin dir in a parent', () => {
-    const root = mkdtempSync(join(tmpdir(), 'cd-test-'));
+    const root = tempDir('cd-test-');
     const chitin = join(root, '.chitin');
     mkdirSync(chitin);
     const nested = join(root, 'a', 'b');
@@ -26,8 +37,8 @@ describe('resolveChitinDir', () => {
     // Sandbox the walk-up inside the temp dir so a stray /tmp/.chitin
     // on the host cannot be found. Passing boundary=sandbox stops the
     // walk at the sandbox, exercising the orphan-fallback path.
-    const sandbox = mkdtempSync(join(tmpdir(), 'cd-cwd-'));
-    const fakeHome = mkdtempSync(join(tmpdir(), 'cd-home-'));
+    const sandbox = tempDir('cd-cwd-');
+    const fakeHome = tempDir('cd-home-');
     process.env.HOME = fakeHome;
 
     const got = resolveChitinDir(sandbox, sandbox);
@@ -37,12 +48,12 @@ describe('resolveChitinDir', () => {
   });
 
   it('stops at workspace boundary', () => {
-    const boundary = mkdtempSync(join(tmpdir(), 'cd-bound-'));
+    const boundary = tempDir('cd-bound-');
     const outside = dirname(boundary);
     mkdirSync(join(outside, '.chitin'), { recursive: true });
     const nested = join(boundary, 'sub');
     mkdirSync(nested);
-    const fakeHome = mkdtempSync(join(tmpdir(), 'cd-home2-'));
+    const fakeHome = tempDir('cd-home2-');
     process.env.HOME = fakeHome;
 
     const got = resolveChitinDir(nested, boundary);

--- a/libs/telemetry/src/sqlite-indexer.ts
+++ b/libs/telemetry/src/sqlite-indexer.ts
@@ -51,6 +51,15 @@ CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
 
 export function indexEvents(dbPath: string, events: V2Event[]): void {
   const db = new BetterSqlite3(dbPath);
+  // WAL + NORMAL synchronous: closes #5. Without WAL, concurrent
+  // readers (events list/tree/replay during indexing) hit a SHARED
+  // lock contention with the indexer's RESERVED writer lock and
+  // serialize at SQLite's level. WAL flips the read path to a
+  // separate snapshot that doesn't block writes. NORMAL synchronous
+  // is fsync-on-checkpoint rather than per-write — durable enough
+  // for an append-only event log whose ground truth is the JSONL.
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
   db.exec(CREATE_SCHEMA);
   const stmt = db.prepare(`
     INSERT OR IGNORE INTO events (

--- a/libs/telemetry/tests/ensure-indexed.test.ts
+++ b/libs/telemetry/tests/ensure-indexed.test.ts
@@ -1,9 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import BetterSqlite3 from 'better-sqlite3';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureIndexed } from '../src/ensure-indexed';
+
+// #8: track temp dirs and rm in afterEach.
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+function tempDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
 
 const sampleEvent = (over: Record<string, unknown> = {}) => ({
   schema_version: '2',
@@ -29,7 +41,7 @@ const sampleEvent = (over: Record<string, unknown> = {}) => ({
 
 describe('ensureIndexed', () => {
   it('materializes JSONL into events.db', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-ei-'));
+    const dir = tempDir('chitin-ei-');
     writeFileSync(
       join(dir, 'events-r-1.jsonl'),
       JSON.stringify(sampleEvent({ this_hash: 'a'.repeat(64) })) + '\n' +
@@ -43,7 +55,7 @@ describe('ensureIndexed', () => {
   });
 
   it('is idempotent on re-run', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-ei-'));
+    const dir = tempDir('chitin-ei-');
     writeFileSync(
       join(dir, 'events-r-1.jsonl'),
       JSON.stringify(sampleEvent({ this_hash: 'a'.repeat(64) })) + '\n',
@@ -57,7 +69,7 @@ describe('ensureIndexed', () => {
   });
 
   it('tolerates malformed lines', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-ei-'));
+    const dir = tempDir('chitin-ei-');
     writeFileSync(
       join(dir, 'events-r-1.jsonl'),
       JSON.stringify(sampleEvent({ this_hash: 'a'.repeat(64) })) + '\n{bad\n' + JSON.stringify(sampleEvent({ this_hash: 'b'.repeat(64) })) + '\n',

--- a/libs/telemetry/tests/jsonl-tailer.test.ts
+++ b/libs/telemetry/tests/jsonl-tailer.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { tailJSONL } from '../src/jsonl-tailer';
+
+// #8: track temp dirs and rm in afterEach.
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+function tempDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
 
 const sampleLine = JSON.stringify({
   schema_version: '2',
@@ -27,7 +39,7 @@ const sampleLine = JSON.stringify({
 
 describe('tailJSONL', () => {
   it('yields parsed v2 events from a JSONL file', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-tel-'));
+    const dir = tempDir('chitin-tel-');
     const path = join(dir, 'events.jsonl');
     writeFileSync(path, sampleLine + '\n' + sampleLine + '\n');
     const out: unknown[] = [];
@@ -37,7 +49,7 @@ describe('tailJSONL', () => {
   });
 
   it('tolerates malformed lines by skipping them', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-tel-'));
+    const dir = tempDir('chitin-tel-');
     const path = join(dir, 'events.jsonl');
     writeFileSync(path, sampleLine + '\n{bad\n' + sampleLine + '\n');
     const out: unknown[] = [];

--- a/libs/telemetry/tests/replay.test.ts
+++ b/libs/telemetry/tests/replay.test.ts
@@ -1,9 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { indexEvents } from '../src/sqlite-indexer';
 import { replaySessionAsTree } from '../src/replay';
+
+// #8: track temp dirs and rm in afterEach.
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+function tempDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
 
 function baseEvent(over: Record<string, unknown>) {
   return {
@@ -31,7 +43,7 @@ function baseEvent(over: Record<string, unknown>) {
 
 describe('replaySessionAsTree', () => {
   it('returns rows for the requested session, time-ordered, JSON columns parsed', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-tel-'));
+    const dir = tempDir('chitin-tel-');
     const dbPath = join(dir, 'events.db');
     indexEvents(dbPath, [
       baseEvent({ this_hash: 'a'.repeat(64), ts: '2026-04-19T12:00:00Z', labels: { env: 'dev' } }),

--- a/libs/telemetry/tests/sqlite-indexer.test.ts
+++ b/libs/telemetry/tests/sqlite-indexer.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { indexEvents } from '../src/sqlite-indexer';
 import BetterSqlite3 from 'better-sqlite3';
+
+// #8: track mkdtempSync dirs and rm them in afterEach so /tmp doesn't
+// accumulate across CI runs. Survives test failures (afterEach fires
+// even on assertion error or thrown exception).
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+function tempDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
 
 const sampleEvent = (over: Record<string, unknown> = {}) => ({
   schema_version: '2',
@@ -29,7 +43,7 @@ const sampleEvent = (over: Record<string, unknown> = {}) => ({
 
 describe('indexEvents', () => {
   it('creates events table and inserts a v2 envelope row', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-tel-'));
+    const dir = tempDir('chitin-tel-');
     const dbPath = join(dir, 'events.db');
     const events = [sampleEvent()];
     indexEvents(dbPath, events);
@@ -42,7 +56,7 @@ describe('indexEvents', () => {
   });
 
   it('is idempotent on duplicate this_hash', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-tel-'));
+    const dir = tempDir('chitin-tel-');
     const dbPath = join(dir, 'events.db');
     const e = sampleEvent();
     indexEvents(dbPath, [e]);


### PR DESCRIPTION
## Summary

Three small standalone TS-side fixes from the Phase 1.5 tail.

- **#5** — SQLite indexer opens with \`journal_mode=WAL\` + \`synchronous=NORMAL\`. Concurrent readers (events list/tree/replay) no longer block the indexer's writer.
- **#9** — \`machine_fingerprint\` now hashes the RESOLVED \`machineID\`, not raw \`hostname()\`. Removes the case where \`driver_identity.machine_id\` and \`driver_identity.machine_fingerprint\` disagree on tests / container setups / hostname-translated envs.
- **#8** — Temp-dir cleanup across 5 test files (sqlite-indexer, jsonl-tailer, replay, ensure-indexed, chitindir-resolve). Each gains a \`tempDir()\` helper + \`afterEach\` rm-rf. Leak path closed even on test failure (afterEach fires on assertion errors and unhandled exceptions).

Considered extracting \`tempDir()\` into a shared \`@chitin/test-utils\` package; deferred — boilerplate is small enough that 5x inlining is lighter than introducing a new lib.

## Test plan
- [x] \`pnpm exec vitest run libs/telemetry/tests/ libs/contracts/tests/ apps/cli/tests/\` — 190/190 pass
- [x] \`/tmp\` no longer accumulates \`chitin-tel-*\`, \`chitin-ei-*\`, \`cd-*\` dirs after a run
- [ ] CI green

Closes #5
Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)