### PR TITLE
test(temporal-worker): workflow-name drift gate — closes #82

### DIFF
--- a/apps/temporal-worker/test/workflow-name-drift.test.ts
+++ b/apps/temporal-worker/test/workflow-name-drift.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { executeRequestWorkflow, reviewGraphWorkflow } from '../src/workflow';
+import { REVIEW_GRAPH_WORKFLOW_NAME } from '../src/review-graph-dispatch';
+
+// Drift gate (closes #82 finding #7). Several callers (submit.ts,
+// dispatcher.ts, groom-pass.ts) dispatch workflows by string name:
+//
+//   const WORKFLOW_NAME = 'executeRequestWorkflow';
+//   await client.workflow.start<typeof executeRequestWorkflow>(WORKFLOW_NAME, {...})
+//
+// The type-only import gives compile-time linkage, but if the export
+// gets renamed the string constant goes stale silently — TypeScript
+// won't catch it because the constant is just a literal. This test
+// asserts that the live function's .name matches the string the
+// dispatchers use.
+//
+// Single source of truth: the dispatch-layer constants are the
+// expected names. A divergence forces an explicit decision (rename
+// both, or keep the string and document why).
+
+const EXPECTED_EXECUTE_REQUEST_WORKFLOW_NAME = 'executeRequestWorkflow';
+
+describe('Workflow name drift gate', () => {
+  it('executeRequestWorkflow.name matches the dispatcher string constant', () => {
+    expect(executeRequestWorkflow.name).toBe(EXPECTED_EXECUTE_REQUEST_WORKFLOW_NAME);
+  });
+
+  it('reviewGraphWorkflow.name matches REVIEW_GRAPH_WORKFLOW_NAME', () => {
+    expect(reviewGraphWorkflow.name).toBe(REVIEW_GRAPH_WORKFLOW_NAME);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #82 (Slice 3 follow-ups) by shipping the last unfixed sub-finding (#7) — the other three already landed in earlier PRs:

| #82 sub | Status |
|---|---|
| #4 driver-id contract for local-* tiers | already shipped in slice 3 (PR #84) |
| #6 decision.params truthiness | already shipped in PR #101 |
| #7 workflow-name drift test | **this PR** |
| #8 repo regex permits \`../foo\` | already shipped in PR #103 |

#7 — Several callers (\`submit.ts\`, \`dispatcher.ts\`, \`groom-pass.ts\`) dispatch \`executeRequestWorkflow\` by string constant. The type-only \`typeof executeRequestWorkflow\` import gives compile linkage, but if the export is renamed the constant goes stale silently. New test asserts \`Function.name\` matches the string constants for both \`executeRequestWorkflow\` and \`reviewGraphWorkflow\`.

## Test plan
- [x] \`pnpm exec vitest run apps/temporal-worker/test/workflow-name-drift.test.ts\` — 2/2 pass
- [ ] CI green
- [ ] Manual drift drill: rename \`executeRequestWorkflow\` to \`foo\`, confirm test fails

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)