### PR TITLE
feat(router): agent-router architecture — TS substrate + auto-flipper

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -230,10 +230,22 @@ function writeWorktreeClaudeSettings(worktreePath: string): void {
   const claudeDir = join(worktreePath, '.claude');
   mkdirSync(claudeDir, { recursive: true });
   const settingsPath = join(claudeDir, 'settings.json');
-  // The hook command must produce a JSON decision the Claude Code hook
-  // protocol recognizes. chitin-kernel's `gate evaluate --hook-stdin`
-  // mode reads the hook payload from stdin, normalizes the tool call,
-  // calls gov.Gate.Evaluate, and prints {decision} on stdout.
+  // The hook command points at the chitin-router-hook wrapper, which
+  // (a) calls chitin-kernel for the deterministic verdict, then
+  // (b) runs heuristic plugins (blast-radius, floundering, drift),
+  // (c) optionally consults an advisor LLM via `claude -p`,
+  // (d) returns a composed allow/deny decision with optional nudge.
+  //
+  // The router is policy-controlled (chitin.yaml `router:` section)
+  // — when policy.enabled=false the wrapper is a transparent
+  // pass-through to the kernel, identical to direct kernel-hook
+  // behavior.
+  //
+  // Hardcoded absolute path so the hook works from worktrees
+  // without relying on PATH propagation. The bin script itself
+  // resolves the TS module relative to its location.
+  const routerHookBin =
+    process.env.CHITIN_ROUTER_HOOK_BIN ?? '/home/red/workspace/chitin/bin/chitin-router-hook';
   const settings = {
     hooks: {
       PreToolUse: [
@@ -242,7 +254,7 @@ function writeWorktreeClaudeSettings(worktreePath: string): void {
           hooks: [
             {
               type: 'command' as const,
-              command: 'chitin-kernel gate evaluate --hook-stdin --agent=claude-code',
+              command: `${routerHookBin} --agent=claude-code`,
             },
           ],
         },

--- a/apps/temporal-worker/src/router/advisor.ts
+++ b/apps/temporal-worker/src/router/advisor.ts
@@ -1,0 +1,184 @@
+// Advisor primitive — wraps `claude -p` (subscription-billed
+// headless mode) to produce structured advice for the router's
+// hook wrapper.
+//
+// Constraint: NO metered API calls. We use the Claude Code CLI's
+// `claude -p "prompt"` interface which authenticates against the
+// user's Claude Code subscription (Pro plan). Per the Anthropic
+// AUP clarification (2026-05-02), headless `claude -p` is
+// supported for automation.
+//
+// MVP: single advisor call per invocation. Chain depth is managed
+// by the hook wrapper, which can call this multiple times with
+// incrementing chain_depth.
+
+import { spawn } from 'node:child_process';
+import type {
+  AdvisorRequest,
+  AdvisorResponse,
+  HeuristicOutcome,
+} from './types.ts';
+
+/** Build the advisor prompt from a structured request. */
+export function buildAdvisorPrompt(request: AdvisorRequest): string {
+  const heuristic_summary = renderHeuristicSummary(request.heuristic_outcome);
+  return `You are a chitin ROUTER ADVISOR — called when a lower-tier agent's tool call triggered a heuristic threshold.
+
+Your job: decide whether the agent should proceed, with what nudge, OR whether the action should be blocked / escalated to a higher-tier human takeover.
+
+PROPOSED ACTION:
+\`\`\`json
+${JSON.stringify(request.proposed_action, null, 2)}
+\`\`\`
+
+HEURISTIC OUTCOME (which signals fired):
+${heuristic_summary}
+
+CALLER CONTEXT:
+- caller_tier: ${request.caller_tier ?? 'unknown'}
+- chain_depth: ${request.chain_depth} (max chain_depth before takeover: typically 3)
+
+QUESTION:
+${request.question}
+
+CONTEXT:
+${request.context}
+
+YOUR OUTPUT — emit EXACTLY this JSON line as your final output (no other text after it):
+
+\`\`\`
+<<<ROUTER_ADVISOR>>>{"nudge": "<short text shown to the agent>", "verdict": "continue"|"takeover", "escalate": <bool>}
+\`\`\`
+
+Where:
+- nudge: short specific text (1-3 sentences) the agent will see in its tool result. Focus on the SPECIFIC concern that fired the heuristic. Don't lecture; nudge.
+- verdict: "continue" lets the action proceed (with nudge attached); "takeover" blocks it and signals re-dispatch at higher tier.
+- escalate: true if you think a higher-tier advisor should be consulted INSTEAD of you (chain to T+1). Use sparingly — only for cases where you don't have the domain knowledge.
+
+Examples of good nudges:
+- "Consider running tests before this commit — the diff touches 12 files."
+- "This is a force-push on a branch with open PRs (#142, #143). Verify intent."
+- "You've tried this same edit 3 times with the same syntax error. The actual issue is X."
+
+Examples of bad nudges:
+- "Be careful." (too vague)
+- "Don't do this." (no reasoning)
+- A multi-paragraph explanation (too verbose for an inline tool message)
+`;
+}
+
+function renderHeuristicSummary(outcome: HeuristicOutcome): string {
+  const parts: string[] = [];
+  if (outcome.blast_radius) {
+    parts.push(
+      `- blast_radius: ${outcome.blast_radius.score} (${outcome.blast_radius.reason})${outcome.blast_radius.fired ? ' [FIRED]' : ''}`,
+    );
+  }
+  if (outcome.drift) {
+    parts.push(
+      `- drift: ${outcome.drift.score} (${outcome.drift.reason})${outcome.drift.fired ? ' [FIRED]' : ''}`,
+    );
+  }
+  if (outcome.floundering) {
+    parts.push(
+      `- floundering: ${outcome.floundering.score} (${outcome.floundering.reason})${outcome.floundering.fired ? ' [FIRED]' : ''}`,
+    );
+  }
+  return parts.length > 0 ? parts.join('\n') : '(no heuristic ran — caller invoked advisor directly)';
+}
+
+/** Pure: parse the advisor's structured output marker. */
+export function parseAdvisorOutput(stdout: string): AdvisorResponse | null {
+  const marker = /<<<ROUTER_ADVISOR>>>(\{[\s\S]*?\})/;
+  const matches = [...stdout.matchAll(new RegExp(marker, 'g'))];
+  if (matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  try {
+    const parsed = JSON.parse(last[1]) as Record<string, unknown>;
+    if (typeof parsed.nudge !== 'string' || typeof parsed.verdict !== 'string') {
+      return null;
+    }
+    if (parsed.verdict !== 'continue' && parsed.verdict !== 'takeover') {
+      return null;
+    }
+    return {
+      nudge: parsed.nudge,
+      verdict: parsed.verdict,
+      escalate: typeof parsed.escalate === 'boolean' ? parsed.escalate : false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the advisor. I/O: spawns `claude -p` with the prompt,
+ * waits for completion (bounded by timeout), parses the output
+ * marker. Returns null on any failure (timeout, parse error,
+ * binary missing) — caller decides fallback (typically: pass-
+ * through to deterministic kernel verdict).
+ */
+export async function callAdvisor(
+  request: AdvisorRequest,
+  opts: { timeoutMs?: number; binary?: string } = {},
+): Promise<AdvisorResponse | null> {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const binary = opts.binary ?? 'claude';
+  const prompt = buildAdvisorPrompt(request);
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    const finish = (val: AdvisorResponse | null): void => {
+      if (resolved) return;
+      resolved = true;
+      resolve(val);
+    };
+
+    const child = spawn(
+      binary,
+      ['-p', '--dangerously-skip-permissions', '--output-format', 'text'],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => (stdout += d.toString('utf8')));
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString('utf8')));
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      // Log the timeout to stderr; caller's logging happens upstream
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          level: 'warn',
+          component: 'router-advisor',
+          msg: 'advisor-timeout',
+          timeoutMs,
+        }),
+      );
+      finish(null);
+    }, timeoutMs);
+
+    child.on('error', () => {
+      clearTimeout(timer);
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          level: 'warn',
+          component: 'router-advisor',
+          msg: 'advisor-spawn-error',
+          stderr: stderr.slice(0, 500),
+        }),
+      );
+      finish(null);
+    });
+    child.on('close', () => {
+      clearTimeout(timer);
+      finish(parseAdvisorOutput(stdout));
+    });
+
+    // Send the prompt over stdin
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}

--- a/apps/temporal-worker/src/router/heuristics/blast-radius.ts
+++ b/apps/temporal-worker/src/router/heuristics/blast-radius.ts
@@ -1,0 +1,158 @@
+// Blast-radius heuristic: scores how big the consequences of an
+// action are. Pure function over the hook input.
+//
+// Four axes (0.0–1.0 each, weighted into a single score):
+//   - reversibility (inverted: 0=fully reversible, 1=irreversible)
+//   - scope         (0=single file/no-op, 1=mass change/whole repo)
+//   - visibility    (0=local, 1=public-internet effect like git push to public repo)
+//   - counterparties (0=self only, 1=external service/user impacted)
+//
+// Combined: irreversibility carries most weight (0.4); scope 0.25;
+// visibility 0.2; counterparties 0.15.
+
+import type { HeuristicScore, HookInput } from '../types.ts';
+
+interface Axes extends Record<string, number> {
+  reversibility: number;
+  scope: number;
+  visibility: number;
+  counterparties: number;
+}
+
+/** Pure: classify a hook input into axes. */
+export function scoreAxes(input: HookInput): { axes: Axes; reason: string } {
+  const command =
+    typeof input.tool_input.command === 'string' ? input.tool_input.command : '';
+  const filePath =
+    typeof input.tool_input.file_path === 'string'
+      ? input.tool_input.file_path
+      : typeof input.tool_input.notebook_path === 'string'
+        ? input.tool_input.notebook_path
+        : '';
+
+  // Read-shaped tools: maximally safe
+  const readShaped = new Set([
+    'Read', 'Glob', 'Grep', 'LS', 'TaskGet', 'TaskList', 'TaskOutput',
+    'ToolSearch', 'AskUserQuestion', 'EnterPlanMode', 'ExitPlanMode',
+  ]);
+  if (readShaped.has(input.tool_name)) {
+    return {
+      axes: { reversibility: 1.0, scope: 0.0, visibility: 0.0, counterparties: 0.0 },
+      reason: 'read-only-tool',
+    };
+  }
+
+  // Outbound network
+  const outboundNet = new Set(['WebFetch', 'WebSearch', 'PushNotification', 'RemoteTrigger']);
+  if (outboundNet.has(input.tool_name)) {
+    return {
+      axes: { reversibility: 0.7, scope: 0.0, visibility: 0.5, counterparties: 0.7 },
+      reason: 'outbound-network',
+    };
+  }
+
+  // Local-file-write
+  if (['Edit', 'Write', 'NotebookEdit', 'TodoWrite'].includes(input.tool_name)) {
+    let scope = 0.2;
+    let reason = 'local-file-write';
+    if (/\/(chitin\.yaml|CLAUDE\.md|\.claude\/)/.test(filePath)) {
+      scope = 0.8;
+      reason = 'governance-config-write';
+    } else if (/\/(node_modules|\.git|dist|build)\//.test(filePath)) {
+      scope = 0.9;
+      reason = 'generated-or-vcs-write';
+    }
+    return {
+      axes: { reversibility: 0.6, scope, visibility: 0.0, counterparties: 0.0 },
+      reason,
+    };
+  }
+
+  // Bash: shape by command pattern
+  if (input.tool_name === 'Bash') {
+    if (/\brm\s+(-[rfRF]+\s+|--recursive\s+)/.test(command)) {
+      return {
+        axes: { reversibility: 0.0, scope: 1.0, visibility: 0.0, counterparties: 0.0 },
+        reason: 'recursive-delete',
+      };
+    }
+    if (/\bgit\s+push\s+(--force|-f)\b/.test(command)) {
+      return {
+        axes: { reversibility: 0.0, scope: 0.5, visibility: 0.9, counterparties: 0.7 },
+        reason: 'force-push',
+      };
+    }
+    if (/\bgit\s+reset\s+--hard\b/.test(command)) {
+      return {
+        axes: { reversibility: 0.0, scope: 0.4, visibility: 0.0, counterparties: 0.0 },
+        reason: 'hard-reset',
+      };
+    }
+    if (/\bgit\s+push\b/.test(command)) {
+      return {
+        axes: { reversibility: 0.2, scope: 0.4, visibility: 0.7, counterparties: 0.6 },
+        reason: 'git-push',
+      };
+    }
+    if (/\bgh\s+pr\s+(create|merge)\b|\bgh\s+issue\s+close\b/.test(command)) {
+      return {
+        axes: { reversibility: 0.4, scope: 0.3, visibility: 0.8, counterparties: 0.8 },
+        reason: 'github-state-change',
+      };
+    }
+    if (/\b(npm|pnpm)\s+publish\b/.test(command)) {
+      return {
+        axes: { reversibility: 0.0, scope: 0.5, visibility: 1.0, counterparties: 1.0 },
+        reason: 'package-publish',
+      };
+    }
+    if (/\b(curl|wget)\b/.test(command)) {
+      return {
+        axes: { reversibility: 0.7, scope: 0.0, visibility: 0.3, counterparties: 0.5 },
+        reason: 'network-out',
+      };
+    }
+    return {
+      axes: { reversibility: 0.5, scope: 0.3, visibility: 0.0, counterparties: 0.0 },
+      reason: 'generic-shell-exec',
+    };
+  }
+
+  // Orchestration / scheduling — typically local, reversible
+  const orchestration = new Set([
+    'Task', 'Agent', 'Skill', 'TaskCreate', 'TaskUpdate', 'TaskStop',
+    'CronCreate', 'CronDelete', 'CronList', 'ScheduleWakeup', 'Monitor',
+    'EnterWorktree', 'ExitWorktree',
+  ]);
+  if (orchestration.has(input.tool_name)) {
+    return {
+      axes: { reversibility: 0.5, scope: 0.3, visibility: 0.0, counterparties: 0.0 },
+      reason: 'orchestration-shape',
+    };
+  }
+
+  // Unknown tool — moderate caution
+  return {
+    axes: { reversibility: 0.4, scope: 0.4, visibility: 0.0, counterparties: 0.0 },
+    reason: `unknown-tool:${input.tool_name}`,
+  };
+}
+
+/**
+ * Pure: compute the blast-radius score for a hook input.
+ * Threshold comparison happens at the caller.
+ */
+export function scoreBlastRadius(input: HookInput, threshold = 0.6): HeuristicScore {
+  const { axes, reason } = scoreAxes(input);
+  const score =
+    (1 - axes.reversibility) * 0.4 +
+    axes.scope * 0.25 +
+    axes.visibility * 0.2 +
+    axes.counterparties * 0.15;
+  return {
+    score: Number(score.toFixed(3)),
+    fired: score >= threshold,
+    reason,
+    axis: axes,
+  };
+}

--- a/apps/temporal-worker/src/router/heuristics/floundering.ts
+++ b/apps/temporal-worker/src/router/heuristics/floundering.ts
@@ -1,0 +1,164 @@
+// Floundering heuristic: detects when an agent is stuck in a loop,
+// stalled without progress, or burning budget without effect.
+//
+// Borrows AutoGen v0.4's termination-condition vocabulary
+// (MaxMessage / Stall / Timeout / TokenBudget) — the agent's
+// chain events are the substrate; this is pure analysis over
+// the chain.
+//
+// MVP signals:
+//   - looping: same tool_name + same target attempted N times in a row
+//   - stalled: no commits + no file_writes for max_stall_seconds
+//   - over-budget: deferred (needs cost-tracking primitive)
+//
+// Integration: takes chain events for ONE session as input;
+// returns score+reason. Pure function — caller fetches events.
+
+import type { HeuristicScore } from '../types.ts';
+
+/** Minimal chain event shape for floundering analysis. */
+export interface ChainEventLite {
+  ts: string;
+  event_type: string;
+  payload?: {
+    decision?: string;
+    rule_id?: string;
+    tool_name?: string;
+    action_target?: string;
+    action_type?: string;
+  };
+}
+
+export interface FlounderingThresholds {
+  max_loop_count: number;
+  max_stall_seconds: number;
+}
+
+/**
+ * Pure: detect a tool-call loop. "Same tool_name with same target,
+ * N times in a row, in the most recent events" → loop.
+ */
+function detectLoop(
+  events: ChainEventLite[],
+  maxLoopCount: number,
+): { detected: boolean; reason: string } {
+  if (events.length < maxLoopCount) {
+    return { detected: false, reason: '' };
+  }
+  // Loop = same tool_name AND same NON-EMPTY action_target N times in
+  // a row. Requiring a non-empty target avoids false positives when
+  // the agent makes multiple distinct calls of the same tool that
+  // happen to lack a target field (e.g., shell commands without
+  // target normalization).
+  const recent = events
+    .filter(
+      (e) =>
+        e.event_type === 'decision' &&
+        e.payload?.tool_name &&
+        typeof e.payload?.action_target === 'string' &&
+        e.payload.action_target.length > 0,
+    )
+    .slice(-maxLoopCount);
+  if (recent.length < maxLoopCount) {
+    return { detected: false, reason: '' };
+  }
+  const sig = (e: ChainEventLite): string =>
+    `${e.payload?.tool_name ?? ''}|${e.payload?.action_target ?? ''}`;
+  const firstSig = sig(recent[0]);
+  const allSame = recent.every((e) => sig(e) === firstSig);
+  if (allSame) {
+    return {
+      detected: true,
+      reason: `looping-tool-call:${firstSig.slice(0, 80)}-x${maxLoopCount}`,
+    };
+  }
+  return { detected: false, reason: '' };
+}
+
+/**
+ * Pure: detect a stall — no file-write decisions in the last
+ * maxStallSeconds wall-clock window.
+ */
+function detectStall(
+  events: ChainEventLite[],
+  maxStallSeconds: number,
+  now: Date,
+): { detected: boolean; reason: string } {
+  const writeEvents = events.filter(
+    (e) =>
+      e.event_type === 'decision' &&
+      e.payload?.decision === 'allow' &&
+      (e.payload?.action_type === 'file.write' ||
+        e.payload?.action_type === 'git.commit' ||
+        e.payload?.action_type === 'git.push'),
+  );
+  if (writeEvents.length === 0) {
+    // No writes ever — only flag stall if the session has been
+    // going long enough to warrant concern
+    if (events.length === 0) return { detected: false, reason: '' };
+    const firstTs = new Date(events[0].ts);
+    const elapsed = (now.getTime() - firstTs.getTime()) / 1000;
+    if (elapsed > maxStallSeconds) {
+      return {
+        detected: true,
+        reason: `no-writes-in-${Math.round(elapsed)}s`,
+      };
+    }
+    return { detected: false, reason: '' };
+  }
+  const lastWrite = new Date(writeEvents[writeEvents.length - 1].ts);
+  const elapsed = (now.getTime() - lastWrite.getTime()) / 1000;
+  if (elapsed > maxStallSeconds) {
+    return {
+      detected: true,
+      reason: `no-writes-since-${Math.round(elapsed)}s-ago`,
+    };
+  }
+  return { detected: false, reason: '' };
+}
+
+/**
+ * Pure: detect cascading permission denials — agent keeps trying
+ * blocked actions; sign of confusion or floundering.
+ */
+function detectDenialCascade(
+  events: ChainEventLite[],
+): { detected: boolean; reason: string } {
+  // Last 5 decisions: 4+ denials = cascade
+  const recent = events
+    .filter((e) => e.event_type === 'decision')
+    .slice(-5);
+  if (recent.length < 5) return { detected: false, reason: '' };
+  const denials = recent.filter((e) => e.payload?.decision === 'deny').length;
+  if (denials >= 4) {
+    return {
+      detected: true,
+      reason: `denial-cascade:${denials}-of-last-5`,
+    };
+  }
+  return { detected: false, reason: '' };
+}
+
+/**
+ * Pure: combined floundering detector. Returns the FIRST signal
+ * that fires (priority: loop > stall > denial-cascade).
+ */
+export function detectFloundering(
+  events: ChainEventLite[],
+  thresholds: FlounderingThresholds,
+  now: Date = new Date(),
+): HeuristicScore {
+  const loop = detectLoop(events, thresholds.max_loop_count);
+  if (loop.detected) {
+    return { score: 1.0, fired: true, reason: loop.reason };
+  }
+  const stall = detectStall(events, thresholds.max_stall_seconds, now);
+  if (stall.detected) {
+    return { score: 0.85, fired: true, reason: stall.reason };
+  }
+  const cascade = detectDenialCascade(events);
+  if (cascade.detected) {
+    return { score: 0.9, fired: true, reason: cascade.reason };
+  }
+  return { score: 0.0, fired: false, reason: 'no-signals' };
+}

--- a/apps/temporal-worker/src/router/hook-wrapper.ts
+++ b/apps/temporal-worker/src/router/hook-wrapper.ts
@@ -1,0 +1,308 @@
+// Router hook wrapper — main entry point invoked by Claude Code's
+// PreToolUse hook (via the `chitin-router-hook` bin shim).
+//
+// Pipeline:
+//   stdin (Claude Code PreToolUse JSON)
+//     ↓
+//   step 1: kernel verdict (chitin-kernel gate evaluate --hook-stdin)
+//     ↓ if deny → return deny immediately
+//   step 2: heuristics (blast-radius + floundering)
+//     ↓ if none fired → return kernel verdict (allow)
+//   step 3: call advisor with structured request
+//     ↓ if advisor signals escalate → call next-tier advisor (chain)
+//     ↓ chain bounded by policy.advisor.chain.max_depth
+//   step 4: compose final response — kernel verdict + advisor nudge
+//     ↓
+//   stdout (Claude Code hook response: { decision, message })
+//
+// Constraints:
+//   - kernel stays deterministic (this wrapper is the LLM-mediated layer)
+//   - all advisor calls go through `claude -p` (sub-billed, no API)
+//   - if anything fails (kernel binary missing, advisor times out),
+//     we FAIL OPEN to the kernel verdict — never harden a fallback
+//     deny that could brick the agent
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { callAdvisor } from './advisor.ts';
+import { scoreBlastRadius } from './heuristics/blast-radius.ts';
+import { detectFloundering, type ChainEventLite } from './heuristics/floundering.ts';
+import { loadRouterPolicy } from './policy-loader.ts';
+import { appendSharedMemory, readSharedMemory } from './shared-memory.ts';
+import type {
+  HeuristicOutcome,
+  HookInput,
+  HookOutput,
+  RouterPolicy,
+} from './types.ts';
+
+/** Read all of stdin as a string. */
+function readStdin(): string {
+  const buf = Buffer.alloc(65536);
+  let total = '';
+  let bytesRead = 0;
+  try {
+    while ((bytesRead = readSync(0, buf, 0, buf.length, null)) > 0) {
+      total += buf.subarray(0, bytesRead).toString('utf8');
+    }
+  } catch {
+    // EAGAIN on a non-blocking fd or EOF — ignore
+  }
+  return total;
+}
+
+/** Pure: Claude Code allow/deny decision protocol. */
+function emitHookResponse(out: HookOutput): void {
+  // Claude Code hook protocol: print JSON on stdout for "advanced"
+  // shape; or exit 0 for allow (silent), exit non-zero for deny.
+  // We use the JSON shape so we can attach a message.
+  console.log(JSON.stringify(out));
+  process.exit(0);
+}
+
+/** Call the kernel hook (deterministic verdict). Returns the parsed
+ *  hook output OR null if the kernel binary isn't available. */
+function callKernel(payload: string, agent: string): HookOutput | null {
+  const result = spawnSync(
+    'chitin-kernel',
+    ['gate', 'evaluate', '--hook-stdin', `--agent=${agent}`],
+    {
+      input: payload,
+      encoding: 'utf8',
+      timeout: 5000,
+    },
+  );
+  if (result.error || result.status === null) {
+    // Binary missing or hung — fail open (allow); operator sees
+    // the warning in stderr.
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        component: 'router-hook',
+        msg: 'kernel-call-failed',
+        error: result.error?.message,
+        status: result.status,
+      }),
+    );
+    return null;
+  }
+  // Kernel exit 0 + empty stdout = silent allow; non-zero + JSON = deny
+  if (result.status === 0 && !result.stdout.trim()) {
+    return { decision: 'allow', source: 'kernel-allow' };
+  }
+  // Kernel emits JSON to stdout when it has something to say
+  try {
+    const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+    // Kernel's shape: { decision: { Allowed: bool, Mode: ..., Reason: ... } } or similar
+    // Map into hook output shape
+    if (typeof parsed.decision === 'object' && parsed.decision) {
+      const d = parsed.decision as Record<string, unknown>;
+      return {
+        decision: d.Allowed === true ? 'allow' : 'deny',
+        message: typeof d.Reason === 'string' ? d.Reason : undefined,
+        source: 'kernel',
+      };
+    }
+    // Fallback: top-level allow/deny
+    if (parsed.decision === 'allow' || parsed.decision === 'deny') {
+      return {
+        decision: parsed.decision,
+        message: typeof parsed.message === 'string' ? parsed.message : undefined,
+        source: 'kernel',
+      };
+    }
+  } catch {
+    // Kernel returned non-JSON (or note like "no_policy_found"); fail open
+  }
+  return { decision: 'allow', source: 'kernel-allow' };
+}
+
+/** Read recent chain events for the agent's session — input to floundering. */
+function readChainEvents(sessionId: string | undefined): ChainEventLite[] {
+  if (!sessionId) return [];
+  // Chain events live at ~/.chitin/events-<chain_id>.jsonl. The
+  // session_id maps to chain_id (1:1 today).
+  const path = join(homedir(), '.chitin', `events-${sessionId}.jsonl`);
+  if (!existsSync(path)) return [];
+  const events: ChainEventLite[] = [];
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line) as ChainEventLite);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return events;
+}
+
+/** Run heuristics per policy. */
+function runHeuristics(input: HookInput, policy: RouterPolicy): HeuristicOutcome {
+  const outcome: HeuristicOutcome = { any_fired: false };
+  if (policy.heuristics.blast_radius?.enabled) {
+    outcome.blast_radius = scoreBlastRadius(input, policy.heuristics.blast_radius.threshold);
+    if (outcome.blast_radius.fired) outcome.any_fired = true;
+  }
+  if (policy.heuristics.floundering?.enabled) {
+    const events = readChainEvents(input.session_id);
+    outcome.floundering = detectFloundering(events, {
+      max_loop_count: policy.heuristics.floundering.max_loop_count,
+      max_stall_seconds: policy.heuristics.floundering.max_stall_seconds,
+    });
+    if (outcome.floundering.fired) outcome.any_fired = true;
+  }
+  return outcome;
+}
+
+/** Should the advisor be invoked? Maps policy.advisor.when to outcome flags. */
+function shouldCallAdvisor(
+  outcome: HeuristicOutcome,
+  kernelDeny: boolean,
+  policy: RouterPolicy,
+): boolean {
+  if (!policy.advisor.enabled) return false;
+  for (const trigger of policy.advisor.when) {
+    if (trigger === 'blast_radius_above_threshold' && outcome.blast_radius?.fired) return true;
+    if (trigger === 'drift_detected' && outcome.drift?.fired) return true;
+    if (trigger === 'floundering_detected' && outcome.floundering?.fired) return true;
+    if (trigger === 'kernel_denied' && kernelDeny) return true;
+  }
+  return false;
+}
+
+/** Main entry — parse stdin, run pipeline, emit response. */
+export async function main(): Promise<void> {
+  // Parse args for --agent=X
+  let agent = 'claude-code';
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith('--agent=')) agent = arg.slice('--agent='.length);
+  }
+
+  const stdin = readStdin();
+  if (!stdin) {
+    // No payload — fail open (allow) so an empty hook call doesn't brick the agent
+    return emitHookResponse({ decision: 'allow', source: 'kernel-allow' });
+  }
+  let input: HookInput;
+  try {
+    input = JSON.parse(stdin) as HookInput;
+  } catch {
+    return emitHookResponse({ decision: 'allow', source: 'kernel-allow' });
+  }
+
+  const cwd = input.cwd ?? process.cwd();
+  const policy = loadRouterPolicy(cwd);
+
+  // Step 1: kernel verdict (deterministic)
+  const kernel = callKernel(stdin, agent) ?? { decision: 'allow' as const, source: 'kernel-allow' as const };
+
+  // If router is policy-disabled, return kernel verdict directly
+  if (!policy.enabled) {
+    return emitHookResponse(kernel);
+  }
+
+  // Step 2: heuristics
+  const outcome = runHeuristics(input, policy);
+
+  // If no heuristic fired AND kernel allowed → silent pass-through
+  if (!outcome.any_fired && kernel.decision === 'allow') {
+    return emitHookResponse(kernel);
+  }
+
+  // Step 3: advisor (if configured to fire)
+  const wantAdvisor = shouldCallAdvisor(outcome, kernel.decision === 'deny', policy);
+  if (!wantAdvisor) {
+    // Heuristic fired but advisor not configured for this trigger — log, pass through
+    if (outcome.any_fired) {
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          level: 'info',
+          component: 'router-hook',
+          msg: 'heuristic-fired-no-advisor',
+          outcome,
+        }),
+      );
+    }
+    return emitHookResponse(kernel);
+  }
+
+  const memory = readSharedMemory(input.session_id ?? 'unknown');
+  const advisorReq = {
+    question:
+      kernel.decision === 'deny'
+        ? `The kernel denied this action: ${kernel.message ?? '(no reason)'}. Should the agent be re-routed or is this denial correct?`
+        : `Heuristic flagged this action. Is the agent on track, or should it pause/escalate?`,
+    context: `Session: ${input.session_id ?? 'unknown'}. Memory entries: ${memory.entries.length}.`,
+    proposed_action: input,
+    heuristic_outcome: outcome,
+    chain_depth: 0,
+  };
+
+  const advice = await callAdvisor(advisorReq, { timeoutMs: 60_000 });
+
+  if (!advice) {
+    // Advisor failed — fall through to kernel verdict
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        component: 'router-hook',
+        msg: 'advisor-failed-falling-through-to-kernel',
+        kernel_decision: kernel.decision,
+      }),
+    );
+    return emitHookResponse(kernel);
+  }
+
+  // Persist the advice in shared memory so the agent's next turn
+  // (or post-completion analysis) can read it.
+  if (input.session_id) {
+    appendSharedMemory(input.session_id, {
+      source: 'router-advisor',
+      payload: { ...advice, heuristic_outcome: outcome },
+    });
+  }
+
+  // Step 4: compose. If advisor verdict=takeover → deny + nudge.
+  // Otherwise allow + nudge attached.
+  if (advice.verdict === 'takeover') {
+    return emitHookResponse({
+      decision: 'deny',
+      message: advice.nudge,
+      source: 'advisor-deny',
+    });
+  }
+  // continue with kernel decision; attach nudge as message
+  return emitHookResponse({
+    decision: kernel.decision,
+    message: advice.nudge + (kernel.message ? `\n\nKernel: ${kernel.message}` : ''),
+    source: 'advisor-allow',
+  });
+}
+
+// Run if invoked as the entrypoint
+import { fileURLToPath } from 'node:url';
+const isCli =
+  import.meta.url.startsWith('file:') &&
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+if (isCli) {
+  main().catch((err: unknown) => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        component: 'router-hook',
+        msg: 'fatal',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    // Fail open
+    console.log(JSON.stringify({ decision: 'allow', source: 'kernel-allow' }));
+    process.exit(0);
+  });
+}

--- a/apps/temporal-worker/src/router/policy-loader.ts
+++ b/apps/temporal-worker/src/router/policy-loader.ts
@@ -1,0 +1,147 @@
+// Reads the router policy from chitin.yaml. The policy file is the
+// operator-facing surface for the router — heuristic thresholds,
+// advisor triggers, chain depth, model selection.
+//
+// MVP: minimal YAML parsing of the `router:` section only. Falls
+// back to DEFAULT_ROUTER_POLICY if the section is missing OR
+// chitin.yaml is unreadable. Never fails open silently — the
+// caller always gets a usable policy.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { DEFAULT_ROUTER_POLICY, type RouterPolicy } from './types.ts';
+
+/**
+ * Locate chitin.yaml relative to the agent's cwd. The file lives
+ * at the repo root by convention (chitin/chitin.yaml). Walks up
+ * parents until found or filesystem root.
+ */
+function findChitinYaml(startCwd: string): string | null {
+  let dir = resolve(startCwd);
+  while (dir !== '/') {
+    const candidate = resolve(dir, 'chitin.yaml');
+    if (existsSync(candidate)) return candidate;
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** Pure: extract the `router:` section's text from a chitin.yaml body. */
+export function extractRouterSection(yaml: string): string | null {
+  const lines = yaml.split('\n');
+  const startIdx = lines.findIndex((l) => /^router:\s*$/.test(l));
+  if (startIdx < 0) return null;
+  const out: string[] = [lines[startIdx]];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    // End of section: a non-indented, non-empty line at column 0
+    if (line && !line.startsWith(' ') && !line.startsWith('\t') && !line.startsWith('#')) break;
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+/**
+ * Pure: parse the router section's YAML body into a RouterPolicy.
+ * MVP shape — handles the specific keys we declare in
+ * DEFAULT_ROUTER_POLICY. Unknown keys ignored. Type errors fall
+ * back to defaults so a malformed config doesn't brick the router.
+ */
+export function parseRouterSection(routerYaml: string): RouterPolicy {
+  // Lightweight key extraction. Each section parsed independently.
+  const policy: RouterPolicy = JSON.parse(JSON.stringify(DEFAULT_ROUTER_POLICY));
+  const lines = routerYaml.split('\n');
+
+  // Top-level enabled flag
+  const enabledMatch = lines.find((l) => /^\s+enabled:\s+(true|false)/.test(l));
+  if (enabledMatch) {
+    policy.enabled = /enabled:\s+true/.test(enabledMatch);
+  }
+
+  // heuristics.<name>.threshold / .enabled / .max_*
+  const setNum = (path: string[], val: number) => {
+    let cur: any = policy;
+    for (const p of path.slice(0, -1)) cur = cur?.[p];
+    if (cur) cur[path[path.length - 1]] = val;
+  };
+  const setBool = (path: string[], val: boolean) => {
+    let cur: any = policy;
+    for (const p of path.slice(0, -1)) cur = cur?.[p];
+    if (cur) cur[path[path.length - 1]] = val;
+  };
+
+  // Match "      <key>: <value>" inside specific sections
+  let section = '';
+  let subsection = '';
+  for (const rawLine of lines) {
+    if (/^\s{2}\w/.test(rawLine)) {
+      section = rawLine.trim().replace(/:\s*$/, '');
+      subsection = '';
+      continue;
+    }
+    if (/^\s{4}\w/.test(rawLine) && /:\s*$/.test(rawLine)) {
+      subsection = rawLine.trim().replace(/:\s*$/, '');
+      continue;
+    }
+    // key: value
+    const m = rawLine.match(/^\s+([a-z_]+):\s+(.+)$/);
+    if (!m) continue;
+    const key = m[1];
+    const value = m[2].trim();
+
+    if (section === 'heuristics' && subsection) {
+      if (key === 'enabled') {
+        setBool(['heuristics', subsection, 'enabled'], value === 'true');
+      } else if (key === 'threshold' || key === 'max_loop_count' || key === 'max_stall_seconds') {
+        const n = Number(value);
+        if (!Number.isNaN(n)) setNum(['heuristics', subsection, key], n);
+      }
+    } else if (section === 'advisor') {
+      if (key === 'enabled') {
+        policy.advisor.enabled = value === 'true';
+      } else if (key === 'model') {
+        policy.advisor.model = value.replace(/^["']|["']$/g, '');
+      } else if (key === 'when' && value.startsWith('[')) {
+        const inside = value.slice(1, -1);
+        policy.advisor.when = inside
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean) as RouterPolicy['advisor']['when'];
+      } else if (subsection === 'chain') {
+        if (key === 'max_depth') {
+          const n = Number(value);
+          if (!Number.isNaN(n)) policy.advisor.chain.max_depth = n;
+        } else if (key === 'tier_steps' && value.startsWith('[')) {
+          const inside = value.slice(1, -1);
+          policy.advisor.chain.tier_steps = inside
+            .split(',')
+            .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+            .filter(Boolean);
+        }
+      }
+    }
+  }
+
+  return policy;
+}
+
+/**
+ * I/O wrapper: locate chitin.yaml from a starting cwd, parse the
+ * router section if present, return policy. Falls back to default
+ * on any failure.
+ */
+export function loadRouterPolicy(cwd: string): RouterPolicy {
+  const path = findChitinYaml(cwd);
+  if (!path) return DEFAULT_ROUTER_POLICY;
+  let yaml: string;
+  try {
+    yaml = readFileSync(path, 'utf8');
+  } catch {
+    return DEFAULT_ROUTER_POLICY;
+  }
+  const section = extractRouterSection(yaml);
+  if (!section) return DEFAULT_ROUTER_POLICY;
+  return parseRouterSection(section);
+}

--- a/apps/temporal-worker/src/router/shared-memory.ts
+++ b/apps/temporal-worker/src/router/shared-memory.ts
@@ -1,0 +1,95 @@
+// Per-workflow shared-memory scratchpad — JSON file at
+// `~/.chitin/shared-memory/<workflow-id>.json`. The simplest possible
+// shape that lets the router write nudges into the workflow's
+// context for the agent's next turn to read.
+//
+// MVP shape — operator-grade but not production:
+//   - Single file per workflow_id (no concurrent writers)
+//   - Append-only via timestamped entries
+//   - Agent reads via `chitin shared-memory get <workflow-id>` (CLI)
+//   - Router writes via this module's writeNudge()
+//
+// Future (deferred): cross-workflow vector retrieval (Hindsight
+// pattern), schema-validated entries, concurrent-safe locking.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+const SHARED_MEMORY_ROOT = join(homedir(), '.chitin', 'shared-memory');
+
+export interface SharedMemoryEntry {
+  /** ISO-8601 timestamp of when this entry was written. */
+  ts: string;
+  /** Source of the entry — usually 'router-nudge' or 'router-takeover-decision' or 'agent-self-report'. */
+  source: string;
+  /** Free-form payload — typically `{ nudge: string, verdict: string, advisor_run_id: string }`. */
+  payload: Record<string, unknown>;
+}
+
+export interface SharedMemoryFile {
+  workflow_id: string;
+  entries: SharedMemoryEntry[];
+}
+
+function pathFor(workflowId: string): string {
+  // Sanitize workflow_id to prevent path traversal.
+  if (workflowId.includes('/') || workflowId.includes('..')) {
+    throw new Error(`shared-memory: invalid workflow_id ${JSON.stringify(workflowId)}`);
+  }
+  return join(SHARED_MEMORY_ROOT, `${workflowId}.json`);
+}
+
+/**
+ * Read the current shared-memory file for a workflow. Returns an
+ * empty file shape if none exists.
+ */
+export function readSharedMemory(workflowId: string): SharedMemoryFile {
+  const path = pathFor(workflowId);
+  if (!existsSync(path)) {
+    return { workflow_id: workflowId, entries: [] };
+  }
+  return JSON.parse(readFileSync(path, 'utf8')) as SharedMemoryFile;
+}
+
+/**
+ * Append an entry to the workflow's shared memory. Creates the
+ * file (and parent dir) if needed.
+ */
+export function appendSharedMemory(
+  workflowId: string,
+  entry: Omit<SharedMemoryEntry, 'ts'>,
+): void {
+  const path = pathFor(workflowId);
+  mkdirSync(dirname(path), { recursive: true });
+  const file = readSharedMemory(workflowId);
+  file.entries.push({ ts: new Date().toISOString(), ...entry });
+  writeFileSync(path, JSON.stringify(file, null, 2));
+}
+
+/**
+ * Convenience: write a router-nudge entry with the standard payload
+ * shape. Called by the dispatcher after an advisor call returns.
+ */
+export function writeNudge(
+  workflowId: string,
+  payload: { nudge: string; verdict: 'continue' | 'takeover'; advisor_run_id?: string; reason?: string },
+): void {
+  appendSharedMemory(workflowId, { source: 'router-nudge', payload });
+}
+
+/**
+ * Render shared memory as a markdown block for inclusion in the
+ * next dispatch's prompt. Returns empty string if no entries.
+ */
+export function renderForPrompt(workflowId: string): string {
+  const file = readSharedMemory(workflowId);
+  if (file.entries.length === 0) return '';
+  let out = '\n\n---\n\nROUTER SHARED MEMORY (prior nudges + decisions for this entry):\n\n';
+  for (const entry of file.entries) {
+    out += `[${entry.ts}] ${entry.source}\n`;
+    out += '```json\n' + JSON.stringify(entry.payload, null, 2) + '\n```\n\n';
+  }
+  out += '---\n';
+  return out;
+}

--- a/apps/temporal-worker/src/router/types.ts
+++ b/apps/temporal-worker/src/router/types.ts
@@ -1,0 +1,113 @@
+// Shared types for the router pipeline. The pipeline shape:
+//   stdin (Claude Code PreToolUse payload)
+//     → kernel hook (deterministic verdict)
+//     → heuristics (blast-radius, drift, floundering)
+//     → advisor (LLM nudge if heuristic fires)
+//     → stdout (composed verdict + advisor message)
+
+/** Inbound payload from Claude Code's PreToolUse hook protocol. */
+export interface HookInput {
+  hook_event_name: 'PreToolUse';
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  cwd?: string;
+  session_id?: string;
+}
+
+/** Outbound payload back to Claude Code. The `decision` field
+ *  controls execution; `message` is shown to the agent in its
+ *  next observation. */
+export interface HookOutput {
+  decision: 'allow' | 'deny';
+  message?: string;
+  /** Internal: which path produced this decision (kernel | heuristic | advisor). */
+  source?: 'kernel' | 'heuristic-deny' | 'advisor-allow' | 'advisor-deny' | 'kernel-allow';
+}
+
+/** Heuristic score — pure function over (action, session-context). */
+export interface HeuristicScore {
+  /** 0.0–1.0. Higher = more concerning. */
+  score: number;
+  /** Whether this heuristic fired (score >= configured threshold). */
+  fired: boolean;
+  /** Short-form reason for telemetry. */
+  reason: string;
+  /** Free-form per-axis breakdown for debugging. */
+  axis?: Record<string, number>;
+}
+
+/** Combined heuristic outcome — one entry per heuristic that ran. */
+export interface HeuristicOutcome {
+  blast_radius?: HeuristicScore;
+  drift?: HeuristicScore;
+  floundering?: HeuristicScore;
+  /** Aggregate: any heuristic fired? */
+  any_fired: boolean;
+}
+
+/** Advisor request payload. */
+export interface AdvisorRequest {
+  question: string;
+  context: string;
+  proposed_action: HookInput;
+  heuristic_outcome: HeuristicOutcome;
+  /** Tier of the calling agent (informs which advisor model is selected). */
+  caller_tier?: string;
+  /** Depth of the chain — used to bound recursion. */
+  chain_depth: number;
+}
+
+/** Advisor response payload. */
+export interface AdvisorResponse {
+  /** Free-form nudge text shown to the agent. */
+  nudge: string;
+  /** Verdict: continue lets the action through, takeover blocks + signals re-dispatch. */
+  verdict: 'continue' | 'takeover';
+  /** If true, the router should chain to the next-tier advisor. */
+  escalate: boolean;
+  /** Optional cost telemetry (tokens / dollars / wall_ms). */
+  cost?: { tokens?: number; usd?: number; wall_ms?: number };
+}
+
+/** Router policy — read from chitin.yaml's `router:` section. */
+export interface RouterPolicy {
+  enabled: boolean;
+  heuristics: {
+    blast_radius?: { enabled: boolean; threshold: number };
+    drift?: { enabled: boolean; threshold: number };
+    floundering?: {
+      enabled: boolean;
+      max_loop_count: number;
+      max_stall_seconds: number;
+    };
+  };
+  advisor: {
+    enabled: boolean;
+    /** Triggers — any matched fires the advisor. */
+    when: Array<
+      | 'blast_radius_above_threshold'
+      | 'drift_detected'
+      | 'floundering_detected'
+      | 'kernel_denied'
+    >;
+    chain: { max_depth: number; tier_steps: string[] };
+    /** Model id (e.g., 'claude-code-headless', 'gemini-cli', 'local-glm-flash'). */
+    model: string;
+  };
+}
+
+/** Default policy used when chitin.yaml omits the router section. */
+export const DEFAULT_ROUTER_POLICY: RouterPolicy = {
+  enabled: false, // off by default — operator opts in
+  heuristics: {
+    blast_radius: { enabled: true, threshold: 0.6 },
+    drift: { enabled: true, threshold: 0.5 },
+    floundering: { enabled: true, max_loop_count: 3, max_stall_seconds: 600 },
+  },
+  advisor: {
+    enabled: true,
+    when: ['blast_radius_above_threshold', 'floundering_detected'],
+    chain: { max_depth: 3, tier_steps: ['T2', 'T3', 'T4'] },
+    model: 'claude-code-headless',
+  },
+};

--- a/apps/temporal-worker/src/router/uncertainty-parser.ts
+++ b/apps/temporal-worker/src/router/uncertainty-parser.ts
@@ -1,0 +1,81 @@
+// Uncertainty marker parser — finds `<<<UNCERTAIN>>>{...json...}`
+// markers in agent stdout and returns the structured payload.
+//
+// The marker is the agent's self-report mechanism: when an agent
+// is genuinely unsure how to proceed, it emits this marker and
+// gracefully exits. The router parses, calls the advisor, writes
+// the nudge to shared memory, and re-dispatches the entry.
+//
+// Marker shape (the agent emits):
+//   <<<UNCERTAIN>>>{"question": "...", "context": "...", "blocker": "..."}
+//
+// Where:
+//   question — what the agent needs help with (one specific ask)
+//   context — what the agent already knows / has tried
+//   blocker — why it can't proceed without the nudge
+
+export interface UncertaintyMarker {
+  question: string;
+  context: string;
+  blocker?: string;
+}
+
+const MARKER_RE = /<<<UNCERTAIN>>>(\{[\s\S]*?\})/;
+
+/**
+ * Pure: extract the LAST uncertainty marker from agent stdout.
+ * Returns null if no marker is found OR if the JSON is malformed
+ * (malformed markers are logged at the caller; no exception thrown
+ * because a malformed marker shouldn't break dispatch).
+ */
+export function parseUncertaintyMarker(stdout: string): UncertaintyMarker | null {
+  if (!stdout) return null;
+  const matches = [...stdout.matchAll(new RegExp(MARKER_RE, 'g'))];
+  if (matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  try {
+    const parsed = JSON.parse(last[1]) as Record<string, unknown>;
+    if (typeof parsed.question !== 'string' || typeof parsed.context !== 'string') {
+      return null;
+    }
+    return {
+      question: parsed.question,
+      context: parsed.context,
+      blocker: typeof parsed.blocker === 'string' ? parsed.blocker : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Boilerplate prompt instructions for any role that should be
+ * uncertainty-marker-aware. Render into the role's prompt at the
+ * end of the workflow section. Tells the agent WHEN + HOW to emit
+ * the marker.
+ */
+export const UNCERTAINTY_MARKER_INSTRUCTIONS = `
+## Uncertainty escalation (router protocol)
+
+If you reach a point where you GENUINELY don't know how to proceed
+— not "this is hard" but "I cannot decide between two paths because
+I'm missing information / context / domain knowledge" — emit this
+marker and exit cleanly:
+
+\`\`\`
+<<<UNCERTAIN>>>{"question": "<one specific ask>", "context": "<what you already know + tried>", "blocker": "<why you can't proceed>"}
+\`\`\`
+
+Then exit with exit code 0. The router will call a higher-tier
+advisor with your question + context, write the advisor's
+response to shared memory, and re-dispatch you. On the re-dispatch
+you'll see the advisor's nudge in your prompt under "ROUTER SHARED
+MEMORY" — read it, then continue from where you left off.
+
+DO NOT emit this marker for routine difficulties (debugging,
+reading docs, trying multiple approaches). It's for genuine
+blockers where the next step requires judgment you don't have.
+
+DO NOT take any tool actions after emitting the marker — the
+router treats the marker as a graceful exit signal.
+`.trim();

--- a/apps/temporal-worker/test/router/heuristics.test.ts
+++ b/apps/temporal-worker/test/router/heuristics.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import { scoreBlastRadius } from '../../src/router/heuristics/blast-radius.ts';
+import {
+  detectFloundering,
+  type ChainEventLite,
+} from '../../src/router/heuristics/floundering.ts';
+import type { HookInput } from '../../src/router/types.ts';
+
+const baseInput: HookInput = {
+  hook_event_name: 'PreToolUse',
+  tool_name: 'Read',
+  tool_input: {},
+  cwd: '/tmp',
+};
+
+describe('scoreBlastRadius', () => {
+  it('scores read-only tools as 0', () => {
+    const score = scoreBlastRadius({ ...baseInput, tool_name: 'Read' });
+    expect(score.score).toBe(0);
+    expect(score.fired).toBe(false);
+    expect(score.reason).toBe('read-only-tool');
+  });
+
+  it('scores rm -rf as max (1.0 reversibility=0 + scope=1)', () => {
+    const score = scoreBlastRadius({
+      ...baseInput,
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /tmp/foo' },
+    });
+    // (1-0)*0.4 + 1.0*0.25 + 0*0.2 + 0*0.15 = 0.65
+    expect(score.score).toBeCloseTo(0.65, 2);
+    expect(score.fired).toBe(true);
+    expect(score.reason).toBe('recursive-delete');
+  });
+
+  it('scores force-push as high', () => {
+    const score = scoreBlastRadius({
+      ...baseInput,
+      tool_name: 'Bash',
+      tool_input: { command: 'git push --force origin main' },
+    });
+    // (1-0)*0.4 + 0.5*0.25 + 0.9*0.2 + 0.7*0.15 = 0.4 + 0.125 + 0.18 + 0.105 = 0.81
+    expect(score.score).toBeCloseTo(0.81, 2);
+    expect(score.fired).toBe(true);
+    expect(score.reason).toBe('force-push');
+  });
+
+  it('scores governance-config writes as elevated (reason flagged for telemetry; threshold-fired depends on threshold)', () => {
+    // Score = (1-0.6)*0.4 + 0.8*0.25 + 0 + 0 = 0.36 — below default 0.6 threshold.
+    // The kernel's `no-governance-self-modification` rule already DENIES these
+    // at the deterministic layer, so the heuristic doesn't need to fire.
+    // What matters is the REASON tag for telemetry / advisor context.
+    const score = scoreBlastRadius({
+      ...baseInput,
+      tool_name: 'Edit',
+      tool_input: { file_path: '/repo/chitin.yaml' },
+    });
+    expect(score.reason).toBe('governance-config-write');
+    expect(score.score).toBeGreaterThan(0.3);
+    // At a lower threshold (0.3), it WOULD fire — operator can opt-in
+    const lowThresh = scoreBlastRadius(
+      {
+        ...baseInput,
+        tool_name: 'Edit',
+        tool_input: { file_path: '/repo/chitin.yaml' },
+      },
+      0.3,
+    );
+    expect(lowThresh.fired).toBe(true);
+  });
+
+  it('scores npm publish as max blast', () => {
+    const score = scoreBlastRadius({
+      ...baseInput,
+      tool_name: 'Bash',
+      tool_input: { command: 'pnpm publish --access public' },
+    });
+    // (1-0)*0.4 + 0.5*0.25 + 1.0*0.2 + 1.0*0.15 = 0.4 + 0.125 + 0.2 + 0.15 = 0.875
+    expect(score.score).toBeCloseTo(0.875, 2);
+    expect(score.fired).toBe(true);
+    expect(score.reason).toBe('package-publish');
+  });
+
+  it('respects custom threshold', () => {
+    const lowThresh = scoreBlastRadius(
+      { ...baseInput, tool_name: 'Bash', tool_input: { command: 'echo hi' } },
+      0.1,
+    );
+    expect(lowThresh.fired).toBe(true); // generic-shell-exec scores 0.275 > 0.1
+    const highThresh = scoreBlastRadius(
+      { ...baseInput, tool_name: 'Bash', tool_input: { command: 'echo hi' } },
+      0.9,
+    );
+    expect(highThresh.fired).toBe(false);
+  });
+
+  it('handles unknown tools with moderate caution', () => {
+    const score = scoreBlastRadius({ ...baseInput, tool_name: 'TotallyMadeUp' });
+    expect(score.reason).toBe('unknown-tool:TotallyMadeUp');
+    expect(score.score).toBeGreaterThan(0);
+    expect(score.score).toBeLessThan(0.6);
+  });
+});
+
+describe('detectFloundering', () => {
+  const thresholds = { max_loop_count: 3, max_stall_seconds: 600 };
+
+  it('returns no-signals on empty events', () => {
+    const result = detectFloundering([], thresholds);
+    expect(result.fired).toBe(false);
+    expect(result.reason).toBe('no-signals');
+  });
+
+  it('detects looping tool calls (3 same-target in a row)', () => {
+    const event = (target: string): ChainEventLite => ({
+      ts: '2026-05-03T20:00:00Z',
+      event_type: 'decision',
+      payload: { tool_name: 'Bash', action_target: target, decision: 'allow' },
+    });
+    const result = detectFloundering(
+      [event('rm /tmp/x'), event('rm /tmp/x'), event('rm /tmp/x')],
+      thresholds,
+    );
+    expect(result.fired).toBe(true);
+    expect(result.score).toBe(1.0);
+    expect(result.reason).toMatch(/looping-tool-call/);
+  });
+
+  it('does not flag varying tool calls', () => {
+    const event = (target: string): ChainEventLite => ({
+      ts: '2026-05-03T20:00:00Z',
+      event_type: 'decision',
+      payload: { tool_name: 'Bash', action_target: target, decision: 'allow' },
+    });
+    // Pass an explicit `now` close to event ts so stall doesn't fire instead.
+    const result = detectFloundering(
+      [event('cmd a'), event('cmd b'), event('cmd c')],
+      thresholds,
+      new Date('2026-05-03T20:00:30Z'),
+    );
+    expect(result.fired).toBe(false);
+  });
+
+  it('detects stall (no writes in window)', () => {
+    const events: ChainEventLite[] = [
+      {
+        ts: '2026-05-03T20:00:00Z',
+        event_type: 'decision',
+        payload: { tool_name: 'Read', action_type: 'file.read', decision: 'allow' },
+      },
+    ];
+    // now is 700s after the only event; max_stall_seconds=600
+    const result = detectFloundering(events, thresholds, new Date('2026-05-03T20:11:40Z'));
+    expect(result.fired).toBe(true);
+    expect(result.reason).toMatch(/no-writes/);
+  });
+
+  it('detects denial cascade (4+ denials in last 5)', () => {
+    // Vary the action_target so loop detector doesn't fire first;
+    // we want denial-cascade to be the reported signal.
+    const denial = (target: string): ChainEventLite => ({
+      ts: '2026-05-03T20:00:00Z',
+      event_type: 'decision',
+      payload: { tool_name: 'Bash', action_target: target, decision: 'deny', rule_id: 'no-rm-recursive' },
+    });
+    const allow: ChainEventLite = {
+      ts: '2026-05-03T20:00:00Z',
+      event_type: 'decision',
+      payload: { tool_name: 'Read', action_target: '/tmp/x', decision: 'allow' },
+    };
+    const result = detectFloundering(
+      [allow, denial('cmd1'), denial('cmd2'), denial('cmd3'), denial('cmd4')],
+      thresholds,
+      new Date('2026-05-03T20:00:30Z'),
+    );
+    expect(result.fired).toBe(true);
+    expect(result.reason).toMatch(/denial-cascade/);
+  });
+
+  it('does not flag mostly-allowed sessions with varying targets', () => {
+    const allow = (target: string): ChainEventLite => ({
+      ts: '2026-05-03T20:00:00Z',
+      event_type: 'decision',
+      payload: { tool_name: 'Read', action_target: target, decision: 'allow' },
+    });
+    const result = detectFloundering(
+      [allow('a'), allow('b'), allow('c'), allow('d'), allow('e')],
+      thresholds,
+      new Date('2026-05-03T20:00:30Z'),
+    );
+    expect(result.fired).toBe(false);
+  });
+});

--- a/apps/temporal-worker/test/slice6.test.ts
+++ b/apps/temporal-worker/test/slice6.test.ts
@@ -138,7 +138,7 @@ describe('slice 6a — writeWorktreeClaudeSettings', () => {
     rmSync(scratch, { recursive: true, force: true });
   });
 
-  it('creates .claude/settings.json with a PreToolUse chitin-kernel hook', () => {
+  it('creates .claude/settings.json with a PreToolUse router-hook entrypoint', () => {
     writeWorktreeClaudeSettings(scratch);
     const settingsPath = join(scratch, '.claude/settings.json');
     expect(existsSync(settingsPath)).toBe(true);
@@ -147,9 +147,13 @@ describe('slice 6a — writeWorktreeClaudeSettings', () => {
     expect(Array.isArray(hooks)).toBe(true);
     expect(hooks.length).toBeGreaterThan(0);
     const cmd = hooks[0]?.hooks?.[0]?.command;
-    expect(cmd).toContain('chitin-kernel');
-    expect(cmd).toContain('gate evaluate');
-    expect(cmd).toContain('--hook-stdin');
+    // The hook command points at chitin-router-hook (which has a hot-path
+    // bypass that exec's chitin-kernel directly when the operator hasn't
+    // touched ~/.chitin/router-enabled). The command therefore contains
+    // chitin-router-hook in default install; older builds pointed at
+    // chitin-kernel directly. Either path is valid; assert on the
+    // structural shape (hook present + agent param) instead of binary name.
+    expect(cmd).toMatch(/chitin-(router-hook|kernel)/);
     expect(cmd).toContain('--agent=claude-code');
   });
 

--- a/bin/chitin-router-hook
+++ b/bin/chitin-router-hook
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# chitin-router-hook — Claude Code PreToolUse entrypoint.
+#
+# Tiny shim that runs the TS hook wrapper via tsx. The wrapper
+# does the work: kernel verdict → heuristics → advisor → response.
+#
+# Installed by Claude Code's `.claude/settings.json` PreToolUse
+# hook config (written by activity.ts writeWorktreeClaudeSettings
+# at worktree provision time).
+
+set -euo pipefail
+
+# HOT-PATH BYPASS: if the operator hasn't enabled the router, skip
+# the TS pipeline entirely and call the kernel directly. Saves the
+# ~500ms-1s pnpm-tsx startup overhead per tool call. Operator opts
+# in by touching the sentinel file:
+#
+#   touch ~/.chitin/router-enabled
+#
+# To disable:
+#
+#   rm ~/.chitin/router-enabled
+#
+# Long-term: heuristics + policy reading move into the Go kernel
+# (see backlog entry `router-heuristics-go-sdk`); the TS layer
+# stays the orchestration + advisor-call surface.
+
+ROUTER_SENTINEL="${CHITIN_ROUTER_SENTINEL:-$HOME/.chitin/router-enabled}"
+
+if [[ ! -e "$ROUTER_SENTINEL" ]]; then
+  # Fast path: forward stdin to chitin-kernel directly. Same shape
+  # as the pre-router hook config.
+  exec chitin-kernel gate evaluate --hook-stdin "$@"
+fi
+
+# Slow path: the router is enabled. Run the TS pipeline.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK_TS="$REPO_ROOT/apps/temporal-worker/src/router/hook-wrapper.ts"
+
+if [[ ! -f "$HOOK_TS" ]]; then
+  # Fail open — emit allow so an installation problem doesn't brick the agent
+  echo '{"decision":"allow","source":"kernel-allow"}'
+  echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"level\":\"error\",\"component\":\"chitin-router-hook\",\"msg\":\"hook-ts-not-found\",\"path\":\"$HOOK_TS\"}" >&2
+  exit 0
+fi
+
+cd "$REPO_ROOT"
+exec pnpm exec tsx "$HOOK_TS" "$@"

--- a/bin/chitin-router-hook
+++ b/bin/chitin-router-hook
@@ -28,22 +28,17 @@ set -euo pipefail
 ROUTER_SENTINEL="${CHITIN_ROUTER_SENTINEL:-$HOME/.chitin/router-enabled}"
 
 if [[ ! -e "$ROUTER_SENTINEL" ]]; then
-  # Fast path: forward stdin to chitin-kernel directly. Same shape
-  # as the pre-router hook config.
+  # Fast path: forward stdin to the deterministic kernel directly.
+  # Same shape as the pre-router hook config; ~3-10ms cold start.
   exec chitin-kernel gate evaluate --hook-stdin "$@"
 fi
 
-# Slow path: the router is enabled. Run the TS pipeline.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-HOOK_TS="$REPO_ROOT/apps/temporal-worker/src/router/hook-wrapper.ts"
-
-if [[ ! -f "$HOOK_TS" ]]; then
-  # Fail open — emit allow so an installation problem doesn't brick the agent
-  echo '{"decision":"allow","source":"kernel-allow"}'
-  echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"level\":\"error\",\"component\":\"chitin-router-hook\",\"msg\":\"hook-ts-not-found\",\"path\":\"$HOOK_TS\"}" >&2
-  exit 0
-fi
-
-cd "$REPO_ROOT"
-exec pnpm exec tsx "$HOOK_TS" "$@"
+# Router-enabled path: kernel binary's `router evaluate` subcommand
+# runs the SAME deterministic kernel + heuristics (in-process Go) +
+# advisor (subprocess to `claude -p`). ~26ms cold start when no
+# heuristic fires; +LLM latency when advisor is consulted.
+#
+# The TS substrate at apps/temporal-worker/src/router/ remains in
+# the repo as the design substrate; the Go path is the production
+# hot path going forward.
+exec chitin-kernel router evaluate --hook-stdin "$@"

--- a/chitin.yaml
+++ b/chitin.yaml
@@ -202,6 +202,19 @@ rules:
 #
 # Cold-start: ~26ms (Go binary). Most tool calls SKIP the advisor
 # (deterministic checks pass + no heuristic fires).
+# Router policy (added 2026-05-03).
+#
+# When the operator opts in (touch ~/.chitin/router-enabled), the
+# chitin-router-hook wrapper engages: kernel verdict → heuristics →
+# optional advisor consultation → composed response.
+#
+# To disable globally: rm ~/.chitin/router-enabled (instant; no
+# config edit needed). To disable selectively per-heuristic, set
+# .heuristics.<name>.enabled to false here.
+#
+# Cost shape: most tool calls SKIP the advisor (deterministic checks
+# pass + no heuristic fires). Advisor only fires when blast_radius
+# is above threshold OR floundering detected OR kernel denied.
 router:
   enabled: true
   heuristics:

--- a/docs/runbooks/chitin-router.md
+++ b/docs/runbooks/chitin-router.md
@@ -1,0 +1,161 @@
+# chitin-router runbook
+
+> The router wraps the kernel's `PreToolUse` hook with a heuristic
+> + advisor pipeline. When enabled, it scores each tool call for
+> blast radius / floundering / drift; if any heuristic fires, it
+> consults a higher-tier advisor (via `claude -p`) for a nudge or
+> takeover verdict.
+>
+> **Off by default** — operator opts in via a sentinel file. Hot
+> path stays fast (kernel only) until then.
+
+## What it does
+
+For each `PreToolUse` hook call from any chitin-governed agent:
+
+1. **Kernel verdict (deterministic)** — `chitin-kernel gate evaluate
+   --hook-stdin`. If the kernel denies, the router returns the deny
+   immediately.
+2. **Heuristics** — pure functions over the hook input + recent chain
+   events:
+   - `blast_radius` — scores actions on reversibility / scope /
+     visibility / counterparties (0.0–1.0; > threshold = fired)
+   - `floundering` — detects looping tool calls, stalled progress,
+     denial cascades over the agent's chain
+3. **Advisor (optional)** — if any heuristic fires AND the policy
+   triggers match, calls `claude -p` with a structured prompt
+   asking for a nudge + verdict (continue / takeover) + escalate
+   bool. The advisor's response is composed into the hook reply.
+4. **Compose** — kernel decision + advisor nudge → Claude Code
+   sees the nudge in the tool-call result and continues.
+
+Hot path performance: when the sentinel file is absent, the
+wrapper is a single `exec chitin-kernel` — adds ~0ms. When the
+sentinel is present, the TS pipeline runs (~500ms cold, but most
+tool calls don't fire heuristics so the advisor isn't invoked).
+
+## Install
+
+The router lives in the chitin repo — no separate install needed.
+Activity provisioning (`writeWorktreeClaudeSettings`) writes the
+hook config pointing at `chitin-router-hook` automatically.
+
+To **enable**:
+
+```bash
+mkdir -p ~/.chitin
+touch ~/.chitin/router-enabled
+```
+
+To **disable** (instant — no config edit needed):
+
+```bash
+rm ~/.chitin/router-enabled
+```
+
+## Verify
+
+Smoke a low-blast action (should pass-through to kernel):
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/tmp/x.txt"},"cwd":"'"$PWD"'","session_id":"smoke"}' \
+  | ~/workspace/chitin/bin/chitin-router-hook --agent=smoke
+# Expect: {"decision":"allow","source":"kernel-allow"}
+```
+
+Smoke a high-blast action (should fire blast_radius + try advisor):
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git push --force origin main"},"cwd":"'"$PWD"'","session_id":"smoke"}' \
+  | ~/workspace/chitin/bin/chitin-router-hook --agent=smoke
+# Expect: {"decision":"allow|deny","message":"<nudge>","source":"advisor-allow|advisor-deny"}
+# (Takes ~30-60s if advisor is reachable.)
+```
+
+If the advisor errors / times out, the wrapper falls through to
+the kernel verdict (fail-open) — the agent isn't blocked.
+
+## Configure
+
+Policy lives in `chitin.yaml` under the `router:` section:
+
+```yaml
+router:
+  enabled: true                     # toggle the policy layer
+  heuristics:
+    blast_radius:
+      enabled: true
+      threshold: 0.6                # 0.0–1.0; lower = more sensitive
+    floundering:
+      enabled: true
+      max_loop_count: 3             # same tool+target N times → fire
+      max_stall_seconds: 600        # no writes in N seconds → fire
+  advisor:
+    enabled: true
+    when:                           # which signals trigger the advisor
+      - blast_radius_above_threshold
+      - floundering_detected
+      - kernel_denied               # advise on every deny too
+    chain:
+      max_depth: 3                  # cap on advisor-chain depth
+      tier_steps: [T2, T3, T4]      # tier ladder for chained advice
+    model: claude-code-headless     # advisor model id
+```
+
+Most edits don't require restarting anything — the TS hook reads
+`chitin.yaml` per-call (with a small cache, but cache is per-
+process and the hook is per-process).
+
+## Operate
+
+Live tail of router decisions (the slow path emits structured JSON
+to stderr; journald captures it for the systemd-driven hooks):
+
+```bash
+journalctl --user -u chitin-worker -f | grep '"component":"router-'
+```
+
+Read the per-workflow shared memory (advisor nudges):
+
+```bash
+cat ~/.chitin/shared-memory/<workflow-id>.json | jq .
+```
+
+Disable a heuristic without touching policy YAML — set the env var
+override on the worker:
+
+```bash
+# (Future — not yet wired; today edit chitin.yaml.)
+```
+
+## Failure modes
+
+| Failure | Impact | Fix |
+|---|---|---|
+| `chitin-kernel` binary missing | Wrapper logs warn, falls open (allow). Agent unaffected. | Rebuild kernel; `chitin-kernel-redeploy.timer` should catch this. |
+| Advisor (`claude -p`) times out | Wrapper logs warn, returns kernel verdict only. Agent gets no nudge but isn't blocked. | Increase `--timeoutMs` in `advisor.ts` (default 60s); verify Claude Code auth. |
+| `chitin.yaml` unreadable / missing `router:` | Wrapper uses `DEFAULT_ROUTER_POLICY` (advisor disabled). | Add or fix the section. |
+| TS hook crashes | Wrapper catches, falls open (allow). Agent unaffected. | Check stderr; report bug. |
+
+## Why a sentinel file (not a config flag)
+
+Two reasons:
+1. **Instant disable** — `rm ~/.chitin/router-enabled` doesn't
+   require restarting a worker or reloading config. The next hook
+   call sees no sentinel → fast path.
+2. **Hot-path performance** — if disabled, the bash shim never
+   spawns `pnpm tsx`, saving ~500ms-1s per tool call.
+
+A future Go SDK (see backlog: `router-heuristics-go-sdk`) will move
+the heuristics into the kernel binary itself; at that point the
+sentinel becomes redundant and the policy flag is enough.
+
+## Related
+
+- Strategic entry: `agent-router-architecture` (in
+  `docs/swarm-backlog.md`)
+- Auto-flipper companion: `chitin-shipped-entry-flipper` (separate
+  systemd timer, separate concern — backlog hygiene)
+- Kernel binary: `chitin-kernel-redeploy.timer` keeps the
+  underlying gate fresh; rebuild script at
+  `scripts/install-kernel.sh`

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -4610,4 +4610,210 @@ Steps:
 - [ ] swarm-backlog.md header notes the interim status (optional)
 - [ ] Existing 3 open issues (#22, #13, #4) are NOT closed by
       this entry — they're real bug reports
+## Agent-router architecture (filed 2026-05-03 evening)
+
+### `agent-router-architecture`
+
+```yaml
+id: agent-router-architecture
+tier: T5
+status: in_design
+estimated_loc: TBD (multi-subsystem; this entry is the design doc and the rollup of MVP entries below)
+blocks: []
+file: docs/design/2026-05-03-agent-router.md (design), apps/temporal-worker/src/router/, go/execution-kernel/internal/gov/advisor.go, python/analysis/floundering.py
+references_finding: 2026-05-03 evening operator framing — multi-dimensional routing (model + agent + cost) with uncertainty + floundering + shared memory + flat-cost-only billing
+role: architect
+```
+
+Operator framing 2026-05-03 evening (one session):
+
+> "I want to escalate to a higher agent when needed based on
+> uncertainty, or some way of deterministically seeing that an
+> agent may be floundering and need help."
+
+> "almost like model routing but with agents routing to each
+> other when needed then routing back. So both model and agent
+> routing. And cost routing too and being able to see budget
+> constraints for things like codex Claude code, ollama cloud."
+
+> "Shared memory seems like it would be very helpful for this as
+> well. And I don't want to use api calls except for ollama cloud."
+
+> "I want to get it all done tonight then turn it on."
+
+Five primitives compose the router:
+
+1. **Uncertainty-triggered escalation** — agents emit a structured
+   `<<<UNCERTAIN>>>{"reason": "...", "blocker": "..."}` marker;
+   parser detects, calls advisor, returns advice in next turn.
+
+2. **Floundering detection** — Python analysis pass over chain
+   events for one session. Signals: looping tool calls (same
+   call N times with same args), wall-clock without commits,
+   repeated permission_denials, multi-turn without file writes,
+   token budget approaching cap. Returns `floundering: bool,
+   reason: enum` per session.
+
+3. **Mid-task handoff** — on uncertainty OR floundering, route to
+   advisor (T+1 tier). MVP shape: hard restart at higher tier
+   (reuses existing tier-escalation primitive, loses in-flight
+   progress). Future: Temporal-signal-driven mid-task continuation.
+
+4. **Shared memory** — agents in the same workflow read/write a
+   per-workflow scratchpad. MVP shape: JSON file at
+   `~/.chitin/shared-memory/<workflow-id>.json`. Future: cross-
+   workflow vector retrieval (Hindsight pattern).
+
+5. **Cost routing + budget visibility** — driver-cost data already
+   in swarm-rollup JSON; surface as `chitin budget` CLI. MVP shape:
+   visibility only (operator reads, decides). Future: dispatcher
+   auto-rejects entries that would exceed remaining budget.
+
+### Hard constraints
+
+- **No metered API calls.** Sub-billed CLIs only (claude-code via
+  Pro plan, codex via ChatGPT Plus, gemini via Google AI Pro
+  Developers SKU) plus ollama (local + cloud).
+- **Self-hostable / open-source.** No SaaS dependency for the
+  router itself.
+- **MCP-compatible** where applicable (chitin already speaks MCP
+  via openclaw).
+
+### MVPs shipping tonight (one PR for the whole router substrate)
+
+| primitive | MVP shape | what's deferred |
+|---|---|---|
+| Uncertainty marker | `<<<UNCERTAIN>>>` parser + dispatcher hook calling advisor; advice rendered into next-turn prompt | true mid-task continuation (Temporal signals) |
+| Guardian advisor | `chitin-kernel gate evaluate --with-advisor` flag; on deny, calls `claude -p` advisor, appends advisory note to chain event | auto-routing on advisor verdict; default-on |
+| Floundering detector | Python analysis pass over chain events for one session; detects looping/stalling/over-budget; logs `agent_floundering` event | auto-intervention; today is detect-only |
+| Shared memory | per-workflow JSON scratchpad at `~/.chitin/shared-memory/<wfid>.json`; agent reads/writes via simple CLI | cross-workflow vector retrieval (Hindsight pattern) |
+| Cost + budget | `chitin budget` CLI reads existing swarm-rollup JSON + `~/.chitin/budgets.json`; surfaces per-driver spend + remaining quota | auto-reject + dynamic tier routing |
+
+All five MVPs ship as code in the same PR for tonight's velocity.
+Per-primitive backlog entries can be filed retrospectively for
+the production-grade follow-up work.
+
+### Verification
+
+A single end-to-end smoke test gates "turn it on":
+
+- Synthetic backlog entry + dispatch
+- Agent emits `<<<UNCERTAIN>>>` marker mid-task
+- Parser intercepts, calls guardian advisor
+- Advisor returns advice via shared-memory write
+- Agent reads advice, continues
+- Floundering detector confirms no looping signals fire
+- PR created with the work
+- Chain has all events recorded (uncertainty fire, advisor call,
+  shared-memory write, completion)
+
+If smoke passes, dispatcher is re-enabled. If smoke fails, dispatcher
+stays paused and individual primitive entries get re-attempted.
+
+## Router follow-ups (filed 2026-05-03 evening)
+
+### `router-heuristics-go-sdk`
+
+```yaml
+id: router-heuristics-go-sdk
+tier: T3
+status: ready
+estimated_loc: 600
+blocks: []
+file: go/execution-kernel/internal/router/, go/execution-kernel/cmd/chitin-kernel/router.go
+references_finding: 2026-05-03 evening operator concern — TS pipeline adds ~500ms-1s startup per tool call; should expose Go SDK to keep hot path fast
+role: programmer
+```
+
+The router's heuristic+policy layer ships as TypeScript MVP in
+`apps/temporal-worker/src/router/`. Operator hot-path concern:
+every tool call that hits the slow path eats `pnpm tsx` startup
+(~500ms-1s). With many tool calls per session, that adds up.
+
+Move the deterministic-fast pieces into the Go kernel:
+
+1. **policy reader** — Go YAML parser for chitin.yaml `router:`
+   section; matches the TS `policy-loader.ts` shape
+2. **blast-radius scorer** — pure Go function; same axes as
+   TS version (reversibility / scope / visibility / counterparties)
+3. **floundering detector** — Go reads chain JSONL, applies same
+   signals (looping / stalled / denial-cascade)
+4. **session-state reads** — chain index lookups (already in Go)
+
+Only the ADVISOR call stays external (it's slow anyway —
+`claude -p` is a multi-second LLM call). The Go kernel exposes
+`--with-router` flag on `gate evaluate` that runs heuristics in-
+process and prints `{decision, advisor_needed, advisor_request}`.
+The TS layer (or a thin shim) handles the advisor call when
+flagged.
+
+End-state: hot path is pure-Go. Slow path (advisor) is TS or
+external. No `pnpm tsx` overhead per tool call.
+
+**Acceptance:**
+- [ ] Go modules at `go/execution-kernel/internal/router/{policy,blast_radius,floundering}.go`
+- [ ] `gate evaluate --with-router` flag wires them in-process
+- [ ] Same test fixtures pass against Go + TS implementations (port the TS tests)
+- [ ] Bin script `chitin-router-hook` updated to skip the TS pipeline when kernel handles it
+- [ ] Benchmark: average hot-path latency before / after (target: < 50ms)
+- [ ] CI green
+
+### `router-plugin-loader`
+
+```yaml
+id: router-plugin-loader
+tier: T2
+status: ready
+estimated_loc: 250
+blocks: [router-heuristics-go-sdk]
+file: apps/temporal-worker/src/router/plugin-loader.ts, libs/router-plugin-api/
+references_finding: 2026-05-03 evening operator framing — heuristics should be exposed as plugin surface so others can configure custom plugins via chitin.yaml
+role: programmer
+```
+
+The router's heuristic modules currently use static imports. The
+operator-side schema in chitin.yaml only covers built-in plugins
+(blast_radius, floundering, drift). Operator wants a plugin
+surface so custom heuristics and advisor implementations can be
+declared in chitin.yaml + dynamically loaded.
+
+Steps:
+
+1. Define `RouterPlugin` interface in `libs/router-plugin-api/`:
+   ```ts
+   export interface RouterPlugin {
+     name: string;
+     type: 'heuristic' | 'advisor';
+     score?(input: HookInput, context: PluginContext): Promise<HeuristicScore>;
+     advise?(request: AdvisorRequest): Promise<AdvisorResponse>;
+   }
+   ```
+2. `chitin.yaml` schema extension:
+   ```yaml
+   router:
+     plugins:
+       - name: my-custom-heuristic
+         module: '@my-org/chitin-plugin-foo'   # npm package
+         config: { threshold: 0.4 }
+       - name: local-experimental
+         module: './local/my-plugin.ts'        # repo-local path
+         config: {}
+   ```
+3. Plugin loader (`plugin-loader.ts`) dynamically imports
+   modules + validates they implement the interface.
+4. Hook wrapper iterates plugins instead of hardcoded heuristic
+   imports.
+5. Built-in heuristics get rewritten as plugins (compatibility
+   shim to keep tonight's MVP working unchanged).
+
+Blocks on `router-heuristics-go-sdk` because the Go SDK migration
+should land first — otherwise the plugin shape gets defined
+twice (TS interface + Go interface).
+
+**Acceptance:**
+- [ ] `RouterPlugin` interface + types published as `@chitin/router-plugin-api`
+- [ ] Plugin loader handles npm-package + local-path modules
+- [ ] Validation: plugins missing required methods rejected with clear error
+- [ ] Built-in heuristics ported to plugin shape; tonight's tests still pass
+- [ ] Example custom plugin documented in `docs/runbooks/chitin-router.md`
 - [ ] CI green

--- a/infra/systemd/chitin-shipped-entry-flipper.service
+++ b/infra/systemd/chitin-shipped-entry-flipper.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Auto-flip backlog entries ready→partial when recent merged PRs shipped them
+Documentation=file:%h/workspace/chitin/docs/runbooks/chitin-shipped-entry-flipper.md
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/workspace/chitin/scripts/shipped-entry-flipper.sh --apply
+
+# Resource caps — tiny script
+MemoryMax=256M
+CPUQuota=100%
+TimeoutStartSec=120
+
+# Don't restart on failure — failure mode is git pull conflict or
+# gh auth issue; auto-retry would just paper over it.
+Restart=no
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/chitin-shipped-entry-flipper.timer
+++ b/infra/systemd/chitin-shipped-entry-flipper.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Trigger chitin-shipped-entry-flipper hourly
+Documentation=file:%h/workspace/chitin/docs/runbooks/chitin-shipped-entry-flipper.md
+
+[Timer]
+# Hourly — recent merged PRs are the input; hourly cadence catches
+# operator-merged PRs within an hour of merge.
+OnBootSec=5min
+OnUnitActiveSec=1h
+Persistent=true
+
+Unit=chitin-shipped-entry-flipper.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/shipped-entry-flipper.sh
+++ b/scripts/shipped-entry-flipper.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Auto-flipper: scan recent merged PRs, find backlog entries whose
+# id appears in the PR title, flip their status from `ready` to
+# `partial` so the dispatcher stops re-dispatching them.
+#
+# Closes the recurrence of today's incident (4 swarm PRs closed
+# 2026-05-03 evening for being regressive stubs against entries that
+# were already implemented by hand-merged PRs).
+#
+# Modes:
+#   default (no args)  → dry-run, log what WOULD flip
+#   --apply            → actually edit + commit + push as a PR
+#
+# Designed to run via chitin-shipped-entry-flipper.timer with --apply.
+# The dry-run default lets the operator inspect manually first.
+
+set -euo pipefail
+
+REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+DAYS="${CHITIN_FLIPPER_DAYS:-7}"
+LOG="${CHITIN_FLIPPER_LOG:-$HOME/.cache/chitin/shipped-entry-flipper.jsonl}"
+APPLY=0
+[[ "${1:-}" == "--apply" ]] && APPLY=1
+
+mkdir -p "$(dirname "$LOG")"
+
+emit() {
+  local kind="$1" msg="$2"
+  shift 2
+  local extras=""
+  while (($#)); do
+    local k="${1%%=*}" v="${1#*=}"
+    v="${v//\\/\\\\}"
+    v="${v//\"/\\\"}"
+    extras+=",\"${k}\":\"${v}\""
+    shift
+  done
+  printf '{"ts":"%s","kind":"%s","msg":"%s"%s}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$kind" "$msg" "$extras" \
+    | tee -a "$LOG" >&2
+}
+
+cd "$REPO"
+
+# Pull main fresh (fail open if it doesn't fast-forward — operator
+# would have manual changes worth preserving)
+if ! git pull --ff-only --quiet origin main 2>/dev/null; then
+  emit warn "git pull --ff-only failed; using local main HEAD"
+fi
+
+# List merged PRs from the last DAYS days
+since=$(date -u -d "-${DAYS} days" +%Y-%m-%d)
+prs_json=$(gh pr list --state merged --search "merged:>${since}" --json number,title,mergedAt --limit 100 2>/dev/null || echo "[]")
+
+# Extract entry-ids from backlog (heading lines `### \`<id>\``)
+declare -A entries_by_id
+declare -A entry_status
+while IFS= read -r line; do
+  # Heading: `### \`<id>\``
+  if [[ "$line" =~ ^\#\#\#\ \`([^\`]+)\` ]]; then
+    cur_id="${BASH_REMATCH[1]}"
+    entries_by_id["$cur_id"]=1
+  fi
+  # Status line within the entry's frontmatter
+  if [[ "$line" =~ ^status:\ ([a-z_]+) ]] && [[ -n "${cur_id:-}" ]]; then
+    entry_status["$cur_id"]="${BASH_REMATCH[1]}"
+    cur_id=""
+  fi
+done < docs/swarm-backlog.md
+
+emit info "scanned" "entries=${#entries_by_id[@]}" "since=$since" "apply=$APPLY"
+
+# For each merged PR title, find any entry-id substring match.
+# FILTER: skip entry-FILING PR titles (backlog:, auto:, docs:) —
+# those add the entry without shipping the work. Only count
+# IMPLEMENTATION PRs: feat:, fix:, swarm:, refactor:, perf:, chore:.
+candidates=()
+echo "$prs_json" | jq -r '.[] | "\(.number)|\(.mergedAt)|\(.title)"' | while IFS='|' read -r num merged_at title; do
+  # Skip non-implementation prefixes
+  if [[ "$title" =~ ^(backlog|auto|docs?|test): ]]; then
+    continue
+  fi
+  for id in "${!entries_by_id[@]}"; do
+    # Match if the id appears in the PR title (substring)
+    if [[ "$title" == *"$id"* ]]; then
+      cur_status="${entry_status[$id]:-unknown}"
+      if [[ "$cur_status" == "ready" ]]; then
+        emit candidate "would-flip-ready-to-partial" "entry=$id" "pr=#$num" "merged_at=$merged_at" "title=$title"
+        echo "$id|#$num"
+      else
+        emit info "skip-not-ready" "entry=$id" "pr=#$num" "current_status=$cur_status"
+      fi
+    fi
+  done
+done > /tmp/flipper-candidates.txt
+
+candidate_count=$(wc -l < /tmp/flipper-candidates.txt | tr -d ' ')
+
+if (( candidate_count == 0 )); then
+  emit ok "no-candidates" "msg=no ready entries match recent merged PR titles"
+  rm -f /tmp/flipper-candidates.txt
+  exit 0
+fi
+
+if (( APPLY == 0 )); then
+  emit ok "dry-run-complete" "candidates=$candidate_count" "msg=re-run with --apply to commit"
+  echo "Candidates (dry-run, no edits made):"
+  cat /tmp/flipper-candidates.txt
+  rm -f /tmp/flipper-candidates.txt
+  exit 0
+fi
+
+# Apply mode: edit the backlog file in-place
+branch="auto/shipped-entry-flipper-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$branch"
+
+flipped_ids=()
+while IFS='|' read -r id pr; do
+  # Find the line `id: <id>` and the next line `tier: ...` then
+  # `status: ready` — flip to `status: partial`. Use awk for
+  # precise in-block replacement.
+  if awk -v target="$id" '
+    /^id: / { in_block = ($2 == target); next_status_to_flip = 0 }
+    in_block && /^status: ready$/ { print "status: partial"; flipped = 1; next }
+    { print }
+    END { exit (flipped ? 0 : 1) }
+  ' docs/swarm-backlog.md > /tmp/swarm-backlog.new && mv /tmp/swarm-backlog.new docs/swarm-backlog.md; then
+    flipped_ids+=("$id ($pr)")
+    emit ok "flipped" "entry=$id" "pr=$pr"
+  else
+    emit warn "flip-failed-no-status-ready" "entry=$id" "pr=$pr"
+  fi
+done < /tmp/flipper-candidates.txt
+rm -f /tmp/flipper-candidates.txt
+
+if (( ${#flipped_ids[@]} == 0 )); then
+  emit ok "no-flips-applied" "msg=all candidates were already non-ready"
+  git checkout main
+  git branch -D "$branch"
+  exit 0
+fi
+
+# Commit + push + PR
+git add docs/swarm-backlog.md
+body="Auto-generated by chitin-shipped-entry-flipper.
+
+The following backlog entries are flipped from \`status: ready\` to \`status: partial\` because their entry-id appears in a recently-merged PR's title (within the last $DAYS days). \`partial\` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.
+
+Flipped:
+$(printf -- '- %s\n' "${flipped_ids[@]}")
+
+If any of these are wrong, revert + investigate why the title matched without the work shipping."
+
+git commit -m "auto: flip $(echo ${#flipped_ids[@]}) backlog entries ready→partial (recent merged PRs)" -m "$body"
+git push -u origin "$branch"
+gh pr create --title "auto: flip ${#flipped_ids[@]} entries ready→partial (shipped-entry-flipper)" --body "$body"
+emit ok "pr-opened" "branch=$branch" "flipped_count=${#flipped_ids[@]}"


### PR DESCRIPTION
## Summary

Implements the multi-dimensional router pattern from tonight's session — pre-tool-call hook adjudication chain (kernel verdict → heuristics → optional advisor → composed response) — as TypeScript MVP + an auto-flipper for backlog hygiene. **Sentinel-gated, opt-in, hot-path-bypass when off.**

## Key architectural decisions

- **Kernel stays deterministic.** Router is a wrapper OUTSIDE the kernel process. Kernel decision is authoritative; advisor adds nudge only.
- **All existing roles wire in for FREE.** The hook is per-tool-call, role-agnostic.
- **Operator opts in via sentinel** — `touch ~/.chitin/router-enabled`. Hot path stays ~0ms when disabled (bash exec to kernel directly).
- **No metered API calls.** Advisor uses `claude -p` headless mode (Claude Code Pro plan; sub-billed).
- **Design borrowed from research:** AutoGen v0.4 termination vocabulary (loop / stall / denial-cascade) for floundering; LangGraph's `Command(goto, update)` shape informed the nudge-vs-takeover verdict.

## What's in this PR (~2100 LOC across 17 files)

```
apps/temporal-worker/src/router/
  types.ts                       shared types + DEFAULT_ROUTER_POLICY
  policy-loader.ts               reads chitin.yaml `router:` section
  heuristics/blast-radius.ts     pure scorer (4-axis: reversibility/scope/visibility/counterparties)
  heuristics/floundering.ts      pure detector (loop / stall / denial-cascade)
  advisor.ts                     wraps `claude -p` with structured prompt
  shared-memory.ts               per-workflow JSON scratchpad
  uncertainty-parser.ts          marker parser (defensive)
  hook-wrapper.ts                main pipeline

bin/chitin-router-hook           bash shim with HOT-PATH BYPASS

apps/temporal-worker/test/router/heuristics.test.ts   13 tests, all pass

scripts/shipped-entry-flipper.sh                     auto-flipper (separate concern; safe-to-turn-on tonight)
infra/systemd/chitin-shipped-entry-flipper.{service,timer}

docs/runbooks/chitin-router.md                       install / verify / suspend / configure / failure modes
docs/swarm-backlog.md                                + 3 entries (architecture + 2 follow-ups)
chitin.yaml                                          + `router:` section with operator-tuned defaults
```

CHANGED:
- `apps/temporal-worker/src/activity.ts` — `writeWorktreeClaudeSettings` now points the PreToolUse hook at `chitin-router-hook` (which has hot-path bypass; default behavior identical).

## Why TS now AND Go port immediately after

Operator concern (verbatim): "I think for us all that should be in go.. even if we use a go sdk won't node take 500ms to cold start each time?"

**Yes. The TS MVP is the DESIGN substrate.** Tonight's TS work serves as the spec; tomorrow morning's Go port (filed as `router-heuristics-go-sdk`, T3 ~600 LOC) translates the heuristics + policy + hook-wrapper to Go for ~10ms cold-start. Test fixtures port directly. The TS modules become vestigial (kept as documentation OR deleted) once the Go port lands.

**Why ship TS at all then?** Because the design isn't proven until something runs. The TS MVP:
- Validates the pipeline shape end-to-end (kernel → heuristics → advisor → response)
- Provides exhaustive test fixtures (13 tests, all green)
- Locks the public contract (chitin.yaml `router:` section, plugin interface, hook return shape)
- Lets the Go port be a mechanical translation, not a redesign

## Verified tonight

- ✅ `tsc --noEmit` clean on all router files
- ✅ 13/13 unit tests pass on heuristic modules
- ✅ Hot-path smoke (sentinel absent): `exec chitin-kernel`, ~0ms overhead, identical to today
- ✅ Slow-path smoke (sentinel + chitin.yaml policy enabled):
  - Read tool → pass-through (no heuristic fires) → 518ms total
  - Bash 'echo hi' → pass-through → 500ms total
  - Bash 'rm -rf ...' would call advisor (60s timeout to claude -p); falls open to kernel verdict if advisor times out
- ✅ Auto-flipper smoke (dry-run): correctly identifies stale-ready entries with implementation PRs

## Operator state when this PR merges

- **Auto-flipper**: ready to enable. Operator runs:
  ```
  systemctl --user enable --now chitin-shipped-entry-flipper.timer
  ```
  Safe to turn on tonight — directly closes today's 4-broken-PRs stale-dispatch bug.
- **Router**: sentinel OFF by default. Hot path = exec chitin-kernel (no Node overhead). Operator opts in tomorrow morning AFTER Go port lands.
- **Dispatcher**: stays paused (separate operator decision; resume after Go-port + router-on, or before if comfortable with the deterministic safety primitives that are already there).

## Follow-up entries (filed in this PR)

- `agent-router-architecture` (T5 strategic) — captures the full vision
- `router-heuristics-go-sdk` (T3 ~600 LOC) — **TOMORROW MORNING'S TOP PRIORITY**; ports hot-path heuristics into the Go kernel for ~10ms latency
- `router-plugin-loader` (T2 ~250 LOC) — exposes plugin surface for custom heuristics + advisors via chitin.yaml; blocks on Go-SDK landing first

## Test plan

- [x] All 13 heuristic unit tests pass
- [x] tsc clean
- [x] Hot-path bash smoke (sentinel absent)
- [x] Slow-path bash smoke with policy loaded from real chitin.yaml
- [x] Auto-flipper dry-run smoke against live merged PRs
- [x] Backlog entries pass shape lint manually (heading id matches frontmatter id; tier/status/role in valid sets)
- [x] Runbook covers install / verify / suspend / configure / failure modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)