### PR TITLE
feat(temporal-worker): pr-event-ingester — wire non-dispatcher PRs into review-graph

### DIFF
--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -202,8 +202,13 @@ export function listOpenPrs(repo: string): OpenPrSummary[] {
       repo,
       '--state',
       'open',
+      // Cap high enough that no realistic chitin-shaped repo blows
+      // past it. gh's hard cap on `pr list --limit` is 1000; setting
+      // exactly that maxes the page size. If the repo ever grows
+      // beyond 1000 open PRs, real pagination via `--paginate`
+      // becomes necessary — until then this is fine.
       '--limit',
-      '50',
+      '1000',
       '--json',
       'number,title,headRefName,additions,deletions,changedFiles,isDraft,url',
     ],
@@ -231,9 +236,20 @@ export function enrichPr(repo: string, pr: OpenPrSummary): OpenPrSummary {
   }
   let copilotCommentCount: number | undefined;
   try {
+    // /pulls/{n}/comments returns ALL inline review comments — humans,
+    // bots, and Copilot. The §5 trigger matrix only escalates on
+    // Copilot's R0 review (see review-graph.ts:computeStartingTier
+    // "copilot_comment_count" branch), so we filter by author.login.
+    // GitHub's Copilot review bot logs in as `copilot-pull-request-reviewer[bot]`;
+    // be tolerant of the historical `Copilot` capitalization too.
     const commentsOut = execFileSync(
       'gh',
-      ['api', `repos/${repo}/pulls/${pr.number}/comments`, '--jq', 'length'],
+      [
+        'api',
+        `repos/${repo}/pulls/${pr.number}/comments`,
+        '--jq',
+        '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" or .user.login == "Copilot")] | length',
+      ],
       { encoding: 'utf8' },
     );
     copilotCommentCount = parseInt(commentsOut.trim(), 10);
@@ -279,7 +295,12 @@ export async function runIngesterTick(opts: {
   dryRun?: boolean;
   log?: (line: string) => void;
 }): Promise<IngesterTickResult> {
-  const log = opts.log ?? ((line) => console.error(line));
+  // Default logger to console.log to match the convention of other
+  // timer-style runners in this repo (alarm-feeder.ts:164,
+  // groomer.ts:174, lessons.ts:382, stale-doc-detector.ts:285).
+  // Sending normal-tick output to stderr would have systemd treat
+  // every successful run as an error and create monitor noise.
+  const log = opts.log ?? ((line) => console.log(line));
   const result: IngesterTickResult = {
     evaluated: 0,
     ingested: 0,
@@ -345,6 +366,14 @@ export async function runIngesterTick(opts: {
             parent_workflow_id: parentWorkflowIdForPr(decision.pr.number),
             pr_url: decision.pr.url,
             worktree: undefined,                  // ingester has no worktree
+            // Pass through the PrMeta we already classified — without
+            // this, enqueueReviewGraph rebuilds from the (empty)
+            // worktree and the §5 trigger matrix re-runs against
+            // diff_loc=0 / files_changed=0 / no Copilot count, so
+            // every ingested PR collapses back to R0→R1. Threading
+            // pr_meta keeps the R2/R3/T5 escalations the ingester
+            // computed in pickPrsToIngest().
+            pr_meta: decision.pr_meta,
             entry: synthesizeBacklogEntry(decision.pr),
             repo: opts.repo,
             log,

--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -1,0 +1,428 @@
+// PR event ingester. Closes the gap that left the 2026-05-03 cohort
+// of human/interactive-opened PRs (#196-#199) un-reviewed by the
+// swarm: enqueueReviewGraph was only called from the dispatcher's
+// programmer-success path, so PRs from any other source bypassed the
+// §5 trigger matrix entirely.
+//
+// What this module does:
+//   1. Polls open PRs on the configured repo (`gh pr list`).
+//   2. For each PR NOT authored by the dispatcher (i.e. no `swarm/`
+//      branch prefix), checks whether a review-graph workflow with
+//      a stable id (`pr-ingest-<pr_number>-review-graph`) is already
+//      running. Skip if so.
+//   3. Reads PR metadata (diff size, file list, Copilot comment
+//      count) and runs `computeStartingTier` from review-graph.ts.
+//   4. Synthesizes a BacklogEntry-shaped object and calls
+//      enqueueReviewGraph(...). The graph runs as it does today;
+//      the PR gets the same R1 → R2 → R3 escalation chain.
+//
+// Pure logic is exported so the test suite can pin every branch of
+// the dedup + trigger logic without standing up Temporal.
+//
+// Usage:
+//   pnpm exec tsx apps/temporal-worker/src/pr-event-ingester.ts [--repo <owner/repo>] [--dry-run]
+//
+//   --repo:    repo slug (default: read from `gh repo view --json nameWithOwner`)
+//   --dry-run: print the PRs that would be ingested, exit 0 without enqueueing.
+
+import { Connection, Client } from '@temporalio/client';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import type { BacklogEntry } from './grooming/parse-backlog.ts';
+import { computeStartingTier, type PrMeta } from './review-graph.ts';
+import {
+  enqueueReviewGraph,
+  REVIEW_GRAPH_WORKFLOW_NAME,
+} from './review-graph-dispatch.ts';
+
+const TASK_QUEUE = 'chitin-worker-q';
+
+// ── Pure logic ──────────────────────────────────────────────────────
+
+/**
+ * Stable parent_workflow_id for an ingester-spawned review-graph.
+ * The review-graph workflow id derives from this as
+ * `${parent_workflow_id}-review-graph` (matches review-graph-dispatch.ts).
+ */
+export function parentWorkflowIdForPr(prNumber: number): string {
+  return `pr-ingest-${prNumber}`;
+}
+
+export function reviewGraphWorkflowIdForPr(prNumber: number): string {
+  return `${parentWorkflowIdForPr(prNumber)}-review-graph`;
+}
+
+export interface OpenPrSummary {
+  number: number;
+  title: string;
+  headRefName: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  isDraft: boolean;
+  /** Repo-relative paths in the diff. Empty when caller hasn't fetched
+   *  them (the path-scope bumps in computeStartingTier are then skipped). */
+  files?: string[];
+  /** Inline review comment count on the PR. Used by §5 trigger matrix. */
+  copilotCommentCount?: number;
+  /** PR url (for the synthesized BacklogEntry's pr_meta). */
+  url: string;
+}
+
+/**
+ * Decision the ingester makes per PR:
+ *   - skip         — branch is dispatcher-owned, draft, already running, etc.
+ *   - ingest       — qualifies; spawn a review-graph
+ *   - ingest_R0    — §5 says "Copilot R0 is enough"; chitin doesn't dispatch
+ *                    (kept distinct from skip so the chain event records
+ *                    "we evaluated it and chose not to escalate")
+ */
+export type IngestDecision =
+  | { kind: 'skip'; pr: OpenPrSummary; reason: string }
+  | { kind: 'ingest_r0'; pr: OpenPrSummary; reasons: string[] }
+  | {
+      kind: 'ingest';
+      pr: OpenPrSummary;
+      pr_meta: PrMeta;
+      starting_tier: 'R1' | 'R2' | 'R3';
+      reasons: string[];
+      t5_shape: boolean;
+    };
+
+/**
+ * Pure: given (open PRs, running review-graph workflow ids), return a
+ * decision per PR.
+ *
+ * Invariant (Knuth-style): every input PR appears in the output exactly
+ * once. The decisions partition the input — no PR is silently dropped.
+ */
+export function pickPrsToIngest(
+  prs: readonly OpenPrSummary[],
+  runningReviewGraphIds: ReadonlySet<string>,
+): IngestDecision[] {
+  return prs.map((pr) => decideForPr(pr, runningReviewGraphIds));
+}
+
+function decideForPr(
+  pr: OpenPrSummary,
+  runningReviewGraphIds: ReadonlySet<string>,
+): IngestDecision {
+  // Skip 1: drafts. Reviewers shouldn't waste tokens on WIP work the
+  // author hasn't asked for review on. The author marks the PR ready
+  // when they want eyes on it.
+  if (pr.isDraft) {
+    return { kind: 'skip', pr, reason: 'draft PR' };
+  }
+
+  // Skip 2: dispatcher-owned PRs. The programmer-success path in
+  // dispatcher.ts already calls enqueueReviewGraph for these.
+  // Re-ingesting would create a duplicate review-graph workflow.
+  if (pr.headRefName.startsWith('swarm/')) {
+    return { kind: 'skip', pr, reason: 'dispatcher-owned (swarm/ branch)' };
+  }
+
+  // Skip 3: review-graph already running for this PR. Stable id-based
+  // dedup means re-running this tick a minute from now is idempotent.
+  const expectedWorkflowId = reviewGraphWorkflowIdForPr(pr.number);
+  if (runningReviewGraphIds.has(expectedWorkflowId)) {
+    return { kind: 'skip', pr, reason: 'review-graph already running' };
+  }
+
+  // Build the PrMeta shape that computeStartingTier expects.
+  const pr_meta: PrMeta = {
+    diff_loc: pr.additions + pr.deletions,
+    files_changed: pr.changedFiles,
+    files: pr.files ?? [],
+    pr_url: pr.url,
+    pr_number: pr.number,
+    copilot_comment_count: pr.copilotCommentCount,
+  };
+
+  const decision = computeStartingTier(pr_meta, synthesizeBacklogEntry(pr));
+
+  if (decision.tier === 'R0') {
+    // §5 says R0 (Copilot) covers it. Don't dispatch chitin reviewers
+    // — but record the decision so audit can confirm we evaluated it.
+    return { kind: 'ingest_r0', pr, reasons: decision.reasons };
+  }
+
+  if (decision.tier === 'R4') {
+    // R4 is "ping operator" — non-dispatchable. Treat as skip with
+    // a clear reason so the chain event captures it.
+    return { kind: 'skip', pr, reason: 'R4 (operator pickup) — not chitin-dispatchable' };
+  }
+
+  return {
+    kind: 'ingest',
+    pr,
+    pr_meta,
+    starting_tier: decision.tier,
+    reasons: decision.reasons,
+    t5_shape: decision.t5_shape,
+  };
+}
+
+/**
+ * Pure: turn a PR summary into a BacklogEntry-shaped object the
+ * existing enqueueReviewGraph API can consume. Synthesized entries
+ * carry an `id` of `pr-ingest-<pr_number>` so chain events tie back
+ * to the parent_workflow_id. Fields match BacklogEntry's actual shape
+ * (camelCase, with rawFrontmatter / rawSection placeholders since
+ * this entry was synthesized, not parsed from swarm-backlog.md).
+ */
+export function synthesizeBacklogEntry(pr: OpenPrSummary): BacklogEntry {
+  return {
+    id: `pr-ingest-${pr.number}`,
+    tier: 'T2',                          // reviewer driver tier; review tier is computed separately
+    status: 'ready',
+    estimatedLoc: String(pr.additions + pr.deletions),
+    blocks: [],
+    file: pr.files?.join(', ') ?? '',
+    role: 'reviewer',
+    rawFrontmatter: '',                  // synthesized; no source yaml
+    description: `Synthesized from PR #${pr.number}: ${pr.title}`,
+    rawSection: '',                      // synthesized; no source section
+  };
+}
+
+// ── I/O wrappers ────────────────────────────────────────────────────
+
+/**
+ * Read open PRs via `gh pr list`. Includes only the fields needed for
+ * the §5 trigger matrix; further fields (diff file list, comment
+ * count) are fetched per-PR by `enrichPr`.
+ */
+export function listOpenPrs(repo: string): OpenPrSummary[] {
+  const out = execFileSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--repo',
+      repo,
+      '--state',
+      'open',
+      '--limit',
+      '50',
+      '--json',
+      'number,title,headRefName,additions,deletions,changedFiles,isDraft,url',
+    ],
+    { encoding: 'utf8' },
+  );
+  return JSON.parse(out) as OpenPrSummary[];
+}
+
+/**
+ * Enrich a PR summary with the file list + Copilot comment count.
+ * These require additional gh calls so we only fetch them for PRs
+ * that look like they might cross a §5 threshold (always for the
+ * non-trivial ones).
+ */
+export function enrichPr(repo: string, pr: OpenPrSummary): OpenPrSummary {
+  let files: string[] = [];
+  try {
+    const filesOut = execFileSync('gh', ['pr', 'diff', String(pr.number), '--repo', repo, '--name-only'], {
+      encoding: 'utf8',
+    });
+    files = filesOut.split('\n').map((l) => l.trim()).filter(Boolean);
+  } catch {
+    // PR has no diff yet (rare) — leave empty; computeStartingTier
+    // tolerates this.
+  }
+  let copilotCommentCount: number | undefined;
+  try {
+    const commentsOut = execFileSync(
+      'gh',
+      ['api', `repos/${repo}/pulls/${pr.number}/comments`, '--jq', 'length'],
+      { encoding: 'utf8' },
+    );
+    copilotCommentCount = parseInt(commentsOut.trim(), 10);
+    if (Number.isNaN(copilotCommentCount)) copilotCommentCount = undefined;
+  } catch {
+    // Permission / API issue — skip this signal.
+  }
+  return { ...pr, files, copilotCommentCount };
+}
+
+/**
+ * Query Temporal for currently-running review-graph workflow ids.
+ * The dedup check uses this to avoid spawning a duplicate.
+ */
+export async function listRunningReviewGraphWorkflows(client: Client): Promise<Set<string>> {
+  const ids = new Set<string>();
+  // Filter by ExecutionStatus = Running and WorkflowType =
+  // reviewGraphWorkflow. Returns workflow ids the ingester might
+  // collide with.
+  const iter = client.workflow.list({
+    query: `WorkflowType="${REVIEW_GRAPH_WORKFLOW_NAME}" AND ExecutionStatus="Running"`,
+  });
+  for await (const wf of iter) {
+    ids.add(wf.workflowId);
+  }
+  return ids;
+}
+
+// ── main entrypoint ────────────────────────────────────────────────
+
+export interface IngesterTickResult {
+  evaluated: number;
+  ingested: number;
+  ingested_r0: number;
+  skipped: number;
+  errors: number;
+}
+
+export async function runIngesterTick(opts: {
+  client: Client;
+  taskQueue: string;
+  repo: string;
+  dryRun?: boolean;
+  log?: (line: string) => void;
+}): Promise<IngesterTickResult> {
+  const log = opts.log ?? ((line) => console.error(line));
+  const result: IngesterTickResult = {
+    evaluated: 0,
+    ingested: 0,
+    ingested_r0: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const summaries = listOpenPrs(opts.repo);
+  result.evaluated = summaries.length;
+
+  if (summaries.length === 0) {
+    log(JSON.stringify({ component: 'pr-event-ingester', msg: 'no open PRs' }));
+    return result;
+  }
+
+  // Enrich only the PRs we'd potentially ingest (skip drafts and
+  // dispatcher-owned branches). Saves gh calls.
+  const enriched = summaries.map((s) => {
+    if (s.isDraft || s.headRefName.startsWith('swarm/')) return s;
+    return enrichPr(opts.repo, s);
+  });
+
+  const running = await listRunningReviewGraphWorkflows(opts.client);
+  const decisions = pickPrsToIngest(enriched, running);
+
+  for (const decision of decisions) {
+    switch (decision.kind) {
+      case 'skip':
+        result.skipped += 1;
+        log(JSON.stringify({
+          component: 'pr-event-ingester',
+          msg: 'skip',
+          pr: decision.pr.number,
+          reason: decision.reason,
+        }));
+        break;
+      case 'ingest_r0':
+        result.ingested_r0 += 1;
+        log(JSON.stringify({
+          component: 'pr-event-ingester',
+          msg: 'ingest_r0',
+          pr: decision.pr.number,
+          reasons: decision.reasons,
+        }));
+        break;
+      case 'ingest':
+        if (opts.dryRun) {
+          log(JSON.stringify({
+            component: 'pr-event-ingester',
+            msg: 'would-ingest',
+            pr: decision.pr.number,
+            tier: decision.starting_tier,
+            reasons: decision.reasons,
+          }));
+          result.ingested += 1;
+          break;
+        }
+        try {
+          const enqResult = await enqueueReviewGraph({
+            client: opts.client,
+            taskQueue: opts.taskQueue,
+            parent_workflow_id: parentWorkflowIdForPr(decision.pr.number),
+            pr_url: decision.pr.url,
+            worktree: undefined,                  // ingester has no worktree
+            entry: synthesizeBacklogEntry(decision.pr),
+            repo: opts.repo,
+            log,
+          });
+          if (enqResult.enqueued) {
+            result.ingested += 1;
+            log(JSON.stringify({
+              component: 'pr-event-ingester',
+              msg: 'ingested',
+              pr: decision.pr.number,
+              workflow_id: enqResult.workflow_id,
+              tier: decision.starting_tier,
+            }));
+          } else {
+            result.errors += 1;
+            log(JSON.stringify({
+              component: 'pr-event-ingester',
+              msg: 'enqueue-failed',
+              pr: decision.pr.number,
+              error: enqResult.error,
+            }));
+          }
+        } catch (err) {
+          result.errors += 1;
+          log(JSON.stringify({
+            component: 'pr-event-ingester',
+            msg: 'enqueue-threw',
+            pr: decision.pr.number,
+            error: err instanceof Error ? err.message : String(err),
+          }));
+        }
+        break;
+    }
+  }
+
+  log(JSON.stringify({
+    component: 'pr-event-ingester',
+    msg: 'tick-complete',
+    ...result,
+  }));
+
+  return result;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const repoIdx = args.indexOf('--repo');
+  const repoFromFlag = repoIdx >= 0 ? args[repoIdx + 1] : undefined;
+  const repo = repoFromFlag ?? defaultRepo();
+
+  const connection = await Connection.connect({ address: '127.0.0.1:7233' });
+  try {
+    const client = new Client({ connection, namespace: 'default' });
+    const result = await runIngesterTick({ client, taskQueue: TASK_QUEUE, repo, dryRun });
+    if (result.errors > 0) {
+      process.exit(1);
+    }
+  } finally {
+    await connection.close();
+  }
+}
+
+function defaultRepo(): string {
+  const out = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+    encoding: 'utf8',
+  });
+  return out.trim();
+}
+
+const isCli = fileURLToPath(import.meta.url) === process.argv[1];
+if (isCli) {
+  main().catch((err: unknown) => {
+    console.error(JSON.stringify({
+      component: 'pr-event-ingester',
+      msg: 'fatal',
+      error: err instanceof Error ? err.message : String(err),
+    }));
+    process.exit(1);
+  });
+}

--- a/apps/temporal-worker/src/review-graph-dispatch.ts
+++ b/apps/temporal-worker/src/review-graph-dispatch.ts
@@ -47,6 +47,13 @@ export interface EnqueueReviewGraphInput {
   /** Repo slug, e.g. 'chitinhq/chitin'. Used by reviewer agents to
    *  call gh CLI. */
   repo: string;
+  /** Optional pre-built PrMeta. When set, the dispatcher skips its
+   *  worktree-derived rebuild and threads this object through to
+   *  reviewGraphWorkflow as-is. Callers like `pr-event-ingester`
+   *  that don't have a worktree but DO have authoritative diff
+   *  stats from `gh pr view` should pass this so the §5 trigger
+   *  matrix evaluates against real metadata, not zeros. */
+  pr_meta?: PrMeta;
   /** Optional log sink (defaults to console.log). Tests inject. */
   log?: (line: string) => void;
 }
@@ -141,13 +148,23 @@ export async function enqueueReviewGraph(
     return { enqueued: false };
   }
 
-  const reviewGraphInput = buildReviewGraphInput(
-    input.parent_workflow_id,
-    input.pr_url,
-    input.worktree,
-    input.entry,
-    input.repo,
-  );
+  // If a pre-built PrMeta was provided (pr-event-ingester path),
+  // thread it through unchanged. Otherwise fall back to the
+  // worktree-derived rebuild (programmer-success path).
+  const reviewGraphInput = input.pr_meta
+    ? {
+        parent_workflow_id: input.parent_workflow_id,
+        pr_meta: input.pr_meta,
+        entry: input.entry,
+        repo: input.repo,
+      }
+    : buildReviewGraphInput(
+        input.parent_workflow_id,
+        input.pr_url,
+        input.worktree,
+        input.entry,
+        input.repo,
+      );
 
   // Reviewer chain workflow_id derives from the parent. Keep it
   // greppable so the operator can correlate `swarm-<entry>-<ts>` to

--- a/apps/temporal-worker/test/pr-event-ingester.test.ts
+++ b/apps/temporal-worker/test/pr-event-ingester.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parentWorkflowIdForPr,
+  pickPrsToIngest,
+  reviewGraphWorkflowIdForPr,
+  synthesizeBacklogEntry,
+  type OpenPrSummary,
+} from '../src/pr-event-ingester.ts';
+
+function pr(overrides: Partial<OpenPrSummary> & { number: number }): OpenPrSummary {
+  return {
+    title: 'test',
+    headRefName: 'feature/test',
+    additions: 10,
+    deletions: 0,
+    changedFiles: 1,
+    isDraft: false,
+    files: [],
+    copilotCommentCount: 0,
+    url: `https://github.com/chitinhq/chitin/pull/${overrides.number}`,
+    ...overrides,
+  };
+}
+
+describe('parentWorkflowIdForPr / reviewGraphWorkflowIdForPr', () => {
+  it('parent id is stable per PR number', () => {
+    expect(parentWorkflowIdForPr(199)).toBe('pr-ingest-199');
+  });
+
+  it('review-graph id is parent + suffix (matches review-graph-dispatch convention)', () => {
+    expect(reviewGraphWorkflowIdForPr(199)).toBe('pr-ingest-199-review-graph');
+  });
+});
+
+describe('synthesizeBacklogEntry', () => {
+  it('packs PR data into a BacklogEntry-shaped object', () => {
+    const entry = synthesizeBacklogEntry(pr({
+      number: 199,
+      title: 'Slice 1 substrate',
+      additions: 800,
+      deletions: 100,
+      files: ['libs/governance/src/decide.ts', 'libs/governance/tests/decide.test.ts'],
+    }));
+    expect(entry.id).toBe('pr-ingest-199');
+    expect(entry.role).toBe('reviewer');
+    expect(entry.tier).toBe('T2');
+    expect(entry.estimatedLoc).toBe('900');
+    expect(entry.file).toContain('decide.ts');
+    expect(entry.description).toContain('PR #199');
+  });
+
+  it('handles PRs with no fetched file list', () => {
+    const entry = synthesizeBacklogEntry(pr({ number: 1, files: undefined }));
+    expect(entry.file).toBe('');
+  });
+});
+
+describe('pickPrsToIngest — invariants', () => {
+  it('every input PR appears exactly once in the output', () => {
+    const inputs = [pr({ number: 1 }), pr({ number: 2 }), pr({ number: 3 })];
+    const decisions = pickPrsToIngest(inputs, new Set());
+    expect(decisions).toHaveLength(inputs.length);
+    const numbers = decisions.map((d) => d.pr.number).sort();
+    expect(numbers).toEqual([1, 2, 3]);
+  });
+});
+
+describe('pickPrsToIngest — skip rules', () => {
+  it('skips draft PRs', () => {
+    const decisions = pickPrsToIngest([pr({ number: 10, isDraft: true })], new Set());
+    expect(decisions[0]).toMatchObject({ kind: 'skip', reason: 'draft PR' });
+  });
+
+  it('skips dispatcher-owned (swarm/) branches', () => {
+    const decisions = pickPrsToIngest(
+      [pr({ number: 11, headRefName: 'swarm/swarm-foo-1234' })],
+      new Set(),
+    );
+    expect(decisions[0]).toMatchObject({
+      kind: 'skip',
+      reason: 'dispatcher-owned (swarm/ branch)',
+    });
+  });
+
+  it('skips PRs with a review-graph workflow already running', () => {
+    const running = new Set([reviewGraphWorkflowIdForPr(12)]);
+    const decisions = pickPrsToIngest([pr({ number: 12, additions: 1000 })], running);
+    expect(decisions[0]).toMatchObject({
+      kind: 'skip',
+      reason: 'review-graph already running',
+    });
+  });
+});
+
+describe('pickPrsToIngest — tier classification', () => {
+  it('small clean PR with no Copilot comments → ingest_r0 (Copilot covers it)', () => {
+    const decisions = pickPrsToIngest(
+      [pr({ number: 20, additions: 5, deletions: 0, changedFiles: 1, copilotCommentCount: 0 })],
+      new Set(),
+    );
+    expect(decisions[0].kind).toBe('ingest_r0');
+  });
+
+  it('PR with > 2 Copilot comments escalates to R1', () => {
+    const decisions = pickPrsToIngest(
+      [pr({ number: 21, additions: 50, deletions: 0, changedFiles: 1, copilotCommentCount: 5 })],
+      new Set(),
+    );
+    expect(decisions[0].kind).toBe('ingest');
+    if (decisions[0].kind === 'ingest') {
+      expect(decisions[0].starting_tier).toBe('R1');
+      expect(decisions[0].reasons.some((r) => r.includes('Copilot bot'))).toBe(true);
+    }
+  });
+
+  it('large diff (> 200 LOC) escalates to R2', () => {
+    const decisions = pickPrsToIngest(
+      [pr({ number: 22, additions: 250, deletions: 0, changedFiles: 5 })],
+      new Set(),
+    );
+    expect(decisions[0].kind).toBe('ingest');
+    if (decisions[0].kind === 'ingest') {
+      expect(decisions[0].starting_tier).toBe('R2');
+    }
+  });
+
+  it('very large diff (> 500 LOC) escalates to R3', () => {
+    const decisions = pickPrsToIngest(
+      [pr({ number: 23, additions: 800, deletions: 100, changedFiles: 12 })],
+      new Set(),
+    );
+    expect(decisions[0].kind).toBe('ingest');
+    if (decisions[0].kind === 'ingest') {
+      expect(decisions[0].starting_tier).toBe('R3');
+    }
+  });
+
+  it('wide diff (> 20 files) escalates to R3 even with small LOC', () => {
+    const decisions = pickPrsToIngest(
+      [pr({ number: 24, additions: 50, deletions: 0, changedFiles: 25 })],
+      new Set(),
+    );
+    expect(decisions[0].kind).toBe('ingest');
+    if (decisions[0].kind === 'ingest') {
+      expect(decisions[0].starting_tier).toBe('R3');
+    }
+  });
+});
+
+describe('pickPrsToIngest — mixed batch', () => {
+  it('partitions a heterogeneous batch into the right buckets', () => {
+    const inputs = [
+      pr({ number: 1, isDraft: true }),                                // skip
+      pr({ number: 2, headRefName: 'swarm/x' }),                       // skip
+      pr({ number: 3, additions: 5, copilotCommentCount: 0 }),         // ingest_r0
+      pr({ number: 4, additions: 50, copilotCommentCount: 5 }),        // ingest R1
+      pr({ number: 5, additions: 800, deletions: 50, changedFiles: 10 }), // ingest R3
+    ];
+    const decisions = pickPrsToIngest(inputs, new Set());
+    expect(decisions.map((d) => d.kind)).toEqual([
+      'skip',
+      'skip',
+      'ingest_r0',
+      'ingest',
+      'ingest',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap from this morning: the §5 review-tier escalation chain was in production, but only the dispatcher could trigger it. PRs from any other source (interactive Claude Code, humans, future Copilot CLI) bypassed the trigger matrix entirely. This module polls for those PRs and wires them in.

This is the **PR-A** half of the factory-gaps work. PR-B (comment-responder + peer-reviewer) lands separately, after the agent-role generator ships.

## What's here

`apps/temporal-worker/src/pr-event-ingester.ts` — pollable module with a CLI:

```bash
pnpm exec tsx apps/temporal-worker/src/pr-event-ingester.ts [--repo <owner/repo>] [--dry-run]
```

For each open PR:
- **skip** if draft / `swarm/`-prefixed (dispatcher-owned) / already has a review-graph workflow running
- **ingest_r0** if §5 says Copilot's R0 review is sufficient (still chain-event-logged, just not chitin-dispatched)
- **ingest** at R1, R2, or R3 by calling the existing `enqueueReviewGraph` API

Stable workflow id `pr-ingest-<pr_number>-review-graph` makes the polling loop idempotent — re-running mid-flight detects the existing workflow and skips.

## Tests (14 new)

- Stable id generation (parent / review-graph)
- BacklogEntry synthesis + the empty-files edge case
- Skip rules: drafts, swarm/ branches, already-running workflows
- §5 tier classification: R0 / R1 / R2 / R3 thresholds
- Mixed batch produces correct partition
- Invariant: every input PR appears exactly once in output (Knuth-style)

```
✓ apps/temporal-worker/test/pr-event-ingester.test.ts (14 tests) 9ms
Test Files: 28 passed (28)
Tests:      565 passed (565)
```

## Operator wiring

The CLI is ready. Hooking it into systemd is a one-time install step (mirror the existing 8 `chitin-*.timer` units). Filed as the `systemd-unit-generator` entry in PR #201 so future periodic units are one command — pr-event-ingester gets reinstalled cleanly once that lands.

For now: a manual `chitin-pr-event-ingester.{service,timer}` pair following the existing convention. Default cadence: every 5 min, matching `chitin-dispatcher.timer`.

## Refs

- Design: `docs/design/2026-05-02-swarm-as-software-factory.md` §5
- Spec: `docs/superpowers/specs/2026-05-03-predictive-execution-policy-design.md`
- Backlog entry: `pr-event-ingester` (filed in PR #200, merged this morning)

## Test plan

- [x] All 565 temporal-worker tests pass locally
- [x] Pure-function tests cover §5 trigger matrix branches
- [ ] CI green
- [ ] Smoke-test once main: `pnpm exec tsx apps/temporal-worker/src/pr-event-ingester.ts --repo chitinhq/chitin --dry-run` — should report any qualifying open PRs

## What this does NOT do

- **Does not dispatch comment-responder.** That role doesn't exist yet (PR-B lands it). For now, the review-graph runs and stops at findings; nobody acts on them.
- **Does not dispatch peer-reviewer.** Same — PR-B introduces it.
- **Does not install the systemd unit.** Manual one-time step, or wait for `systemd-unit-generator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)