### PR TITLE
feat(skill-loader): dispatcher-stitcher + peer-reviewer fixture

### DIFF
--- a/apps/temporal-worker/skills/peer-reviewer/SKILL.md
+++ b/apps/temporal-worker/skills/peer-reviewer/SKILL.md
@@ -26,26 +26,31 @@ YOUR WORKFLOW:
 
    Make NO review comments or other side effects. The dispatcher's apply step would otherwise pick up an empty worktree and produce a bogus no-op PR (you're supposed to be read-only). Bail before that happens.
 
-1. Read the PR diff:
+1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** Then pass them through every `gh` command via the `--repo` flag. You're running in a tempdir without a git repository, so plain `gh pr ...` invocations would fail with "not in a git repo." Format every gh call like:
    ```
-   gh pr diff <pr_number>
-   ```
-
-2. Read the PR description (for stated scope/intent):
-   ```
-   gh pr view <pr_number> --json title,body
+   gh pr <subcmd> --repo <owner>/<repo> <pr_number> [args...]
    ```
 
-3. For each meaningful chunk of the diff, evaluate against the [five-axis review checklist](./checklist.md).
-
-4. Compose your findings as a single review comment, posted via:
+2. Read the PR diff:
    ```
-   gh pr review <pr_number> --comment --body "<your structured review>"
+   gh pr diff --repo <owner>/<repo> <pr_number>
+   ```
+
+3. Read the PR description (for stated scope/intent):
+   ```
+   gh pr view --repo <owner>/<repo> <pr_number> --json title,body
+   ```
+
+4. For each meaningful chunk of the diff, evaluate against the [five-axis review checklist](./checklist.md).
+
+5. Compose your findings as a single review comment, posted via:
+   ```
+   gh pr review --repo <owner>/<repo> <pr_number> --comment --body "<your structured review>"
    ```
 
    Format the body using the [structured review template](./review-template.md).
 
-5. Emit your final structured signal so the runner can record outcomes:
+6. Emit your final structured signal so the runner can record outcomes:
    ```
    <<<PEER_REVIEW>>>{"red": <n>, "yellow": <n>, "green": <n>, "verdict": "<APPROVE|REQUEST_CHANGES|OBSERVE>"}
    ```

--- a/apps/temporal-worker/skills/peer-reviewer/SKILL.md
+++ b/apps/temporal-worker/skills/peer-reviewer/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: peer-reviewer
+description: Independent second-opinion reviewer that fires per-PR alongside Copilot R0
+tier_hint: T2
+activation: when a PR is opened or updated; runs in parallel with the chitin reviewer chain (R1-R3); non-escalating
+tools: [gh, exec]
+---
+
+You are playing the peer-reviewer role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §5.
+
+You are a SECOND OPINION on this PR — independent of Copilot's R0 review and the chitin reviewer chain (R1-R3). Your job is one adversarial pass: re-read the diff, look for what would surprise a reader, and post your findings as a single PR comment. You are NOT the final word; you are one voice. Output structured findings; the operator and the gatekeeper compose them with R0/R1+.
+
+ENTRY ID: {{entry.id}}
+ROLE: peer-reviewer
+
+ENTRY DETAIL:
+{{entry.description}}
+
+YOUR WORKFLOW:
+
+0. **Verify your dispatch shape FIRST.** Look at ENTRY DETAIL above for a PR URL of the form `https://github.com/<owner>/<repo>/pull/<n>`. If there is none, you've been dispatched through the generic backlog pipeline instead of the dedicated peer-reviewer dispatcher. EXIT CLEAN with:
+
+   ```
+   <<<PEER_REVIEW>>>{"red": 0, "yellow": 0, "green": 0, "verdict": "SKIPPED", "skipped_reason": "no PR URL in dispatch context — wrong dispatcher path; await dedicated dispatch"}
+   ```
+
+   Make NO review comments or other side effects. The dispatcher's apply step would otherwise pick up an empty worktree and produce a bogus no-op PR (you're supposed to be read-only). Bail before that happens.
+
+1. Read the PR diff:
+   ```
+   gh pr diff <pr_number>
+   ```
+
+2. Read the PR description (for stated scope/intent):
+   ```
+   gh pr view <pr_number> --json title,body
+   ```
+
+3. For each meaningful chunk of the diff, evaluate against the [five-axis review checklist](./checklist.md).
+
+4. Compose your findings as a single review comment, posted via:
+   ```
+   gh pr review <pr_number> --comment --body "<your structured review>"
+   ```
+
+   Format the body using the [structured review template](./review-template.md).
+
+5. Emit your final structured signal so the runner can record outcomes:
+   ```
+   <<<PEER_REVIEW>>>{"red": <n>, "yellow": <n>, "green": <n>, "verdict": "<APPROVE|REQUEST_CHANGES|OBSERVE>"}
+   ```
+
+INVARIANTS:
+- One review per dispatch — never spam the PR with multiple comments.
+- Cite specific lines — "the function looks complicated" is noise; "X on line Y violates Z invariant" is signal.
+- 🟢 (nice-to-have) findings are optional — skip the section if you have none. Don't pad the review.
+
+R0 (Copilot) overlap handling:
+- DO read R0's comments first via `gh api repos/<o>/<r>/pulls/<n>/comments`.
+- DO include findings R0 already flagged in your structured counts (red/yellow/green) — those issues still need a comment-responder pass, and the responder's trigger reads YOUR red count. If you silently dropped duplicates, R0's findings would never get acted on.
+- Annotate duplicates in your review body so the operator can see what overlaps R0:
+  `- path:line — <description> (also flagged by R0)`
+- The point of the dedup-aware annotation is operator readability, NOT downstream signal suppression. Counts must reflect the full set of issues you'd flag if R0 didn't exist.
+
+DON'T:
+- Don't dispatch a comment-responder yourself; the dispatcher chains that based on your <<<PEER_REVIEW>>> output (red > 0 → responder).
+- Don't checkout the branch or run tests yourself — peer review is read-only by design (write_policy=none in your bounds).
+- Don't escalate to R2/R3 directly; that's the review-graph workflow's job. You set verdict=OBSERVE if you want a heavier tier; the graph picks it up.

--- a/apps/temporal-worker/skills/peer-reviewer/checklist.md
+++ b/apps/temporal-worker/skills/peer-reviewer/checklist.md
@@ -1,0 +1,28 @@
+# Peer-reviewer five-axis checklist
+
+For each meaningful chunk of the diff, walk the five axes below.
+Cite specific lines; "the function looks complicated" is noise, "X
+on line Y violates Z invariant" is signal.
+
+**Correctness:** does the code do what its surrounding context (tests,
+docstrings, callers) implies it should? Does it handle the obvious
+edge cases (empty input, single input, N-equal input, max-int)? If
+you can articulate the invariant in one sentence, walk it.
+
+**Scope drift:** does the diff exceed what the PR description says it
+does? A diff that adds an "incidental refactor" or a "while I'm here"
+change beyond the stated scope is a flag — it's harder to review, and
+the bonus changes often slip in unintended behavior.
+
+**Security:** any user input crossing trust boundaries (network,
+filesystem, subprocess, SQL, shell)? Look for shell-metacharacter
+passthrough, path traversal, missing auth checks, missing rate
+limits, predictable temp paths.
+
+**Observability:** if this code can fail in production, will the
+operator know? Logs at the right level (errors → stderr structured
+JSON), chain-event emission for governance-relevant decisions.
+
+**Test coverage:** the diff adds behavior — does it add tests for
+that behavior? Edge cases? Negative paths (the function rejects bad
+input)? If you find untested branches, name them.

--- a/apps/temporal-worker/skills/peer-reviewer/review-template.md
+++ b/apps/temporal-worker/skills/peer-reviewer/review-template.md
@@ -1,0 +1,30 @@
+# Peer-reviewer structured review template
+
+Post your review with this exact body shape so the gatekeeper's
+parser keys on it cleanly:
+
+```
+### peer-reviewer findings
+
+🔴 (real bug) findings:
+- <path>:<line> — <one-paragraph description; cite the line, name
+  the invariant violation, propose the fix>
+
+🟡 (worth a second look) findings:
+- <path>:<line> — <one-paragraph description; explain the concern
+  and what would resolve it>
+
+🟢 (nice-to-have, non-blocking) findings:
+- <path>:<line> — <brief>
+
+Overall: <APPROVE | REQUEST_CHANGES | OBSERVE>
+- APPROVE: zero 🔴 + acceptable 🟡 count
+- REQUEST_CHANGES: any 🔴
+- OBSERVE: complexity merits a second tier reviewer (R2/R3)
+```
+
+Skip the 🟢 section entirely if you have none. Don't pad the review.
+
+Findings R0 (Copilot) already flagged: include them in counts, but
+annotate "(also flagged by R0)" in the description so the operator
+can see overlap at a glance.

--- a/apps/temporal-worker/src/skill-loader/stitcher.ts
+++ b/apps/temporal-worker/src/skill-loader/stitcher.ts
@@ -1,0 +1,323 @@
+// Skill-folder dispatcher-stitcher.
+//
+// Reads a `SKILL.md` from a skill folder + any files SKILL.md
+// references, substitutes `{{var}}` template tokens with caller-
+// provided values, and returns the assembled prompt string.
+//
+// Tier-shape:
+//   - T0-T2 (Copilot CLI, ollama, claude-haiku): the harness has no
+//     native skill-discovery, so the dispatcher must inline SKILL.md
+//     content into the prompt at dispatch time. The stitcher returns
+//     a single rendered string the dispatcher passes via
+//     ExecutionRequest.prompt.
+//   - T3-T4 (Claude Code headless): the harness CAN discover skills
+//     from a known path. The stitcher's `materializePath` helper
+//     returns the skill folder so the activity can copy it into the
+//     agent's working dir; the harness handles the rest.
+//
+// SKILL.md format:
+//   YAML frontmatter (--- delimited):
+//     name: <skill-id>
+//     description: <one-line>
+//     tier_hint: <T0|T1|T2|T3|T4>
+//     activation: <when this skill is relevant — for the agent's
+//                  skill-discovery decision; ignored by tiers that
+//                  inline the body>
+//     tools: [tool, names, agent, can, call]
+//   Markdown body — the prompt content. Reference companion files
+//   via `[label](./companion.md)`; the stitcher pulls them in
+//   verbatim during inline rendering.
+//
+// Variable substitution:
+//   `{{var.path}}` resolves against the `vars` object passed to
+//   render(). Missing vars throw — explicit failure beats silent
+//   stub-text rendering.
+//
+// Pure functions exposed for testing; one I/O wrapper (loadSkill)
+// reads from disk.
+
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface SkillFrontmatter {
+  name: string;
+  description: string;
+  tier_hint?: string;
+  activation?: string;
+  tools?: string[];
+  /** Allow extra fields without strict-schema rejection — frontmatter
+   *  conventions evolve and the stitcher shouldn't fail-closed on a
+   *  new field. The linter (#208 entry 2) is the strict gate. */
+  [key: string]: unknown;
+}
+
+export interface ParsedSkill {
+  /** Path to the skill folder (the dir containing SKILL.md). */
+  folder: string;
+  frontmatter: SkillFrontmatter;
+  /** Markdown body of SKILL.md, post-frontmatter. */
+  body: string;
+}
+
+// ── Pure logic ─────────────────────────────────────────────────────
+
+/**
+ * Pure: split a SKILL.md text into (frontmatter, body). The
+ * frontmatter is YAML between `---` delimiters at the top of the
+ * file. Frontmatter is optional — files without it are treated as
+ * body-only with empty frontmatter.
+ */
+export function splitFrontmatter(text: string): {
+  frontmatterText: string;
+  body: string;
+} {
+  if (!text.startsWith('---\n') && !text.startsWith('---\r\n')) {
+    return { frontmatterText: '', body: text };
+  }
+  const afterFirst = text.slice(text.indexOf('\n') + 1);
+  const closeIdx = afterFirst.indexOf('\n---');
+  if (closeIdx < 0) {
+    // No closing fence — treat the whole thing as body (loose
+    // parsing; the linter catches malformed cases).
+    return { frontmatterText: '', body: text };
+  }
+  const frontmatterText = afterFirst.slice(0, closeIdx);
+  // Skip past the closing `---` line, plus its newline.
+  const afterClose = afterFirst.slice(closeIdx + '\n---'.length);
+  const body = afterClose.startsWith('\n') ? afterClose.slice(1) : afterClose;
+  return { frontmatterText, body };
+}
+
+/**
+ * Pure: minimal YAML parser sufficient for the flat key:value-and-
+ * inline-list frontmatter we use. Mirrors the parser already in
+ * apps/temporal-worker/src/grooming/parse-backlog.ts so the stitcher
+ * doesn't pull a yaml lib in.
+ *
+ * Recognized shapes:
+ *   key: value
+ *   key: "value with spaces"
+ *   key: [a, b, c]
+ *   key:                 # then indented list items follow on next lines
+ *     - a
+ *     - b
+ */
+export function parseSimpleYaml(text: string): SkillFrontmatter {
+  const fields: Record<string, unknown> = {};
+  const lines = text.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const rawLine = lines[i] ?? '';
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      i += 1;
+      continue;
+    }
+    const colonIdx = line.indexOf(':');
+    if (colonIdx <= 0) {
+      i += 1;
+      continue;
+    }
+    const key = line.slice(0, colonIdx).trim();
+    let val = line.slice(colonIdx + 1).trim();
+
+    // Inline array: `key: [a, b, c]`
+    if (val.startsWith('[') && val.endsWith(']')) {
+      fields[key] = val
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+        .filter((s) => s.length > 0);
+      i += 1;
+      continue;
+    }
+
+    // Block array: empty value, then indented `- item` lines
+    if (val === '') {
+      const items: string[] = [];
+      let j = i + 1;
+      while (j < lines.length) {
+        const next = lines[j] ?? '';
+        if (!next.startsWith('  -') && !next.startsWith('  ') && !next.startsWith('-')) break;
+        const m = next.match(/^\s*-\s*(.*)$/);
+        if (!m) break;
+        items.push(m[1].replace(/^["']|["']$/g, ''));
+        j += 1;
+      }
+      if (items.length > 0) {
+        fields[key] = items;
+        i = j;
+        continue;
+      }
+    }
+
+    // Quoted scalar
+    if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+    if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+    fields[key] = val;
+    i += 1;
+  }
+
+  // Validate the required fields. Non-strict on extras.
+  if (typeof fields.name !== 'string' || !fields.name) {
+    throw new Error('SKILL.md frontmatter requires a non-empty `name` field');
+  }
+  if (typeof fields.description !== 'string') {
+    fields.description = '';
+  }
+  return fields as SkillFrontmatter;
+}
+
+/**
+ * Pure: substitute `{{var.path}}` tokens in `text` with values from
+ * `vars`. Dot-paths supported (`{{entry.id}}`). Missing vars throw —
+ * fail-closed beats silently rendering a stub literal.
+ */
+export function substituteVars(
+  text: string,
+  vars: Record<string, unknown>,
+): string {
+  return text.replace(/\{\{([^}]+)\}\}/g, (match, expr: string) => {
+    const path = expr.trim().split('.');
+    let cursor: unknown = vars;
+    for (const seg of path) {
+      if (cursor === null || typeof cursor !== 'object') {
+        throw new Error(
+          `stitcher: cannot resolve {{${expr}}} — segment "${seg}" reached non-object`,
+        );
+      }
+      cursor = (cursor as Record<string, unknown>)[seg];
+      if (cursor === undefined) {
+        throw new Error(`stitcher: variable {{${expr}}} not provided in vars`);
+      }
+    }
+    if (cursor === null) {
+      throw new Error(`stitcher: variable {{${expr}}} resolved to null`);
+    }
+    return typeof cursor === 'string' ? cursor : JSON.stringify(cursor);
+  });
+}
+
+/**
+ * Pure: inline the contents of any `[label](./path/to/file)` link in
+ * `body` into the rendered output. Each linked file is fenced with
+ * its label as the heading, so the agent sees the structure clearly.
+ *
+ * Only same-folder relative paths are inlined (./foo, foo). Absolute
+ * paths and parent-directory traversals are rejected — the linter
+ * catches these earlier, but the stitcher fails-closed in case it
+ * sees one.
+ */
+export function inlineCompanions(
+  body: string,
+  loadCompanion: (relativePath: string) => string,
+): string {
+  return body.replace(
+    /\[([^\]]+)\]\((\.\/[^)\s]+|[^)\s/]+\.md)\)/g,
+    (match, label: string, path: string) => {
+      // Reject parent traversal explicitly.
+      if (path.includes('..')) {
+        throw new Error(`stitcher: companion path must not include ".."  — got ${path}`);
+      }
+      const cleanPath = path.startsWith('./') ? path.slice(2) : path;
+      const content = loadCompanion(cleanPath);
+      return `\n--- ${label} (${cleanPath}) ---\n\n${content}\n\n--- end of ${cleanPath} ---\n`;
+    },
+  );
+}
+
+/**
+ * Pure: assemble the final prompt string. Composition:
+ *   1. Substitute {{var}} tokens in the body
+ *   2. Inline any `[label](./companion.md)` links
+ *   3. Strip leading/trailing whitespace
+ *
+ * Companion inlining happens AFTER variable substitution so that
+ * companion paths can themselves be variable-driven (`{{role}}`).
+ */
+export function renderSkillBody(
+  body: string,
+  vars: Record<string, unknown>,
+  loadCompanion: (relativePath: string) => string,
+): string {
+  const substituted = substituteVars(body, vars);
+  const inlined = inlineCompanions(substituted, loadCompanion);
+  return inlined.trim();
+}
+
+// ── I/O wrappers ───────────────────────────────────────────────────
+
+/**
+ * Load + parse a SKILL.md file at the given folder. Returns a
+ * ParsedSkill object the stitcher's render fns consume.
+ */
+export function loadSkill(folder: string): ParsedSkill {
+  const skillPath = join(folder, 'SKILL.md');
+  let text: string;
+  try {
+    text = readFileSync(skillPath, 'utf8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`stitcher: cannot read SKILL.md at ${skillPath}: ${msg}`);
+  }
+  const { frontmatterText, body } = splitFrontmatter(text);
+  const frontmatter = parseSimpleYaml(frontmatterText);
+  return {
+    folder: resolve(folder),
+    frontmatter,
+    body,
+  };
+}
+
+/**
+ * Render a skill folder's prompt string, with companion files
+ * inlined. Convenience wrapper around loadSkill + renderSkillBody.
+ */
+export function renderSkill(
+  folder: string,
+  vars: Record<string, unknown>,
+): string {
+  const skill = loadSkill(folder);
+  return renderSkillBody(skill.body, vars, (relativePath) => {
+    const fullPath = join(skill.folder, relativePath);
+    try {
+      return readFileSync(fullPath, 'utf8');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`stitcher: cannot read companion ${relativePath}: ${msg}`);
+    }
+  });
+}
+
+/**
+ * For tier=T3-T4 (Claude Code headless) — return the skill folder
+ * path so the activity can copy it into the agent's working dir.
+ * The harness then handles native skill discovery.
+ */
+export function materializePath(folder: string): string {
+  // Just confirm the folder exists; the activity does the actual copy.
+  try {
+    statSync(folder);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`stitcher: skill folder ${folder} does not exist: ${msg}`);
+  }
+  return resolve(folder);
+}
+
+/**
+ * Where chitin's skill folders live. Conventionally:
+ * `apps/temporal-worker/skills/<role>/`. The dispatcher resolves
+ * by role name; future skills (cross-role helpers) live alongside.
+ */
+export const SKILLS_ROOT = 'apps/temporal-worker/skills';
+
+export function skillFolderForRole(rootDir: string, role: string): string {
+  return join(rootDir, SKILLS_ROOT, role);
+}
+
+// Suppress dirname-imported warning in cases where this module is
+// imported but not all helpers are used.
+void dirname;

--- a/apps/temporal-worker/src/skill-loader/stitcher.ts
+++ b/apps/temporal-worker/src/skill-loader/stitcher.ts
@@ -37,7 +37,7 @@
 // reads from disk.
 
 import { readFileSync, statSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -66,8 +66,15 @@ export interface ParsedSkill {
 /**
  * Pure: split a SKILL.md text into (frontmatter, body). The
  * frontmatter is YAML between `---` delimiters at the top of the
- * file. Frontmatter is optional — files without it are treated as
- * body-only with empty frontmatter.
+ * file. SplitFrontmatter is tolerant — missing or unclosed
+ * frontmatter is treated as body-only — but `loadSkill` later
+ * requires a `name:` field via `parseSimpleYaml`. SKILL.md files
+ * without a frontmatter block (or without `name:`) will fail at
+ * `loadSkill`, not here.
+ *
+ * Newline handling: strips one leading newline (\n OR \r\n) from
+ * the body so a clean body starts on its own line regardless of
+ * the original file's line endings.
  */
 export function splitFrontmatter(text: string): {
   frontmatterText: string;
@@ -85,16 +92,25 @@ export function splitFrontmatter(text: string): {
   }
   const frontmatterText = afterFirst.slice(0, closeIdx);
   // Skip past the closing `---` line, plus its newline.
-  const afterClose = afterFirst.slice(closeIdx + '\n---'.length);
-  const body = afterClose.startsWith('\n') ? afterClose.slice(1) : afterClose;
-  return { frontmatterText, body };
+  let afterClose = afterFirst.slice(closeIdx + '\n---'.length);
+  // Normalize CRLF → LF for the leading-newline strip so files
+  // authored on Windows produce identical bodies to LF files.
+  if (afterClose.startsWith('\r\n')) {
+    afterClose = afterClose.slice(2);
+  } else if (afterClose.startsWith('\n')) {
+    afterClose = afterClose.slice(1);
+  }
+  return { frontmatterText, body: afterClose };
 }
 
 /**
  * Pure: minimal YAML parser sufficient for the flat key:value-and-
- * inline-list frontmatter we use. Mirrors the parser already in
- * apps/temporal-worker/src/grooming/parse-backlog.ts so the stitcher
- * doesn't pull a yaml lib in.
+ * inline-list frontmatter we use. Inspired by the parser in
+ * apps/temporal-worker/src/grooming/parse-backlog.ts (and consistent
+ * with its quoted/unquoted scalar handling), but extends it with
+ * inline arrays and indented block arrays needed for SKILL.md
+ * frontmatter (`tools: [a, b]` and the multiline list shape).
+ * Avoids pulling a yaml lib in.
  *
  * Recognized shapes:
  *   key: value
@@ -297,12 +313,19 @@ export function renderSkill(
  * The harness then handles native skill discovery.
  */
 export function materializePath(folder: string): string {
-  // Just confirm the folder exists; the activity does the actual copy.
+  // Confirm the folder exists AND is a directory; the activity
+  // does the actual copy. Pointing materializePath at a regular
+  // file would silently succeed under a bare `statSync` and then
+  // fail at copy-time with a confusing error, so reject up-front.
+  let stat;
   try {
-    statSync(folder);
+    stat = statSync(folder);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`stitcher: skill folder ${folder} does not exist: ${msg}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`stitcher: skill folder ${folder} is not a directory`);
   }
   return resolve(folder);
 }
@@ -318,6 +341,3 @@ export function skillFolderForRole(rootDir: string, role: string): string {
   return join(rootDir, SKILLS_ROOT, role);
 }
 
-// Suppress dirname-imported warning in cases where this module is
-// imported but not all helpers are used.
-void dirname;

--- a/apps/temporal-worker/src/skill-loader/stitcher.ts
+++ b/apps/temporal-worker/src/skill-loader/stitcher.ts
@@ -37,7 +37,7 @@
 // reads from disk.
 
 import { readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve, win32 } from 'node:path';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -236,6 +236,14 @@ export function inlineCompanions(
       // Reject parent traversal explicitly.
       if (path.includes('..')) {
         throw new Error(`stitcher: companion path must not include ".."  — got ${path}`);
+      }
+      // Reject ABSOLUTE paths (POSIX `/etc/x.md` AND Windows
+      // `C:\foo.md` / `\\server\share\x.md`). Without this guard,
+      // `join(skill.folder, 'C:\\secret.md')` on Windows returns
+      // the absolute path verbatim and reads outside the skill
+      // folder. (Copilot review #213 #1 second-round — security.)
+      if (isAbsolute(path) || win32.isAbsolute(path)) {
+        throw new Error(`stitcher: companion path must be relative — got ${path}`);
       }
       const cleanPath = path.startsWith('./') ? path.slice(2) : path;
       const content = loadCompanion(cleanPath);

--- a/apps/temporal-worker/test/skill-loader-stitcher.test.ts
+++ b/apps/temporal-worker/test/skill-loader-stitcher.test.ts
@@ -5,6 +5,7 @@ import { join, posix } from 'node:path';
 import {
   inlineCompanions,
   loadSkill,
+  materializePath,
   parseSimpleYaml,
   renderSkill,
   renderSkillBody,
@@ -164,6 +165,28 @@ describe('inlineCompanions', () => {
     ).toThrow(/\.\./);
   });
 
+  it('does not match POSIX-absolute paths in markdown links (regex shape)', () => {
+    // `[bad](/etc/passwd.md)` — the regex requires either `./`
+    // prefix or no `/` chars in a bare `.md` name. POSIX-absolute
+    // paths fail BOTH alternatives → no match → no file read.
+    // Naturally fail-safe; the Windows-absolute case is the real
+    // attack vector since backslashes match the bare-name shape.
+    const body = '[bad](/etc/secret.md)';
+    expect(inlineCompanions(body, () => 'never')).toBe(body);
+  });
+
+  it('rejects Windows-absolute companion paths', () => {
+    // Windows-shape absolute paths like `C:\secret.md` would be
+    // accepted by the second alternative of the regex
+    // (`[^)\s/]+\.md`). The win32.isAbsolute guard rejects them
+    // BEFORE join() is called (where they'd escape the skill
+    // folder on Windows). (Copilot review #213 #1, security.)
+    const body = '[bad](C:\\secret.md)';
+    expect(() =>
+      inlineCompanions(body, () => 'never reached'),
+    ).toThrow(/must be relative/);
+  });
+
   it('does not match bare ../ (no leading ./) — those silently pass through', () => {
     // The regex requires `./` or a `.md`-suffixed bare name, so `../x`
     // doesn't match and isn't inlined. That's a fail-safe: the link is
@@ -264,14 +287,10 @@ describe('materializePath', () => {
     const dir = tmp('chitin-mat-');
     const filePath = join(dir, 'not-a-folder.txt');
     writeFileSync(filePath, 'I am a file, not a directory.');
-    // Lazy import of materializePath so this test stays adjacent
-    // to the splitFrontmatter shape; no need to hoist the import.
-    const { materializePath } = require('../src/skill-loader/stitcher.ts');
     expect(() => materializePath(filePath)).toThrow(/not a directory/);
   });
 
   it('rejects a path that does not exist', () => {
-    const { materializePath } = require('../src/skill-loader/stitcher.ts');
     expect(() => materializePath('/nonexistent/skill-folder')).toThrow(
       /does not exist/,
     );

--- a/apps/temporal-worker/test/skill-loader-stitcher.test.ts
+++ b/apps/temporal-worker/test/skill-loader-stitcher.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, posix } from 'node:path';
 import {
   inlineCompanions,
   loadSkill,
@@ -12,6 +12,22 @@ import {
   substituteVars,
   skillFolderForRole,
 } from '../src/skill-loader/stitcher.ts';
+
+// Track temp dirs created by the tests below so afterEach can
+// rmrf them. Otherwise each CI run + each local run accumulates
+// scratch dirs under $TMPDIR (Copilot review #213 #3).
+const tmpDirs: string[] = [];
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()!;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('splitFrontmatter', () => {
   it('extracts YAML frontmatter and body', () => {
@@ -32,6 +48,15 @@ describe('splitFrontmatter', () => {
     const text = '---\nname: foo\n\nNo closing fence';
     const { frontmatterText } = splitFrontmatter(text);
     expect(frontmatterText).toBe('');
+  });
+
+  it('strips a leading CRLF off the body (windows-authored files)', () => {
+    // The body must not begin with a stray \r when the file was
+    // saved with CRLF line endings. (Copilot review #213 #7.)
+    const text = '---\r\nname: foo\r\n---\r\nThe body.\r\n';
+    const { body } = splitFrontmatter(text);
+    expect(body).toBe('The body.\r\n');
+    expect(body.startsWith('\r')).toBe(false);
   });
 });
 
@@ -173,7 +198,7 @@ describe('renderSkillBody — composition', () => {
 
 describe('loadSkill / renderSkill — fixture roundtrip', () => {
   function makeFixture(): string {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-skill-'));
+    const dir = tmp('chitin-skill-');
     writeFileSync(
       join(dir, 'SKILL.md'),
       `---
@@ -217,12 +242,12 @@ See [the checklist](./checklist.md).
   });
 
   it('throws when SKILL.md is missing', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-empty-'));
+    const dir = tmp('chitin-empty-');
     expect(() => loadSkill(dir)).toThrow(/SKILL\.md/);
   });
 
   it('throws when a companion file is referenced but missing', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'chitin-broken-'));
+    const dir = tmp('chitin-broken-');
     writeFileSync(
       join(dir, 'SKILL.md'),
       `---\nname: broken\n---\n\n[missing](./not-here.md)`,
@@ -231,11 +256,48 @@ See [the checklist](./checklist.md).
   });
 });
 
+describe('materializePath', () => {
+  it('rejects a path that exists but is not a directory', () => {
+    // Pointing materializePath at a regular file would silently
+    // pass `statSync` but later fail at copy-time with a
+    // confusing error (Copilot review #213 #1).
+    const dir = tmp('chitin-mat-');
+    const filePath = join(dir, 'not-a-folder.txt');
+    writeFileSync(filePath, 'I am a file, not a directory.');
+    // Lazy import of materializePath so this test stays adjacent
+    // to the splitFrontmatter shape; no need to hoist the import.
+    const { materializePath } = require('../src/skill-loader/stitcher.ts');
+    expect(() => materializePath(filePath)).toThrow(/not a directory/);
+  });
+
+  it('rejects a path that does not exist', () => {
+    const { materializePath } = require('../src/skill-loader/stitcher.ts');
+    expect(() => materializePath('/nonexistent/skill-folder')).toThrow(
+      /does not exist/,
+    );
+  });
+});
+
 describe('skillFolderForRole', () => {
   it('resolves the conventional path', () => {
+    // Build the expected path with `path.join` so the assertion
+    // matches the platform `skillFolderForRole` runs on (Windows
+    // backslash vs POSIX forward-slash). Hardcoded POSIX would make
+    // the test platform-dependent for an aspect that isn't part
+    // of the function's contract.
     expect(skillFolderForRole('/repo', 'peer-reviewer')).toBe(
-      '/repo/apps/temporal-worker/skills/peer-reviewer',
+      join('/repo', 'apps', 'temporal-worker', 'skills', 'peer-reviewer'),
     );
+  });
+
+  it('produces a POSIX path on POSIX hosts', () => {
+    // Where we DO want POSIX-shape, use posix.join explicitly so
+    // the assertion is unambiguous about what's being tested.
+    if (process.platform !== 'win32') {
+      expect(skillFolderForRole('/repo', 'peer-reviewer')).toBe(
+        posix.join('/repo', 'apps', 'temporal-worker', 'skills', 'peer-reviewer'),
+      );
+    }
   });
 });
 

--- a/apps/temporal-worker/test/skill-loader-stitcher.test.ts
+++ b/apps/temporal-worker/test/skill-loader-stitcher.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  inlineCompanions,
+  loadSkill,
+  parseSimpleYaml,
+  renderSkill,
+  renderSkillBody,
+  splitFrontmatter,
+  substituteVars,
+  skillFolderForRole,
+} from '../src/skill-loader/stitcher.ts';
+
+describe('splitFrontmatter', () => {
+  it('extracts YAML frontmatter and body', () => {
+    const text = '---\nname: foo\ndescription: bar\n---\n\nThe body.\n';
+    const { frontmatterText, body } = splitFrontmatter(text);
+    expect(frontmatterText).toBe('name: foo\ndescription: bar');
+    expect(body).toBe('\nThe body.\n');
+  });
+
+  it('returns empty frontmatter for files without it', () => {
+    const text = 'No frontmatter, just body.\n';
+    const { frontmatterText, body } = splitFrontmatter(text);
+    expect(frontmatterText).toBe('');
+    expect(body).toBe(text);
+  });
+
+  it('handles unclosed frontmatter as body-only (loose)', () => {
+    const text = '---\nname: foo\n\nNo closing fence';
+    const { frontmatterText } = splitFrontmatter(text);
+    expect(frontmatterText).toBe('');
+  });
+});
+
+describe('parseSimpleYaml', () => {
+  it('parses scalar key:value', () => {
+    expect(parseSimpleYaml('name: foo\ndescription: bar')).toEqual({
+      name: 'foo',
+      description: 'bar',
+    });
+  });
+
+  it('parses inline arrays', () => {
+    expect(parseSimpleYaml('name: foo\ntools: [gh, exec, read]')).toEqual({
+      name: 'foo',
+      description: '',
+      tools: ['gh', 'exec', 'read'],
+    });
+  });
+
+  it('parses block arrays', () => {
+    const yaml = `name: foo\ntools:\n  - gh\n  - exec\n  - read`;
+    expect(parseSimpleYaml(yaml)).toEqual({
+      name: 'foo',
+      description: '',
+      tools: ['gh', 'exec', 'read'],
+    });
+  });
+
+  it('strips quotes from quoted scalars', () => {
+    expect(parseSimpleYaml('name: foo\ndescription: "with quotes"')).toEqual({
+      name: 'foo',
+      description: 'with quotes',
+    });
+  });
+
+  it('throws on missing required `name`', () => {
+    expect(() => parseSimpleYaml('description: bar')).toThrow(/name/);
+  });
+
+  it('preserves extra fields without strict-schema rejection', () => {
+    const parsed = parseSimpleYaml('name: foo\ntier_hint: T2\ncustom_field: hello');
+    expect(parsed.tier_hint).toBe('T2');
+    expect(parsed.custom_field).toBe('hello');
+  });
+});
+
+describe('substituteVars', () => {
+  it('substitutes simple {{var}} tokens', () => {
+    expect(substituteVars('hello {{name}}', { name: 'world' })).toBe('hello world');
+  });
+
+  it('substitutes dot-paths', () => {
+    expect(
+      substituteVars('id={{entry.id}}', { entry: { id: 'pr-199' } }),
+    ).toBe('id=pr-199');
+  });
+
+  it('substitutes deeper dot-paths', () => {
+    expect(
+      substituteVars('{{a.b.c}}', { a: { b: { c: 'deep' } } }),
+    ).toBe('deep');
+  });
+
+  it('JSON-stringifies non-string values', () => {
+    expect(substituteVars('{{n}}', { n: 42 })).toBe('42');
+    expect(substituteVars('{{xs}}', { xs: ['a', 'b'] })).toBe('["a","b"]');
+  });
+
+  it('throws on missing variable', () => {
+    expect(() => substituteVars('{{missing}}', {})).toThrow(/{{missing}}/);
+  });
+
+  it('throws on non-object dot-path traversal', () => {
+    expect(() => substituteVars('{{a.b.c}}', { a: { b: 'leaf' } })).toThrow(/non-object/);
+  });
+
+  it('throws on null value', () => {
+    expect(() => substituteVars('{{n}}', { n: null })).toThrow(/null/);
+  });
+
+  it('leaves ungrouped braces untouched', () => {
+    // Single braces should NOT be matched
+    expect(substituteVars('plain { not a var }', {})).toBe('plain { not a var }');
+  });
+});
+
+describe('inlineCompanions', () => {
+  it('inlines [label](./companion.md) links', () => {
+    const body = 'See [the rules](./rules.md) for details.';
+    const out = inlineCompanions(body, (path) => {
+      expect(path).toBe('rules.md');
+      return 'RULE 1\nRULE 2';
+    });
+    expect(out).toContain('--- the rules (rules.md) ---');
+    expect(out).toContain('RULE 1\nRULE 2');
+    expect(out).toContain('--- end of rules.md ---');
+  });
+
+  it('rejects parent traversal in companion paths (./../ form)', () => {
+    // The regex matches `./<path>` shape; `./../escape.md` matches and
+    // then the explicit ".."-rejection fires.
+    const body = '[bad](./../escape.md)';
+    expect(() =>
+      inlineCompanions(body, () => 'never reached'),
+    ).toThrow(/\.\./);
+  });
+
+  it('does not match bare ../ (no leading ./) — those silently pass through', () => {
+    // The regex requires `./` or a `.md`-suffixed bare name, so `../x`
+    // doesn't match and isn't inlined. That's a fail-safe: the link is
+    // left as-is, agent sees a literal markdown link, no file is read.
+    const body = '[bad](../escape.md)';
+    const out = inlineCompanions(body, () => 'should not run');
+    expect(out).toBe(body);
+  });
+
+  it('leaves non-link markdown alone', () => {
+    const body = 'Just text. [external link](https://example.com).';
+    const out = inlineCompanions(body, () => 'should not run');
+    expect(out).toBe(body);
+  });
+});
+
+describe('renderSkillBody — composition', () => {
+  it('substitutes vars, then inlines companions', () => {
+    const body = 'Hello {{name}}.\n\nSee [doc](./{{file}}.md).';
+    const out = renderSkillBody(
+      body,
+      { name: 'agent', file: 'companion' },
+      (path) => {
+        expect(path).toBe('companion.md');
+        return 'companion content';
+      },
+    );
+    expect(out).toContain('Hello agent.');
+    expect(out).toContain('companion content');
+  });
+});
+
+describe('loadSkill / renderSkill — fixture roundtrip', () => {
+  function makeFixture(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'chitin-skill-'));
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---
+name: test-skill
+description: A test
+tier_hint: T2
+tools: [gh]
+---
+
+You are a test agent.
+
+ENTRY: {{entry.id}}
+
+See [the checklist](./checklist.md).
+`,
+    );
+    writeFileSync(
+      join(dir, 'checklist.md'),
+      'Item 1\nItem 2\nItem 3\n',
+    );
+    return dir;
+  }
+
+  it('loadSkill parses frontmatter + body', () => {
+    const dir = makeFixture();
+    const skill = loadSkill(dir);
+    expect(skill.frontmatter.name).toBe('test-skill');
+    expect(skill.frontmatter.tier_hint).toBe('T2');
+    expect(skill.frontmatter.tools).toEqual(['gh']);
+    expect(skill.body).toContain('You are a test agent.');
+  });
+
+  it('renderSkill substitutes vars + inlines companions end-to-end', () => {
+    const dir = makeFixture();
+    const out = renderSkill(dir, { entry: { id: 'pr-199' } });
+    expect(out).toContain('You are a test agent.');
+    expect(out).toContain('ENTRY: pr-199');
+    expect(out).toContain('Item 1');
+    expect(out).toContain('Item 2');
+    expect(out).toContain('Item 3');
+  });
+
+  it('throws when SKILL.md is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chitin-empty-'));
+    expect(() => loadSkill(dir)).toThrow(/SKILL\.md/);
+  });
+
+  it('throws when a companion file is referenced but missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chitin-broken-'));
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---\nname: broken\n---\n\n[missing](./not-here.md)`,
+    );
+    expect(() => renderSkill(dir, {})).toThrow(/not-here\.md/);
+  });
+});
+
+describe('skillFolderForRole', () => {
+  it('resolves the conventional path', () => {
+    expect(skillFolderForRole('/repo', 'peer-reviewer')).toBe(
+      '/repo/apps/temporal-worker/skills/peer-reviewer',
+    );
+  });
+});
+
+describe('renderSkill — with the bundled peer-reviewer fixture', () => {
+  it('renders the real peer-reviewer skill folder', () => {
+    // Resolve against the worktree root so the test runs from
+    // wherever vitest is launched.
+    const folder = join(
+      process.cwd(),
+      'apps/temporal-worker/skills/peer-reviewer',
+    );
+    const out = renderSkill(folder, {
+      entry: {
+        id: 'peer-review-pr-207',
+        description: 'Peer-review PR https://github.com/chitinhq/chitin/pull/207',
+      },
+    });
+    // Spot-check the rendering: vars substituted, companions inlined.
+    expect(out).toContain('peer-review-pr-207');
+    expect(out).toContain('https://github.com/chitinhq/chitin/pull/207');
+    // Companion content present
+    expect(out).toContain('Correctness');
+    expect(out).toContain('Scope drift');
+    expect(out).toContain('Security');
+    expect(out).toContain('🔴 (real bug) findings:');
+    // Step-0 dispatch-shape guard preserved
+    expect(out).toMatch(/Verify your dispatch shape FIRST/);
+  });
+});


### PR DESCRIPTION
## Summary

First half of #208's skill-folder cohort. The stitcher reads `SKILL.md` + companion files, substitutes `{{var.path}}` template tokens, and returns a single rendered prompt string — the load-bearing adapter for tiers without harness skill discovery (Copilot CLI, ollama including the new T0 GLM-4.7-flash from #209).

For tiers WITH skill discovery (Claude Code headless = T3/T4), the stitcher's `materializePath` helper exposes the skill folder so the activity can copy it into the agent's working dir; the harness handles native loading.

## What's here

- `apps/temporal-worker/src/skill-loader/stitcher.ts` — pure functions (splitFrontmatter, parseSimpleYaml, substituteVars, inlineCompanions, renderSkillBody) + thin I/O wrappers (loadSkill, renderSkill, materializePath). Same shape as the rest of chitin's pure-logic-with-I/O-wrappers libraries.
- `apps/temporal-worker/skills/peer-reviewer/` — bundled fixture with SKILL.md + checklist.md + review-template.md. Worked example showing the progressive-disclosure shape (SKILL.md as entry point, companions referenced via `[label](./file.md)`).
- `apps/temporal-worker/test/skill-loader-stitcher.test.ts` — 21 tests covering frontmatter split, YAML parse shapes, variable substitution edge cases, companion inlining + traversal rejection, fixture roundtrip, and a real-fixture render against the bundled skill folder.

## SKILL.md format (codified for the followup linter)

```yaml
---
name: <skill-id>
description: <one-line>
tier_hint: <T0|T1|T2|T3|T4>
activation: <when this skill is relevant>
tools: [tool, names, agent, can, call]
---

<markdown body — agent reads this>

See [the rules](./rules.md) for details.       # ← inlined verbatim
ENTRY: {{entry.id}}                              # ← substituted at render
```

## What this PR does NOT do

- **Doesn't migrate the existing `prompt.ts` builders.** The fixture is a worked example, not a wired migration; `role-prompts.ts` still imports `buildPeerReviewerPrompt` as before. Migration is the next entry from #208's cohort; doing it as a separate PR lets us pin a "stitcher output ≡ legacy prompt output" regression-guard test before flipping the source-of-truth.
- **Doesn't add tier-shape branching at the dispatcher level.** `materializePath` is exposed for the activity to use when copying to a Claude Code working dir; wiring that in lands alongside the migration.
- **Doesn't add `lint-skill-folder-shape`.** That's #208 entry 2 — depends on the authoring doc landing first per #208's sequencing.

## Verified

```
nx run-many -t test --parallel=3      → 11 projects pass
nx run @chitin/tooling-lint:lint:layer-tag-coverage  → green
nx run @chitin/tooling-lint:lint:role-coverage       → green
```

Stitcher renders the bundled peer-reviewer fixture cleanly:
- `{{entry.id}}` and `{{entry.description}}` substituted
- `[the five-axis checklist](./checklist.md)` and `[structured review template](./review-template.md)` inlined
- Step-0 dispatch-shape guard preserved
- `<<<PEER_REVIEW>>>` marker preserved

## Test plan

- [x] 21 unit tests pass
- [x] All 11 workspace projects' tests pass
- [x] Real-fixture render works end-to-end
- [ ] CI green
- [ ] Follow-up: migrate `peer-reviewer/prompt.ts` to call the stitcher (regression-guarded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)