### PR TITLE
feat(roles): comment-responder + peer-reviewer agent roles

### DIFF
--- a/apps/temporal-worker/src/comment-responder/prompt.ts
+++ b/apps/temporal-worker/src/comment-responder/prompt.ts
@@ -47,6 +47,20 @@ THE OPERATOR'S RULE (do not violate):
 
 YOUR WORKFLOW (one tool call per step where possible):
 
+0. **Verify your dispatch shape FIRST.** Look at ENTRY DETAIL above for
+   a PR URL of the form \`https://github.com/<owner>/<repo>/pull/<n>\`.
+   If there is none, you've been dispatched through the generic backlog
+   pipeline instead of the dedicated comment-responder dispatcher.
+   EXIT CLEAN with:
+
+   \`\`\`
+   <<<COMMENT_RESPONSE>>>{"applied": 0, "dismissed": 0, "escalated": 0, "commit_sha": null, "tests_passed": null, "skipped_reason": "no PR URL in dispatch context — wrong dispatcher path; await dedicated dispatch"}
+   \`\`\`
+
+   Make NO edits, commits, or comments. The dispatcher's apply step
+   would otherwise pick up an empty worktree and produce a bogus no-op
+   PR. Bail before that happens.
+
 1. Use the \`exec\` tool to checkout the PR's branch:
    \`\`\`
    gh pr checkout <pr_number>
@@ -86,7 +100,26 @@ YOUR WORKFLOW (one tool call per step where possible):
    git push
    \`\`\`
 
-6. Post a summary comment on the PR via \`gh pr comment <pr_number>\` with
+6. **Reply to each individual review comment thread** with the per-comment
+   decision. Without this, a future dispatch will see the same root-level
+   comments still un-replied-to and re-process them. For each comment you
+   evaluated, post a reply via:
+   \`\`\`
+   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies \\
+     --method POST --field body="<one-line per-decision text>"
+   \`\`\`
+   Format the reply body as one of:
+   - \`✅ APPLIED in <commit_sha>: <one-line summary of the fix>\`
+   - \`❌ DISMISSED: <reason; cite specific source-of-truth — file path,
+     test name, line number>\`
+   - \`🔁 ESCALATED to operator: <reason; what kind of judgment is needed>\`
+
+   These per-thread replies are the durable record. The summary comment
+   in step 7 is for the operator's overview; the per-thread replies are
+   what GitHub uses to mark threads as resolved/replied so future
+   dispatches don't reprocess them.
+
+7. Post a summary comment on the PR via \`gh pr comment <pr_number>\` with
    the following structure (one bullet per inline comment evaluated):
 
    \`\`\`
@@ -100,7 +133,7 @@ YOUR WORKFLOW (one tool call per step where possible):
    Commit: <commit_sha>
    \`\`\`
 
-7. Emit your final structured signal so the runner can record outcomes:
+8. Emit your final structured signal so the runner can record outcomes:
    \`\`\`
    <<<COMMENT_RESPONSE>>>{"applied": <n>, "dismissed": <n>, "escalated": <n>, "commit_sha": "<sha or null>", "tests_passed": <bool>}
    \`\`\`

--- a/apps/temporal-worker/src/comment-responder/prompt.ts
+++ b/apps/temporal-worker/src/comment-responder/prompt.ts
@@ -1,0 +1,126 @@
+// Prompt builder for the `comment-responder` role.
+//
+// The agent reads unresolved review comments off a PR, evaluates each
+// on merit (per the operator's "do NOT dismiss as noise" rule —
+// memory: project_copilot_review_is_heuristic_not_reviewer.md), and
+// produces a fix commit + a summary comment.
+//
+// The role's contract:
+//   IN  — a PR URL (and optional repo override) carried through the
+//         entry's `description` field by the dispatch helper
+//         (apps/temporal-worker/src/comment-responder/dispatch.ts).
+//   OUT — at most one fix commit pushed to the PR's branch + one
+//         summary comment posted on the PR. If no comments need
+//         action, the agent posts a "no-op" summary and exits clean.
+//
+// Bounds shape:
+//   - write_policy=branch: agent commits + pushes to the PR's branch
+//   - network=allowlist: gh CLI calls + npm registry only
+//   - max_tool_calls=80: large but bounded; reading 5-15 comments + a
+//     handful of edits + tests + commit + push fits inside this
+//   - wall_timeout=1800s: 30 min; tracks the R3 reviewer ceiling
+
+import type { BacklogEntry } from '../grooming/parse-backlog.ts';
+
+/**
+ * Hand the agent everything it needs to act on the PR's comments
+ * with full context. The entry's `description` carries `pr_url` and
+ * (optionally) `repo`; the dispatch helper formats these into the
+ * description before workflow start.
+ */
+export function buildCommentResponderPrompt(entry: BacklogEntry): string {
+  return `You are playing the comment-responder role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3.
+
+The factory's reviewer roles (R0 = Copilot, R1-R3 = chitin-dispatched) produce *findings*. Your job is to *act on* those findings: read each unresolved review comment, evaluate it on merit, and either push a fix commit or post a documented dismissal — never silently ignore a comment.
+
+ENTRY ID: ${entry.id}
+ROLE: comment-responder
+
+ENTRY DETAIL:
+${entry.description}
+
+THE OPERATOR'S RULE (do not violate):
+> Evaluate each comment on merit. Do NOT dismiss as noise. Verify against
+> source-of-truth: re-read the line/function/test referenced; confirm the
+> claim before applying or dismissing. (PR #78 caught 8 of 11 real bugs;
+> this rule exists because false-positive instinct gets them wrong.)
+
+YOUR WORKFLOW (one tool call per step where possible):
+
+1. Use the \`exec\` tool to checkout the PR's branch:
+   \`\`\`
+   gh pr checkout <pr_number>
+   \`\`\`
+   (pr_number from ENTRY DETAIL above.)
+
+2. Pull all unresolved inline comments:
+   \`\`\`
+   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments
+   \`\`\`
+   The response is a JSON array; each entry has \`id\`, \`path\`, \`line\`,
+   \`diff_hunk\`, \`body\`, \`user.login\`. Filter to comments whose author
+   is a reviewer (Copilot, github-advanced-security, or other) and whose
+   \`in_reply_to_id\` is null (root-level, not part of an existing thread).
+
+3. For each comment: read the file at the \`path\`/\`line\` referenced,
+   re-read the surrounding context, and decide one of:
+     - APPLY: the comment identifies a real issue; edit the file to fix it.
+     - DISMISS: the comment is wrong (verified against source). Record
+       the reason — be specific (cite the file/test that proves the
+       comment's premise wrong).
+     - ESCALATE: the comment requires architectural judgment beyond your
+       scope. Mark it for human review.
+
+4. After all decisions: if any APPLY actions produced edits, run the
+   relevant tests:
+   \`\`\`
+   pnpm exec nx affected -t test --base=origin/main
+   \`\`\`
+   Resolve any failures before committing. If tests still fail, ESCALATE
+   the failing comments (don't ship a red commit).
+
+5. If APPLY edits passed tests, commit + push:
+   \`\`\`
+   git add -A
+   git commit -m "fix: address review comments on PR #<n>"
+   git push
+   \`\`\`
+
+6. Post a summary comment on the PR via \`gh pr comment <pr_number>\` with
+   the following structure (one bullet per inline comment evaluated):
+
+   \`\`\`
+   ### comment-responder summary
+
+   - [APPLIED] <path>:<line> — <one-line summary of the fix>
+   - [DISMISSED] <path>:<line> — <reason; cite the source-of-truth>
+   - [ESCALATED] <path>:<line> — <reason; what kind of judgment is needed>
+
+   Tests: \`<which tests ran and passed/failed>\`
+   Commit: <commit_sha>
+   \`\`\`
+
+7. Emit your final structured signal so the runner can record outcomes:
+   \`\`\`
+   <<<COMMENT_RESPONSE>>>{"applied": <n>, "dismissed": <n>, "escalated": <n>, "commit_sha": "<sha or null>", "tests_passed": <bool>}
+   \`\`\`
+
+INVARIANTS:
+- You make AT MOST ONE commit per dispatch (operator can re-dispatch
+  if needed; ladder logic is at the dispatcher's level).
+- An ESCALATE on any comment means: do NOT auto-merge, surface to operator.
+- DISMISS without a cited source-of-truth is forbidden — that's "dismiss
+  as noise," exactly what the rule above bans.
+- If the PR's branch can't be checked out (closed, merged, deleted), exit
+  cleanly with all-escalated outputs and a note explaining why.
+
+DON'T:
+- Don't evaluate stale comments (in_reply_to_id != null OR commit_id !=
+  the PR's current HEAD). Those are pre-fix discussions.
+- Don't address comments outside the PR's diff scope (rare, but if
+  it happens, escalate).
+- Don't disable tests to "make CI green" — that's the textbook bad fix.
+- Don't dismiss everything with the same boilerplate reason — each
+  dismissal must cite specific source-of-truth.
+`;
+}

--- a/apps/temporal-worker/src/peer-reviewer/prompt.ts
+++ b/apps/temporal-worker/src/peer-reviewer/prompt.ts
@@ -39,6 +39,21 @@ ${entry.description}
 
 YOUR WORKFLOW:
 
+0. **Verify your dispatch shape FIRST.** Look at ENTRY DETAIL above for
+   a PR URL of the form \`https://github.com/<owner>/<repo>/pull/<n>\`.
+   If there is none, you've been dispatched through the generic backlog
+   pipeline instead of the dedicated peer-reviewer dispatcher. EXIT
+   CLEAN with:
+
+   \`\`\`
+   <<<PEER_REVIEW>>>{"red": 0, "yellow": 0, "green": 0, "verdict": "SKIPPED", "skipped_reason": "no PR URL in dispatch context — wrong dispatcher path; await dedicated dispatch"}
+   \`\`\`
+
+   Make NO review comments or other side effects. The dispatcher's
+   apply step would otherwise pick up an empty worktree and produce a
+   bogus no-op PR (you're supposed to be read-only). Bail before that
+   happens.
+
 1. Read the PR diff:
    \`\`\`
    gh pr diff <pr_number>
@@ -108,12 +123,24 @@ YOUR WORKFLOW:
 
 INVARIANTS:
 - One review per dispatch — never spam the PR with multiple comments.
-- Don't repeat what Copilot's R0 already flagged (read R0's comments
-  via \`gh api repos/<o>/<r>/pulls/<n>/comments\` first to dedupe).
 - Cite specific lines — "the function looks complicated" is noise; "X
   on line Y violates Z invariant" is signal.
 - 🟢 (nice-to-have) findings are optional — skip the section if you
   have none. Don't pad the review.
+
+R0 (Copilot) overlap handling:
+- DO read R0's comments first via
+  \`gh api repos/<o>/<r>/pulls/<n>/comments\`.
+- DO include findings R0 already flagged in your structured counts
+  (red/yellow/green) — those issues still need a comment-responder
+  pass, and the responder's trigger reads YOUR red count. If you
+  silently dropped duplicates, R0's findings would never get acted on.
+- Annotate duplicates in your review body so the operator can see what
+  overlaps R0:
+  \`- path:line — <description> (also flagged by R0)\`
+- The point of the dedup-aware annotation is operator readability,
+  NOT downstream signal suppression. Counts must reflect the full
+  set of issues you'd flag if R0 didn't exist.
 
 DON'T:
 - Don't dispatch a comment-responder yourself; the dispatcher chains

--- a/apps/temporal-worker/src/peer-reviewer/prompt.ts
+++ b/apps/temporal-worker/src/peer-reviewer/prompt.ts
@@ -1,0 +1,127 @@
+// Prompt builder for the `peer-reviewer` role.
+//
+// Independent second-opinion reviewer that fires per-PR alongside
+// Copilot's R0 review. Distinct from the existing R1-R3 escalation
+// chain — peer-reviewer is non-escalating, runs at one tier, and is
+// dispatched in parallel (not sequentially) with the comment-responder
+// when both apply.
+//
+// The role's contract:
+//   IN  — a PR URL + diff metadata
+//   OUT — a single review comment posted to the PR with structured
+//         findings (🔴 / 🟡 / 🟢 per the §5 reviewer convention)
+//
+// Bounds shape:
+//   - write_policy=none: read-only (no commits)
+//   - network=allowlist: gh CLI to read PR, post comment
+//   - max_tool_calls=30
+//   - wall_timeout=900s (15 min — peer review shouldn't be slow)
+
+import type { BacklogEntry } from '../grooming/parse-backlog.ts';
+
+/**
+ * Hand the agent the PR context and the adversarial review framing.
+ * Mirrors reviewer-prompts.ts shape but explicitly NON-ESCALATING:
+ * the peer-reviewer outputs a single review and exits. Escalation
+ * (to R2/R3) is the review-graph's job — the peer is one of many
+ * voices, not a tier.
+ */
+export function buildPeerReviewerPrompt(entry: BacklogEntry): string {
+  return `You are playing the peer-reviewer role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §5.
+
+You are a SECOND OPINION on this PR — independent of Copilot's R0 review and the chitin reviewer chain (R1-R3). Your job is one adversarial pass: re-read the diff, look for what would surprise a reader, and post your findings as a single PR comment. You are NOT the final word; you are one voice. Output structured findings; the operator and the gatekeeper compose them with R0/R1+.
+
+ENTRY ID: ${entry.id}
+ROLE: peer-reviewer
+
+ENTRY DETAIL:
+${entry.description}
+
+YOUR WORKFLOW:
+
+1. Read the PR diff:
+   \`\`\`
+   gh pr diff <pr_number>
+   \`\`\`
+
+2. Read the PR description (for stated scope/intent):
+   \`\`\`
+   gh pr view <pr_number> --json title,body
+   \`\`\`
+
+3. For each meaningful chunk of the diff, evaluate against this checklist:
+
+   **Correctness:** does the code do what its surrounding context (tests,
+   docstrings, callers) implies it should? Does it handle the obvious
+   edge cases (empty input, single input, N-equal input, max-int)? If
+   you can articulate the invariant in one sentence, walk it.
+
+   **Scope drift:** does the diff exceed what the PR description says
+   it does? A diff that adds an "incidental refactor" or a "while I'm
+   here" change beyond the stated scope is a flag — it's harder to
+   review, and the bonus changes often slip in unintended behavior.
+
+   **Security:** any user input crossing trust boundaries (network,
+   filesystem, subprocess, SQL, shell)? Look for shell-metacharacter
+   passthrough, path traversal, missing auth checks, missing rate
+   limits, predictable temp paths.
+
+   **Observability:** if this code can fail in production, will the
+   operator know? Logs at the right level (errors → stderr structured
+   JSON), chain-event emission for governance-relevant decisions.
+
+   **Test coverage:** the diff adds behavior — does it add tests for
+   that behavior? Edge cases? Negative paths (the function rejects
+   bad input)? If you find untested branches, name them.
+
+4. Compose your findings as a single review comment, posted via:
+   \`\`\`
+   gh pr review <pr_number> --comment --body "<your structured review>"
+   \`\`\`
+
+   Format the body as follows:
+
+   \`\`\`
+   ### peer-reviewer findings
+
+   🔴 (real bug) findings:
+   - <path>:<line> — <one-paragraph description; cite the line, name
+     the invariant violation, propose the fix>
+
+   🟡 (worth a second look) findings:
+   - <path>:<line> — <one-paragraph description; explain the concern
+     and what would resolve it>
+
+   🟢 (nice-to-have, non-blocking) findings:
+   - <path>:<line> — <brief>
+
+   Overall: <APPROVE | REQUEST_CHANGES | OBSERVE>
+   - APPROVE: zero 🔴 + acceptable 🟡 count
+   - REQUEST_CHANGES: any 🔴
+   - OBSERVE: complexity merits a second tier reviewer (R2/R3)
+   \`\`\`
+
+5. Emit your final structured signal so the runner can record outcomes:
+   \`\`\`
+   <<<PEER_REVIEW>>>{"red": <n>, "yellow": <n>, "green": <n>, "verdict": "<APPROVE|REQUEST_CHANGES|OBSERVE>"}
+   \`\`\`
+
+INVARIANTS:
+- One review per dispatch — never spam the PR with multiple comments.
+- Don't repeat what Copilot's R0 already flagged (read R0's comments
+  via \`gh api repos/<o>/<r>/pulls/<n>/comments\` first to dedupe).
+- Cite specific lines — "the function looks complicated" is noise; "X
+  on line Y violates Z invariant" is signal.
+- 🟢 (nice-to-have) findings are optional — skip the section if you
+  have none. Don't pad the review.
+
+DON'T:
+- Don't dispatch a comment-responder yourself; the dispatcher chains
+  that based on your <<<PEER_REVIEW>>> output (red > 0 → responder).
+- Don't checkout the branch or run tests yourself — peer review is
+  read-only by design (write_policy=none in your bounds).
+- Don't escalate to R2/R3 directly; that's the review-graph workflow's
+  job. You set verdict=OBSERVE if you want a heavier tier; the
+  graph picks it up.
+`;
+}

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -201,15 +201,25 @@ const ROLE_PROMPTS: Record<Role, RolePromptBuilder> = {
   // comments) that a single BacklogEntry can't carry. See
   // docs/design/2026-05-02-swarm-as-software-factory.md §5.
   reviewer: (entry) => buildStubPrompt('reviewer', entry),
-  // Peer-reviewer fires per-PR alongside Copilot R0 — independent
-  // second opinion, non-escalating. See docs/design/2026-05-02-swarm-
-  // as-software-factory.md §5; dispatched by `pr-event-ingester` (or
-  // its successor) when a PR opens.
+  // Peer-reviewer + comment-responder are registered here so the
+  // role-coverage linter passes (every Role in RoleSchema must have
+  // a builder). BUT: the generic backlog dispatcher
+  // (apps/temporal-worker/src/dispatcher.ts) sets
+  // write_policy='worktree' and runs apply-workflow-result for every
+  // dispatch, which is wrong for these roles:
+  //   - peer-reviewer is read-only (write_policy=none) — apply step
+  //     would push an accidental edit as a PR
+  //   - comment-responder commits to the PR's branch
+  //     (write_policy=branch); apply step would try to push + open a
+  //     SECOND PR on top of the responder's commit
+  // Until the pr-event-ingester (#202) extends to dispatch these
+  // through a dedicated path with the right bounds, both prompts'
+  // first-step instructions detect "no PR URL in the entry" and exit
+  // clean — refusing to act when the dispatch shape is wrong. The
+  // dedicated dispatch path lands in the comment-responder /
+  // peer-reviewer wiring follow-up entries from PR #200's
+  // factory-gaps backlog.
   'peer-reviewer': buildPeerReviewerPrompt,
-  // Comment-responder reads PR review comments, evaluates each on
-  // merit (per the operator's "do NOT dismiss as noise" rule), and
-  // pushes a fix commit + summary. Closes the loop the swarm was
-  // missing this morning (PRs #196-#199 sat un-actioned).
   'comment-responder': buildCommentResponderPrompt,
   qa: (entry) => buildStubPrompt('qa', entry),
   gatekeeper: (entry) => buildStubPrompt('gatekeeper', entry),

--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -16,6 +16,8 @@ import type { Role } from '@chitin/contracts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 import { RESEARCHER_OUTPUT_INSTRUCTIONS } from './researcher-prompts.ts';
 import { getRecentLessonsSync } from './lessons.ts';
+import { buildCommentResponderPrompt } from './comment-responder/prompt.ts';
+import { buildPeerReviewerPrompt } from './peer-reviewer/prompt.ts';
 
 // How many of the most-recent lessons to prepend to a programmer
 // prompt. Picked low enough that the overhead per dispatch is small,
@@ -199,6 +201,16 @@ const ROLE_PROMPTS: Record<Role, RolePromptBuilder> = {
   // comments) that a single BacklogEntry can't carry. See
   // docs/design/2026-05-02-swarm-as-software-factory.md §5.
   reviewer: (entry) => buildStubPrompt('reviewer', entry),
+  // Peer-reviewer fires per-PR alongside Copilot R0 — independent
+  // second opinion, non-escalating. See docs/design/2026-05-02-swarm-
+  // as-software-factory.md §5; dispatched by `pr-event-ingester` (or
+  // its successor) when a PR opens.
+  'peer-reviewer': buildPeerReviewerPrompt,
+  // Comment-responder reads PR review comments, evaluates each on
+  // merit (per the operator's "do NOT dismiss as noise" rule), and
+  // pushes a fix commit + summary. Closes the loop the swarm was
+  // missing this morning (PRs #196-#199 sat un-actioned).
+  'comment-responder': buildCommentResponderPrompt,
   qa: (entry) => buildStubPrompt('qa', entry),
   gatekeeper: (entry) => buildStubPrompt('gatekeeper', entry),
   'tech-writer': (entry) => buildStubPrompt('tech-writer', entry),

--- a/apps/temporal-worker/test/comment-responder-prompt.test.ts
+++ b/apps/temporal-worker/test/comment-responder-prompt.test.ts
@@ -64,4 +64,18 @@ describe('buildCommentResponderPrompt', () => {
     const prompt = buildCommentResponderPrompt(makeEntry('x'));
     expect(prompt).toMatch(/AT MOST ONE commit/);
   });
+
+  it('guards against wrong-dispatcher-path: refuse to act without a PR URL', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Verify your dispatch shape FIRST/);
+    expect(prompt).toMatch(/no PR URL in dispatch context/);
+    expect(prompt).toMatch(/skipped_reason/);
+  });
+
+  it('instructs per-thread replies for durable resolution', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Reply to each individual review comment thread/);
+    expect(prompt).toMatch(/comments\/<comment_id>\/replies/);
+    expect(prompt).toMatch(/durable record/);
+  });
 });

--- a/apps/temporal-worker/test/comment-responder-prompt.test.ts
+++ b/apps/temporal-worker/test/comment-responder-prompt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildCommentResponderPrompt } from '../src/comment-responder/prompt.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+
+function makeEntry(description: string): BacklogEntry {
+  return {
+    id: 'comment-respond-pr-199',
+    status: 'ready',
+    role: 'comment-responder',
+    description,
+    rawFrontmatter: '',
+    rawSection: '',
+  };
+}
+
+describe('buildCommentResponderPrompt', () => {
+  it('frames the role with reference to the factory design', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('Address comments on PR #199'));
+    expect(prompt).toMatch(/comment-responder role/);
+    expect(prompt).toContain('docs/design/2026-05-02-swarm-as-software-factory.md');
+  });
+
+  it('cites the operator do-not-dismiss-as-noise rule', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/do NOT dismiss as noise/i);
+    expect(prompt).toMatch(/PR #78 caught 8 of 11/);
+  });
+
+  it('surfaces the entry detail verbatim', () => {
+    const detail = 'Address comments on PR https://github.com/chitinhq/chitin/pull/199';
+    const prompt = buildCommentResponderPrompt(makeEntry(detail));
+    expect(prompt).toContain(detail);
+  });
+
+  it('embeds the entry id', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toContain('comment-respond-pr-199');
+  });
+
+  it('lists the three decision verbs (APPLY / DISMISS / ESCALATE)', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toContain('APPLY');
+    expect(prompt).toContain('DISMISS');
+    expect(prompt).toContain('ESCALATE');
+  });
+
+  it('describes the structured output marker', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toContain('<<<COMMENT_RESPONSE>>>');
+    expect(prompt).toMatch(/applied.*dismissed.*escalated/);
+  });
+
+  it('forbids dismissal without source-of-truth citation', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/DISMISS without.*source.*forbidden/i);
+  });
+
+  it('forbids disabling tests as a fix', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Don't disable tests/);
+  });
+
+  it('caps the agent at one commit per dispatch (re-dispatch ladder lives in dispatcher)', () => {
+    const prompt = buildCommentResponderPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/AT MOST ONE commit/);
+  });
+});

--- a/apps/temporal-worker/test/peer-reviewer-prompt.test.ts
+++ b/apps/temporal-worker/test/peer-reviewer-prompt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildPeerReviewerPrompt } from '../src/peer-reviewer/prompt.ts';
+import type { BacklogEntry } from '../src/grooming/parse-backlog.ts';
+
+function makeEntry(description: string): BacklogEntry {
+  return {
+    id: 'peer-review-pr-199',
+    status: 'ready',
+    role: 'peer-reviewer',
+    description,
+    rawFrontmatter: '',
+    rawSection: '',
+  };
+}
+
+describe('buildPeerReviewerPrompt', () => {
+  it('frames the role as second-opinion (not part of the R1-R3 chain)', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/SECOND OPINION/);
+    expect(prompt).toMatch(/independent of Copilot's R0 review/);
+    expect(prompt).toContain('docs/design/2026-05-02-swarm-as-software-factory.md');
+  });
+
+  it('embeds entry id and detail', () => {
+    const detail = 'Review PR https://github.com/chitinhq/chitin/pull/199';
+    const prompt = buildPeerReviewerPrompt(makeEntry(detail));
+    expect(prompt).toContain('peer-review-pr-199');
+    expect(prompt).toContain(detail);
+  });
+
+  it('lists the four review-finding axes (correctness/scope/security/observability/tests)', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Correctness/);
+    expect(prompt).toMatch(/Scope drift/);
+    expect(prompt).toMatch(/Security/);
+    expect(prompt).toMatch(/Observability/);
+    expect(prompt).toMatch(/Test coverage/);
+  });
+
+  it('describes the structured output marker with the three severity buckets', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toContain('<<<PEER_REVIEW>>>');
+    expect(prompt).toMatch(/red.*yellow.*green.*verdict/);
+  });
+
+  it('explicitly enforces ONE review per dispatch (no spam)', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/One review per dispatch/);
+  });
+
+  it('forbids self-dispatching downstream agents', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Don't dispatch a comment-responder yourself/);
+    expect(prompt).toMatch(/Don't escalate to R2\/R3 directly/);
+  });
+
+  it('marks the role as read-only (no checkout, no test runs)', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/read-only/);
+    expect(prompt).toMatch(/Don't checkout the branch/);
+  });
+
+  it('requires deduping against R0 (Copilot) before posting', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Don't repeat what Copilot's R0 already flagged/);
+  });
+});

--- a/apps/temporal-worker/test/peer-reviewer-prompt.test.ts
+++ b/apps/temporal-worker/test/peer-reviewer-prompt.test.ts
@@ -60,8 +60,22 @@ describe('buildPeerReviewerPrompt', () => {
     expect(prompt).toMatch(/Don't checkout the branch/);
   });
 
-  it('requires deduping against R0 (Copilot) before posting', () => {
+  it('reads R0 (Copilot) comments first but counts duplicates in red/yellow/green', () => {
+    // PR #207 review: silently dropping duplicates would suppress the
+    // very findings that should drive the comment-responder. Counts
+    // must reflect the full set; duplicates are annotated in the
+    // review body, not removed from the structured signal.
     const prompt = buildPeerReviewerPrompt(makeEntry('x'));
-    expect(prompt).toMatch(/Don't repeat what Copilot's R0 already flagged/);
+    expect(prompt).toMatch(/DO read R0's comments first/);
+    expect(prompt).toMatch(/include findings R0 already flagged in your structured counts/);
+    expect(prompt).toMatch(/also flagged by R0/);
+    expect(prompt).toMatch(/operator readability/);
+  });
+
+  it('guards against wrong-dispatcher-path: refuse to act without a PR URL', () => {
+    const prompt = buildPeerReviewerPrompt(makeEntry('x'));
+    expect(prompt).toMatch(/Verify your dispatch shape FIRST/);
+    expect(prompt).toMatch(/no PR URL in dispatch context/);
+    expect(prompt).toMatch(/SKIPPED/);
   });
 });

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -36,18 +36,20 @@ export const TierSchema = z.enum(['T0', 'T1', 'T2', 'T3', 'T4']);
 // Absent = generic programmer (the slice-7b dispatcher's pre-Phase-1
 // behavior). Existing manual dispatches keep working.
 export const RoleSchema = z.enum([
-  'researcher',     // Pull external signals (arxiv, Reddit, openclaw, ollama)
-  'product',        // Turn signals into 1-paragraph problem statements
-  'groomer',        // Tier-classify, size, identify file scope, mark blockers
-  'architect',      // Write design docs / ADRs
-  'programmer',     // Read entry's file:, edit, commit, push (the current swarm)
-  'reviewer',       // Tier-escalating review (R0-R3, see design §5)
-  'qa',             // Generate / run E2E tests; smoke-test
-  'gatekeeper',     // CI + reviews + telemetry → merge or escalate
-  'tech-writer',    // Update wiki + ADRs + runbooks; lessons-learned
-  'analyst',        // Author analysis-lib queries; explain telemetry
-  'refactorer',     // Find duplication / dead code / hot-path debt
-  'debt-curator',   // Maintain debt-ledger; surface debt that blocks other work
+  'researcher',         // Pull external signals (arxiv, Reddit, openclaw, ollama)
+  'product',            // Turn signals into 1-paragraph problem statements
+  'groomer',            // Tier-classify, size, identify file scope, mark blockers
+  'architect',          // Write design docs / ADRs
+  'programmer',         // Read entry's file:, edit, commit, push (the current swarm)
+  'reviewer',           // Tier-escalating review (R0-R3, see design §5)
+  'peer-reviewer',      // Independent second-opinion per PR, parallel to Copilot R0
+  'comment-responder',  // Read PR review comments, evaluate, push fix commits
+  'qa',                 // Generate / run E2E tests; smoke-test
+  'gatekeeper',         // CI + reviews + telemetry → merge or escalate
+  'tech-writer',        // Update wiki + ADRs + runbooks; lessons-learned
+  'analyst',            // Author analysis-lib queries; explain telemetry
+  'refactorer',         // Find duplication / dead code / hot-path debt
+  'debt-curator',       // Maintain debt-ledger; surface debt that blocks other work
 ]);
 
 // Driver tiers for the swarm. The 2026-04-30 framing that excluded

--- a/libs/contracts/tests/execution-request.schema.test.ts
+++ b/libs/contracts/tests/execution-request.schema.test.ts
@@ -247,7 +247,8 @@ describe('ExecutionRequestSchema', () => {
   it('accepts each valid role value', () => {
     const roles = [
       'researcher', 'product', 'groomer', 'architect', 'programmer',
-      'reviewer', 'qa', 'gatekeeper', 'tech-writer', 'analyst',
+      'reviewer', 'peer-reviewer', 'comment-responder',
+      'qa', 'gatekeeper', 'tech-writer', 'analyst',
       'refactorer', 'debt-curator',
     ] as const;
     for (const role of roles) {

--- a/tools/lint/tests/role-coverage.test.ts
+++ b/tools/lint/tests/role-coverage.test.ts
@@ -64,6 +64,8 @@ describe('findRoleCoverageGaps', () => {
       'architect',
       'programmer',
       'reviewer',
+      'peer-reviewer',
+      'comment-responder',
       'qa',
       'gatekeeper',
       'tech-writer',
@@ -71,7 +73,7 @@ describe('findRoleCoverageGaps', () => {
       'refactorer',
       'debt-curator',
     ];
-    expect(expectedRoles.length).toBe(12);
+    expect(expectedRoles.length).toBe(14);
     // Self-symmetric — sanity for the snapshot itself, not a real
     // drift check.
     const gaps = findRoleCoverageGaps(new Set(expectedRoles), new Set(expectedRoles));


### PR DESCRIPTION
## Summary

Closes the loop that started this whole session — PRs #196–#199 sat with Copilot review comments un-actioned because no role read them and pushed fixes. The `comment-responder` fills that gap. The `peer-reviewer` adds an independent second-opinion review per PR (distinct from the R1-R3 escalation chain).

Both agents are **real implementations, not stubs**. They land *without* a generator first — generator templates ossify against unknown shapes, so building two by hand informs what the generator's `--shape` flag should default. The agent-role generator stays filed in PR #201's tooling cohort backlog as a follow-up.

## What's here

| File | Purpose |
|---|---|
| `libs/contracts/src/execution-request.schema.ts` | `RoleSchema` gains `'peer-reviewer'` and `'comment-responder'` |
| `apps/temporal-worker/src/comment-responder/prompt.ts` | Prompt builder — per-comment APPLY/DISMISS/ESCALATE, single fix commit, summary comment. Cites the "do NOT dismiss as noise" rule. |
| `apps/temporal-worker/src/peer-reviewer/prompt.ts` | Prompt builder — independent review, 🔴/🟡/🟢 findings, single review comment per dispatch. Read-only (write_policy=none). |
| `apps/temporal-worker/src/role-prompts.ts` | Registers both in `ROLE_PROMPTS` |
| `test/comment-responder-prompt.test.ts` | 9 tests pinning the invariants |
| `test/peer-reviewer-prompt.test.ts` | 7 tests pinning the invariants |

## Comment-responder contract

- Reads PR review comments via `gh api repos/<o>/<r>/pulls/<n>/comments`
- For each: APPLY (fix commit), DISMISS (with cited source-of-truth — never as noise), or ESCALATE (operator only)
- AT MOST ONE commit per dispatch (re-dispatch ladder lives at the dispatcher level)
- Posts a single summary comment with apply/dismiss/escalate per finding
- Emits structured marker `<<<COMMENT_RESPONSE>>>{...}` for runner ingest

## Peer-reviewer contract

- Reads diff via `gh pr diff` and PR description via `gh pr view`
- Evaluates against five axes: correctness / scope drift / security / observability / test coverage
- Posts ONE structured review comment via `gh pr review --comment`
- Verdict: APPROVE / REQUEST_CHANGES / OBSERVE
- Read-only — does not checkout the branch, does not run tests
- Dedupes against Copilot R0 before posting (don't repeat what's already there)
- Emits structured marker `<<<PEER_REVIEW>>>{...}` for runner ingest

## What this PR does NOT do

- **No dispatcher wiring.** The agents are ready to dispatch but the dispatcher's tier-driver map and the pr-event-ingester need to be extended to call them. Filing as a follow-up backlog entry. This PR ships the agents so the dispatcher work has something concrete to call.
- **No bounds defaults in the tier-driver map.** Same follow-up.

## Verification

```
nx run @chitin/temporal-worker:test            → clean (16 new + 565 existing)
nx run @chitin/tooling-lint:lint:role-coverage → clean
```

The `lint:role-coverage` linter (#205) validated that both new roles are in `RoleSchema` AND have prompt builders — exactly what it was built for. The linter caught its own first true positive on a previous PR; here it certifies the new additions.

## Test plan

- [x] 16 new prompt-builder tests pass
- [x] role-coverage lint clean
- [x] All temporal-worker tests pass
- [ ] CI green
- [ ] Follow-up: wire dispatcher to actually invoke these on PR events

🤖 Generated with [Claude Code](https://claude.com/claude-code)