### PR TITLE
swarm: tc-extend-to-tests-and-tools

### DIFF
--- a/libs/contracts/tsconfig.json
+++ b/libs/contracts/tsconfig.json
@@ -5,6 +5,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/libs/contracts/tsconfig.spec.json
+++ b/libs/contracts/tsconfig.spec.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/libs/telemetry/tsconfig.json
+++ b/libs/telemetry/tsconfig.json
@@ -5,6 +5,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/libs/telemetry/tsconfig.spec.json
+++ b/libs/telemetry/tsconfig.spec.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `tc-extend-to-tests-and-tools`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-tc-extend-to-tests-and-tools-1777832765280`

## Entry context

The CI typecheck gate added in PR #203 catches accumulated errors in
each project's `src/**/*.ts` (via tsconfig.lib.json) but misses:

- **Lib tests** (`libs/*/tests/*.ts`): they're not in any tsconfig
  the typecheck target reaches. A test that imports a non-existent
  symbol or has a type error still merges green.
- **`tools/`**: only `tools/lint/` has its own package + tsconfig
  (added in PR #204). Other tools/ scripts (`generate-go-types.ts`,
  `lint/role-coverage.ts` if/when added) are unchecked.
- **Root configs** (`vite.config.ts`, etc.): not in any project ref.

Apps' tests ARE covered today (each app's tsconfig.json includes
tests/). Libs aren't, by current convention.

Fix: each lib gets a `tsconfig.spec.json` that includes both `src/`
and `tests/`, referenced from `tsconfig.json` so `tsc --build`
catches it. The nx typecheck target then walks all references.

Steps:
1. For each `libs/*/`, add `tsconfig.spec.json` extending the base,
   `include: ["src/**/*.ts", "tests/**/*.ts"]`.
2. Update each `libs/*/tsconfig.json` `references` to include
   `./tsconfig.spec.json`.
3. Add `tools/*/tsconfig.json` for tooling scripts that aren't yet
   workspace packages.
4. Verify `pnpm exec nx run-many -t typecheck` covers the whole
   workspace. Document in CI yml comment.

**Acceptance:**
- [ ] Every `libs/*/tests/*.ts` is type-checked by the existing
      typecheck CI gate
- [ ] Every `tools/*/*.ts` either has its own tsconfig or is part
      of an existing workspace package
- [ ] A test introducing a deliberate type error fails the
      `TypeScript typecheck (Nx affected)` step (proves the gate
      now catches what it used to miss)
- [ ] CI green on current main


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-tc-extend-to-tests-and-tools-1777832765280`
Branch: `swarm/swarm-tc-extend-to-tests-and-tools-1777832765280`
Head: `d079bd95`
Diff: `4 files changed, 14 insertions(+)`
Commits: 1