### PR TITLE
feat(t0): route T0 to local-glm-flash (glm-4.7-flash on the 3090)

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -23,13 +23,16 @@ interface DriverInvocation {
 // Per-driver openclaw agent mapping (slice 3). Each local-* driver routes to
 // a distinct openclaw agent so reasoning and mechanical models can be
 // configured independently — the spec calls for qwen3-coder for mechanical
-// (local-qwen), glm-5.1:cloud for reasoning (local-glm), deepseek for code
-// (local-deepseek). Override per driver via env var, e.g.
-// CHITIN_AGENT_LOCAL_QWEN=my-agent. Falls back to `main` if neither env var
-// nor the default mapping resolves the driver — `main` always exists.
+// (local-qwen), glm-5.1:cloud for reasoning (local-glm), glm-4.7-flash for
+// local mechanical (local-glm-flash, added 2026-05-03 to replace copilot at
+// T0 once the model is hot on the 3090), deepseek for code (local-deepseek).
+// Override per driver via env var, e.g. CHITIN_AGENT_LOCAL_QWEN=my-agent.
+// Falls back to `main` if neither env var nor the default mapping resolves
+// the driver — `main` always exists.
 const DRIVER_AGENT_MAP: Record<string, string> = {
   'local-qwen': 'qwen-agent',
   'local-glm': 'glm-agent',
+  'local-glm-flash': 'glm-flash-agent',
   'local-deepseek': 'deepseek-agent',
 };
 
@@ -132,6 +135,7 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
     }
     case 'local-qwen':
     case 'local-glm':
+    case 'local-glm-flash':
     case 'local-deepseek':
       // Dispatch through openclaw + chitin-governance plugin. The plugin
       // is loaded at openclaw startup (~/.openclaw/openclaw.json plugins.allow
@@ -360,7 +364,7 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     // files. We provision a per-workflow OPENCLAW_STATE_DIR with a remapped
     // openclaw.json instead of mutating the user's global config.
     const localDriver = req.allowed_drivers.find((d) =>
-      d === 'local-qwen' || d === 'local-glm' || d === 'local-deepseek',
+      d === 'local-qwen' || d === 'local-glm' || d === 'local-glm-flash' || d === 'local-deepseek',
     );
     if (localDriver) {
       const agentId = resolveAgent(localDriver as DriverId);

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -61,15 +61,14 @@ const STATE_DIR = resolve(homedir(), '.cache/chitin/swarm-state/dispatched');
 
 // Tier → driver routing. The cheapest reliable driver capable of the
 // work. local-qwen is architecturally the right T0 driver (free, on-
-// the-3090, mechanical) but qwen3-coder:30b on this rig is currently
-// unstable (ollama stream crashes mid-generation; agent
-// misinterprets relative paths as absolute; scope drift onto files
-// outside the entry). Slice 7-tuning's first live run uncovered all
-// three. Routing T0 → copilot temporarily until the qwen layer is
-// fixed (those fixes are backlog entries; the swarm itself produces
-// PRs for them via this same dispatcher). Cost: still $0 under
-// Jared's Copilot plan. One-line revert to local-qwen once the local
-// model is reliable.
+// the-3090, mechanical) but qwen3-coder:30b on this rig was unstable
+// (ollama stream crashes mid-generation; agent misinterprets relative
+// paths as absolute; scope drift onto files outside the entry). T0
+// routed to copilot through 2026-05-02. As of 2026-05-03, T0 routes
+// to local-glm-flash (glm-4.7-flash:latest, hot on the 3090, 32K
+// context, 19 GB on disk). Operator can revert to copilot via env
+// override CHITIN_TIER_DRIVER_T0=copilot if local model regresses.
+//
 // 2026-05-02: T2 temporarily routed to copilot. The overnight 2026-05-02
 // run produced 4/4 bucket-B contaminated PRs on T2/T3 claude-code-
 // headless (and 1/5 successes total). Root cause: the worker's
@@ -81,13 +80,31 @@ const STATE_DIR = resolve(homedir(), '.cache/chitin/swarm-state/dispatched');
 // auto-commit path; once it's been live for a swarm cycle and the
 // rate stays at 0, flip T2 (and T3) back to claude-code-headless.
 // See docs/observations/2026-05-02-bucket-b-after-action.md.
-const TIER_DRIVER: Record<Tier, DriverId> = {
-  T0: 'copilot',                     // Copilot GPT-4.1 free (was local-qwen — see comment)
+const TIER_DRIVER_DEFAULTS: Record<Tier, DriverId> = {
+  T0: 'local-glm-flash',             // glm-4.7-flash:latest on the 3090 via ollama
   T1: 'copilot',                     // Copilot GPT-4.1 free
-  T2: 'copilot',                     // (was claude-code-headless — see comment above; flip back after CCH bucket-B rate stays at 0)
+  T2: 'copilot',                     // (was claude-code-headless — see comment above)
   T3: 'claude-code-headless',        // claude-sonnet-4-6
   T4: 'claude-code-headless',        // claude-opus-4-7
 };
+
+// Operator can override per-tier driver routing via env:
+// CHITIN_TIER_DRIVER_T0=copilot pulls T0 back to copilot at runtime
+// without a code change. Useful for hotfixes when a local model
+// regresses or is offline.
+function envDriverOverride(tier: Tier): DriverId | undefined {
+  const v = process.env[`CHITIN_TIER_DRIVER_${tier}`];
+  if (!v || !v.trim()) return undefined;
+  return v.trim() as DriverId;
+}
+
+const TIER_DRIVER: Record<Tier, DriverId> = (Object.keys(TIER_DRIVER_DEFAULTS) as Tier[]).reduce(
+  (acc, tier) => {
+    acc[tier] = envDriverOverride(tier) ?? TIER_DRIVER_DEFAULTS[tier];
+    return acc;
+  },
+  {} as Record<Tier, DriverId>,
+);
 
 // Per-entry wall_timeout — short enough that a stuck workflow doesn't
 // hold the queue long, generous enough that real work has room. The

--- a/docs/runbooks/local-glm-flash-stack.md
+++ b/docs/runbooks/local-glm-flash-stack.md
@@ -1,0 +1,131 @@
+# Local GLM-4.7-Flash Stack Runbook
+
+> **Status: draft, pending operator validation on the 3090 rig.** This
+> runbook captures the operator-side wiring needed to make the new
+> `local-glm-flash` driver (added 2026-05-03) actually dispatch work
+> through `glm-4.7-flash:latest` when chitin's dispatcher routes T0
+> there. Reference companion to `local-qwen-stack.md`.
+
+`local-glm-flash` is the T0 default as of 2026-05-03 — the cheapest
+local mechanical-tier driver (free, on-the-3090, ~32K context, 19 GB
+on disk, currently hot in GPU memory). Replaces `copilot` at T0
+unless the operator overrides via `CHITIN_TIER_DRIVER_T0`.
+
+## Stack versions
+
+| Component | Required | Verify with |
+|---|---|---|
+| ollama | ≥ 0.22.x | `ollama --version` |
+| glm-4.7-flash | latest | `ollama list \| grep glm-4.7-flash` |
+| openclaw | 2026.4.x | `openclaw --version` |
+
+## 1. Pull the model
+
+```bash
+ollama pull glm-4.7-flash:latest
+ollama list | grep glm-4.7-flash    # confirm 19-20 GB on disk
+```
+
+Heat the GPU once before chitin's first dispatch; cold-load on first
+hit adds ~2-5 s latency on a 3090:
+
+```bash
+ollama run glm-4.7-flash:latest "ready" >/dev/null
+ollama ps                            # confirm it's loaded on GPU
+```
+
+## 2. Configure the openclaw `glm-flash-agent`
+
+The chitin activity (`apps/temporal-worker/src/activity.ts`) routes
+`local-glm-flash` to an openclaw agent named `glm-flash-agent`.
+Configure that agent in `~/.openclaw/openclaw.json`:
+
+```jsonc
+{
+  "agents": {
+    "glm-flash-agent": {
+      "model": "ollama/glm-4.7-flash:latest",
+      "max_tokens": 8192,
+      "temperature": 0.2,
+      "context_window": 32768,
+      // Tools are governed via chitin-governance plugin's
+      // before_tool_call; openclaw's allow-list is permissive here.
+      "tools": ["shell.exec", "read_file", "write_file", "search_files"]
+    }
+    // ...other agents (qwen-agent, glm-agent, deepseek-agent, main)
+    // unchanged.
+  },
+  "plugins": {
+    "allow": ["chitin-governance"]
+  }
+}
+```
+
+Override the agent name with `CHITIN_AGENT_LOCAL_GLM_FLASH=my-agent`
+if a different agent name is preferable.
+
+## 3. Smoke test the dispatch
+
+With the agent configured, dispatch a one-off T0 entry through the
+worker:
+
+```bash
+WORKFLOW_ID="smoke-glm-flash-$(date +%s)" \
+DRIVER=local-glm-flash \
+PROMPT='Use shell.exec to run exactly: echo hello-from-glm-flash. Then stop.' \
+MAX_TOOL_CALLS=3 \
+WALL_TIMEOUT_S=60 \
+pnpm exec tsx apps/temporal-worker/src/submit.ts
+```
+
+Watch the worker log; expect:
+- `openclaw agent --local --agent glm-flash-agent ...` in the spawn line
+- one `before_tool_call` event in the chitin gate event log
+  (`docs/observations/governance-debt-ledger.md` or wherever your
+   gov-decisions chain is)
+- one tool call to `shell.exec` with `cmd: echo hello-from-glm-flash`
+- exit code 0
+
+## 4. Operator override — pulling T0 back to copilot
+
+If the local model regresses (slow, errors, hallucination), revert
+to copilot at T0 without a code change:
+
+```bash
+# In the dispatcher's environment (systemd unit drop-in or shell env):
+export CHITIN_TIER_DRIVER_T0=copilot
+
+systemctl --user restart chitin-dispatcher.timer    # or however the
+                                                    # dispatcher is run
+```
+
+The dispatcher reads `CHITIN_TIER_DRIVER_T0` at tick time;
+flipping back to `local-glm-flash` is the same env var unset.
+
+## 5. Failure modes and recovery
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| `ollama: model not found` in agent stderr | model not pulled | `ollama pull glm-4.7-flash:latest` |
+| Agent times out at wall_timeout | model cold-loading + bounds too tight | warm the model (`ollama run …`); bump `wall_timeout_s` for that entry |
+| Repeated tool-call denials in the chain | governance policy blocking the model's actions | inspect `gov-decisions-*.jsonl`; if false-positive, the policy needs a rule (file as backlog entry) |
+| Quality degradation on tasks T0 used to handle on copilot | model under-fit | flip back via `CHITIN_TIER_DRIVER_T0=copilot`; file backlog entry to either tune the prompt (skill folder) or escalate to T1 |
+| GPU OOM | model loaded alongside another model | `ollama stop <other>`; or run a second 3090, or give T0 a smaller budget so it doesn't keep two models hot |
+
+## 6. Tier-router consultation (when it ships)
+
+Once `tier-router-with-advisor-consultation` (filed in PR #208's
+skill-folder cohort) lands, GLM-4.7-flash hitting a judgment call
+will get a structured T2 (Sonnet) consultation rather than failing
+silently or escalating the whole task. Until then: low-confidence
+classification is just a deny-with-reason on the chain, and the
+operator (or the dispatcher's tier ladder) re-dispatches at T1.
+
+## Reference
+
+- The driver definition: `libs/contracts/src/execution-request.schema.ts`
+  (`DriverIdSchema` enum)
+- Agent mapping: `apps/temporal-worker/src/activity.ts`
+  (`DRIVER_AGENT_MAP`)
+- Tier defaults + env override: `apps/temporal-worker/src/dispatcher.ts`
+  (`TIER_DRIVER_DEFAULTS` + `envDriverOverride`)

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -65,7 +65,14 @@ export const DriverIdSchema = z.enum([
   'copilot',
   'claude-code-headless',
   'local-qwen',
+  // `local-glm` historically routed to glm-5.1:cloud for reasoning
+  // delegation; kept for that role. `local-glm-flash` is the local
+  // mechanical-tier variant added 2026-05-03 — glm-4.7-flash:latest
+  // on the 3090, T0 default. Distinct driver because the cost/latency
+  // profile is fundamentally different (flash = local + fast,
+  // glm-5.1 = cloud + slower + smarter).
   'local-glm',
+  'local-glm-flash',
   'local-deepseek',
 ]);
 


### PR DESCRIPTION
## Summary

GLM-4.7-flash is now hot on the 3090 (19 GB on disk, 32K context, loaded on GPU). This PR adds a dedicated `local-glm-flash` driver and routes T0 to it by default, reclaiming the "T0 should be local mechanical" architectural ideal that's been stuck on copilot since the qwen3-coder instability work in early May.

## What changes

| File | Change |
|---|---|
| `libs/contracts/src/execution-request.schema.ts` | `DriverIdSchema` adds `'local-glm-flash'` (distinct from `local-glm`, which stays as the glm-5.1:cloud reasoning route) |
| `apps/temporal-worker/src/activity.ts` | `DRIVER_AGENT_MAP` adds `'local-glm-flash' → 'glm-flash-agent'`; `planInvocation` and the localDriver detection cover the new case |
| `apps/temporal-worker/src/dispatcher.ts` | `TIER_DRIVER_DEFAULTS[T0]` flips from `'copilot'` to `'local-glm-flash'`; new `envDriverOverride()` lets operators revert at runtime via `CHITIN_TIER_DRIVER_T0=copilot` |
| `docs/runbooks/local-glm-flash-stack.md` (new) | Operator runbook: ollama pull, openclaw `glm-flash-agent` config, smoke test, common failure-mode recovery |

## Why a dedicated driver, not a model swap

`local-glm` historically routed to `glm-5.1:cloud` for reasoning delegation. Repurposing it to a local-flash variant would conflate two different cost/latency profiles. Distinct driver = clean separation, the cloud-reasoning path stays available, and the new local-mechanical path doesn't accidentally inherit the cloud's slower-but-smarter behavior.

## Operator-side wiring (not in this PR — tracked in the new runbook)

This PR ships the chitin-side wiring; the operator needs to:

1. Pull the model: `ollama pull glm-4.7-flash:latest`
2. Configure `glm-flash-agent` in `~/.openclaw/openclaw.json` (example in `docs/runbooks/local-glm-flash-stack.md`)
3. Smoke-test with `DRIVER=local-glm-flash` via `submit.ts`

Until those steps run, dispatches at T0 will fail with "agent not found" until the openclaw config is updated. **Operator should do that before this PR's first T0 dispatch fires.** No code path requires the agent at PR-merge time — only at runtime.

## Operator escape hatch

If the model regresses (slow, errors, hallucinated paths), pull T0 back to copilot without a code change:

```bash
export CHITIN_TIER_DRIVER_T0=copilot
systemctl --user restart chitin-dispatcher.timer
```

The dispatcher reads `CHITIN_TIER_DRIVER_T0` at tick time. Flipping back is the same env var unset.

## Pair-programming connection

Lower-tier work that hits judgment calls is the use case for the `tier-router-with-advisor-consultation` entry filed in PR #208's skill-folder cohort. Until that ships, low-confidence classifications at T0 just deny-with-reason on the chain, and the dispatcher's existing tier ladder re-dispatches at T1 on retry. Once tier-router ships, GLM-4.7-flash hitting an unfamiliar pattern gets a structured T2 (Sonnet) consultation in-line.

## Verification

```
nx run-many -t test --parallel=3   → 11 projects pass
DriverIdSchema enum extended       → downstream type checks pass
```

## Test plan

- [x] All workspace tests pass locally
- [x] CI green
- [ ] Operator: pull model + configure `glm-flash-agent`
- [ ] Operator: smoke-test dispatch via `submit.ts` with `DRIVER=local-glm-flash`
- [ ] Operator: confirm the chitin-governance plugin's `before_tool_call` fires on the agent's tool calls
- [ ] After first 24h: revert via `CHITIN_TIER_DRIVER_T0=copilot` if quality regresses; document the regression as a backlog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)