### PR TITLE
swarm: nx-generator-backlog-entry

### DIFF
--- a/tools/generators/backlog-entry/generate.ts
+++ b/tools/generators/backlog-entry/generate.ts
@@ -1,0 +1,79 @@
+// Pure generation logic for backlog entries — no I/O. All functions are
+// side-effect-free so tests can exercise them without touching the filesystem.
+
+import type { BacklogEntry } from '../../../apps/temporal-worker/src/grooming/parse-backlog.js';
+
+export interface EntryOptions {
+  id: string;
+  tier: string;
+  status: string;
+  role: string;
+  file: string;
+  blocks: string[];
+  estimated_loc: string;
+  references_finding: string;
+  references_spec: string;
+  references_design: string;
+  description: string;
+}
+
+// Builds the full markdown section for a backlog entry.
+// Invariant: the generated heading id (`### \`<id>\``) matches the
+// frontmatter `id:` field — both come from opts.id.
+export function buildSection(opts: EntryOptions): string {
+  const yaml: string[] = [
+    `id: ${opts.id}`,
+    `tier: ${opts.tier}`,
+    `status: ${opts.status}`,
+  ];
+  if (opts.estimated_loc) yaml.push(`estimated_loc: ${opts.estimated_loc}`);
+  yaml.push(`blocks: [${opts.blocks.join(', ')}]`);
+  if (opts.file) yaml.push(`file: ${opts.file}`);
+  if (opts.references_finding) yaml.push(`references_finding: ${opts.references_finding}`);
+  if (opts.references_spec) yaml.push(`references_spec: ${opts.references_spec}`);
+  if (opts.references_design) yaml.push(`references_design: ${opts.references_design}`);
+  yaml.push(`role: ${opts.role}`);
+
+  const description = opts.description.trim() || '(no description)';
+  return `### \`${opts.id}\`\n\n\`\`\`yaml\n${yaml.join('\n')}\n\`\`\`\n\n${description}`;
+}
+
+// Inserts `section` at the end of `text` (after the last ### entry's
+// content), before any trailing ## section that follows. If no ## section
+// follows, appends at end of file.
+//
+// Invariant: the resulting text begins with `text`'s original prefix up
+// to the insertion point, followed by `\n\n---\n\n{section}`, followed
+// by any original trailing content.
+export function insertEntry(text: string, section: string): string {
+  // Find the last ### heading
+  const h3Matches = [...text.matchAll(/^### /gm)];
+  if (h3Matches.length === 0) {
+    return `${text.trimEnd()}\n\n---\n\n${section}\n`;
+  }
+
+  const lastH3 = h3Matches[h3Matches.length - 1]!;
+  const afterLastH3 = text.slice(lastH3.index!);
+
+  // Find a ## heading that follows the last ### (next major section)
+  const nextH2Match = afterLastH3.match(/\n(?=## )/);
+
+  let insertAt: number;
+  if (nextH2Match?.index !== undefined) {
+    insertAt = lastH3.index! + nextH2Match.index;
+  } else {
+    insertAt = text.length;
+  }
+
+  const before = text.slice(0, insertAt).trimEnd();
+  const after = text.slice(insertAt).trimStart();
+
+  if (after) {
+    return `${before}\n\n---\n\n${section}\n\n${after}`;
+  }
+  return `${before}\n\n---\n\n${section}\n`;
+}
+
+export function hasDuplicateId(entries: readonly BacklogEntry[], id: string): boolean {
+  return entries.some((e) => e.id === id);
+}

--- a/tools/generators/backlog-entry/index.ts
+++ b/tools/generators/backlog-entry/index.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Interactive generator for docs/swarm-backlog.md entries.
+//
+// Usage (from repo root):
+//   pnpm exec tsx tools/generators/backlog-entry/index.ts
+//   pnpm exec tsx tools/generators/backlog-entry/index.ts --backlog docs/swarm-backlog.md
+
+import { createInterface } from 'node:readline/promises';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+import { RoleSchema } from '@chitin/contracts';
+import { parseBacklog } from '../../../apps/temporal-worker/src/grooming/parse-backlog.js';
+import { buildSection, insertEntry, hasDuplicateId } from './generate.js';
+
+const ROLES: string[] = RoleSchema.options;
+const TIERS = ['T0', 'T1', 'T2', 'T3', 'T4', 'T5'];
+const STATUSES = ['ready', 'in_design', 'needs_human', 'blocked'];
+
+function completer(line: string): [string[], string] {
+  const hits = ROLES.filter((r) => r.startsWith(line));
+  return [hits.length > 0 ? hits : ROLES, line];
+}
+
+async function prompt(rl: Awaited<ReturnType<typeof createInterface>>, question: string): Promise<string> {
+  const answer = await rl.question(question);
+  return answer.trim();
+}
+
+async function promptWithDefault(
+  rl: Awaited<ReturnType<typeof createInterface>>,
+  question: string,
+  defaultVal: string,
+): Promise<string> {
+  const answer = await prompt(rl, `${question} [${defaultVal}]: `);
+  return answer || defaultVal;
+}
+
+async function promptEnum(
+  rl: Awaited<ReturnType<typeof createInterface>>,
+  question: string,
+  choices: string[],
+  defaultVal?: string,
+): Promise<string> {
+  const hint = defaultVal ? `[${defaultVal}] ` : '';
+  while (true) {
+    const raw = await prompt(rl, `${question} (${choices.join('|')}) ${hint}`);
+    const val = raw || defaultVal || '';
+    if (choices.includes(val)) return val;
+    console.error(`  Invalid choice "${val}". Pick one of: ${choices.join(', ')}`);
+  }
+}
+
+async function run(backlogPath: string): Promise<void> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    completer,
+  });
+
+  try {
+    console.log('\nNew backlog entry generator');
+    console.log('---------------------------');
+    console.log('(Tab-completes role names)\n');
+
+    const existingEntries = parseBacklog(backlogPath);
+    const existingIds = new Set(existingEntries.map((e) => e.id));
+
+    // Prompt for id
+    let id = '';
+    while (!id) {
+      id = await prompt(rl, 'Entry id (slug, e.g. my-new-feature): ');
+      if (!id) { console.error('  id is required'); continue; }
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+        console.error('  id must be lowercase alphanumeric + hyphens');
+        id = '';
+        continue;
+      }
+      if (existingIds.has(id)) {
+        console.error(`  id "${id}" already exists in the backlog (duplicate ids are rejected)`);
+        id = '';
+      }
+    }
+
+    const tier = await promptEnum(rl, 'Tier', TIERS, 'T1');
+    const status = await promptEnum(rl, 'Status', STATUSES, 'ready');
+
+    // Role prompt with tab completion
+    let role = '';
+    while (!role) {
+      role = await prompt(rl, `Role (Tab to complete, choices: ${ROLES.join(', ')})\n  > `);
+      if (!ROLES.includes(role)) {
+        console.error(`  Unknown role "${role}". Valid: ${ROLES.join(', ')}`);
+        role = '';
+      }
+    }
+
+    const file = await prompt(rl, 'File scope (comma-separated paths, or leave blank): ');
+    const blocksRaw = await prompt(rl, 'Blocks (comma-separated entry ids, or leave blank): ');
+    const blocks = blocksRaw ? blocksRaw.split(',').map((s) => s.trim()).filter(Boolean) : [];
+    const estimatedLoc = await prompt(rl, 'Estimated LOC (optional): ');
+    const referencesFinding = await prompt(rl, 'references_finding (optional): ');
+    const referencesSpec = await prompt(rl, 'references_spec (optional): ');
+    const referencesDesign = await prompt(rl, 'references_design (optional): ');
+
+    console.log('\nDescription (multi-line; enter a single "." on a line to finish):');
+    const descLines: string[] = [];
+    while (true) {
+      const line = await prompt(rl, '  ');
+      if (line === '.') break;
+      descLines.push(line);
+    }
+    const description = descLines.join('\n');
+
+    const section = buildSection({
+      id,
+      tier,
+      status,
+      role,
+      file,
+      blocks,
+      estimated_loc: estimatedLoc,
+      references_finding: referencesFinding,
+      references_spec: referencesSpec,
+      references_design: referencesDesign,
+      description,
+    });
+
+    console.log('\n--- Preview ---');
+    console.log(section);
+    console.log('---------------\n');
+
+    const confirm = await prompt(rl, 'Write to backlog? (y/N): ');
+    if (confirm.toLowerCase() !== 'y') {
+      console.log('Aborted.');
+      return;
+    }
+
+    const original = readFileSync(backlogPath, 'utf8');
+    const updated = insertEntry(original, section);
+
+    // Round-trip validation: parse the updated text via parseBacklog.
+    // Write to a temp file, parse, verify the entry appears with correct id.
+    const tmpPath = `${backlogPath}.gen-tmp`;
+    writeFileSync(tmpPath, updated, 'utf8');
+    try {
+      const parsed = parseBacklog(tmpPath);
+      if (hasDuplicateId(parsed.filter((e) => e.id === id).slice(1), id)) {
+        throw new Error(`duplicate id "${id}" detected after write — aborting`);
+      }
+      const entry = parsed.find((e) => e.id === id);
+      if (!entry) throw new Error(`round-trip failed: id "${id}" not found after parse`);
+      // Verify heading id matches frontmatter id
+      const fmIdMatch = entry.rawFrontmatter.match(/^id:\s*(\S+)/m);
+      if (fmIdMatch && fmIdMatch[1] !== entry.id) {
+        throw new Error(`heading id "${entry.id}" ≠ frontmatter id "${fmIdMatch[1]}"`);
+      }
+    } catch (err) {
+      // Remove temp file and abort
+      try { writeFileSync(tmpPath, '', 'utf8'); } catch { /* ignore */ }
+      const { unlinkSync } = await import('node:fs');
+      try { unlinkSync(tmpPath); } catch { /* ignore */ }
+      throw err;
+    }
+
+    // Validation passed — rename temp to real file
+    const { renameSync, unlinkSync } = await import('node:fs');
+    try { unlinkSync(`${backlogPath}.gen-bak`); } catch { /* no backup to remove */ }
+    // Write backup then overwrite
+    writeFileSync(backlogPath, updated, 'utf8');
+    unlinkSync(tmpPath);
+
+    console.log(`\nWrote entry "${id}" to ${backlogPath}`);
+  } finally {
+    rl.close();
+  }
+}
+
+const program = new Command();
+program
+  .name('backlog-entry')
+  .description('Interactive generator for docs/swarm-backlog.md entries')
+  .option('--backlog <path>', 'path to swarm-backlog.md', 'docs/swarm-backlog.md')
+  .action(async (opts: { backlog: string }) => {
+    const backlogPath = resolve(process.cwd(), opts.backlog);
+    try {
+      await run(backlogPath);
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
+  });
+
+const isCli = fileURLToPath(import.meta.url) === process.argv[1];
+if (isCli) {
+  program.parse();
+}

--- a/tools/generators/backlog-entry/index.ts
+++ b/tools/generators/backlog-entry/index.ts
@@ -6,7 +6,7 @@
 //   pnpm exec tsx tools/generators/backlog-entry/index.ts --backlog docs/swarm-backlog.md
 
 import { createInterface } from 'node:readline/promises';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
@@ -23,32 +23,26 @@ function completer(line: string): [string[], string] {
   return [hits.length > 0 ? hits : ROLES, line];
 }
 
-async function prompt(rl: Awaited<ReturnType<typeof createInterface>>, question: string): Promise<string> {
-  const answer = await rl.question(question);
-  return answer.trim();
-}
-
-async function promptWithDefault(
-  rl: Awaited<ReturnType<typeof createInterface>>,
+async function ask(
+  rl: ReturnType<typeof createInterface>,
   question: string,
-  defaultVal: string,
 ): Promise<string> {
-  const answer = await prompt(rl, `${question} [${defaultVal}]: `);
-  return answer || defaultVal;
+  return (await rl.question(question)).trim();
 }
 
-async function promptEnum(
-  rl: Awaited<ReturnType<typeof createInterface>>,
+async function askEnum(
+  rl: ReturnType<typeof createInterface>,
   question: string,
   choices: string[],
   defaultVal?: string,
 ): Promise<string> {
-  const hint = defaultVal ? `[${defaultVal}] ` : '';
+  const hint = defaultVal ? ` [${defaultVal}]` : '';
+  const choiceStr = choices.join('|');
   while (true) {
-    const raw = await prompt(rl, `${question} (${choices.join('|')}) ${hint}`);
+    const raw = await ask(rl, `${question} (${choiceStr})${hint}: `);
     const val = raw || defaultVal || '';
     if (choices.includes(val)) return val;
-    console.error(`  Invalid choice "${val}". Pick one of: ${choices.join(', ')}`);
+    console.error(`  Invalid: "${val}". Choose one of: ${choices.join(', ')}`);
   }
 }
 
@@ -65,49 +59,49 @@ async function run(backlogPath: string): Promise<void> {
     console.log('(Tab-completes role names)\n');
 
     const existingEntries = parseBacklog(backlogPath);
-    const existingIds = new Set(existingEntries.map((e) => e.id));
 
-    // Prompt for id
     let id = '';
     while (!id) {
-      id = await prompt(rl, 'Entry id (slug, e.g. my-new-feature): ');
+      id = await ask(rl, 'Entry id (slug, e.g. my-new-feature): ');
       if (!id) { console.error('  id is required'); continue; }
       if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
         console.error('  id must be lowercase alphanumeric + hyphens');
         id = '';
         continue;
       }
-      if (existingIds.has(id)) {
-        console.error(`  id "${id}" already exists in the backlog (duplicate ids are rejected)`);
+      if (hasDuplicateId(existingEntries, id)) {
+        console.error(`  id "${id}" already exists in the backlog — duplicate ids are rejected`);
         id = '';
       }
     }
 
-    const tier = await promptEnum(rl, 'Tier', TIERS, 'T1');
-    const status = await promptEnum(rl, 'Status', STATUSES, 'ready');
+    const tier = await askEnum(rl, 'Tier', TIERS, 'T1');
+    const status = await askEnum(rl, 'Status', STATUSES, 'ready');
 
-    // Role prompt with tab completion
     let role = '';
     while (!role) {
-      role = await prompt(rl, `Role (Tab to complete, choices: ${ROLES.join(', ')})\n  > `);
+      role = await ask(
+        rl,
+        `Role (Tab to complete; choices: ${ROLES.join(', ')})\n  > `,
+      );
       if (!ROLES.includes(role)) {
         console.error(`  Unknown role "${role}". Valid: ${ROLES.join(', ')}`);
         role = '';
       }
     }
 
-    const file = await prompt(rl, 'File scope (comma-separated paths, or leave blank): ');
-    const blocksRaw = await prompt(rl, 'Blocks (comma-separated entry ids, or leave blank): ');
+    const file = await ask(rl, 'File scope (comma-separated paths, or blank): ');
+    const blocksRaw = await ask(rl, 'Blocks (comma-separated ids, or blank): ');
     const blocks = blocksRaw ? blocksRaw.split(',').map((s) => s.trim()).filter(Boolean) : [];
-    const estimatedLoc = await prompt(rl, 'Estimated LOC (optional): ');
-    const referencesFinding = await prompt(rl, 'references_finding (optional): ');
-    const referencesSpec = await prompt(rl, 'references_spec (optional): ');
-    const referencesDesign = await prompt(rl, 'references_design (optional): ');
+    const estimatedLoc = await ask(rl, 'Estimated LOC (optional): ');
+    const referencesFinding = await ask(rl, 'references_finding (optional): ');
+    const referencesSpec = await ask(rl, 'references_spec (optional): ');
+    const referencesDesign = await ask(rl, 'references_design (optional): ');
 
-    console.log('\nDescription (multi-line; enter a single "." on a line to finish):');
+    console.log('\nDescription (multi-line; enter "." alone on a line to finish):');
     const descLines: string[] = [];
     while (true) {
-      const line = await prompt(rl, '  ');
+      const line = await ask(rl, '  ');
       if (line === '.') break;
       descLines.push(line);
     }
@@ -131,7 +125,7 @@ async function run(backlogPath: string): Promise<void> {
     console.log(section);
     console.log('---------------\n');
 
-    const confirm = await prompt(rl, 'Write to backlog? (y/N): ');
+    const confirm = await ask(rl, 'Write to backlog? (y/N): ');
     if (confirm.toLowerCase() !== 'y') {
       console.log('Aborted.');
       return;
@@ -140,37 +134,26 @@ async function run(backlogPath: string): Promise<void> {
     const original = readFileSync(backlogPath, 'utf8');
     const updated = insertEntry(original, section);
 
-    // Round-trip validation: parse the updated text via parseBacklog.
-    // Write to a temp file, parse, verify the entry appears with correct id.
+    // Round-trip validation via a temp file
     const tmpPath = `${backlogPath}.gen-tmp`;
     writeFileSync(tmpPath, updated, 'utf8');
     try {
       const parsed = parseBacklog(tmpPath);
-      if (hasDuplicateId(parsed.filter((e) => e.id === id).slice(1), id)) {
-        throw new Error(`duplicate id "${id}" detected after write — aborting`);
-      }
       const entry = parsed.find((e) => e.id === id);
       if (!entry) throw new Error(`round-trip failed: id "${id}" not found after parse`);
+
       // Verify heading id matches frontmatter id
       const fmIdMatch = entry.rawFrontmatter.match(/^id:\s*(\S+)/m);
       if (fmIdMatch && fmIdMatch[1] !== entry.id) {
         throw new Error(`heading id "${entry.id}" ≠ frontmatter id "${fmIdMatch[1]}"`);
       }
     } catch (err) {
-      // Remove temp file and abort
-      try { writeFileSync(tmpPath, '', 'utf8'); } catch { /* ignore */ }
-      const { unlinkSync } = await import('node:fs');
       try { unlinkSync(tmpPath); } catch { /* ignore */ }
       throw err;
     }
 
-    // Validation passed — rename temp to real file
-    const { renameSync, unlinkSync } = await import('node:fs');
-    try { unlinkSync(`${backlogPath}.gen-bak`); } catch { /* no backup to remove */ }
-    // Write backup then overwrite
-    writeFileSync(backlogPath, updated, 'utf8');
     unlinkSync(tmpPath);
-
+    writeFileSync(backlogPath, updated, 'utf8');
     console.log(`\nWrote entry "${id}" to ${backlogPath}`);
   } finally {
     rl.close();

--- a/tools/generators/backlog-entry/package.json
+++ b/tools/generators/backlog-entry/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@chitin/tooling-generators-backlog-entry",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "backlog-entry": "./index.ts"
+  },
+  "dependencies": {
+    "@chitin/contracts": "workspace:*"
+  },
+  "nx": {
+    "tags": ["layer:tooling"],
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm exec vitest run --config tools/generators/backlog-entry/vitest.config.ts",
+          "cwd": "{workspaceRoot}"
+        }
+      },
+      "generate": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "pnpm exec tsx tools/generators/backlog-entry/index.ts",
+          "cwd": "{workspaceRoot}"
+        }
+      }
+    }
+  }
+}

--- a/tools/generators/backlog-entry/tests/generate.test.ts
+++ b/tools/generators/backlog-entry/tests/generate.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildSection, insertEntry, hasDuplicateId, type EntryOptions } from '../generate.js';
+import { parseBacklog } from '../../../../apps/temporal-worker/src/grooming/parse-backlog.js';
+
+const BASE_OPTS: EntryOptions = {
+  id: 'my-new-feature',
+  tier: 'T1',
+  status: 'ready',
+  role: 'programmer',
+  file: 'apps/temporal-worker/src/foo.ts',
+  blocks: [],
+  estimated_loc: '80',
+  references_finding: '',
+  references_spec: '',
+  references_design: '',
+  description: 'Adds the foo capability.',
+};
+
+// ── buildSection ──────────────────────────────────────────────────────────
+
+describe('buildSection', () => {
+  it('heading id matches frontmatter id', () => {
+    const section = buildSection(BASE_OPTS);
+    expect(section).toContain('### `my-new-feature`');
+    expect(section).toContain('id: my-new-feature');
+  });
+
+  it('emits required yaml fields', () => {
+    const section = buildSection(BASE_OPTS);
+    expect(section).toContain('tier: T1');
+    expect(section).toContain('status: ready');
+    expect(section).toContain('role: programmer');
+    expect(section).toContain('blocks: []');
+  });
+
+  it('emits optional fields when set', () => {
+    const section = buildSection({
+      ...BASE_OPTS,
+      estimated_loc: '120',
+      references_finding: 'some-finding',
+      references_spec: 'some-spec',
+      references_design: 'docs/design/foo.md',
+    });
+    expect(section).toContain('estimated_loc: 120');
+    expect(section).toContain('references_finding: some-finding');
+    expect(section).toContain('references_spec: some-spec');
+    expect(section).toContain('references_design: docs/design/foo.md');
+  });
+
+  it('omits optional fields when empty', () => {
+    const section = buildSection(BASE_OPTS);
+    expect(section).not.toContain('references_finding');
+    expect(section).not.toContain('references_spec');
+    expect(section).not.toContain('references_design');
+  });
+
+  it('blocks list serialised correctly', () => {
+    const section = buildSection({ ...BASE_OPTS, blocks: ['dep-a', 'dep-b'] });
+    expect(section).toContain('blocks: [dep-a, dep-b]');
+  });
+
+  it('uses (no description) placeholder when description is empty', () => {
+    const section = buildSection({ ...BASE_OPTS, description: '' });
+    expect(section).toContain('(no description)');
+  });
+
+  it('includes the description text', () => {
+    const section = buildSection({ ...BASE_OPTS, description: 'My description line.' });
+    expect(section).toContain('My description line.');
+  });
+
+  it('yaml block is fenced in ```yaml', () => {
+    const section = buildSection(BASE_OPTS);
+    expect(section).toContain('```yaml\n');
+    expect(section).toMatch(/```yaml[\s\S]*?```/);
+  });
+});
+
+// ── insertEntry ───────────────────────────────────────────────────────────
+
+describe('insertEntry', () => {
+  const existingBacklog = [
+    '## Ready',
+    '',
+    '### `entry-a`',
+    '',
+    '```yaml',
+    'id: entry-a',
+    'tier: T1',
+    'status: ready',
+    'blocks: []',
+    'role: programmer',
+    '```',
+    '',
+    'Description of entry a.',
+  ].join('\n');
+
+  it('appends new entry after existing last ### entry', () => {
+    const section = buildSection(BASE_OPTS);
+    const result = insertEntry(existingBacklog, section);
+    expect(result).toContain('### `entry-a`');
+    expect(result).toContain('### `my-new-feature`');
+    const aIdx = result.indexOf('### `entry-a`');
+    const bIdx = result.indexOf('### `my-new-feature`');
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  it('separates entries with --- divider', () => {
+    const section = buildSection(BASE_OPTS);
+    const result = insertEntry(existingBacklog, section);
+    expect(result).toContain('\n\n---\n\n');
+  });
+
+  it('preserves trailing ## section when present', () => {
+    const withTrailing = `${existingBacklog}\n\n## Completed\n\n### \`old-entry\`\n\nDone.\n`;
+    const section = buildSection(BASE_OPTS);
+    const result = insertEntry(withTrailing, section);
+    // New entry should appear before ## Completed
+    const newIdx = result.indexOf('### `my-new-feature`');
+    const completedIdx = result.indexOf('## Completed');
+    expect(newIdx).toBeLessThan(completedIdx);
+  });
+
+  it('appends correctly to empty text', () => {
+    const section = buildSection(BASE_OPTS);
+    const result = insertEntry('', section);
+    expect(result).toContain('### `my-new-feature`');
+  });
+});
+
+// ── hasDuplicateId ────────────────────────────────────────────────────────
+
+describe('hasDuplicateId', () => {
+  it('returns false when id is not present', () => {
+    const entries = parseBacklog(
+      writeTempBacklog([
+        '## Ready',
+        '',
+        '### `existing-entry`',
+        '',
+        '```yaml',
+        'id: existing-entry',
+        'tier: T1',
+        'status: ready',
+        'blocks: []',
+        'role: programmer',
+        '```',
+        '',
+        'Some description.',
+      ].join('\n')),
+    );
+    expect(hasDuplicateId(entries, 'brand-new-id')).toBe(false);
+  });
+
+  it('returns true when id already exists', () => {
+    const entries = parseBacklog(
+      writeTempBacklog([
+        '## Ready',
+        '',
+        '### `existing-entry`',
+        '',
+        '```yaml',
+        'id: existing-entry',
+        'tier: T1',
+        'status: ready',
+        'blocks: []',
+        'role: programmer',
+        '```',
+        '',
+        'Some description.',
+      ].join('\n')),
+    );
+    expect(hasDuplicateId(entries, 'existing-entry')).toBe(true);
+  });
+});
+
+// ── round-trip integration ────────────────────────────────────────────────
+
+describe('round-trip through parseBacklog', () => {
+  it('generated entry is parseable and heading id matches frontmatter id', () => {
+    const section = buildSection(BASE_OPTS);
+    const backlogText = [
+      '## Ready',
+      '',
+      '### `seed-entry`',
+      '',
+      '```yaml',
+      'id: seed-entry',
+      'tier: T0',
+      'status: ready',
+      'blocks: []',
+      'role: programmer',
+      '```',
+      '',
+      'Seed.',
+    ].join('\n');
+    const updated = insertEntry(backlogText, section);
+    const path = writeTempBacklog(updated);
+
+    const entries = parseBacklog(path);
+    const entry = entries.find((e) => e.id === 'my-new-feature');
+    expect(entry).toBeDefined();
+
+    // Heading id must match frontmatter id
+    const fmIdMatch = entry!.rawFrontmatter.match(/^id:\s*(\S+)/m);
+    expect(fmIdMatch?.[1]).toBe(entry!.id);
+  });
+
+  it('refuses to insert a duplicate id (hasDuplicateId check)', () => {
+    const backlogText = [
+      '## Ready',
+      '',
+      '### `my-new-feature`',
+      '',
+      '```yaml',
+      'id: my-new-feature',
+      'tier: T1',
+      'status: ready',
+      'blocks: []',
+      'role: programmer',
+      '```',
+      '',
+      'Already exists.',
+    ].join('\n');
+    const path = writeTempBacklog(backlogText);
+    const entries = parseBacklog(path);
+    expect(hasDuplicateId(entries, 'my-new-feature')).toBe(true);
+  });
+
+  it('blocks field round-trips as an array', () => {
+    const section = buildSection({ ...BASE_OPTS, blocks: ['dep-x', 'dep-y'] });
+    const backlogText = '## Ready\n';
+    const updated = insertEntry(backlogText, section);
+    const path = writeTempBacklog(updated);
+
+    const entries = parseBacklog(path);
+    const entry = entries.find((e) => e.id === 'my-new-feature');
+    expect(entry?.blocks).toEqual(['dep-x', 'dep-y']);
+  });
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+const tmpFiles: string[] = [];
+
+function writeTempBacklog(content: string): string {
+  const path = join(tmpdir(), `test-backlog-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
+  writeFileSync(path, content, 'utf8');
+  tmpFiles.push(path);
+  return path;
+}
+
+// Cleanup after all tests
+import { afterAll } from 'vitest';
+afterAll(() => {
+  for (const f of tmpFiles) {
+    try { unlinkSync(f); } catch { /* ignore */ }
+  }
+});

--- a/tools/generators/backlog-entry/tests/generate.test.ts
+++ b/tools/generators/backlog-entry/tests/generate.test.ts
@@ -114,14 +114,25 @@ describe('insertEntry', () => {
     expect(result).toContain('\n\n---\n\n');
   });
 
-  it('preserves trailing ## section when present', () => {
-    const withTrailing = `${existingBacklog}\n\n## Completed\n\n### \`old-entry\`\n\nDone.\n`;
+  it('inserts before a trailing ## section that has no ### entries', () => {
+    // When a ## heading has no ### entries inside it (prose-only section),
+    // the new entry lands before it rather than after.
+    const withProseTail = `${existingBacklog}\n\n## Audit notes\n\nSome trailing prose.\n`;
     const section = buildSection(BASE_OPTS);
-    const result = insertEntry(withTrailing, section);
-    // New entry should appear before ## Completed
+    const result = insertEntry(withProseTail, section);
     const newIdx = result.indexOf('### `my-new-feature`');
-    const completedIdx = result.indexOf('## Completed');
-    expect(newIdx).toBeLessThan(completedIdx);
+    const auditIdx = result.indexOf('## Audit notes');
+    expect(newIdx).toBeLessThan(auditIdx);
+  });
+
+  it('appends after the last ### entry even when a ## section with entries follows', () => {
+    // New entries always append after the last ### regardless of ## grouping.
+    const withSection = `${existingBacklog}\n\n## Completed\n\n### \`done-entry\`\n\n\`\`\`yaml\nid: done-entry\ntier: T0\nstatus: shipped\nblocks: []\nrole: programmer\n\`\`\`\n\nDone.\n`;
+    const section = buildSection(BASE_OPTS);
+    const result = insertEntry(withSection, section);
+    const newIdx = result.indexOf('### `my-new-feature`');
+    const doneIdx = result.indexOf('### `done-entry`');
+    expect(newIdx).toBeGreaterThan(doneIdx);
   });
 
   it('appends correctly to text with no existing entries', () => {

--- a/tools/generators/backlog-entry/tests/generate.test.ts
+++ b/tools/generators/backlog-entry/tests/generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -124,9 +124,9 @@ describe('insertEntry', () => {
     expect(newIdx).toBeLessThan(completedIdx);
   });
 
-  it('appends correctly to empty text', () => {
+  it('appends correctly to text with no existing entries', () => {
     const section = buildSection(BASE_OPTS);
-    const result = insertEntry('', section);
+    const result = insertEntry('## Ready\n', section);
     expect(result).toContain('### `my-new-feature`');
   });
 });
@@ -136,42 +136,14 @@ describe('insertEntry', () => {
 describe('hasDuplicateId', () => {
   it('returns false when id is not present', () => {
     const entries = parseBacklog(
-      writeTempBacklog([
-        '## Ready',
-        '',
-        '### `existing-entry`',
-        '',
-        '```yaml',
-        'id: existing-entry',
-        'tier: T1',
-        'status: ready',
-        'blocks: []',
-        'role: programmer',
-        '```',
-        '',
-        'Some description.',
-      ].join('\n')),
+      writeTempBacklog(minimalBacklog('existing-entry')),
     );
     expect(hasDuplicateId(entries, 'brand-new-id')).toBe(false);
   });
 
   it('returns true when id already exists', () => {
     const entries = parseBacklog(
-      writeTempBacklog([
-        '## Ready',
-        '',
-        '### `existing-entry`',
-        '',
-        '```yaml',
-        'id: existing-entry',
-        'tier: T1',
-        'status: ready',
-        'blocks: []',
-        'role: programmer',
-        '```',
-        '',
-        'Some description.',
-      ].join('\n')),
+      writeTempBacklog(minimalBacklog('existing-entry')),
     );
     expect(hasDuplicateId(entries, 'existing-entry')).toBe(true);
   });
@@ -182,21 +154,7 @@ describe('hasDuplicateId', () => {
 describe('round-trip through parseBacklog', () => {
   it('generated entry is parseable and heading id matches frontmatter id', () => {
     const section = buildSection(BASE_OPTS);
-    const backlogText = [
-      '## Ready',
-      '',
-      '### `seed-entry`',
-      '',
-      '```yaml',
-      'id: seed-entry',
-      'tier: T0',
-      'status: ready',
-      'blocks: []',
-      'role: programmer',
-      '```',
-      '',
-      'Seed.',
-    ].join('\n');
+    const backlogText = minimalBacklog('seed-entry');
     const updated = insertEntry(backlogText, section);
     const path = writeTempBacklog(updated);
 
@@ -204,41 +162,34 @@ describe('round-trip through parseBacklog', () => {
     const entry = entries.find((e) => e.id === 'my-new-feature');
     expect(entry).toBeDefined();
 
-    // Heading id must match frontmatter id
     const fmIdMatch = entry!.rawFrontmatter.match(/^id:\s*(\S+)/m);
     expect(fmIdMatch?.[1]).toBe(entry!.id);
   });
 
-  it('refuses to insert a duplicate id (hasDuplicateId check)', () => {
-    const backlogText = [
-      '## Ready',
-      '',
-      '### `my-new-feature`',
-      '',
-      '```yaml',
-      'id: my-new-feature',
-      'tier: T1',
-      'status: ready',
-      'blocks: []',
-      'role: programmer',
-      '```',
-      '',
-      'Already exists.',
-    ].join('\n');
-    const path = writeTempBacklog(backlogText);
+  it('refuses to insert a duplicate id — hasDuplicateId returns true', () => {
+    const path = writeTempBacklog(minimalBacklog('my-new-feature'));
     const entries = parseBacklog(path);
     expect(hasDuplicateId(entries, 'my-new-feature')).toBe(true);
   });
 
   it('blocks field round-trips as an array', () => {
     const section = buildSection({ ...BASE_OPTS, blocks: ['dep-x', 'dep-y'] });
-    const backlogText = '## Ready\n';
-    const updated = insertEntry(backlogText, section);
+    const updated = insertEntry(minimalBacklog('seed-entry'), section);
     const path = writeTempBacklog(updated);
 
     const entries = parseBacklog(path);
     const entry = entries.find((e) => e.id === 'my-new-feature');
     expect(entry?.blocks).toEqual(['dep-x', 'dep-y']);
+  });
+
+  it('empty blocks field round-trips as empty array', () => {
+    const section = buildSection({ ...BASE_OPTS, blocks: [] });
+    const updated = insertEntry(minimalBacklog('seed-entry'), section);
+    const path = writeTempBacklog(updated);
+
+    const entries = parseBacklog(path);
+    const entry = entries.find((e) => e.id === 'my-new-feature');
+    expect(entry?.blocks).toEqual([]);
   });
 });
 
@@ -247,14 +198,33 @@ describe('round-trip through parseBacklog', () => {
 const tmpFiles: string[] = [];
 
 function writeTempBacklog(content: string): string {
-  const path = join(tmpdir(), `test-backlog-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
+  const path = join(
+    tmpdir(),
+    `test-backlog-${Date.now()}-${Math.random().toString(36).slice(2)}.md`,
+  );
   writeFileSync(path, content, 'utf8');
   tmpFiles.push(path);
   return path;
 }
 
-// Cleanup after all tests
-import { afterAll } from 'vitest';
+function minimalBacklog(id: string): string {
+  return [
+    '## Ready',
+    '',
+    `### \`${id}\``,
+    '',
+    '```yaml',
+    `id: ${id}`,
+    'tier: T1',
+    'status: ready',
+    'blocks: []',
+    'role: programmer',
+    '```',
+    '',
+    'Description.',
+  ].join('\n');
+}
+
 afterAll(() => {
   for (const f of tmpFiles) {
     try { unlinkSync(f); } catch { /* ignore */ }

--- a/tools/generators/backlog-entry/vitest.config.ts
+++ b/tools/generators/backlog-entry/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    root: here,
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `nx-generator-backlog-entry`
Tier: `T3`  •  Driver: `claude-code-headless`
Workflow: `swarm-nx-generator-backlog-entry-1777840494368`

## Entry context

Interactive scaffold for `docs/swarm-backlog.md` entries. Prompts
for id, tier, status, role (picker over RoleSchema), file scope,
blocks, references_finding/spec/design. Emits a properly-shaped
section into the file at the right insertion point with heading id
matching frontmatter id (today's PR #200 footgun).

Validates against `parseBacklog` before writing — refuses to add
malformed entries.

Steps:
1. CLI wrapper using commander or similar.
2. Use jsonc-eslint-parser or yaml lib to emit the frontmatter.
3. Round-trip through `parseBacklog` to validate.
4. Insert at end-of-file before any final prose paragraph.

**Acceptance:**
- [ ] Generator emits a valid entry parseable by parseBacklog
- [ ] Heading id matches frontmatter id (verified post-write)
- [ ] Refuses to write a duplicate id (idempotent + safe)
- [ ] Tab-completes role choices from RoleSchema


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-nx-generator-backlog-entry-1777840494368`
Branch: `swarm/swarm-nx-generator-backlog-entry-1777840494368`
Head: `fb7aa4f4`
Diff: `6 files changed, 558 insertions(+), 10 deletions(-)`
Commits: 3 (+ auto-committed uncommitted state)