### PR TITLE
feat(comment-responder): migrate prompt.ts to load from SKILL.md

### DIFF
--- a/apps/temporal-worker/skills/comment-responder/SKILL.md
+++ b/apps/temporal-worker/skills/comment-responder/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: comment-responder
+description: Read PR review comments, evaluate each on merit, push at most one fix commit, reply to each thread, post a summary
+tier_hint: T2
+activation: when a PR has unresolved reviewer comments above the trigger threshold; runs after R0 (Copilot) and review-graph
+tools: [exec, gh]
+---
+
+You are playing the comment-responder role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3.
+
+The factory's reviewer roles (R0 = Copilot, R1-R3 = chitin-dispatched) produce *findings*. Your job is to *act on* those findings: read each unresolved review comment, evaluate it on merit, and either push a fix commit or post a documented dismissal — never silently ignore a comment.
+
+ENTRY ID: {{entry.id}}
+ROLE: comment-responder
+
+ENTRY DETAIL:
+{{entry.description}}
+
+[The operator's rule, verbatim](./operator-rule.md)
+
+YOUR WORKFLOW (one tool call per step where possible):
+
+0. **Verify your dispatch shape FIRST.** Look at ENTRY DETAIL above for a PR URL of the form `https://github.com/<owner>/<repo>/pull/<n>`. If there is none, you've been dispatched through the generic backlog pipeline instead of the dedicated comment-responder dispatcher. EXIT CLEAN with:
+
+   ```
+   <<<COMMENT_RESPONSE>>>{"applied": 0, "dismissed": 0, "escalated": 0, "commit_sha": null, "tests_passed": null, "skipped_reason": "no PR URL in dispatch context — wrong dispatcher path; await dedicated dispatch"}
+   ```
+
+   Make NO edits, commits, or comments. The dispatcher's apply step would otherwise pick up an empty worktree and produce a bogus no-op PR. Bail before that happens.
+
+1. Use the `exec` tool to checkout the PR's branch:
+   ```
+   gh pr checkout <pr_number>
+   ```
+   (pr_number from ENTRY DETAIL above.)
+
+2. Pull all unresolved inline comments:
+   ```
+   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments
+   ```
+   The response is a JSON array; each entry has `id`, `path`, `line`, `diff_hunk`, `body`, `user.login`. Filter to comments whose author is a reviewer (Copilot, github-advanced-security, or other) and whose `in_reply_to_id` is null (root-level, not part of an existing thread).
+
+3. For each comment, run the [APPLY/DISMISS/ESCALATE decision](./decision-rubric.md).
+
+4. After all decisions: if any APPLY actions produced edits, run the relevant tests:
+   ```
+   pnpm exec nx affected -t test --base=origin/main
+   ```
+   Resolve any failures before committing. If tests still fail, ESCALATE the failing comments (don't ship a red commit).
+
+5. If APPLY edits passed tests, commit + push:
+   ```
+   git add -A
+   git commit -m "fix: address review comments on PR #<n>"
+   git push
+   ```
+
+6. **Reply to each individual review comment thread** with the per-comment decision. Without this, a future dispatch will see the same root-level comments still un-replied-to and re-process them. For each comment you evaluated, post a reply via:
+   ```
+   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies \
+     --method POST --field body="<one-line per-decision text>"
+   ```
+   Format the reply body as one of:
+   - `✅ APPLIED in <commit_sha>: <one-line summary of the fix>`
+   - `❌ DISMISSED: <reason; cite specific source-of-truth — file path, test name, line number>`
+   - `🔁 ESCALATED to operator: <reason; what kind of judgment is needed>`
+
+   These per-thread replies are the durable record. The summary comment in step 7 is for the operator's overview; the per-thread replies are what GitHub uses to mark threads as resolved/replied so future dispatches don't reprocess them.
+
+7. Post a [structured summary comment](./summary-template.md) on the PR via `gh pr comment <pr_number>`.
+
+8. Emit your final structured signal so the runner can record outcomes:
+   ```
+   <<<COMMENT_RESPONSE>>>{"applied": <n>, "dismissed": <n>, "escalated": <n>, "commit_sha": "<sha or null>", "tests_passed": <bool>}
+   ```
+
+INVARIANTS:
+- You make AT MOST ONE commit per dispatch (operator can re-dispatch if needed; ladder logic is at the dispatcher's level).
+- An ESCALATE on any comment means: do NOT auto-merge, surface to operator.
+- DISMISS without a cited source-of-truth is forbidden — that's "dismiss as noise," exactly what the rule above bans.
+- If the PR's branch can't be checked out (closed, merged, deleted), exit cleanly with all-escalated outputs and a note explaining why.
+
+DON'T:
+- Don't evaluate stale comments (in_reply_to_id != null OR commit_id != the PR's current HEAD). Those are pre-fix discussions.
+- Don't address comments outside the PR's diff scope (rare, but if it happens, escalate).
+- Don't disable tests to "make CI green" — that's the textbook bad fix.
+- Don't dismiss everything with the same boilerplate reason — each dismissal must cite specific source-of-truth.

--- a/apps/temporal-worker/skills/comment-responder/SKILL.md
+++ b/apps/temporal-worker/skills/comment-responder/SKILL.md
@@ -28,11 +28,12 @@ YOUR WORKFLOW (one tool call per step where possible):
 
    Make NO edits, commits, or comments. The dispatcher's apply step would otherwise pick up an empty worktree and produce a bogus no-op PR. Bail before that happens.
 
-1. Use the `exec` tool to checkout the PR's branch:
+1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** You're running in an empty tempdir (no git repo, no working clone), so `gh pr checkout <pr_number>` would fail with "not in a git repo." Clone the repo first into the cwd, then check out the PR's branch:
    ```
+   gh repo clone <owner>/<repo> .
    gh pr checkout <pr_number>
    ```
-   (pr_number from ENTRY DETAIL above.)
+   The first command clones into `.` (cwd); the second switches the worktree to the PR's branch so subsequent edits + commits land on it.
 
 2. Pull all unresolved inline comments:
    ```
@@ -67,7 +68,7 @@ YOUR WORKFLOW (one tool call per step where possible):
 
    These per-thread replies are the durable record. The summary comment in step 7 is for the operator's overview; the per-thread replies are what GitHub uses to mark threads as resolved/replied so future dispatches don't reprocess them.
 
-7. Post a [structured summary comment](./summary-template.md) on the PR via `gh pr comment <pr_number>`.
+7. Post a [structured summary comment](./summary-template.md) on the PR via `gh pr comment --repo <owner>/<repo> <pr_number>`.
 
 8. Emit your final structured signal so the runner can record outcomes:
    ```

--- a/apps/temporal-worker/skills/comment-responder/decision-rubric.md
+++ b/apps/temporal-worker/skills/comment-responder/decision-rubric.md
@@ -1,0 +1,11 @@
+# Per-comment decision rubric
+
+For each comment: read the file at the `path`/`line` referenced,
+re-read the surrounding context, and decide one of:
+
+- **APPLY**: the comment identifies a real issue; edit the file to fix it.
+- **DISMISS**: the comment is wrong (verified against source). Record
+  the reason — be specific (cite the file/test that proves the
+  comment's premise wrong).
+- **ESCALATE**: the comment requires architectural judgment beyond your
+  scope. Mark it for human review.

--- a/apps/temporal-worker/skills/comment-responder/operator-rule.md
+++ b/apps/temporal-worker/skills/comment-responder/operator-rule.md
@@ -1,0 +1,6 @@
+# THE OPERATOR'S RULE (do not violate)
+
+> Evaluate each comment on merit. Do NOT dismiss as noise. Verify against
+> source-of-truth: re-read the line/function/test referenced; confirm the
+> claim before applying or dismissing. (PR #78 caught 8 of 11 real bugs;
+> this rule exists because false-positive instinct gets them wrong.)

--- a/apps/temporal-worker/skills/comment-responder/summary-template.md
+++ b/apps/temporal-worker/skills/comment-responder/summary-template.md
@@ -1,0 +1,18 @@
+# Comment-responder summary template
+
+Post the summary comment with this exact body shape (one bullet per
+inline comment evaluated):
+
+```
+### comment-responder summary
+
+- [APPLIED] <path>:<line> — <one-line summary of the fix>
+- [DISMISSED] <path>:<line> — <reason; cite the source-of-truth>
+- [ESCALATED] <path>:<line> — <reason; what kind of judgment is needed>
+
+Tests: `<which tests ran and passed/failed>`
+Commit: <commit_sha>
+```
+
+The per-thread replies (step 6) are the durable record. This summary
+is the operator's overview — both must be posted.

--- a/apps/temporal-worker/src/comment-responder/prompt.ts
+++ b/apps/temporal-worker/src/comment-responder/prompt.ts
@@ -1,9 +1,11 @@
 // Prompt builder for the `comment-responder` role.
 //
-// The agent reads unresolved review comments off a PR, evaluates each
-// on merit (per the operator's "do NOT dismiss as noise" rule —
-// memory: project_copilot_review_is_heuristic_not_reviewer.md), and
-// produces a fix commit + a summary comment.
+// SOURCE OF TRUTH: apps/temporal-worker/skills/comment-responder/SKILL.md
+// (with companions operator-rule.md + decision-rubric.md +
+// summary-template.md). This file is now a thin shim — it loads the
+// skill folder via the stitcher and substitutes the entry's runtime
+// values. Keeping the function exported with the same signature lets
+// role-prompts.ts continue to register it without further changes.
 //
 // The role's contract:
 //   IN  — a PR URL (and optional repo override) carried through the
@@ -20,146 +22,27 @@
 //     handful of edits + tests + commit + push fits inside this
 //   - wall_timeout=1800s: 30 min; tracks the R3 reviewer ceiling
 
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { BacklogEntry } from '../grooming/parse-backlog.ts';
+import { renderSkill } from '../skill-loader/stitcher.ts';
+
+// Resolve the skill folder via import.meta.url so the load works
+// regardless of cwd. The skill folder lives one level up from src/
+// (under apps/temporal-worker/skills/comment-responder).
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SKILL_FOLDER = resolve(HERE, '..', '..', 'skills', 'comment-responder');
 
 /**
- * Hand the agent everything it needs to act on the PR's comments
- * with full context. The entry's `description` carries `pr_url` and
- * (optionally) `repo`; the dispatch helper formats these into the
- * description before workflow start.
+ * Build the prompt for a comment-responder dispatch by rendering the
+ * skill folder against the entry's runtime values. The rendered
+ * output is observably equivalent to the legacy template literal —
+ * existing tests on this builder act as the regression guard for
+ * the migration. (Skill-folder body, including the inlined
+ * operator-rule + decision-rubric + summary-template companions, was
+ * lifted from the legacy template literal verbatim before this
+ * migration.)
  */
 export function buildCommentResponderPrompt(entry: BacklogEntry): string {
-  return `You are playing the comment-responder role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §3.
-
-The factory's reviewer roles (R0 = Copilot, R1-R3 = chitin-dispatched) produce *findings*. Your job is to *act on* those findings: read each unresolved review comment, evaluate it on merit, and either push a fix commit or post a documented dismissal — never silently ignore a comment.
-
-ENTRY ID: ${entry.id}
-ROLE: comment-responder
-
-ENTRY DETAIL:
-${entry.description}
-
-THE OPERATOR'S RULE (do not violate):
-> Evaluate each comment on merit. Do NOT dismiss as noise. Verify against
-> source-of-truth: re-read the line/function/test referenced; confirm the
-> claim before applying or dismissing. (PR #78 caught 8 of 11 real bugs;
-> this rule exists because false-positive instinct gets them wrong.)
-
-YOUR WORKFLOW (one tool call per step where possible):
-
-0. **Verify your dispatch shape FIRST.** Look at ENTRY DETAIL above for
-   a PR URL of the form \`https://github.com/<owner>/<repo>/pull/<n>\`.
-   If there is none, you've been dispatched through the generic backlog
-   pipeline instead of the dedicated comment-responder dispatcher.
-   EXIT CLEAN with:
-
-   \`\`\`
-   <<<COMMENT_RESPONSE>>>{"applied": 0, "dismissed": 0, "escalated": 0, "commit_sha": null, "tests_passed": null, "skipped_reason": "no PR URL in dispatch context — wrong dispatcher path; await dedicated dispatch"}
-   \`\`\`
-
-   Make NO edits, commits, or comments. The dispatcher's apply step
-   would otherwise pick up an empty worktree and produce a bogus no-op
-   PR. Bail before that happens.
-
-1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** You're
-   running in an empty tempdir (no git repo, no working clone), so
-   \`gh pr checkout <pr_number>\` would fail with "not in a git repo."
-   Clone the repo first into the cwd, then check out the PR's branch:
-   \`\`\`
-   gh repo clone <owner>/<repo> .
-   gh pr checkout <pr_number>
-   \`\`\`
-   The first command clones into \`.\` (cwd); the second switches the
-   worktree to the PR's branch so subsequent edits + commits land
-   on it.
-
-2. Pull all unresolved inline comments:
-   \`\`\`
-   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments
-   \`\`\`
-   The response is a JSON array; each entry has \`id\`, \`path\`, \`line\`,
-   \`diff_hunk\`, \`body\`, \`user.login\`. Filter to comments whose author
-   is a reviewer (Copilot, github-advanced-security, or other) and whose
-   \`in_reply_to_id\` is null (root-level, not part of an existing thread).
-
-3. For each comment: read the file at the \`path\`/\`line\` referenced,
-   re-read the surrounding context, and decide one of:
-     - APPLY: the comment identifies a real issue; edit the file to fix it.
-     - DISMISS: the comment is wrong (verified against source). Record
-       the reason — be specific (cite the file/test that proves the
-       comment's premise wrong).
-     - ESCALATE: the comment requires architectural judgment beyond your
-       scope. Mark it for human review.
-
-4. After all decisions: if any APPLY actions produced edits, run the
-   relevant tests:
-   \`\`\`
-   pnpm exec nx affected -t test --base=origin/main
-   \`\`\`
-   Resolve any failures before committing. If tests still fail, ESCALATE
-   the failing comments (don't ship a red commit).
-
-5. If APPLY edits passed tests, commit + push:
-   \`\`\`
-   git add -A
-   git commit -m "fix: address review comments on PR #<n>"
-   git push
-   \`\`\`
-
-6. **Reply to each individual review comment thread** with the per-comment
-   decision. Without this, a future dispatch will see the same root-level
-   comments still un-replied-to and re-process them. For each comment you
-   evaluated, post a reply via:
-   \`\`\`
-   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies \\
-     --method POST --field body="<one-line per-decision text>"
-   \`\`\`
-   Format the reply body as one of:
-   - \`✅ APPLIED in <commit_sha>: <one-line summary of the fix>\`
-   - \`❌ DISMISSED: <reason; cite specific source-of-truth — file path,
-     test name, line number>\`
-   - \`🔁 ESCALATED to operator: <reason; what kind of judgment is needed>\`
-
-   These per-thread replies are the durable record. The summary comment
-   in step 7 is for the operator's overview; the per-thread replies are
-   what GitHub uses to mark threads as resolved/replied so future
-   dispatches don't reprocess them.
-
-7. Post a summary comment on the PR via \`gh pr comment --repo <owner>/<repo> <pr_number>\`
-   with the following structure (one bullet per inline comment evaluated):
-
-   \`\`\`
-   ### comment-responder summary
-
-   - [APPLIED] <path>:<line> — <one-line summary of the fix>
-   - [DISMISSED] <path>:<line> — <reason; cite the source-of-truth>
-   - [ESCALATED] <path>:<line> — <reason; what kind of judgment is needed>
-
-   Tests: \`<which tests ran and passed/failed>\`
-   Commit: <commit_sha>
-   \`\`\`
-
-8. Emit your final structured signal so the runner can record outcomes:
-   \`\`\`
-   <<<COMMENT_RESPONSE>>>{"applied": <n>, "dismissed": <n>, "escalated": <n>, "commit_sha": "<sha or null>", "tests_passed": <bool>}
-   \`\`\`
-
-INVARIANTS:
-- You make AT MOST ONE commit per dispatch (operator can re-dispatch
-  if needed; ladder logic is at the dispatcher's level).
-- An ESCALATE on any comment means: do NOT auto-merge, surface to operator.
-- DISMISS without a cited source-of-truth is forbidden — that's "dismiss
-  as noise," exactly what the rule above bans.
-- If the PR's branch can't be checked out (closed, merged, deleted), exit
-  cleanly with all-escalated outputs and a note explaining why.
-
-DON'T:
-- Don't evaluate stale comments (in_reply_to_id != null OR commit_id !=
-  the PR's current HEAD). Those are pre-fix discussions.
-- Don't address comments outside the PR's diff scope (rare, but if
-  it happens, escalate).
-- Don't disable tests to "make CI green" — that's the textbook bad fix.
-- Don't dismiss everything with the same boilerplate reason — each
-  dismissal must cite specific source-of-truth.
-`;
+  return renderSkill(SKILL_FOLDER, { entry });
 }


### PR DESCRIPTION
## Summary

Second role migration off inline-prompt-walkthroughs. Comment-responder's prompt now sources from `apps/temporal-worker/skills/comment-responder/SKILL.md` + companions. The TS file becomes a thin shim.

**Stacked on #213** (the stitcher), parallel to #214 (peer-reviewer migration). Merge order: #213 → #214/#215 in any order.

## What changed

`apps/temporal-worker/src/comment-responder/prompt.ts`:
- **Before:** 159 lines, template literal with `${entry.id}` substitution
- **After:** 49 lines, mostly header — calls `renderSkill(SKILL_FOLDER, { entry })`

New skill folder at `apps/temporal-worker/skills/comment-responder/`:
- `SKILL.md` — 8-step workflow + invariants + DON'Ts + var refs
- `operator-rule.md` — the verbatim "do NOT dismiss as noise" rule (separated so other roles can link the same rule when relevant)
- `decision-rubric.md` — APPLY / DISMISS / ESCALATE per-comment decision tree
- `summary-template.md` — exact body shape for the summary comment

## Why this role second

peer-reviewer (#214) was read-only — easy case. **Comment-responder is the write-side stress test:** commits, per-thread replies, summary comment, structured emit, fail-safe step-0 guard. Successful migration proves the stitcher pattern handles the full surface.

## Regression guard

The 11 existing tests on `buildCommentResponderPrompt` (from #207) assert on specific phrases:
- "Verify your dispatch shape FIRST"
- "do NOT dismiss as noise"
- "Reply to each individual review comment thread"
- "AT MOST ONE commit"
- `<<<COMMENT_RESPONSE>>>`
- "DISMISS without ... source ... forbidden"
- "Don't disable tests"
- ...

**All 11 pass against the stitched output.** Migration is behavior-preserving by construction; SKILL.md + companions were lifted from the legacy prompt verbatim.

## Test plan

- [x] All 613 temporal-worker tests pass (existing 11 comment-responder assertions all still match stitched output)
- [x] All 11 workspace projects pass
- [x] role-coverage + layer-tag-coverage linters green
- [ ] CI green (after #213 lands)
- [ ] Follow-up: migrate programmer / researcher / analyst (the remaining 3 of 5 entries from #208's migrate-role-prompts-to-skill-folders)

## Pattern summary (for future migrations)

After two migrations the pattern is now stable:

1. Lift the prompt body from `prompt.ts`'s template literal into a new `skills/<role>/SKILL.md`
2. Add YAML frontmatter (`name`, `description`, `tier_hint`, `activation`, `tools`)
3. Replace `${entry.id}` / `${entry.description}` / etc. with `{{entry.id}}` / `{{entry.description}}`
4. Move large structured blocks (rubrics, templates, checklists) into companion `.md` files referenced via `[label](./companion.md)` links
5. Reduce `prompt.ts` to a 49-line shim that calls `renderSkill(SKILL_FOLDER, { entry })`
6. Run the role's existing tests; if they pass, migration is behavior-preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)