### PR TITLE
feat(review-graph): chain comment-responder on request-changes verdict

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -602,6 +602,14 @@ function findMatchingOpenBrace(s: string, end: number): number {
 // proxies this for the terminal-state Slack digest.
 export { runGatekeeperNotify } from './gatekeeper.ts';
 
+// Re-export runCommentResponderEnqueue so the worker registers it
+// as an activity. reviewGraphWorkflow calls this after a
+// 'request-changes' verdict to spawn a comment-responder workflow
+// that addresses the findings. Workflows can't spawn arbitrary
+// top-level workflows directly (executeChild creates a parent-
+// child); the activity bridges via a normal Temporal client.
+export { runCommentResponderEnqueue } from './comment-responder/enqueue-activity.ts';
+
 export const __test__ = {
   parseToolSummary,
   planInvocation,

--- a/apps/temporal-worker/src/comment-responder/dispatch.ts
+++ b/apps/temporal-worker/src/comment-responder/dispatch.ts
@@ -14,7 +14,9 @@
 // reviewer comments AND no comment-responder workflow is currently
 // running for this PR.
 
+import { randomUUID } from 'node:crypto';
 import type { Client } from '@temporalio/client';
+import { ExecutionRequestSchema } from '@chitin/contracts';
 import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
 import type { executeRequestWorkflow } from '../workflow.ts';
 import type { BacklogEntry } from '../grooming/parse-backlog.ts';
@@ -47,11 +49,20 @@ export interface EnqueueCommentResponderResult {
 
 /**
  * Stable workflow id for the comment-respond cycle on a given PR.
- * Re-dispatches reuse the id once the previous workflow completes;
- * a still-running workflow blocks new dispatch (Temporal's
- * id-reuse-policy = AllowDuplicate by default; we rely on the
- * ingester's "no responder running for this PR" check before
- * calling enqueue).
+ * Re-dispatches against this id are governed by two policies set
+ * explicitly on the start call below:
+ *   - workflowIdReusePolicy: default (ALLOW_DUPLICATE) — a new
+ *     run can start once the previous run is in a Closed state.
+ *   - workflowIdConflictPolicy: USE_EXISTING — if a run is still
+ *     RUNNING, the start returns a handle to the running workflow
+ *     instead of throwing WorkflowExecutionAlreadyStartedError.
+ * Combined: concurrent ingester ticks against the same PR don't
+ * inflate the ingester's `errors` counter; a closed run for the
+ * same PR is naturally re-runnable on subsequent ticks.
+ *
+ * Belt-and-suspenders: the ingester also has a "no responder
+ * running for this PR" check upstream of enqueue, so the
+ * USE_EXISTING path is the safety net, not the primary defense.
  */
 export function commentResponderWorkflowIdForPr(prNumber: number): string {
   return `comment-respond-pr-${prNumber}`;
@@ -90,15 +101,22 @@ export function buildCommentResponderRequest(
   const driver = input.driver ?? 'copilot';
   const tier = input.tier ?? 'T2';
 
-  return {
+  // Validate via the schema rather than asserting. Other dispatch
+  // paths in this worker use ExecutionRequestSchema.parse() so
+  // contract drift fails fast at the dispatch site, not later
+  // inside the workflow. (Copilot review #211 round-2 #6.)
+  return ExecutionRequestSchema.parse({
     schema_version: '1',
     workflow_id: workflowId,
     // run_id must be UNIQUE PER EXECUTION — the kernel writes
     // canonical events to `.chitin/events-<run_id>.jsonl`, so a
     // stable run_id collapses repeat dispatches' telemetry into a
-    // single file and breaks per-run auditability. (Copilot review
-    // #212 #3; same fix as peer-reviewer/dispatch.ts.)
-    run_id: `${workflowId}-${Date.now()}`,
+    // single file and breaks per-run auditability. randomUUID()
+    // avoids the millisecond-collision risk that a bare Date.now()
+    // suffix has when concurrent dispatches fire in the same tick.
+    // (Copilot review #212 #3 + round-2 #1; same shape as
+    // peer-reviewer/dispatch.ts.)
+    run_id: `${workflowId}-${randomUUID()}`,
     repo: input.repo,
     task_class: 'bug_fix',              // closest fit — addressing review-flagged issues
     risk_level: 'medium',               // commits land on PR branch
@@ -116,7 +134,7 @@ export function buildCommentResponderRequest(
     // base_ref intentionally absent — agent does its own
     // `gh pr checkout` so a worktree set up by the activity would
     // collide with the agent's branch state.
-  } as ExecutionRequest;
+  });
 }
 
 /**
@@ -150,6 +168,11 @@ export async function enqueueCommentResponder(
       args: [request],
       taskQueue: input.taskQueue,
       workflowId: request.workflow_id,
+      // Stable per-PR workflow id: USE_EXISTING returns a handle to
+      // the running workflow rather than throwing
+      // WorkflowExecutionAlreadyStartedError on concurrent ingester
+      // ticks. (Copilot review #211 round-2 #2.)
+      workflowIdConflictPolicy: 'USE_EXISTING',
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/apps/temporal-worker/src/comment-responder/dispatch.ts
+++ b/apps/temporal-worker/src/comment-responder/dispatch.ts
@@ -1,0 +1,172 @@
+// Dispatch helper for the comment-responder agent role (#207).
+//
+// Mirrors peer-reviewer-dispatch.ts in shape but with the bounds the
+// comment-responder needs:
+//   - write_policy=branch: agent commits + pushes directly to the PR's
+//     branch via `gh pr checkout` + `git push`. Activity skips the
+//     worktree+apply pipeline because base_ref is absent.
+//   - max_tool_calls=80: 5-15 comments × (read context + decide + edit
+//     + reply) + tests + commit + push fits in this budget.
+//   - wall_timeout=1800s: tracks the R3 reviewer ceiling.
+//
+// Caller (pr-event-ingester or downstream) is responsible for the
+// "should we dispatch?" decision — typically: there are unresolved
+// reviewer comments AND no comment-responder workflow is currently
+// running for this PR.
+
+import type { Client } from '@temporalio/client';
+import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
+import type { executeRequestWorkflow } from '../workflow.ts';
+import type { BacklogEntry } from '../grooming/parse-backlog.ts';
+import { buildCommentResponderPrompt } from './prompt.ts';
+
+const EXECUTE_REQUEST_WORKFLOW_NAME = 'executeRequestWorkflow';
+
+export interface EnqueueCommentResponderInput {
+  client: Client;
+  taskQueue: string;
+  /** PR URL the agent is responding to. Required. */
+  pr_url: string;
+  /** Repo slug for the agent's gh calls. */
+  repo: string;
+  /** Optional driver override. Default: copilot at T2 (Sonnet) for the
+   *  judgment to evaluate comments on merit. Operator can flip via
+   *  the existing tier-driver env override. */
+  driver?: DriverId;
+  /** Optional tier override. Default: T2. */
+  tier?: Tier;
+  /** Optional log sink (defaults to console.log). */
+  log?: (line: string) => void;
+}
+
+export interface EnqueueCommentResponderResult {
+  enqueued: boolean;
+  workflow_id?: string;
+  error?: string;
+}
+
+/**
+ * Stable workflow id for the comment-respond cycle on a given PR.
+ * Re-dispatches reuse the id once the previous workflow completes;
+ * a still-running workflow blocks new dispatch (Temporal's
+ * id-reuse-policy = AllowDuplicate by default; we rely on the
+ * ingester's "no responder running for this PR" check before
+ * calling enqueue).
+ */
+export function commentResponderWorkflowIdForPr(prNumber: number): string {
+  return `comment-respond-pr-${prNumber}`;
+}
+
+export function extractPrNumber(pr_url: string): number {
+  const m = pr_url.match(/\/pull\/(\d+)/);
+  if (!m) {
+    throw new Error(`comment-responder-dispatch: pr_url does not contain /pull/<n>: ${pr_url}`);
+  }
+  return Number(m[1]);
+}
+
+export function buildCommentResponderEntry(pr_url: string, repo: string): BacklogEntry {
+  const prNumber = extractPrNumber(pr_url);
+  return {
+    id: `comment-respond-pr-${prNumber}`,
+    status: 'ready',
+    role: 'comment-responder',
+    description:
+      `Address unresolved review comments on PR ${pr_url} (repo: ${repo}). ` +
+      `Read each via gh api, evaluate on merit (do NOT dismiss as noise), ` +
+      `apply/dismiss/escalate per comment, push at most one fix commit, ` +
+      `reply to each thread, post a summary comment.`,
+    rawFrontmatter: '',
+    rawSection: '',
+  };
+}
+
+export function buildCommentResponderRequest(
+  input: Pick<EnqueueCommentResponderInput, 'pr_url' | 'repo' | 'driver' | 'tier'>,
+): ExecutionRequest {
+  const prNumber = extractPrNumber(input.pr_url);
+  const workflowId = commentResponderWorkflowIdForPr(prNumber);
+  const entry = buildCommentResponderEntry(input.pr_url, input.repo);
+  const driver = input.driver ?? 'copilot';
+  const tier = input.tier ?? 'T2';
+
+  return {
+    schema_version: '1',
+    workflow_id: workflowId,
+    run_id: `${workflowId}-attempt-1`,
+    repo: input.repo,
+    task_class: 'bug_fix',              // closest fit — addressing review-flagged issues
+    risk_level: 'medium',               // commits land on PR branch
+    allowed_drivers: [driver],
+    network_policy: 'allowlist',        // gh CLI + npm registry
+    write_policy: 'branch',             // commits to the PR's branch
+    bounds: {
+      max_tool_calls: 80,
+      max_cost_usd: 0,
+      wall_timeout_s: 1800,             // 30 min — same ceiling as R3
+    },
+    prompt: buildCommentResponderPrompt(entry),
+    role: 'comment-responder',
+    tier,
+    // base_ref intentionally absent — agent does its own
+    // `gh pr checkout` so a worktree set up by the activity would
+    // collide with the agent's branch state.
+  } as ExecutionRequest;
+}
+
+/**
+ * Spawn the comment-responder workflow. Failure is logged but never
+ * propagates — missing the dispatch leaves the comments unaddressed,
+ * but doesn't break the PR's existing state.
+ */
+export async function enqueueCommentResponder(
+  input: EnqueueCommentResponderInput,
+): Promise<EnqueueCommentResponderResult> {
+  const log = input.log ?? ((l: string) => console.log(l));
+
+  let request: ExecutionRequest;
+  try {
+    request = buildCommentResponderRequest(input);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'warn',
+      component: 'comment-responder-dispatch',
+      msg: 'request build failed',
+      pr_url: input.pr_url,
+      error: msg,
+    }));
+    return { enqueued: false, error: msg };
+  }
+
+  try {
+    await input.client.workflow.start<typeof executeRequestWorkflow>(EXECUTE_REQUEST_WORKFLOW_NAME, {
+      args: [request],
+      taskQueue: input.taskQueue,
+      workflowId: request.workflow_id,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'warn',
+      component: 'comment-responder-dispatch',
+      msg: 'submit failed; comments will remain unaddressed until next cycle',
+      pr_url: input.pr_url,
+      error: msg,
+    }));
+    return { enqueued: false, error: msg };
+  }
+
+  log(JSON.stringify({
+    ts: new Date().toISOString(),
+    level: 'info',
+    component: 'comment-responder-dispatch',
+    msg: 'comment-responder enqueued',
+    workflow_id: request.workflow_id,
+    pr_url: input.pr_url,
+  }));
+
+  return { enqueued: true, workflow_id: request.workflow_id };
+}

--- a/apps/temporal-worker/src/comment-responder/dispatch.ts
+++ b/apps/temporal-worker/src/comment-responder/dispatch.ts
@@ -93,7 +93,12 @@ export function buildCommentResponderRequest(
   return {
     schema_version: '1',
     workflow_id: workflowId,
-    run_id: `${workflowId}-attempt-1`,
+    // run_id must be UNIQUE PER EXECUTION — the kernel writes
+    // canonical events to `.chitin/events-<run_id>.jsonl`, so a
+    // stable run_id collapses repeat dispatches' telemetry into a
+    // single file and breaks per-run auditability. (Copilot review
+    // #212 #3; same fix as peer-reviewer/dispatch.ts.)
+    run_id: `${workflowId}-${Date.now()}`,
     repo: input.repo,
     task_class: 'bug_fix',              // closest fit — addressing review-flagged issues
     risk_level: 'medium',               // commits land on PR branch

--- a/apps/temporal-worker/src/comment-responder/enqueue-activity.ts
+++ b/apps/temporal-worker/src/comment-responder/enqueue-activity.ts
@@ -1,0 +1,85 @@
+// Activity that enqueues a comment-responder workflow.
+//
+// Called from reviewGraphWorkflow after the §5 escalation chain
+// terminates with action='request-changes'. Workflows can't spawn
+// arbitrary top-level workflows directly (executeChild creates a
+// parent-child relationship; we want a peer); the indirection
+// through an activity gives us a normal Temporal client to call
+// `workflow.start()` on.
+//
+// Failure-tolerant: if the enqueue fails (Temporal flaky, dispatch
+// error), we log and return enqueued=false. The reviewer chain has
+// already completed; missing the responder dispatch isn't worse
+// than the pre-this-PR baseline.
+//
+// Why a new activity instead of folding into runGatekeeperNotify:
+// the gatekeeper makes auto-merge decisions; this activity dispatches
+// follow-on work. Conceptually distinct, even though both fire after
+// reviewGraphWorkflow's loop. A future "post-loop chain" abstraction
+// could fold them, but that's premature.
+
+import { Connection, Client } from '@temporalio/client';
+import { enqueueCommentResponder } from './dispatch.ts';
+
+const TEMPORAL_ADDRESS = process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233';
+const TASK_QUEUE = 'chitin-worker-q';
+
+export interface EnqueueCommentResponderActivityInput {
+  pr_url: string;
+  repo: string;
+}
+
+export interface EnqueueCommentResponderActivityResult {
+  enqueued: boolean;
+  workflow_id?: string;
+  /** Reason when enqueued=false. */
+  reason?: string;
+}
+
+/**
+ * Open a temporal connection, dispatch the comment-responder
+ * workflow, close the connection. Each call is independent — we
+ * don't pool the connection across activity invocations because
+ * Temporal activities are short-lived and the call frequency here
+ * is low (at most once per review-graph completion).
+ */
+export async function runCommentResponderEnqueue(
+  input: EnqueueCommentResponderActivityInput,
+): Promise<EnqueueCommentResponderActivityResult> {
+  if (!input.pr_url) {
+    return { enqueued: false, reason: 'missing pr_url' };
+  }
+  if (!input.repo) {
+    return { enqueued: false, reason: 'missing repo' };
+  }
+
+  let connection: Connection | undefined;
+  try {
+    connection = await Connection.connect({ address: TEMPORAL_ADDRESS });
+    const client = new Client({ connection, namespace: 'default' });
+    const result = await enqueueCommentResponder({
+      client,
+      taskQueue: TASK_QUEUE,
+      pr_url: input.pr_url,
+      repo: input.repo,
+    });
+    if (!result.enqueued) {
+      return {
+        enqueued: false,
+        reason: result.error ?? 'enqueue helper returned not-enqueued',
+      };
+    }
+    return { enqueued: true, workflow_id: result.workflow_id };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { enqueued: false, reason: `activity error: ${msg}` };
+  } finally {
+    if (connection) {
+      await connection.close().catch(() => {
+        // Connection close error doesn't change the outcome — the
+        // workflow is already started (or the start failed before
+        // close); swallow.
+      });
+    }
+  }
+}

--- a/apps/temporal-worker/src/comment-responder/prompt.ts
+++ b/apps/temporal-worker/src/comment-responder/prompt.ts
@@ -61,11 +61,17 @@ YOUR WORKFLOW (one tool call per step where possible):
    would otherwise pick up an empty worktree and produce a bogus no-op
    PR. Bail before that happens.
 
-1. Use the \`exec\` tool to checkout the PR's branch:
+1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** You're
+   running in an empty tempdir (no git repo, no working clone), so
+   \`gh pr checkout <pr_number>\` would fail with "not in a git repo."
+   Clone the repo first into the cwd, then check out the PR's branch:
    \`\`\`
+   gh repo clone <owner>/<repo> .
    gh pr checkout <pr_number>
    \`\`\`
-   (pr_number from ENTRY DETAIL above.)
+   The first command clones into \`.\` (cwd); the second switches the
+   worktree to the PR's branch so subsequent edits + commits land
+   on it.
 
 2. Pull all unresolved inline comments:
    \`\`\`
@@ -119,8 +125,8 @@ YOUR WORKFLOW (one tool call per step where possible):
    what GitHub uses to mark threads as resolved/replied so future
    dispatches don't reprocess them.
 
-7. Post a summary comment on the PR via \`gh pr comment <pr_number>\` with
-   the following structure (one bullet per inline comment evaluated):
+7. Post a summary comment on the PR via \`gh pr comment --repo <owner>/<repo> <pr_number>\`
+   with the following structure (one bullet per inline comment evaluated):
 
    \`\`\`
    ### comment-responder summary

--- a/apps/temporal-worker/src/peer-reviewer/dispatch.ts
+++ b/apps/temporal-worker/src/peer-reviewer/dispatch.ts
@@ -12,7 +12,9 @@
 // flagged on PR #207, where apply-workflow-result would otherwise
 // try to push an empty diff as a no-op PR.
 
+import { randomUUID } from 'node:crypto';
 import type { Client } from '@temporalio/client';
+import { ExecutionRequestSchema } from '@chitin/contracts';
 import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
 import type { executeRequestWorkflow } from '../workflow.ts';
 import type { BacklogEntry } from '../grooming/parse-backlog.ts';
@@ -95,7 +97,11 @@ export function buildPeerReviewerRequest(
   const driver = input.driver ?? 'copilot';
   const tier = input.tier ?? 'T2';
 
-  return {
+  // Validate via the schema rather than asserting. Other dispatch
+  // paths in this worker use ExecutionRequestSchema.parse() so
+  // contract drift fails fast at the dispatch site, not later
+  // inside the workflow. (Copilot review #211 round-2 #4.)
+  return ExecutionRequestSchema.parse({
     schema_version: '1',
     workflow_id: workflowId,
     // run_id must be UNIQUE PER EXECUTION — the kernel writes
@@ -103,8 +109,10 @@ export function buildPeerReviewerRequest(
     // stable run_id collapses repeat dispatches' telemetry into a
     // single file and breaks per-run auditability. workflow_id is
     // stable per PR (for Temporal dedup); run_id is per-dispatch.
-    // (Copilot review #212 #2.)
-    run_id: `${workflowId}-${Date.now()}`,
+    // randomUUID() avoids the millisecond-collision risk that a
+    // bare Date.now() suffix has when concurrent dispatches fire
+    // in the same tick. (Copilot review #212 #2 + round-2 #1.)
+    run_id: `${workflowId}-${randomUUID()}`,
     repo: input.repo,
     task_class: 'exploration',          // closest fit for read-only review
     risk_level: 'low',
@@ -120,7 +128,7 @@ export function buildPeerReviewerRequest(
     role: 'peer-reviewer',
     tier,
     // base_ref intentionally absent — no worktree, no apply step.
-  } as ExecutionRequest;
+  });
 }
 
 /**
@@ -154,6 +162,13 @@ export async function enqueuePeerReviewer(
       args: [request],
       taskQueue: input.taskQueue,
       workflowId: request.workflow_id,
+      // Stable per-PR workflow id means concurrent ingester ticks
+      // can race a workflow.start() against an already-running run.
+      // USE_EXISTING returns a handle to the running workflow rather
+      // than throwing WorkflowExecutionAlreadyStartedError, so the
+      // ingester doesn't inflate its `errors` counter on the race.
+      // (Copilot review #211 round-2 #2.)
+      workflowIdConflictPolicy: 'USE_EXISTING',
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/apps/temporal-worker/src/peer-reviewer/dispatch.ts
+++ b/apps/temporal-worker/src/peer-reviewer/dispatch.ts
@@ -98,7 +98,13 @@ export function buildPeerReviewerRequest(
   return {
     schema_version: '1',
     workflow_id: workflowId,
-    run_id: `${workflowId}-attempt-1`,
+    // run_id must be UNIQUE PER EXECUTION — the kernel writes
+    // canonical events to `.chitin/events-<run_id>.jsonl`, so a
+    // stable run_id collapses repeat dispatches' telemetry into a
+    // single file and breaks per-run auditability. workflow_id is
+    // stable per PR (for Temporal dedup); run_id is per-dispatch.
+    // (Copilot review #212 #2.)
+    run_id: `${workflowId}-${Date.now()}`,
     repo: input.repo,
     task_class: 'exploration',          // closest fit for read-only review
     risk_level: 'low',

--- a/apps/temporal-worker/src/peer-reviewer/dispatch.ts
+++ b/apps/temporal-worker/src/peer-reviewer/dispatch.ts
@@ -1,0 +1,175 @@
+// Dispatch helper for the peer-reviewer agent role (#207).
+//
+// Mirrors review-graph-dispatch.ts in shape: takes the bits the
+// pr-event-ingester (or any other caller) has, produces an
+// ExecutionRequest, spawns executeRequestWorkflow with a stable
+// workflow id for dedup. The agent self-bounds (read-only) and does
+// its own gh CLI reads + posts a single review comment.
+//
+// The dispatch is base_ref-less (no worktree). The peer-reviewer is
+// read-only so the activity's worktree + apply-step machinery is
+// pure overhead — and skipping it avoids the wrong-bounds problem
+// flagged on PR #207, where apply-workflow-result would otherwise
+// try to push an empty diff as a no-op PR.
+
+import type { Client } from '@temporalio/client';
+import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
+import type { executeRequestWorkflow } from '../workflow.ts';
+import type { BacklogEntry } from '../grooming/parse-backlog.ts';
+import { buildPeerReviewerPrompt } from './prompt.ts';
+
+const EXECUTE_REQUEST_WORKFLOW_NAME = 'executeRequestWorkflow';
+
+export interface EnqueuePeerReviewerInput {
+  client: Client;
+  taskQueue: string;
+  /** PR URL for the agent to review. Required — the prompt's step-0
+   *  guard refuses to act without a PR URL in the entry detail. */
+  pr_url: string;
+  /** Repo slug, e.g. 'chitinhq/chitin'. Used by the agent's gh calls. */
+  repo: string;
+  /** Optional driver override. Default: copilot at T2 (Sonnet) for
+   *  enough judgment to do an adversarial review. */
+  driver?: DriverId;
+  /** Optional tier override. Default: T2. */
+  tier?: Tier;
+  /** Optional log sink (defaults to console.log). Tests inject. */
+  log?: (line: string) => void;
+}
+
+export interface EnqueuePeerReviewerResult {
+  enqueued: boolean;
+  workflow_id?: string;
+  error?: string;
+}
+
+/**
+ * Stable workflow id for the peer-review on a given PR. Same id
+ * across re-dispatches lets the ingester dedup against an already-
+ * running review without hitting Temporal's id-already-in-use path.
+ */
+export function peerReviewerWorkflowIdForPr(prNumber: number): string {
+  return `peer-review-pr-${prNumber}`;
+}
+
+export function extractPrNumber(pr_url: string): number {
+  const m = pr_url.match(/\/pull\/(\d+)/);
+  if (!m) {
+    throw new Error(`peer-reviewer-dispatch: pr_url does not contain /pull/<n>: ${pr_url}`);
+  }
+  return Number(m[1]);
+}
+
+/**
+ * Build the synthetic BacklogEntry the prompt builder consumes.
+ * Entry description carries the PR URL — the prompt's step-0 guard
+ * scans for `https://github.com/<o>/<r>/pull/<n>` and refuses to
+ * act if absent.
+ */
+export function buildPeerReviewerEntry(pr_url: string, repo: string): BacklogEntry {
+  const prNumber = extractPrNumber(pr_url);
+  return {
+    id: `peer-review-pr-${prNumber}`,
+    status: 'ready',
+    role: 'peer-reviewer',
+    description:
+      `Peer-review PR ${pr_url} (repo: ${repo}). ` +
+      `Read the diff, evaluate against the five-axis checklist, ` +
+      `post one structured review comment. See SKILL.md for full workflow.`,
+    rawFrontmatter: '',
+    rawSection: '',
+  };
+}
+
+/**
+ * Build the ExecutionRequest the peer-reviewer agent will receive.
+ * Pure — exported so tests can pin the field-mapping without standing
+ * up a Temporal client.
+ */
+export function buildPeerReviewerRequest(
+  input: Pick<EnqueuePeerReviewerInput, 'pr_url' | 'repo' | 'driver' | 'tier'>,
+): ExecutionRequest {
+  const prNumber = extractPrNumber(input.pr_url);
+  const workflowId = peerReviewerWorkflowIdForPr(prNumber);
+  const entry = buildPeerReviewerEntry(input.pr_url, input.repo);
+  const driver = input.driver ?? 'copilot';
+  const tier = input.tier ?? 'T2';
+
+  return {
+    schema_version: '1',
+    workflow_id: workflowId,
+    run_id: `${workflowId}-attempt-1`,
+    repo: input.repo,
+    task_class: 'exploration',          // closest fit for read-only review
+    risk_level: 'low',
+    allowed_drivers: [driver],
+    network_policy: 'allowlist',        // gh CLI only
+    write_policy: 'none',               // strictly read-only
+    bounds: {
+      max_tool_calls: 30,
+      max_cost_usd: 0,
+      wall_timeout_s: 900,              // 15 min — peer review shouldn't be slow
+    },
+    prompt: buildPeerReviewerPrompt(entry),
+    role: 'peer-reviewer',
+    tier,
+    // base_ref intentionally absent — no worktree, no apply step.
+  } as ExecutionRequest;
+}
+
+/**
+ * Spawn the peer-reviewer workflow. Failure is logged but never
+ * propagates — peer review is consultative; missing it is not worse
+ * than the pre-PR baseline where Copilot R0 was the only review.
+ */
+export async function enqueuePeerReviewer(
+  input: EnqueuePeerReviewerInput,
+): Promise<EnqueuePeerReviewerResult> {
+  const log = input.log ?? ((l: string) => console.log(l));
+
+  let request: ExecutionRequest;
+  try {
+    request = buildPeerReviewerRequest(input);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'warn',
+      component: 'peer-reviewer-dispatch',
+      msg: 'request build failed',
+      pr_url: input.pr_url,
+      error: msg,
+    }));
+    return { enqueued: false, error: msg };
+  }
+
+  try {
+    await input.client.workflow.start<typeof executeRequestWorkflow>(EXECUTE_REQUEST_WORKFLOW_NAME, {
+      args: [request],
+      taskQueue: input.taskQueue,
+      workflowId: request.workflow_id,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'warn',
+      component: 'peer-reviewer-dispatch',
+      msg: 'submit failed; PR review will rely on R0 only',
+      pr_url: input.pr_url,
+      error: msg,
+    }));
+    return { enqueued: false, error: msg };
+  }
+
+  log(JSON.stringify({
+    ts: new Date().toISOString(),
+    level: 'info',
+    component: 'peer-reviewer-dispatch',
+    msg: 'peer-reviewer enqueued',
+    workflow_id: request.workflow_id,
+    pr_url: input.pr_url,
+  }));
+
+  return { enqueued: true, workflow_id: request.workflow_id };
+}

--- a/apps/temporal-worker/src/peer-reviewer/prompt.ts
+++ b/apps/temporal-worker/src/peer-reviewer/prompt.ts
@@ -54,17 +54,26 @@ YOUR WORKFLOW:
    bogus no-op PR (you're supposed to be read-only). Bail before that
    happens.
 
-1. Read the PR diff:
+1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** Then
+   pass them through every \`gh\` command via the \`--repo\` flag.
+   You're running in a tempdir without a git repository, so plain
+   \`gh pr ...\` invocations would fail with "not in a git repo."
+   Format every gh call like:
    \`\`\`
-   gh pr diff <pr_number>
+   gh pr <subcmd> --repo <owner>/<repo> <pr_number> [args...]
    \`\`\`
 
-2. Read the PR description (for stated scope/intent):
+2. Read the PR diff:
    \`\`\`
-   gh pr view <pr_number> --json title,body
+   gh pr diff --repo <owner>/<repo> <pr_number>
    \`\`\`
 
-3. For each meaningful chunk of the diff, evaluate against this checklist:
+3. Read the PR description (for stated scope/intent):
+   \`\`\`
+   gh pr view --repo <owner>/<repo> <pr_number> --json title,body
+   \`\`\`
+
+4. For each meaningful chunk of the diff, evaluate against this checklist:
 
    **Correctness:** does the code do what its surrounding context (tests,
    docstrings, callers) implies it should? Does it handle the obvious
@@ -89,9 +98,9 @@ YOUR WORKFLOW:
    that behavior? Edge cases? Negative paths (the function rejects
    bad input)? If you find untested branches, name them.
 
-4. Compose your findings as a single review comment, posted via:
+5. Compose your findings as a single review comment, posted via:
    \`\`\`
-   gh pr review <pr_number> --comment --body "<your structured review>"
+   gh pr review --repo <owner>/<repo> <pr_number> --comment --body "<your structured review>"
    \`\`\`
 
    Format the body as follows:
@@ -116,7 +125,7 @@ YOUR WORKFLOW:
    - OBSERVE: complexity merits a second tier reviewer (R2/R3)
    \`\`\`
 
-5. Emit your final structured signal so the runner can record outcomes:
+6. Emit your final structured signal so the runner can record outcomes:
    \`\`\`
    <<<PEER_REVIEW>>>{"red": <n>, "yellow": <n>, "green": <n>, "verdict": "<APPROVE|REQUEST_CHANGES|OBSERVE>"}
    \`\`\`

--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -34,6 +34,22 @@ import {
   enqueueReviewGraph,
   REVIEW_GRAPH_WORKFLOW_NAME,
 } from './review-graph-dispatch.ts';
+import {
+  enqueuePeerReviewer,
+  peerReviewerWorkflowIdForPr,
+} from './peer-reviewer/dispatch.ts';
+import {
+  enqueueCommentResponder,
+  commentResponderWorkflowIdForPr,
+} from './comment-responder/dispatch.ts';
+
+// Threshold above which the ingester dispatches a comment-responder.
+// Mirrors the §5 review-graph trigger ("Copilot bot leaves > 2 inline
+// comments → escalate to R1") so the comment-responder fires on
+// roughly the same PRs that get an R1 reviewer.
+const COMMENT_RESPONDER_THRESHOLD = 2;
+
+const EXECUTE_REQUEST_WORKFLOW_NAME = 'executeRequestWorkflow';
 
 const TASK_QUEUE = 'chitin-worker-q';
 
@@ -266,11 +282,30 @@ export function enrichPr(repo: string, pr: OpenPrSummary): OpenPrSummary {
  */
 export async function listRunningReviewGraphWorkflows(client: Client): Promise<Set<string>> {
   const ids = new Set<string>();
-  // Filter by ExecutionStatus = Running and WorkflowType =
-  // reviewGraphWorkflow. Returns workflow ids the ingester might
-  // collide with.
   const iter = client.workflow.list({
     query: `WorkflowType="${REVIEW_GRAPH_WORKFLOW_NAME}" AND ExecutionStatus="Running"`,
+  });
+  for await (const wf of iter) {
+    ids.add(wf.workflowId);
+  }
+  return ids;
+}
+
+/**
+ * Query Temporal for currently-running peer-reviewer + comment-
+ * responder workflow ids. Both share the executeRequestWorkflow type;
+ * we filter by workflow_id prefix instead of WorkflowType. Same
+ * dedup purpose as listRunningReviewGraphWorkflows.
+ */
+export async function listRunningAgentWorkflows(client: Client): Promise<Set<string>> {
+  const ids = new Set<string>();
+  // Match both `peer-review-pr-*` and `comment-respond-pr-*` workflow
+  // ids. These are spawned via executeRequestWorkflow by the
+  // peer-reviewer + comment-responder dispatch helpers.
+  const iter = client.workflow.list({
+    query:
+      `WorkflowType="${EXECUTE_REQUEST_WORKFLOW_NAME}" AND ExecutionStatus="Running" ` +
+      `AND (WorkflowId STARTS_WITH "peer-review-pr-" OR WorkflowId STARTS_WITH "comment-respond-pr-")`,
   });
   for await (const wf of iter) {
     ids.add(wf.workflowId);
@@ -282,8 +317,14 @@ export async function listRunningReviewGraphWorkflows(client: Client): Promise<S
 
 export interface IngesterTickResult {
   evaluated: number;
+  /** review-graph workflows enqueued */
   ingested: number;
+  /** §5 said R0 (Copilot covers it) — recorded but not dispatched */
   ingested_r0: number;
+  /** peer-reviewer workflows enqueued (per-PR, parallel to review-graph) */
+  peer_reviewers_enqueued: number;
+  /** comment-responder workflows enqueued */
+  comment_responders_enqueued: number;
   skipped: number;
   errors: number;
 }
@@ -305,6 +346,8 @@ export async function runIngesterTick(opts: {
     evaluated: 0,
     ingested: 0,
     ingested_r0: 0,
+    peer_reviewers_enqueued: 0,
+    comment_responders_enqueued: 0,
     skipped: 0,
     errors: 0,
   };
@@ -325,6 +368,7 @@ export async function runIngesterTick(opts: {
   });
 
   const running = await listRunningReviewGraphWorkflows(opts.client);
+  const runningAgents = await listRunningAgentWorkflows(opts.client);
   const decisions = pickPrsToIngest(enriched, running);
 
   for (const decision of decisions) {
@@ -406,6 +450,69 @@ export async function runIngesterTick(opts: {
           }));
         }
         break;
+    }
+  }
+
+  // Per-PR agent dispatches — peer-reviewer + comment-responder.
+  // Iterate the same enriched set so the dispatch decision sees the
+  // up-to-date Copilot comment count and PR shape. Non-skip decisions
+  // already qualify (non-draft, non-swarm/, non-already-running review-
+  // graph); we add per-agent dedup against runningAgents.
+  for (const decision of decisions) {
+    if (decision.kind === 'skip') continue;
+    const pr = decision.pr;
+
+    // Peer-reviewer fires per-PR — independent second opinion. Skip
+    // if one is already running for this PR.
+    const peerWorkflowId = peerReviewerWorkflowIdForPr(pr.number);
+    if (!runningAgents.has(peerWorkflowId)) {
+      if (opts.dryRun) {
+        log(JSON.stringify({
+          component: 'pr-event-ingester',
+          msg: 'would-enqueue-peer-reviewer',
+          pr: pr.number,
+        }));
+        result.peer_reviewers_enqueued += 1;
+      } else {
+        const peerRes = await enqueuePeerReviewer({
+          client: opts.client,
+          taskQueue: opts.taskQueue,
+          pr_url: pr.url,
+          repo: opts.repo,
+          log,
+        });
+        if (peerRes.enqueued) result.peer_reviewers_enqueued += 1;
+        else result.errors += 1;
+      }
+    }
+
+    // Comment-responder fires when there are unresolved Copilot
+    // comments above the threshold. Same threshold as the §5
+    // matrix's R1 escalation (>2 comments) so the responder fires
+    // on roughly the same PRs that get an R1 reviewer. Skip if one
+    // is already running.
+    const responderWorkflowId = commentResponderWorkflowIdForPr(pr.number);
+    const commentCount = pr.copilotCommentCount ?? 0;
+    if (commentCount > COMMENT_RESPONDER_THRESHOLD && !runningAgents.has(responderWorkflowId)) {
+      if (opts.dryRun) {
+        log(JSON.stringify({
+          component: 'pr-event-ingester',
+          msg: 'would-enqueue-comment-responder',
+          pr: pr.number,
+          comment_count: commentCount,
+        }));
+        result.comment_responders_enqueued += 1;
+      } else {
+        const respRes = await enqueueCommentResponder({
+          client: opts.client,
+          taskQueue: opts.taskQueue,
+          pr_url: pr.url,
+          repo: opts.repo,
+          log,
+        });
+        if (respRes.enqueued) result.comment_responders_enqueued += 1;
+        else result.errors += 1;
+      }
     }
   }
 

--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -294,21 +294,50 @@ export async function listRunningReviewGraphWorkflows(client: Client): Promise<S
 /**
  * Query Temporal for currently-running peer-reviewer + comment-
  * responder workflow ids. Both share the executeRequestWorkflow type;
- * we filter by workflow_id prefix instead of WorkflowType. Same
- * dedup purpose as listRunningReviewGraphWorkflows.
+ * we filter by workflow_id prefix in-process (NOT in the visibility
+ * query) because `STARTS_WITH` + boolean OR in visibility queries
+ * isn't uniformly supported across Temporal visibility backends —
+ * the default SQLite backend in particular rejects it. (Copilot
+ * review #211 #3.)
+ *
+ * Failure mode: if the visibility query throws (backend down, schema
+ * drift, etc.), this returns an empty set and logs a warn line
+ * rather than letting the entire ingester tick fail. Treating "no
+ * running agents" on query failure means the ingester might
+ * dispatch a duplicate peer-reviewer for one tick — which Temporal
+ * itself rejects via stable workflow id, since peer-review-pr-<n>
+ * is a unique-by-PR id. Fail-open here is bounded.
  */
-export async function listRunningAgentWorkflows(client: Client): Promise<Set<string>> {
+export async function listRunningAgentWorkflows(
+  client: Client,
+  log?: (line: string) => void,
+): Promise<Set<string>> {
   const ids = new Set<string>();
-  // Match both `peer-review-pr-*` and `comment-respond-pr-*` workflow
-  // ids. These are spawned via executeRequestWorkflow by the
-  // peer-reviewer + comment-responder dispatch helpers.
-  const iter = client.workflow.list({
-    query:
-      `WorkflowType="${EXECUTE_REQUEST_WORKFLOW_NAME}" AND ExecutionStatus="Running" ` +
-      `AND (WorkflowId STARTS_WITH "peer-review-pr-" OR WorkflowId STARTS_WITH "comment-respond-pr-")`,
-  });
-  for await (const wf of iter) {
-    ids.add(wf.workflowId);
+  try {
+    const iter = client.workflow.list({
+      query: `WorkflowType="${EXECUTE_REQUEST_WORKFLOW_NAME}" AND ExecutionStatus="Running"`,
+    });
+    for await (const wf of iter) {
+      const id = wf.workflowId;
+      // Filter to the agent ids in-process (peer-review-pr-* and
+      // comment-respond-pr-*) so the visibility query stays
+      // backend-portable.
+      if (id.startsWith('peer-review-pr-') || id.startsWith('comment-respond-pr-')) {
+        ids.add(id);
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'warn',
+      component: 'pr-event-ingester',
+      msg: 'listRunningAgentWorkflows failed; treating as empty',
+      error: msg,
+    });
+    if (log) log(line);
+    else console.warn(line);
+    return new Set();
   }
   return ids;
 }
@@ -368,7 +397,7 @@ export async function runIngesterTick(opts: {
   });
 
   const running = await listRunningReviewGraphWorkflows(opts.client);
-  const runningAgents = await listRunningAgentWorkflows(opts.client);
+  const runningAgents = await listRunningAgentWorkflows(opts.client, log);
   const decisions = pickPrsToIngest(enriched, running);
 
   for (const decision of decisions) {

--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -515,11 +515,22 @@ export async function runIngesterTick(opts: {
       }
     }
 
-    // Comment-responder fires when there are unresolved Copilot
-    // comments above the threshold. Same threshold as the §5
-    // matrix's R1 escalation (>2 comments) so the responder fires
-    // on roughly the same PRs that get an R1 reviewer. Skip if one
-    // is already running.
+    // Comment-responder fires when the PR has more than
+    // COMMENT_RESPONDER_THRESHOLD raw Copilot inline review
+    // comments. NOTE: the count is total inline comments returned
+    // by `/pulls/{n}/comments` — it does NOT distinguish resolved
+    // vs unresolved threads, so once a responder run completes the
+    // count remains above threshold and the next ingester tick
+    // will redispatch. That respawn is gated by the
+    // `runningAgents` check (one in flight blocks the next), but
+    // not by a "previously responded" check. Both gaps are
+    // tracked as backlog follow-ups
+    // (`pr-event-ingester-comment-count-is-unresolved` +
+    // `pr-event-ingester-dedup-against-completed-workflows`,
+    // PR #223).
+    // Same threshold as the §5 matrix's R1 escalation (>2
+    // comments) so the responder fires on roughly the same PRs
+    // that get an R1 reviewer.
     const responderWorkflowId = commentResponderWorkflowIdForPr(pr.number);
     const commentCount = pr.copilotCommentCount ?? 0;
     if (commentCount > COMMENT_RESPONDER_THRESHOLD && !runningAgents.has(responderWorkflowId)) {

--- a/apps/temporal-worker/src/review-graph-workflow.ts
+++ b/apps/temporal-worker/src/review-graph-workflow.ts
@@ -443,6 +443,25 @@ const { runGatekeeperNotify } = proxyActivities<{
   retry: { maximumAttempts: 1 },
 });
 
+// Activity proxy for the comment-responder enqueue. 30s — the
+// activity opens a Temporal connection, calls workflow.start, and
+// closes. Best-effort: activity returns enqueued=false rather than
+// throwing on dispatch errors so a missing comment-responder never
+// fails the review-graph workflow.
+const { runCommentResponderEnqueue } = proxyActivities<{
+  runCommentResponderEnqueue(input: {
+    pr_url: string;
+    repo: string;
+  }): Promise<{
+    enqueued: boolean;
+    workflow_id?: string;
+    reason?: string;
+  }>;
+}>({
+  startToCloseTimeout: '30 seconds',
+  retry: { maximumAttempts: 1 },
+});
+
 /**
  * The Temporal workflow chitin's review-graph runs as. Thin shell —
  * dispatches each reviewer via `executeChild(executeRequestWorkflow,
@@ -481,7 +500,46 @@ export async function reviewGraphWorkflow(input: ReviewGraphInput): Promise<Revi
     // (worker offline, etc.). The workflow still returns its result.
   }
 
+  // Chain to comment-responder when the loop's verdict requests
+  // implementor changes. The chained workflow runs as a peer (top-
+  // level), reads the same PR via gh, evaluates each finding, and
+  // pushes a fix commit + replies to threads. Other terminal
+  // actions skip:
+  //   - 'approve'                  — no findings to act on
+  //   - 'escalate-to-operator'     — operator pickup, agent shouldn't
+  //                                  preempt the human
+  //   - 'parse-failure-at-r4'      — no clean signal to act on
+  //
+  // Best-effort: the activity returns enqueued=false on dispatch
+  // errors rather than throwing, and we silently swallow Temporal
+  // rejections (same shape as the gatekeeper notify above). A
+  // missing chain is no worse than the pre-this-PR baseline — the
+  // operator still gets the gatekeeper digest.
+  if (shouldChainCommentResponder(result.action, input.pr_meta.pr_url)) {
+    try {
+      await runCommentResponderEnqueue({
+        pr_url: input.pr_meta.pr_url!,
+        repo: input.repo,
+      });
+    } catch {
+      // Same fall-through as above — never let a chain-dispatch
+      // error fail the parent workflow.
+    }
+  }
+
   return result;
+}
+
+/**
+ * Pure: should the workflow chain to a comment-responder for this
+ * outcome? Extracted so tests can pin every (action, pr_url)
+ * combination without standing up a Temporal worker.
+ */
+export function shouldChainCommentResponder(
+  action: ReviewGraphAction,
+  pr_url: string | undefined,
+): boolean {
+  return action === 'request-changes' && Boolean(pr_url);
 }
 
 export const __test__ = {

--- a/apps/temporal-worker/test/comment-responder-dispatch.test.ts
+++ b/apps/temporal-worker/test/comment-responder-dispatch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCommentResponderEntry,
+  buildCommentResponderRequest,
+  commentResponderWorkflowIdForPr,
+} from '../src/comment-responder/dispatch.ts';
+
+describe('commentResponderWorkflowIdForPr', () => {
+  it('produces a stable id per PR number', () => {
+    expect(commentResponderWorkflowIdForPr(199)).toBe('comment-respond-pr-199');
+    expect(commentResponderWorkflowIdForPr(207)).toBe('comment-respond-pr-207');
+  });
+});
+
+describe('buildCommentResponderEntry', () => {
+  it('embeds the PR URL in the description (prompt step-0 guard reads it)', () => {
+    const entry = buildCommentResponderEntry(
+      'https://github.com/chitinhq/chitin/pull/207',
+      'chitinhq/chitin',
+    );
+    expect(entry.description).toContain('https://github.com/chitinhq/chitin/pull/207');
+    expect(entry.role).toBe('comment-responder');
+    expect(entry.id).toBe('comment-respond-pr-207');
+  });
+
+  it('mentions the do-NOT-dismiss-as-noise rule in the description', () => {
+    const entry = buildCommentResponderEntry(
+      'https://github.com/chitinhq/chitin/pull/1',
+      'chitinhq/chitin',
+    );
+    expect(entry.description).toMatch(/do NOT dismiss as noise/);
+  });
+});
+
+describe('buildCommentResponderRequest', () => {
+  it('produces an ExecutionRequest with branch-write bounds', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/207',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.write_policy).toBe('branch');
+    expect(req.network_policy).toBe('allowlist');
+    expect(req.role).toBe('comment-responder');
+    expect(req.task_class).toBe('bug_fix');
+    expect(req.risk_level).toBe('medium');
+  });
+
+  it('omits base_ref so the activity skips worktree+apply (agent does its own gh pr checkout)', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.base_ref).toBeUndefined();
+  });
+
+  it('default driver is copilot at T2 (judgment-tier reasoning)', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.allowed_drivers).toEqual(['copilot']);
+    expect(req.tier).toBe('T2');
+  });
+
+  it('honors driver + tier overrides', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+      driver: 'claude-code-headless',
+      tier: 'T4',
+    });
+    expect(req.allowed_drivers).toEqual(['claude-code-headless']);
+    expect(req.tier).toBe('T4');
+  });
+
+  it('caps tool calls at 80 (handles 5-15 comments × evaluate+edit+commit+push)', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.bounds.max_tool_calls).toBe(80);
+  });
+
+  it('wall_timeout=1800s — tracks the R3 reviewer ceiling', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.bounds.wall_timeout_s).toBe(1800);
+  });
+
+  it('workflow_id matches the stable per-PR id', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/207',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.workflow_id).toBe('comment-respond-pr-207');
+  });
+
+  it('embeds the prompt with the PR URL in entry detail (step-0 guard wired)', () => {
+    const req = buildCommentResponderRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/207',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.prompt).toContain('https://github.com/chitinhq/chitin/pull/207');
+    expect(req.prompt).toMatch(/Verify your dispatch shape FIRST/);
+    expect(req.prompt).toMatch(/Reply to each individual review comment thread/);
+  });
+});

--- a/apps/temporal-worker/test/peer-reviewer-dispatch.test.ts
+++ b/apps/temporal-worker/test/peer-reviewer-dispatch.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPeerReviewerEntry,
+  buildPeerReviewerRequest,
+  extractPrNumber,
+  peerReviewerWorkflowIdForPr,
+} from '../src/peer-reviewer/dispatch.ts';
+
+describe('peerReviewerWorkflowIdForPr', () => {
+  it('produces a stable id per PR number', () => {
+    expect(peerReviewerWorkflowIdForPr(199)).toBe('peer-review-pr-199');
+    expect(peerReviewerWorkflowIdForPr(207)).toBe('peer-review-pr-207');
+  });
+});
+
+describe('extractPrNumber', () => {
+  it('parses a github pull URL', () => {
+    expect(extractPrNumber('https://github.com/chitinhq/chitin/pull/207')).toBe(207);
+  });
+
+  it('throws on a URL without /pull/', () => {
+    expect(() => extractPrNumber('https://example.com/x')).toThrow(/does not contain/);
+  });
+});
+
+describe('buildPeerReviewerEntry', () => {
+  it('embeds the PR URL in the description (the prompt step-0 guard reads it)', () => {
+    const entry = buildPeerReviewerEntry(
+      'https://github.com/chitinhq/chitin/pull/207',
+      'chitinhq/chitin',
+    );
+    expect(entry.description).toContain('https://github.com/chitinhq/chitin/pull/207');
+    expect(entry.role).toBe('peer-reviewer');
+    expect(entry.id).toBe('peer-review-pr-207');
+    expect(entry.status).toBe('ready');
+  });
+
+  it('includes the repo slug', () => {
+    const entry = buildPeerReviewerEntry(
+      'https://github.com/chitinhq/chitin/pull/1',
+      'chitinhq/chitin',
+    );
+    expect(entry.description).toContain('chitinhq/chitin');
+  });
+});
+
+describe('buildPeerReviewerRequest', () => {
+  it('produces an ExecutionRequest with read-only bounds', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/207',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.write_policy).toBe('none');
+    expect(req.network_policy).toBe('allowlist');
+    expect(req.role).toBe('peer-reviewer');
+    expect(req.task_class).toBe('exploration');
+    expect(req.risk_level).toBe('low');
+  });
+
+  it('omits base_ref so the activity skips worktree+apply', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.base_ref).toBeUndefined();
+  });
+
+  it('default driver is copilot, default tier is T2', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.allowed_drivers).toEqual(['copilot']);
+    expect(req.tier).toBe('T2');
+  });
+
+  it('honors driver + tier overrides', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+      driver: 'claude-code-headless',
+      tier: 'T3',
+    });
+    expect(req.allowed_drivers).toEqual(['claude-code-headless']);
+    expect(req.tier).toBe('T3');
+  });
+
+  it('workflow_id matches the stable per-PR id', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/207',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.workflow_id).toBe('peer-review-pr-207');
+  });
+
+  it('embeds the prompt with the PR URL in entry detail (step-0 guard wired)', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/207',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.prompt).toContain('https://github.com/chitinhq/chitin/pull/207');
+    // Sanity: the prompt's step-0 guard markers are present
+    expect(req.prompt).toMatch(/Verify your dispatch shape FIRST/);
+  });
+
+  it('wall_timeout=900s — peer review shouldn\'t be slow', () => {
+    const req = buildPeerReviewerRequest({
+      pr_url: 'https://github.com/chitinhq/chitin/pull/1',
+      repo: 'chitinhq/chitin',
+    });
+    expect(req.bounds.wall_timeout_s).toBe(900);
+  });
+});

--- a/apps/temporal-worker/test/review-graph-workflow.test.ts
+++ b/apps/temporal-worker/test/review-graph-workflow.test.ts
@@ -6,6 +6,7 @@ import {
 } from './review-graph-workflow.helpers.ts';
 import {
   runReviewGraphLoop,
+  shouldChainCommentResponder,
   __test__,
   type ReviewGraphInput,
   type ReviewerDispatch,
@@ -434,6 +435,37 @@ describe('runReviewGraphLoop — output retention', () => {
     expect(result.action).toBe('parse-failure-at-r4');
     expect(result.output).toBeUndefined();
     expect(result.tier_log.every((e) => !e.parsed)).toBe(true);
+  });
+});
+
+describe('shouldChainCommentResponder', () => {
+  // Pure function — tests pin the chain-on-action decision without
+  // standing up a Temporal worker.
+
+  const PR_URL = 'https://github.com/chitinhq/chitin/pull/207';
+
+  it('chains on request-changes with a PR URL', () => {
+    expect(shouldChainCommentResponder('request-changes', PR_URL)).toBe(true);
+  });
+
+  it('skips on approve (nothing to act on)', () => {
+    expect(shouldChainCommentResponder('approve', PR_URL)).toBe(false);
+  });
+
+  it('skips on escalate-to-operator (operator pickup; agent should NOT preempt)', () => {
+    expect(shouldChainCommentResponder('escalate-to-operator', PR_URL)).toBe(false);
+  });
+
+  it('skips on parse-failure-at-r4 (no clean signal)', () => {
+    expect(shouldChainCommentResponder('parse-failure-at-r4', PR_URL)).toBe(false);
+  });
+
+  it('skips when pr_url is undefined (responder needs the PR to act on)', () => {
+    expect(shouldChainCommentResponder('request-changes', undefined)).toBe(false);
+  });
+
+  it('skips when pr_url is empty string', () => {
+    expect(shouldChainCommentResponder('request-changes', '')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the swarm-authored side of today's loop. The pr-event-ingester (#202 + #211) triggers comment-responder on Copilot R0 count; this PR triggers it ALSO when chitin's R1-R3 escalation chain returns `request-changes`. Together: any reviewer signal that wants implementor changes spawns a responder.

## What's here

- `apps/temporal-worker/src/comment-responder/enqueue-activity.ts` — new activity that spawns a comment-responder workflow. Workflows can't `executeChild` an arbitrary top-level workflow (creates parent-child); the activity bridges via a normal Temporal client.
- `apps/temporal-worker/src/activity.ts` — re-exports `runCommentResponderEnqueue` so the worker registers it.
- `apps/temporal-worker/src/review-graph-workflow.ts` — proxyActivity for the new activity + conditional dispatch after the gatekeeper notify. `shouldChainCommentResponder()` pure helper exported for testing.
- `apps/temporal-worker/test/review-graph-workflow.test.ts` — 6 new tests pinning every `(action, pr_url)` combination.

## Decision matrix

| ReviewGraphAction | pr_url | Chain? |
|---|---|---|
| `request-changes` | present | ✅ chain |
| `request-changes` | absent | ❌ skip (no PR to act on) |
| `approve` | * | ❌ skip (no findings) |
| `escalate-to-operator` | * | ❌ skip (operator pickup; agent shouldn't preempt) |
| `parse-failure-at-r4` | * | ❌ skip (no clean signal) |

## Stacking

This PR depends on #211 (which adds `enqueueCommentResponder`). Merge order: **#211 → this PR**.

## Why an activity instead of `executeChild`

`executeChild` creates a parent-child workflow relationship — the responder's lifecycle would be tied to the review-graph's. We want them independent (comment-responder may continue past the parent's completion, especially if the parent immediately returns the gatekeeper digest). The activity → `Connection.connect` → `workflow.start` flow gives a peer relationship.

## Why a separate activity instead of folding into `runGatekeeperNotify`

Gatekeeper makes auto-merge decisions. This dispatches follow-on work. Conceptually distinct, even though both fire after the loop. A future "post-loop chain" abstraction could fold them; that's premature.

## Test plan

- [x] All temporal-worker tests pass (608 + 6 new)
- [x] `shouldChainCommentResponder` covered for every action + pr_url combination
- [ ] CI green (after #211 merges)
- [ ] Smoke-test: trigger a review-graph manually with a request-changes outcome on a real PR; verify a `comment-respond-pr-<n>` workflow appears in Temporal alongside the review-graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)