### PR TITLE
fix(ci): nx target override for governance plugin tests

### DIFF
--- a/apps/openclaw-plugin-governance/package.json
+++ b/apps/openclaw-plugin-governance/package.json
@@ -21,6 +21,18 @@
   "scripts": {
     "test": "vitest run test/"
   },
+  "nx": {
+    "tags": ["layer:app"],
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm exec vitest run apps/openclaw-plugin-governance/test",
+          "cwd": "{workspaceRoot}"
+        }
+      }
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

`apps/openclaw-plugin-governance` had no `nx` block in its `package.json`, so nx fell back to `nx:run-script` and ran `vitest run test/` from the package directory. With workspace-rooted vitest include patterns (`apps/**/*.test.ts`), vitest finds no test files there and exits 1.

This makes the plugin's `:test` target fail on **`main`**, which means every PR inherits the failure — including PRs that don't touch the plugin.

## Fix

Add an explicit `nx:run-commands` target that runs vitest from the workspace root with the full path — same pattern `temporal-worker` uses.

```diff
+  "nx": {
+    "tags": ["layer:app"],
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm exec vitest run apps/openclaw-plugin-governance/test",
+          "cwd": "{workspaceRoot}"
+        }
+      }
+    }
+  },
```

Verified locally: 3 test files, 41 tests pass.

```
> nx run @chitinhq/openclaw-plugin-governance:test
 ✓ apps/openclaw-plugin-governance/test/resolve-config.test.ts (11 tests) 4ms
 ✓ apps/openclaw-plugin-governance/test/subagent-gate.test.ts   (20 tests) 4ms
 ✓ apps/openclaw-plugin-governance/test/bridge.test.ts          (10 tests) 237ms
 Test Files  3 passed (3)
      Tests  41 passed (41)
```

## Impact on swarm cohort

This unblocks the openclaw-plugin-governance failure on the cohort opened tonight. Per failing-job inspection:

| PR | Cause |
|---|---|
| #190 scheduler-lib-foundation | governance:test red (this fix) |
| #191 mcp-server-chitin-cli | governance:test red (this fix) |
| #192 scheduler-rank-ingest-notify | governance:test red (this fix) |
| #194 slack-l1-notifier | governance:test red (this fix) |
| #189 nx-angular-workspace-install | pnpm-lock drift (separate) |
| #193 scheduler-dashboard-angular | pnpm-lock drift (separate) |
| #195 slack-l2-actions | pnpm-lock drift (separate) |

The lockfile-drift PRs need their own fix (re-run with `pnpm install` to regenerate the lock); a backlog entry will follow for the swarm-implementor harness behavior that produced this pattern.

## Test plan

- [x] `pnpm exec nx run @chitinhq/openclaw-plugin-governance:test` passes locally
- [ ] CI green on this PR
- [ ] After merge, rebase one of #190/#191/#192/#194 to confirm cohort unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)