### PR TITLE
backlog: pr-event-ingester (T2) + comment-responder role (T3)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -2555,3 +2555,154 @@ Steps:
 ---
 
 That's the cohort. PRs Z, B, M, E run in parallel tonight; tomorrow operator merges in order, the dispatcher picks up the next wave (C → D, S1, S2). All eight unblocked-or-soft-blocked.
+
+### `pr-event-ingester`
+
+```yaml
+id: pr-event-ingester
+tier: T2
+status: ready
+estimated_loc: 250
+blocks: [comment-responder]
+file: apps/temporal-worker/src/pr-event-ingester.ts (new), apps/temporal-worker/src/worker.ts (wire)
+references_finding: 2026-05-03-review-graph-not-firing-on-non-dispatcher-prs
+references_design: docs/design/2026-05-02-swarm-as-software-factory.md §5
+role: programmer
+```
+
+The review-graph (`reviewGraphWorkflow`, in production per factory
+design §5) currently only runs on PRs the dispatcher itself opens —
+`enqueueReviewGraph` is called from exactly one place,
+`apps/temporal-worker/src/dispatcher.ts:711`, on the programmer-success
+path. PRs opened by humans, by interactive Claude Code sessions, by
+Copilot (when wired), or by any caller that's not the dispatcher
+never trigger the §5 trigger matrix.
+
+Concrete impact (2026-05-03 morning): four PRs (#196, #197, #198, #199)
+opened overnight by interactive Claude Code sat with Copilot's R0
+review comments unactioned. PR #199 had 6 inline comments — the §5
+matrix says ">2 comments → escalate to R1" — but no review-graph was
+ever enqueued because no programmer-dispatch ran.
+
+Fix: a poller (or webhook receiver, but poller is cheaper for v1)
+that watches GitHub PR events, evaluates each open PR against the §5
+trigger matrix, and calls `enqueueReviewGraph` when a PR matches and
+has no existing review-graph workflow.
+
+Steps:
+1. Create `apps/temporal-worker/src/pr-event-ingester.ts`. Polls
+   `gh api repos/chitinhq/chitin/pulls?state=open` every 5 minutes
+   (mirrors `chitin-dispatcher.timer` cadence — file the
+   companion systemd timer separately or fold into the dispatcher
+   tick).
+2. For each open PR not authored by the dispatcher (i.e., no
+   `swarm/` branch prefix), check if a `review-graph-<pr_number>`
+   workflow already exists in Temporal. Skip if so.
+3. Read PR metadata: review comment count, diff size, files
+   touched. Match against §5 trigger matrix
+   (`apps/temporal-worker/src/review-graph.ts: computeStartingTier`).
+4. Synthesize a `BacklogEntry`-shaped object for the existing
+   `enqueueReviewGraph` API. Use `tier` from the §5 matrix; `role:
+   reviewer`; `file:` from the PR's changed-files list. The
+   `parent_workflow_id` is null/synthetic (use `pr-ingest-<pr>`).
+5. `enqueueReviewGraph(...)`. The graph runs as it does today; the
+   PR gets the same R1 → R2 → R3 escalation chain.
+6. Write a chain event of kind `pr_ingest_decision` per evaluated
+   PR (skipped / dispatched / errored) so audit can reconstruct
+   which PRs hit the matrix and which didn't.
+
+Tests:
+- Unit: `pickPrsToIngest(prs, runningWorkflows)` returns the right
+  set under various PR states (closed PR skipped, swarm-branch
+  skipped, already-running graph skipped, qualifying PR included).
+- Integration: with a fake `gh` and Temporal client, poller picks
+  up #199-shape PR (6 comments, 1100 LOC, 1 layer:governance package)
+  and calls `enqueueReviewGraph` once.
+
+**Acceptance:**
+- [ ] Ingester polls + matches §5 trigger matrix
+- [ ] Existing review-graph workflows are not duplicated
+- [ ] Chain event emitted per evaluated PR
+- [ ] Backfill demo: running once against current open PRs picks up
+      qualifying ones (e.g., #199 if still open) and starts review
+- [ ] CI green
+
+---
+
+### `comment-responder` role
+
+```yaml
+id: comment-responder-role
+tier: T3
+status: ready
+estimated_loc: 350
+blocks: []
+blockedBy: [pr-event-ingester]
+file: apps/temporal-worker/src/role-prompts.ts (extend), apps/temporal-worker/src/comment-responder/* (new), libs/contracts/src/execution-request.schema.ts (extend RoleSchema)
+references_finding: 2026-05-03-no-comment-responder-role
+references_design: docs/design/2026-05-02-swarm-as-software-factory.md §3 (role registry)
+role: programmer
+```
+
+The factory's `reviewer` role (R1-R3) produces *findings* on a PR.
+There is no role responsible for *acting on* findings — pulling the
+comments off the PR, evaluating each on merit, writing patches,
+running tests, and pushing the fix commit. Today, addressing comments
+is a human-only step.
+
+Concrete impact (2026-05-03 morning): operator manually addressed all
+six review comments on PR #199 (5 Copilot + 1 GHAS). Each was
+legitimate per the "do NOT dismiss as noise" rule
+(memory: `project_copilot_review_is_heuristic_not_reviewer.md`,
+2026-04-30 update). A swarm role doing the same work would have closed
+the loop without the operator's morning.
+
+Add a 13th role to the factory: `comment-responder`. Input = PR with
+unresolved review comments. Output = a fix commit pushed to the PR's
+branch, addressing each comment on its merits, with a chain event per
+comment recording which were applied vs dismissed (and why).
+
+Steps:
+1. Extend `RoleSchema` in `libs/contracts/src/execution-request.schema.ts`
+   to include `'comment-responder'`. Bump
+   `apps/temporal-worker/src/role-prompts.ts` `ROLE_PROMPTS` map.
+2. Author `apps/temporal-worker/src/comment-responder/prompt.ts`. The
+   prompt walks the agent through:
+   - List comments via `gh api repos/<owner>/<repo>/pulls/<pr>/comments`
+   - For each: read the comment + the diff_hunk + the linked file/line
+   - Evaluate on merit (the `do NOT dismiss as noise` rule). Decide
+     apply / dismiss-with-reason / escalate-to-operator.
+   - For applies: edit the file, run targeted tests, commit
+   - At end: post one summary comment to the PR (`gh pr comment`)
+     with apply/dismiss/escalate per comment + reasons
+3. Author `apps/temporal-worker/src/comment-responder/dispatch.ts` —
+   companion to `review-graph-dispatch.ts`. Triggered by the
+   review-graph (or by `pr-event-ingester` directly) when a PR's
+   comment count crosses a threshold AND the PR has no in-flight
+   comment-responder workflow. Tier defaults to T2 (Copilot Sonnet);
+   escalates to T3 (claude-code-headless Opus) if the responder fails
+   or stalls — same ladder shape as the implementor escalation.
+4. Wire into the §5 review-graph: when a reviewer flags 🟡 / 🔴
+   findings, instead of ending the chain, dispatch a
+   comment-responder for the same PR. Re-run the reviewer chain on
+   the responder's fix commit. Loop until clean or escalation to R4.
+5. Tests: with a fixture PR that has known comments, the responder
+   produces the expected fix commit and apply/dismiss summary.
+
+**Acceptance:**
+- [ ] `comment-responder` role added to RoleSchema + role-prompts
+- [ ] Dispatch path wires from review-graph (or ingester) to responder
+- [ ] Responder produces apply/dismiss/escalate decision per comment
+- [ ] Each decision recorded as a chain event
+- [ ] Backfill demo on a synthesized PR with 3+ Copilot comments:
+      responder lands a fix commit that addresses all and posts the
+      summary comment
+- [ ] CI green
+
+**Note on dependency ordering:** `pr-event-ingester` must land first.
+Without it, the responder has no upstream trigger for human-opened
+PRs. Once both ship, the chain is: ingester → review-graph (R1+) →
+findings → comment-responder → fix commit → review-graph re-runs →
+gatekeeper auto-merge (or operator at R4). That closes the loop the
+factory design described.
+


### PR DESCRIPTION
## Summary

Two backlog entries closing the gap that left this morning's PRs (#196–#199) un-reviewed by the swarm. Both are mechanical extensions of the factory design (`docs/design/2026-05-02-swarm-as-software-factory.md`); neither needs new infra.

## Gap 1: review-graph only fires on dispatcher-opened PRs

`enqueueReviewGraph` is called from exactly one place — `apps/temporal-worker/src/dispatcher.ts:711` on the programmer-success path. PRs from any other source (interactive Claude Code, humans, future Copilot CLI) never trigger the §5 trigger matrix. The factory's R0 → R1 → R2 → R3 escalation has no PR-event ingress.

**Concrete impact (this morning):** PR #199 had 6 inline comments (5 Copilot + 1 GHAS). The §5 matrix says ">2 comments → escalate to R1". No review-graph was ever enqueued because no programmer-dispatch ran. Operator addressed all 6 manually.

**Fix entry:** `pr-event-ingester` (T2, ~250 LOC). Polls open PRs every 5 min; for each non-dispatcher PR with no in-flight review-graph, evaluates the §5 matrix and calls `enqueueReviewGraph`. Reuses existing review-graph runtime; new caller, no new workflow.

## Gap 2: no comment-responder role

The reviewer roles (R1-R3) produce *findings*. No role *acts on* them — reads each PR comment on its merits (per the "do NOT dismiss as noise" rule from `project_copilot_review_is_heuristic_not_reviewer.md`, 2026-04-30 update), patches, tests, pushes. Today this is a human-only step.

**Fix entry:** `comment-responder` (T3, ~350 LOC). 13th factory role. Input = PR with unresolved comments; output = fix commit + summary comment with apply/dismiss/escalate per finding. Wires into the §5 chain: reviewer flags issues → responder produces fix → reviewer re-runs → gatekeeper auto-merges or escalates to R4.

## Dependency

`comment-responder` blockedBy `pr-event-ingester` — the responder needs the ingester so non-dispatcher PRs can enter the loop in the first place.

Once both ship, the closed loop is:

```
human / interactive PR
  → ingester picks up
  → review-graph R1+
  → findings (Copilot, R1, R2)
  → comment-responder produces fix commit
  → review-graph re-runs
  → gatekeeper auto-merge OR R4 (operator escalation)
```

That's what the factory design described in §5; this is just the missing wiring.

## Test plan

This PR adds documentation only. Real verification happens when the swarm picks up each entry:

- [ ] `pr-event-ingester` ships, demo against current open PRs picks up qualifying ones
- [ ] `comment-responder` ships, demo on a PR with synthesized comments produces a clean fix commit
- [ ] End-to-end loop: deliberately open a PR with a known issue → ingester catches → R1 flags → responder fixes → re-review clean → auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)