### PR TITLE
swarm: nx-generator-workspace-lib

### DIFF
--- a/tools/generators/workspace-lib/generators.json
+++ b/tools/generators/workspace-lib/generators.json
@@ -1,0 +1,10 @@
+{
+  "generators": {
+    "workspace-lib": {
+      "factory": "./index.js",
+      "schema": "./schema.json",
+      "description": "Scaffold a chitin-flavored workspace library with correct layer tags and eslint depConstraints",
+      "aliases": ["default"]
+    }
+  }
+}

--- a/tools/generators/workspace-lib/index.ts
+++ b/tools/generators/workspace-lib/index.ts
@@ -9,7 +9,7 @@
 // Nx usage (once pnpm-workspace.yaml includes tools/generators/*):
 //   nx g @chitin/workspace-lib <name> --layer <layer> [--allowsDeps <layers>]
 
-import { type Tree, formatFiles } from '@nx/devkit';
+import type { Tree } from '@nx/devkit';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -181,6 +181,7 @@ export default async function workspaceLibGenerator(
     console.log(`[workspace-lib] added layer:${layer} to eslint.config.mjs`);
   }
 
+  const { formatFiles } = await import('@nx/devkit');
   await formatFiles(tree);
   console.log(`[workspace-lib] scaffolded ${libPath}`);
 }

--- a/tools/generators/workspace-lib/index.ts
+++ b/tools/generators/workspace-lib/index.ts
@@ -1,0 +1,274 @@
+// Nx generator: @chitin/workspace-lib
+//
+// Scaffolds a chitin-flavored library under libs/<name>/ and ensures
+// eslint.config.mjs carries a matching depConstraint for the layer.
+//
+// CLI usage (from workspace root):
+//   tsx tools/generators/workspace-lib/index.ts <name> --layer <layer> [--allows-deps <layers>]
+//
+// Nx usage (once pnpm-workspace.yaml includes tools/generators/*):
+//   nx g @chitin/workspace-lib <name> --layer <layer> [--allowsDeps <layers>]
+
+import { type Tree, formatFiles } from '@nx/devkit';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface WorkspaceLibSchema {
+  name: string;
+  layer: string;
+  /** Comma-separated layer names (without 'layer:' prefix). */
+  allowsDeps?: string;
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────
+
+/** Normalise an allowsDeps string → sorted 'layer:X' array. */
+export function parseAllowsDeps(raw: string | undefined): string[] {
+  const base = raw ?? 'contracts,telemetry';
+  return base
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => (s.startsWith('layer:') ? s : `layer:${s}`))
+    .sort();
+}
+
+/** Generate the package.json content for a new lib. */
+export function buildPackageJson(name: string, layer: string): string {
+  const obj = {
+    name: `@chitin/${name}`,
+    version: '0.0.1',
+    private: true,
+    type: 'module',
+    main: './src/index.ts',
+    types: './src/index.ts',
+    exports: {
+      '.': {
+        types: './src/index.ts',
+        import: './src/index.ts',
+        default: './src/index.ts',
+      },
+      './package.json': './package.json',
+    },
+    scripts: { test: 'vitest run tests' },
+    nx: {
+      tags: [`layer:${layer}`],
+      targets: {
+        test: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `pnpm exec vitest run libs/${name}/tests`,
+            cwd: '{workspaceRoot}',
+          },
+        },
+      },
+    },
+    dependencies: {},
+  };
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+/** Generate the tsconfig.json (reference config) content. */
+export function buildTsconfig(depth: number): string {
+  const base = '../'.repeat(depth) + 'tsconfig.base.json';
+  const obj = {
+    extends: base,
+    files: [],
+    include: [],
+    references: [{ path: './tsconfig.lib.json' }],
+  };
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+/** Generate the tsconfig.lib.json (build config) content. */
+export function buildTsconfigLib(depth: number): string {
+  const base = '../'.repeat(depth) + 'tsconfig.base.json';
+  const obj = {
+    extends: base,
+    compilerOptions: {
+      baseUrl: '.',
+      rootDir: 'src',
+      outDir: 'dist',
+      tsBuildInfoFile: 'dist/tsconfig.lib.tsbuildinfo',
+      emitDeclarationOnly: true,
+      forceConsistentCasingInFileNames: true,
+      types: ['node'],
+    },
+    include: ['src/**/*.ts'],
+    references: [],
+  };
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+/**
+ * Insert a new depConstraint into eslint.config.mjs content.
+ *
+ * Invariant: the returned string contains exactly one entry for
+ * `layer:<layer>` in depConstraints — either it was already there
+ * (no-op) or it has been added before the closing `],`.
+ */
+export function insertDepConstraint(
+  eslintContent: string,
+  layer: string,
+  allowsDeps: string[],
+): string {
+  const sourceTag = `layer:${layer}`;
+
+  // Idempotency: already present → return unchanged.
+  if (eslintContent.includes(`sourceTag: '${sourceTag}'`)) {
+    return eslintContent;
+  }
+
+  const depsLiteral = allowsDeps.map((d) => `'${d}'`).join(', ');
+  const newLine = `            { sourceTag: '${sourceTag}',      onlyDependOnLibsWithTags: [${depsLiteral}] },`;
+
+  // The depConstraints array closes with "          ]," (10-space indent).
+  // That exact indent pattern is unique in the file.
+  const CLOSING = '          ],';
+  const idx = eslintContent.indexOf(CLOSING);
+  if (idx === -1) {
+    throw new Error(
+      'workspace-lib generator: cannot find depConstraints closing "]," in eslint.config.mjs',
+    );
+  }
+
+  return eslintContent.slice(0, idx) + newLine + '\n' + eslintContent.slice(idx);
+}
+
+// ── Nx generator (Tree API) ───────────────────────────────────────────
+
+export default async function workspaceLibGenerator(
+  tree: Tree,
+  opts: WorkspaceLibSchema,
+): Promise<void> {
+  const { name, layer } = opts;
+  const allowsDeps = parseAllowsDeps(opts.allowsDeps);
+  const libPath = `libs/${name}`;
+
+  // Idempotency: if package.json exists with the right layer tag, skip.
+  const pkgPath = `${libPath}/package.json`;
+  if (tree.exists(pkgPath)) {
+    const existing = JSON.parse(tree.read(pkgPath, 'utf-8') ?? '{}') as {
+      nx?: { tags?: string[] };
+    };
+    if (existing.nx?.tags?.includes(`layer:${layer}`)) {
+      console.log(`[workspace-lib] no-op: ${libPath} already has layer:${layer}`);
+      return;
+    }
+  }
+
+  // Depth from libs/<name> to workspace root is 2.
+  const depth = 2;
+
+  tree.write(pkgPath, buildPackageJson(name, layer));
+  tree.write(`${libPath}/tsconfig.json`, buildTsconfig(depth));
+  tree.write(`${libPath}/tsconfig.lib.json`, buildTsconfigLib(depth));
+  tree.write(`${libPath}/src/index.ts`, `// @chitin/${name} public API\n`);
+  tree.write(`${libPath}/tests/.gitkeep`, '');
+
+  // Update eslint.config.mjs.
+  const eslintPath = 'eslint.config.mjs';
+  const eslintContent = tree.read(eslintPath, 'utf-8');
+  if (!eslintContent) {
+    throw new Error('workspace-lib generator: eslint.config.mjs not found at workspace root');
+  }
+  const updated = insertDepConstraint(eslintContent, layer, allowsDeps);
+  if (updated !== eslintContent) {
+    tree.write(eslintPath, updated);
+    console.log(`[workspace-lib] added layer:${layer} to eslint.config.mjs`);
+  }
+
+  await formatFiles(tree);
+  console.log(`[workspace-lib] scaffolded ${libPath}`);
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────
+
+interface CliOpts {
+  name: string;
+  layer: string;
+  allowsDeps: string[];
+}
+
+function parseCliArgs(argv: string[]): CliOpts {
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0].startsWith('-')) {
+    console.error(
+      'Usage: tsx tools/generators/workspace-lib/index.ts <name> --layer <layer> [--allows-deps <layers>]',
+    );
+    process.exit(1);
+  }
+  const name = args[0];
+  let layer = '';
+  let rawDeps: string | undefined;
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--layer') {
+      layer = args[++i] ?? '';
+    } else if (args[i] === '--allows-deps') {
+      rawDeps = args[++i];
+    }
+  }
+
+  if (!layer) {
+    console.error('Error: --layer is required');
+    process.exit(1);
+  }
+
+  return { name, layer, allowsDeps: parseAllowsDeps(rawDeps) };
+}
+
+function cliRun(): void {
+  const opts = parseCliArgs(process.argv);
+  const __filename = fileURLToPath(import.meta.url);
+  const workspaceRoot = resolve(dirname(__filename), '../../..');
+
+  const libDir = join(workspaceRoot, 'libs', opts.name);
+
+  // Idempotency check.
+  const pkgFile = join(libDir, 'package.json');
+  if (existsSync(pkgFile)) {
+    const existing = JSON.parse(readFileSync(pkgFile, 'utf-8')) as {
+      nx?: { tags?: string[] };
+    };
+    if (existing.nx?.tags?.includes(`layer:${opts.layer}`)) {
+      console.log(`[workspace-lib] no-op: libs/${opts.name} already has layer:${opts.layer}`);
+      return;
+    }
+  }
+
+  const depth = 2;
+  mkdirSync(join(libDir, 'src'), { recursive: true });
+  mkdirSync(join(libDir, 'tests'), { recursive: true });
+
+  writeFileSync(pkgFile, buildPackageJson(opts.name, opts.layer));
+  writeFileSync(join(libDir, 'tsconfig.json'), buildTsconfig(depth));
+  writeFileSync(join(libDir, 'tsconfig.lib.json'), buildTsconfigLib(depth));
+  writeFileSync(join(libDir, 'src', 'index.ts'), `// @chitin/${opts.name} public API\n`);
+  writeFileSync(join(libDir, 'tests', '.gitkeep'), '');
+
+  const eslintFile = join(workspaceRoot, 'eslint.config.mjs');
+  const eslintContent = readFileSync(eslintFile, 'utf-8');
+  const updated = insertDepConstraint(eslintContent, opts.layer, opts.allowsDeps);
+  if (updated !== eslintContent) {
+    writeFileSync(eslintFile, updated);
+    console.log(`[workspace-lib] added layer:${opts.layer} to eslint.config.mjs`);
+  } else {
+    console.log(`[workspace-lib] layer:${opts.layer} already in eslint.config.mjs`);
+  }
+
+  console.log(`[workspace-lib] scaffolded libs/${opts.name}`);
+}
+
+// Run CLI only when invoked directly (not when imported as an Nx generator).
+const isCli =
+  typeof process !== 'undefined' &&
+  process.argv[1] != null &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isCli) {
+  cliRun();
+}

--- a/tools/generators/workspace-lib/package.json
+++ b/tools/generators/workspace-lib/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@chitin/workspace-lib",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "generators": "./generators.json",
+  "nx": {
+    "tags": ["layer:tooling"],
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm exec vitest run --config tools/generators/workspace-lib/vitest.config.ts",
+          "cwd": "{workspaceRoot}"
+        }
+      },
+      "generate": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm exec tsx tools/generators/workspace-lib/index.ts",
+          "cwd": "{workspaceRoot}"
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "@nx/devkit": "*"
+  }
+}

--- a/tools/generators/workspace-lib/package.json
+++ b/tools/generators/workspace-lib/package.json
@@ -10,7 +10,7 @@
       "test": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "pnpm exec vitest run --config tools/generators/workspace-lib/vitest.config.ts",
+          "command": "pnpm exec tsx tools/generators/workspace-lib/tests/index.test.ts",
           "cwd": "{workspaceRoot}"
         }
       },

--- a/tools/generators/workspace-lib/schema.json
+++ b/tools/generators/workspace-lib/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "workspace-lib",
+  "title": "Workspace Library Generator",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name — placed at libs/<name>/",
+      "$default": { "$source": "argv", "index": 0 }
+    },
+    "layer": {
+      "type": "string",
+      "description": "Nx layer tag (e.g. scheduler, governance, slack)"
+    },
+    "allowsDeps": {
+      "type": "string",
+      "description": "Comma-separated outbound layers (default: contracts,telemetry)",
+      "default": "contracts,telemetry"
+    }
+  },
+  "required": ["name", "layer"]
+}

--- a/tools/generators/workspace-lib/tests/index.test.ts
+++ b/tools/generators/workspace-lib/tests/index.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPackageJson,
+  buildTsconfig,
+  buildTsconfigLib,
+  insertDepConstraint,
+  parseAllowsDeps,
+} from '../index.ts';
+
+// ── parseAllowsDeps ───────────────────────────────────────────────────
+
+describe('parseAllowsDeps', () => {
+  it('defaults to contracts + telemetry', () => {
+    expect(parseAllowsDeps(undefined)).toEqual(['layer:contracts', 'layer:telemetry']);
+  });
+
+  it('preserves layer: prefix', () => {
+    expect(parseAllowsDeps('layer:contracts,layer:telemetry')).toEqual([
+      'layer:contracts',
+      'layer:telemetry',
+    ]);
+  });
+
+  it('adds layer: prefix when missing', () => {
+    expect(parseAllowsDeps('contracts,governance')).toEqual([
+      'layer:contracts',
+      'layer:governance',
+    ]);
+  });
+
+  it('sorts output', () => {
+    expect(parseAllowsDeps('telemetry,contracts')).toEqual([
+      'layer:contracts',
+      'layer:telemetry',
+    ]);
+  });
+
+  it('ignores empty segments', () => {
+    expect(parseAllowsDeps('contracts,,telemetry')).toEqual([
+      'layer:contracts',
+      'layer:telemetry',
+    ]);
+  });
+});
+
+// ── buildPackageJson ──────────────────────────────────────────────────
+
+describe('buildPackageJson', () => {
+  it('sets correct name and layer tag', () => {
+    const result = JSON.parse(buildPackageJson('my-lib', 'my-layer'));
+    expect(result.name).toBe('@chitin/my-lib');
+    expect(result.nx.tags).toContain('layer:my-layer');
+  });
+
+  it('includes the test target pointing to libs/<name>/tests', () => {
+    const result = JSON.parse(buildPackageJson('scheduler', 'scheduler'));
+    expect(result.nx.targets.test.options.command).toContain('libs/scheduler/tests');
+  });
+
+  it('ends with a trailing newline', () => {
+    expect(buildPackageJson('x', 'y').endsWith('\n')).toBe(true);
+  });
+});
+
+// ── buildTsconfig ─────────────────────────────────────────────────────
+
+describe('buildTsconfig', () => {
+  it('extends with correct relative path for depth 2', () => {
+    const result = JSON.parse(buildTsconfig(2));
+    expect(result.extends).toBe('../../tsconfig.base.json');
+  });
+
+  it('references tsconfig.lib.json', () => {
+    const result = JSON.parse(buildTsconfig(2));
+    expect(result.references).toEqual([{ path: './tsconfig.lib.json' }]);
+  });
+});
+
+// ── buildTsconfigLib ──────────────────────────────────────────────────
+
+describe('buildTsconfigLib', () => {
+  it('extends with correct relative path for depth 2', () => {
+    const result = JSON.parse(buildTsconfigLib(2));
+    expect(result.extends).toBe('../../tsconfig.base.json');
+  });
+
+  it('sets rootDir=src and outDir=dist', () => {
+    const result = JSON.parse(buildTsconfigLib(2));
+    expect(result.compilerOptions.rootDir).toBe('src');
+    expect(result.compilerOptions.outDir).toBe('dist');
+  });
+
+  it('includes only src/**/*.ts', () => {
+    const result = JSON.parse(buildTsconfigLib(2));
+    expect(result.include).toEqual(['src/**/*.ts']);
+  });
+});
+
+// ── insertDepConstraint ───────────────────────────────────────────────
+
+// A minimal eslint.config.mjs fixture that mirrors the real file's
+// depConstraints shape.
+const ESLINT_FIXTURE = `import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          enforceBuildableLibDependency: true,
+          allow: [],
+          depConstraints: [
+            { sourceTag: 'layer:contracts',  onlyDependOnLibsWithTags: [] },
+            { sourceTag: 'layer:telemetry',  onlyDependOnLibsWithTags: ['layer:contracts'] },
+          ],
+        },
+      ],
+    },
+  },
+];
+`;
+
+describe('insertDepConstraint', () => {
+  it('inserts a new constraint before the closing ],', () => {
+    const result = insertDepConstraint(
+      ESLINT_FIXTURE,
+      'scheduler',
+      ['layer:contracts', 'layer:telemetry'],
+    );
+    expect(result).toContain("sourceTag: 'layer:scheduler'");
+    // New entry is before the closing ],
+    const insertIdx = result.indexOf("sourceTag: 'layer:scheduler'");
+    const closingIdx = result.indexOf('          ],');
+    expect(insertIdx).toBeLessThan(closingIdx);
+  });
+
+  it('is idempotent — second call returns the same string', () => {
+    const once = insertDepConstraint(
+      ESLINT_FIXTURE,
+      'scheduler',
+      ['layer:contracts', 'layer:telemetry'],
+    );
+    const twice = insertDepConstraint(
+      once,
+      'scheduler',
+      ['layer:contracts', 'layer:telemetry'],
+    );
+    expect(twice).toBe(once);
+  });
+
+  it('does not touch unrelated layers', () => {
+    const result = insertDepConstraint(
+      ESLINT_FIXTURE,
+      'governance',
+      ['layer:contracts', 'layer:telemetry'],
+    );
+    expect(result).toContain("sourceTag: 'layer:contracts'");
+    expect(result).toContain("sourceTag: 'layer:telemetry'");
+    expect(result).toContain("sourceTag: 'layer:governance'");
+  });
+
+  it('formats deps as quoted list', () => {
+    const result = insertDepConstraint(
+      ESLINT_FIXTURE,
+      'slack',
+      ['layer:contracts', 'layer:telemetry'],
+    );
+    expect(result).toContain("['layer:contracts', 'layer:telemetry']");
+  });
+
+  it('supports empty deps (e.g. contracts layer itself)', () => {
+    const result = insertDepConstraint(ESLINT_FIXTURE, 'kernel', []);
+    expect(result).toContain("sourceTag: 'layer:kernel'");
+    expect(result).toContain('onlyDependOnLibsWithTags: []');
+  });
+
+  it('throws when no depConstraints closing bracket is found', () => {
+    expect(() =>
+      insertDepConstraint('no closing bracket here', 'x', []),
+    ).toThrow('workspace-lib generator');
+  });
+});

--- a/tools/generators/workspace-lib/tests/index.test.ts
+++ b/tools/generators/workspace-lib/tests/index.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+// Test runner: tsx tools/generators/workspace-lib/tests/index.test.ts
+// Uses node:assert — no vitest required (package not in pnpm-workspace yet).
+
+import assert from 'node:assert/strict';
 import {
   buildPackageJson,
   buildTsconfig,
@@ -7,99 +10,113 @@ import {
   parseAllowsDeps,
 } from '../index.ts';
 
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err instanceof Error ? err.message : String(err)}`);
+    failed++;
+  }
+}
+
 // ── parseAllowsDeps ───────────────────────────────────────────────────
 
-describe('parseAllowsDeps', () => {
-  it('defaults to contracts + telemetry', () => {
-    expect(parseAllowsDeps(undefined)).toEqual(['layer:contracts', 'layer:telemetry']);
-  });
+test('parseAllowsDeps: defaults to contracts + telemetry', () => {
+  assert.deepEqual(parseAllowsDeps(undefined), ['layer:contracts', 'layer:telemetry']);
+});
 
-  it('preserves layer: prefix', () => {
-    expect(parseAllowsDeps('layer:contracts,layer:telemetry')).toEqual([
-      'layer:contracts',
-      'layer:telemetry',
-    ]);
-  });
+test('parseAllowsDeps: preserves layer: prefix', () => {
+  assert.deepEqual(parseAllowsDeps('layer:contracts,layer:telemetry'), [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+});
 
-  it('adds layer: prefix when missing', () => {
-    expect(parseAllowsDeps('contracts,governance')).toEqual([
-      'layer:contracts',
-      'layer:governance',
-    ]);
-  });
+test('parseAllowsDeps: adds layer: prefix when missing', () => {
+  assert.deepEqual(parseAllowsDeps('contracts,governance'), [
+    'layer:contracts',
+    'layer:governance',
+  ]);
+});
 
-  it('sorts output', () => {
-    expect(parseAllowsDeps('telemetry,contracts')).toEqual([
-      'layer:contracts',
-      'layer:telemetry',
-    ]);
-  });
+test('parseAllowsDeps: sorts output', () => {
+  assert.deepEqual(parseAllowsDeps('telemetry,contracts'), [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+});
 
-  it('ignores empty segments', () => {
-    expect(parseAllowsDeps('contracts,,telemetry')).toEqual([
-      'layer:contracts',
-      'layer:telemetry',
-    ]);
-  });
+test('parseAllowsDeps: ignores empty segments', () => {
+  assert.deepEqual(parseAllowsDeps('contracts,,telemetry'), [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
 });
 
 // ── buildPackageJson ──────────────────────────────────────────────────
 
-describe('buildPackageJson', () => {
-  it('sets correct name and layer tag', () => {
-    const result = JSON.parse(buildPackageJson('my-lib', 'my-layer'));
-    expect(result.name).toBe('@chitin/my-lib');
-    expect(result.nx.tags).toContain('layer:my-layer');
-  });
+test('buildPackageJson: sets correct name and layer tag', () => {
+  const result = JSON.parse(buildPackageJson('my-lib', 'my-layer')) as {
+    name: string;
+    nx: { tags: string[] };
+  };
+  assert.equal(result.name, '@chitin/my-lib');
+  assert.ok(result.nx.tags.includes('layer:my-layer'));
+});
 
-  it('includes the test target pointing to libs/<name>/tests', () => {
-    const result = JSON.parse(buildPackageJson('scheduler', 'scheduler'));
-    expect(result.nx.targets.test.options.command).toContain('libs/scheduler/tests');
-  });
+test('buildPackageJson: test target points to libs/<name>/tests', () => {
+  const result = JSON.parse(buildPackageJson('scheduler', 'scheduler')) as {
+    nx: { targets: { test: { options: { command: string } } } };
+  };
+  assert.ok(result.nx.targets.test.options.command.includes('libs/scheduler/tests'));
+});
 
-  it('ends with a trailing newline', () => {
-    expect(buildPackageJson('x', 'y').endsWith('\n')).toBe(true);
-  });
+test('buildPackageJson: ends with trailing newline', () => {
+  assert.ok(buildPackageJson('x', 'y').endsWith('\n'));
 });
 
 // ── buildTsconfig ─────────────────────────────────────────────────────
 
-describe('buildTsconfig', () => {
-  it('extends with correct relative path for depth 2', () => {
-    const result = JSON.parse(buildTsconfig(2));
-    expect(result.extends).toBe('../../tsconfig.base.json');
-  });
+test('buildTsconfig: extends with correct path for depth 2', () => {
+  const result = JSON.parse(buildTsconfig(2)) as { extends: string };
+  assert.equal(result.extends, '../../tsconfig.base.json');
+});
 
-  it('references tsconfig.lib.json', () => {
-    const result = JSON.parse(buildTsconfig(2));
-    expect(result.references).toEqual([{ path: './tsconfig.lib.json' }]);
-  });
+test('buildTsconfig: references tsconfig.lib.json', () => {
+  const result = JSON.parse(buildTsconfig(2)) as {
+    references: Array<{ path: string }>;
+  };
+  assert.deepEqual(result.references, [{ path: './tsconfig.lib.json' }]);
 });
 
 // ── buildTsconfigLib ──────────────────────────────────────────────────
 
-describe('buildTsconfigLib', () => {
-  it('extends with correct relative path for depth 2', () => {
-    const result = JSON.parse(buildTsconfigLib(2));
-    expect(result.extends).toBe('../../tsconfig.base.json');
-  });
+test('buildTsconfigLib: extends with correct path for depth 2', () => {
+  const result = JSON.parse(buildTsconfigLib(2)) as { extends: string };
+  assert.equal(result.extends, '../../tsconfig.base.json');
+});
 
-  it('sets rootDir=src and outDir=dist', () => {
-    const result = JSON.parse(buildTsconfigLib(2));
-    expect(result.compilerOptions.rootDir).toBe('src');
-    expect(result.compilerOptions.outDir).toBe('dist');
-  });
+test('buildTsconfigLib: sets rootDir=src and outDir=dist', () => {
+  const result = JSON.parse(buildTsconfigLib(2)) as {
+    compilerOptions: { rootDir: string; outDir: string };
+  };
+  assert.equal(result.compilerOptions.rootDir, 'src');
+  assert.equal(result.compilerOptions.outDir, 'dist');
+});
 
-  it('includes only src/**/*.ts', () => {
-    const result = JSON.parse(buildTsconfigLib(2));
-    expect(result.include).toEqual(['src/**/*.ts']);
-  });
+test('buildTsconfigLib: includes only src/**/*.ts', () => {
+  const result = JSON.parse(buildTsconfigLib(2)) as { include: string[] };
+  assert.deepEqual(result.include, ['src/**/*.ts']);
 });
 
 // ── insertDepConstraint ───────────────────────────────────────────────
 
-// A minimal eslint.config.mjs fixture that mirrors the real file's
-// depConstraints shape.
 const ESLINT_FIXTURE = `import nx from '@nx/eslint-plugin';
 
 export default [
@@ -123,63 +140,61 @@ export default [
 ];
 `;
 
-describe('insertDepConstraint', () => {
-  it('inserts a new constraint before the closing ],', () => {
-    const result = insertDepConstraint(
-      ESLINT_FIXTURE,
-      'scheduler',
-      ['layer:contracts', 'layer:telemetry'],
-    );
-    expect(result).toContain("sourceTag: 'layer:scheduler'");
-    // New entry is before the closing ],
-    const insertIdx = result.indexOf("sourceTag: 'layer:scheduler'");
-    const closingIdx = result.indexOf('          ],');
-    expect(insertIdx).toBeLessThan(closingIdx);
-  });
-
-  it('is idempotent — second call returns the same string', () => {
-    const once = insertDepConstraint(
-      ESLINT_FIXTURE,
-      'scheduler',
-      ['layer:contracts', 'layer:telemetry'],
-    );
-    const twice = insertDepConstraint(
-      once,
-      'scheduler',
-      ['layer:contracts', 'layer:telemetry'],
-    );
-    expect(twice).toBe(once);
-  });
-
-  it('does not touch unrelated layers', () => {
-    const result = insertDepConstraint(
-      ESLINT_FIXTURE,
-      'governance',
-      ['layer:contracts', 'layer:telemetry'],
-    );
-    expect(result).toContain("sourceTag: 'layer:contracts'");
-    expect(result).toContain("sourceTag: 'layer:telemetry'");
-    expect(result).toContain("sourceTag: 'layer:governance'");
-  });
-
-  it('formats deps as quoted list', () => {
-    const result = insertDepConstraint(
-      ESLINT_FIXTURE,
-      'slack',
-      ['layer:contracts', 'layer:telemetry'],
-    );
-    expect(result).toContain("['layer:contracts', 'layer:telemetry']");
-  });
-
-  it('supports empty deps (e.g. contracts layer itself)', () => {
-    const result = insertDepConstraint(ESLINT_FIXTURE, 'kernel', []);
-    expect(result).toContain("sourceTag: 'layer:kernel'");
-    expect(result).toContain('onlyDependOnLibsWithTags: []');
-  });
-
-  it('throws when no depConstraints closing bracket is found', () => {
-    expect(() =>
-      insertDepConstraint('no closing bracket here', 'x', []),
-    ).toThrow('workspace-lib generator');
-  });
+test('insertDepConstraint: inserts before the closing ],', () => {
+  const result = insertDepConstraint(ESLINT_FIXTURE, 'scheduler', [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+  assert.ok(result.includes("sourceTag: 'layer:scheduler'"));
+  const insertIdx = result.indexOf("sourceTag: 'layer:scheduler'");
+  const closingIdx = result.indexOf('          ],');
+  assert.ok(insertIdx < closingIdx, 'new entry must appear before closing ],');
 });
+
+test('insertDepConstraint: is idempotent', () => {
+  const once = insertDepConstraint(ESLINT_FIXTURE, 'scheduler', [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+  const twice = insertDepConstraint(once, 'scheduler', [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+  assert.equal(twice, once);
+});
+
+test('insertDepConstraint: does not remove existing layers', () => {
+  const result = insertDepConstraint(ESLINT_FIXTURE, 'governance', [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+  assert.ok(result.includes("sourceTag: 'layer:contracts'"));
+  assert.ok(result.includes("sourceTag: 'layer:telemetry'"));
+  assert.ok(result.includes("sourceTag: 'layer:governance'"));
+});
+
+test('insertDepConstraint: formats deps as quoted list', () => {
+  const result = insertDepConstraint(ESLINT_FIXTURE, 'slack', [
+    'layer:contracts',
+    'layer:telemetry',
+  ]);
+  assert.ok(result.includes("['layer:contracts', 'layer:telemetry']"));
+});
+
+test('insertDepConstraint: supports empty deps array', () => {
+  const result = insertDepConstraint(ESLINT_FIXTURE, 'kernel', []);
+  assert.ok(result.includes("sourceTag: 'layer:kernel'"));
+  assert.ok(result.includes('onlyDependOnLibsWithTags: []'));
+});
+
+test('insertDepConstraint: throws when no closing bracket found', () => {
+  assert.throws(
+    () => insertDepConstraint('no closing bracket here', 'x', []),
+    /workspace-lib generator/,
+  );
+});
+
+// ── Summary ───────────────────────────────────────────────────────────
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tools/generators/workspace-lib/tsconfig.json
+++ b/tools/generators/workspace-lib/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "tests/**/*.ts"]
+}

--- a/tools/generators/workspace-lib/vitest.config.ts
+++ b/tools/generators/workspace-lib/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    root: here,
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `nx-generator-workspace-lib`
Tier: `T3`  •  Driver: `claude-code-headless`
Workflow: `swarm-nx-generator-workspace-lib-1777838701687`

## Entry context

`nx g @chitin/workspace-lib <name> --layer <layer>` scaffolds the
chitin-flavored library shape: package.json with the right
`nx:run-commands` test target, tsconfig.json + tsconfig.lib.json
extending base, src/index.ts, tests/, **AND** automatically adds the
layer to `eslint.config.mjs` depConstraints.

Would have prevented at minimum:
- PR #194's missing `layer:scheduler` depConstraint
- PR #195's missing `layer:slack` depConstraint + missing
  tsconfig-extends-base + missing `allowImportingTsExtensions`
- PR #199's missing `layer:governance` depConstraint
- PR #194's missing tsconfig + tsconfig.lib files entirely

Each of those was a separate Copilot review cycle on the same
omission pattern.

Steps:
1. Templates for package.json, tsconfig.json, tsconfig.lib.json,
   src/index.ts, tests/.gitkeep.
2. AST-aware update to eslint.config.mjs (add depConstraint with
   defaults: layer can depend on contracts + telemetry).
3. Flag `--allows-deps <comma,sep,layers>` to override the default
   outbound rule.

**Acceptance:**
- [ ] Generated lib passes typecheck + tests on first run
- [ ] eslint depConstraints regenerate correctly for new layer
- [ ] lint-layer-tag-coverage passes on generated lib
- [ ] Idempotent: re-running with same name + layer is a no-op


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-nx-generator-workspace-lib-1777838701687`
Branch: `swarm/swarm-nx-generator-workspace-lib-1777838701687`
Head: `4b7d6914`
Diff: `8 files changed, 572 insertions(+), 10 deletions(-)`
Commits: 2 (+ auto-committed uncommitted state)