### PR TITLE
swarm: swarm-implementor-pnpm-lock-discipline

### DIFF
--- a/apps/temporal-worker/src/role-prompts.ts
+++ b/apps/temporal-worker/src/role-prompts.ts
@@ -73,7 +73,10 @@ CONSTRAINTS:
 - Forbid editing files not named in the entry's \`file\` field, and instruct the agent to \`read\` ONLY the target file before editing.
 - If you decide the entry is misclassified or requires human judgment, exit without committing — empty worktrees are not pushed.
 
-REMEMBER: chat replies do nothing. Tool calls are the only thing that produces work. Commit BEFORE testing. Start by reading ${targetFile} now.`;
+REMEMBER: chat replies do nothing. Tool calls are the only thing that produces work. Commit BEFORE testing. Start by reading ${targetFile} now.
+
+// pnpm discipline: If you edit any package.json, you MUST run `pnpm install --no-frozen-lockfile` before committing. This ensures pnpm-lock.yaml is updated and consistent. Do not commit a package.json change without a matching lockfile update.
+`;
 }
 
 // Researcher prompt for the BacklogEntry path. The richer runner-level


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `swarm-implementor-pnpm-lock-discipline`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-swarm-implementor-pnpm-lock-discipline-1777832458819`

## Entry context

Three of seven open swarm PRs from the 2026-05-02 → 03 overnight run
(#189 nx-angular-workspace-install, #193 scheduler-dashboard-angular,
#195 slack-l2-actions) failed CI with `ERR_PNPM_OUTDATED_LOCKFILE` — the
implementor agent edited a `package.json` (root, scheduler-dashboard, or
slack-app) without regenerating `pnpm-lock.yaml`.

The pattern is structural, not per-PR: the implementor harness lacks a
post-edit gate that detects "package.json modified, pnpm-lock.yaml not
modified" and runs `pnpm install` (or fails the run with a clear message).
Adding the dep manually as a JSON edit and skipping `pnpm install` is the
fast path the model takes when not corrected.

Three places this can be enforced (pick one — the cheapest is best):

1. **Pre-commit hook in implementor worktree** — refuse to stage
   `package.json` changes without a matching `pnpm-lock.yaml` change.
   Cheapest, but only fires at the implementor's commit step.
2. **Role-prompt rule** in `apps/temporal-worker/src/role-prompts.ts`
   ("if you edit package.json, run `pnpm install --no-frozen-lockfile`
   before committing"). Soft enforcement, but cheap and reusable.
3. **Dispatcher post-write check** — after the implementor returns, the
   dispatcher inspects the worktree diff; if `package.json` is dirty and
   `pnpm-lock.yaml` is not, the dispatcher runs `pnpm install` itself
   before `git push`. Hard enforcement, slightly more work.

Recommended: (2) + (3). Role-prompt sets the expectation; dispatcher
post-check enforces it in case the agent forgets. Same shape as the
existing `gatekeeper.ts` post-write checks for governance paths.

Steps:
1. Add the rule to the relevant role-prompt section in `role-prompts.ts`
   (probably the `programmer` role; check current shape).
2. Extend `gatekeeper.ts` (or wherever post-write inspection lives) with
   a `pnpm-lock-coherent` invariant: package.json modified ⇒ lockfile
   must be modified. On violation, run `pnpm install` in the worktree,
   stage the lockfile, append a chain event noting the auto-fix.
3. Tests: synthesize a worktree with the violation; assert the
   gatekeeper auto-fix lands the right files.

**Acceptance:**
- [ ] Role-prompt mentions the rule
- [ ] Gatekeeper auto-fixes a worktree where `package.json` changed and
      lockfile didn't
- [ ] Backfill: re-run one of #189/#193/#195 (or synthesize the
      pattern); after the post-write check, `pnpm install
      --frozen-lockfile` succeeds
- [ ] CI green


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-swarm-implementor-pnpm-lock-discipline-1777832458819`
Branch: `swarm/swarm-swarm-implementor-pnpm-lock-discipline-1777832458819`
Head: `958f7e0f`
Diff: `1 file changed, 4 insertions(+), 1 deletion(-)`
Commits: 1