### PR TITLE
feat(router): Go SDK — heuristics in-process, ~26ms cold start

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -192,3 +192,30 @@ rules:
     action: unknown
     effect: deny
     reason: "Unknown tools are denied — the action vocabulary is a closed enum. If Normalize returns ActUnknown, extend the normalizer rather than broadening this rule."
+
+# Router policy (added 2026-05-03; see also TS substrate in PR #230).
+#
+# When the operator opts in (touch ~/.chitin/router-enabled), the
+# kernel's `router evaluate --hook-stdin` engages: kernel verdict →
+# heuristics (in-process Go) → optional advisor consultation
+# (claude -p subprocess) → composed response.
+#
+# Cold-start: ~26ms (Go binary). Most tool calls SKIP the advisor
+# (deterministic checks pass + no heuristic fires).
+router:
+  enabled: true
+  heuristics:
+    blast_radius:
+      enabled: true
+      threshold: 0.6
+    floundering:
+      enabled: true
+      max_loop_count: 3
+      max_stall_seconds: 600
+  advisor:
+    enabled: true
+    when: [blast_radius_above_threshold, floundering_detected]
+    chain:
+      max_depth: 3
+      tier_steps: [T2, T3, T4]
+    model: claude-code-headless

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -58,6 +58,8 @@ func main() {
 		cmdGate(args)
 	case "envelope":
 		cmdEnvelope(args)
+	case "router":
+		cmdRouter(args)
 	case "drive":
 		if len(args) < 1 {
 			exitErr("drive_no_driver", "usage: chitin-kernel drive <driver> [flags]")

--- a/go/execution-kernel/cmd/chitin-kernel/router_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/router"
+)
+
+// runRouterHookStdin is the production entry point for the
+// router-augmented PreToolUse hook. Wires real stdin/stdout/os.Exit
+// around evalRouterHookStdin (the pure core).
+//
+// The pipeline:
+//   1. Capture the kernel verdict (calls evalHookStdin internally
+//      with a buffered stdout so we can re-process the result)
+//   2. Load the router policy from chitin.yaml
+//   3. If policy disabled OR kernel denied + advisor not configured
+//      for kernel_denied → emit kernel verdict directly (fast path)
+//   4. Run heuristics (blast-radius + floundering) per policy
+//   5. If any heuristic fired (or kernel denied + advisor wants it)
+//      → call advisor via `claude -p`
+//   6. Compose final response: kernel verdict + advisor nudge if any
+//
+// Cold-start target: ~10ms (heuristics are pure Go); only the
+// advisor call (when fired) takes seconds (LLM latency).
+func runRouterHookStdin(agent, envelopeFlag string, requirePolicy bool) {
+	code := evalRouterHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag, requirePolicy)
+	os.Exit(code)
+}
+
+func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag string, requirePolicy bool) int {
+	if agent == "" {
+		agent = "claude-code"
+	}
+
+	// Read stdin once — we reuse for both the kernel evaluator and
+	// the router pipeline.
+	in, err := io.ReadAll(r)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{"error": "router_hook_read_stdin", "message": err.Error()})
+		return claudecode.ExitNonBlockError
+	}
+
+	// Parse to peek at the cwd / session_id for policy + heuristics
+	var payload claudecode.HookInput
+	if err := json.Unmarshal(in, &payload); err != nil {
+		writeJSONLine(errOut, map[string]string{"error": "router_hook_parse_stdin", "message": err.Error()})
+		return claudecode.ExitNonBlockError
+	}
+	cwd := payload.Cwd
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	absCwd, _ := filepath.Abs(cwd)
+
+	// Load router policy (separate from gov.Policy — this is the
+	// router's own configuration surface)
+	policy := router.LoadPolicy(absCwd)
+
+	// Step 1: kernel verdict via evalHookStdin's pure core
+	var kernelOut bytes.Buffer
+	kernelCode := evalHookStdin(bytes.NewReader(in), &kernelOut, errOut, agent, envelopeFlag, requirePolicy)
+
+	// Fast path: router policy disabled → emit kernel verdict directly
+	if !policy.Enabled {
+		if kernelOut.Len() > 0 {
+			_, _ = out.Write(kernelOut.Bytes())
+		}
+		return kernelCode
+	}
+
+	// Step 2: heuristics
+	hookInput := router.HookInput{
+		HookEventName: payload.HookEventName,
+		ToolName:      payload.ToolName,
+		ToolInput:     payload.ToolInput,
+		Cwd:           cwd,
+		SessionID:     payload.SessionID,
+	}
+	outcome := router.HeuristicOutcome{}
+	if cfg, ok := policy.Heuristics["blast_radius"]; ok && cfg.Enabled {
+		score := router.ScoreBlastRadius(hookInput, cfg.Threshold)
+		outcome.BlastRadius = &score
+		if score.Fired {
+			outcome.AnyFired = true
+		}
+	}
+	if cfg, ok := policy.Heuristics["floundering"]; ok && cfg.Enabled {
+		events := router.ReadChainEvents(payload.SessionID)
+		score := router.DetectFloundering(events, router.FlounderingThresholds{
+			MaxLoopCount:    cfg.MaxLoopCount,
+			MaxStallSeconds: cfg.MaxStallSeconds,
+		}, time.Now())
+		outcome.Floundering = &score
+		if score.Fired {
+			outcome.AnyFired = true
+		}
+	}
+
+	// Decide whether to invoke the advisor
+	kernelDeny := kernelCode == claudecode.ExitBlock
+	wantAdvisor := false
+	if policy.Advisor.Enabled {
+		for _, trigger := range policy.Advisor.When {
+			switch trigger {
+			case "blast_radius_above_threshold":
+				if outcome.BlastRadius != nil && outcome.BlastRadius.Fired {
+					wantAdvisor = true
+				}
+			case "floundering_detected":
+				if outcome.Floundering != nil && outcome.Floundering.Fired {
+					wantAdvisor = true
+				}
+			case "kernel_denied":
+				if kernelDeny {
+					wantAdvisor = true
+				}
+			}
+			if wantAdvisor {
+				break
+			}
+		}
+	}
+
+	if !wantAdvisor {
+		// No advisor needed → emit kernel verdict (fast)
+		if kernelOut.Len() > 0 {
+			_, _ = out.Write(kernelOut.Bytes())
+		}
+		// Log heuristic outcome to stderr for telemetry even if advisor skipped
+		if outcome.AnyFired {
+			writeRouterTelemetry(errOut, "heuristic-fired-no-advisor", outcome, kernelDeny)
+		}
+		return kernelCode
+	}
+
+	// Step 3: call advisor
+	question := "Heuristic flagged this action. Is the agent on track, or should it pause/escalate?"
+	if kernelDeny {
+		var krDecision struct {
+			Reason string `json:"reason"`
+		}
+		_ = json.Unmarshal(kernelOut.Bytes(), &krDecision)
+		question = fmt.Sprintf(
+			"The kernel denied this action: %s. Should the agent be re-routed or is this denial correct?",
+			krDecision.Reason,
+		)
+	}
+	advisorReq := router.AdvisorRequest{
+		Question:         question,
+		Context:          fmt.Sprintf("Session: %s. Heuristic outcome attached.", payload.SessionID),
+		ProposedAction:   hookInput,
+		HeuristicOutcome: outcome,
+		ChainDepth:       0,
+	}
+	ctx := context.Background()
+	advice, advErr := router.CallAdvisor(ctx, advisorReq, "", 60*time.Second)
+	if advErr != nil || advice == nil {
+		writeJSONLine(errOut, map[string]string{
+			"warning":         "router_advisor_failed",
+			"err":             errStringFor(advErr),
+			"kernel_decision": kernelDecisionLabel(kernelDeny),
+		})
+		// Fall through to kernel verdict
+		if kernelOut.Len() > 0 {
+			_, _ = out.Write(kernelOut.Bytes())
+		}
+		return kernelCode
+	}
+
+	// Step 4: compose
+	if advice.Verdict == "takeover" {
+		// Force a deny with the advisor's nudge as the reason
+		composed := map[string]string{"decision": "block", "reason": advice.Nudge}
+		body, _ := json.Marshal(composed)
+		_, _ = out.Write(body)
+		_, _ = out.Write([]byte{'\n'})
+		writeRouterTelemetry(errOut, "advisor-takeover", outcome, kernelDeny)
+		return claudecode.ExitBlock
+	}
+
+	// continue: append nudge to the kernel output's reason field
+	if kernelOut.Len() > 0 {
+		var kernelObj map[string]interface{}
+		if err := json.Unmarshal(kernelOut.Bytes(), &kernelObj); err == nil {
+			existing, _ := kernelObj["reason"].(string)
+			if existing != "" {
+				kernelObj["reason"] = advice.Nudge + "\n\nKernel: " + existing
+			} else {
+				kernelObj["reason"] = advice.Nudge
+			}
+			body, _ := json.Marshal(kernelObj)
+			_, _ = out.Write(body)
+			_, _ = out.Write([]byte{'\n'})
+		} else {
+			// Kernel output not JSON — emit as-is
+			_, _ = out.Write(kernelOut.Bytes())
+		}
+	} else if kernelCode == claudecode.ExitAllow {
+		// Kernel was silent (allow). Emit the advisor's nudge as a hint.
+		composed := map[string]string{"hookSpecificOutput": advice.Nudge}
+		body, _ := json.Marshal(composed)
+		_, _ = out.Write(body)
+		_, _ = out.Write([]byte{'\n'})
+	}
+	writeRouterTelemetry(errOut, "advisor-allow", outcome, kernelDeny)
+	return kernelCode
+}
+
+func writeRouterTelemetry(errOut io.Writer, kind string, outcome router.HeuristicOutcome, kernelDeny bool) {
+	out := map[string]interface{}{
+		"ts":                time.Now().UTC().Format(time.RFC3339),
+		"level":             "info",
+		"component":         "router-hook",
+		"msg":               kind,
+		"kernel_denied":     kernelDeny,
+		"heuristic_outcome": outcome,
+	}
+	body, _ := json.Marshal(out)
+	_, _ = errOut.Write(body)
+	_, _ = errOut.Write([]byte{'\n'})
+}
+
+func errStringFor(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func kernelDecisionLabel(deny bool) string {
+	if deny {
+		return "deny"
+	}
+	return "allow"
+}
+
+// cmdRouter dispatches `chitin-kernel router <subcommand>`. Today only
+// `evaluate --hook-stdin` is supported.
+func cmdRouter(args []string) {
+	if len(args) < 1 {
+		exitErr("router_no_subcommand", "usage: chitin-kernel router <evaluate> [flags]")
+	}
+	switch args[0] {
+	case "evaluate":
+		cmdRouterEvaluate(args[1:])
+	default:
+		exitErr("router_unknown_subcommand", args[0])
+	}
+}
+
+func cmdRouterEvaluate(args []string) {
+	// Minimal flag set — mirrors the gate evaluate hook flags
+	agent := "claude-code"
+	envelopeFlag := ""
+	requirePolicy := false
+	hookStdin := false
+	for _, a := range args {
+		switch {
+		case a == "--hook-stdin":
+			hookStdin = true
+		case strings.HasPrefix(a, "--agent="):
+			agent = a[len("--agent="):]
+		case strings.HasPrefix(a, "--envelope="):
+			envelopeFlag = a[len("--envelope="):]
+		case a == "--require-policy":
+			requirePolicy = true
+		}
+	}
+	if !hookStdin {
+		exitErr("router_evaluate_missing_args", "--hook-stdin required (other modes deferred)")
+	}
+	runRouterHookStdin(agent, envelopeFlag, requirePolicy)
+}

--- a/go/execution-kernel/internal/router/advisor.go
+++ b/go/execution-kernel/internal/router/advisor.go
@@ -1,0 +1,110 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// CallAdvisor spawns `claude -p` (sub-billed Claude Code Pro plan)
+// with a structured advisor prompt and parses the
+// <<<ROUTER_ADVISOR>>>{...} marker from stdout. Returns
+// (response, nil) on success, (nil, err) on failure.
+//
+// Constraint: NO metered API calls. We use the Claude Code CLI's
+// `claude -p` interface which authenticates against the user's
+// Claude Code subscription. Per the Anthropic AUP clarification
+// (2026-05-02), headless `claude -p` is supported for automation.
+func CallAdvisor(ctx context.Context, req AdvisorRequest, binary string, timeout time.Duration) (*AdvisorResponse, error) {
+	if binary == "" {
+		binary = "claude"
+	}
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+	prompt := buildAdvisorPrompt(req)
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, binary, "-p", "--dangerously-skip-permissions", "--output-format", "text")
+	cmd.Stdin = strings.NewReader(prompt)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("advisor spawn failed: %w", err)
+	}
+	resp := parseAdvisorOutput(string(out))
+	if resp == nil {
+		return nil, fmt.Errorf("advisor output missing or malformed marker")
+	}
+	return resp, nil
+}
+
+func buildAdvisorPrompt(req AdvisorRequest) string {
+	heur, _ := json.MarshalIndent(req.HeuristicOutcome, "", "  ")
+	action, _ := json.MarshalIndent(req.ProposedAction, "", "  ")
+	return fmt.Sprintf(`You are a chitin ROUTER ADVISOR — called when a lower-tier agent's tool call triggered a heuristic threshold.
+
+Your job: decide whether the agent should proceed (with what nudge), OR whether the action should be blocked / escalated to a higher-tier human takeover.
+
+PROPOSED ACTION:
+%s
+
+HEURISTIC OUTCOME:
+%s
+
+CALLER CONTEXT:
+- caller_tier: %s
+- chain_depth: %d (max chain_depth before takeover: typically 3)
+
+QUESTION:
+%s
+
+CONTEXT:
+%s
+
+YOUR OUTPUT — emit EXACTLY this JSON line as your final output (no other text after it):
+
+<<<ROUTER_ADVISOR>>>{"nudge": "<short text shown to the agent>", "verdict": "continue"|"takeover", "escalate": <bool>}
+`,
+		string(action), string(heur), req.CallerTier, req.ChainDepth,
+		req.Question, req.Context,
+	)
+}
+
+func parseAdvisorOutput(stdout string) *AdvisorResponse {
+	const marker = "<<<ROUTER_ADVISOR>>>"
+	lastIdx := strings.LastIndex(stdout, marker)
+	if lastIdx < 0 {
+		return nil
+	}
+	rest := stdout[lastIdx+len(marker):]
+	if !strings.HasPrefix(rest, "{") {
+		return nil
+	}
+	depth := 0
+	end := -1
+	for i, ch := range rest {
+		if ch == '{' {
+			depth++
+		} else if ch == '}' {
+			depth--
+			if depth == 0 {
+				end = i + 1
+				break
+			}
+		}
+	}
+	if end < 0 {
+		return nil
+	}
+	var resp AdvisorResponse
+	if err := json.Unmarshal([]byte(rest[:end]), &resp); err != nil {
+		return nil
+	}
+	if resp.Verdict != "continue" && resp.Verdict != "takeover" {
+		return nil
+	}
+	return &resp
+}

--- a/go/execution-kernel/internal/router/blast_radius.go
+++ b/go/execution-kernel/internal/router/blast_radius.go
@@ -1,0 +1,183 @@
+package router
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// blastRadiusAxes computes the four-axis breakdown for a hook input.
+// Mirrors the TS implementation in
+// apps/temporal-worker/src/router/heuristics/blast-radius.ts.
+//
+// Axes (each 0.0-1.0):
+//   - reversibility: 1.0=fully reversible, 0.0=irreversible
+//   - scope: 0.0=single file/no-op, 1.0=mass change
+//   - visibility: 0.0=local, 1.0=public-internet effect
+//   - counterparties: 0.0=self only, 1.0=external service/user impacted
+//
+// Combined score: irreversibility weighted 0.4, scope 0.25,
+// visibility 0.2, counterparties 0.15.
+func blastRadiusAxes(input HookInput) (axes map[string]float64, reason string) {
+	command := stringField(input.ToolInput, "command")
+	filePath := stringField(input.ToolInput, "file_path")
+	if filePath == "" {
+		filePath = stringField(input.ToolInput, "notebook_path")
+	}
+
+	// Read-shaped tools — maximally safe
+	readShaped := map[string]bool{
+		"Read": true, "Glob": true, "Grep": true, "LS": true,
+		"TaskGet": true, "TaskList": true, "TaskOutput": true,
+		"ToolSearch": true, "AskUserQuestion": true,
+		"EnterPlanMode": true, "ExitPlanMode": true,
+	}
+	if readShaped[input.ToolName] {
+		return map[string]float64{
+			"reversibility": 1.0, "scope": 0.0,
+			"visibility": 0.0, "counterparties": 0.0,
+		}, "read-only-tool"
+	}
+
+	// Outbound network
+	outboundNet := map[string]bool{
+		"WebFetch": true, "WebSearch": true,
+		"PushNotification": true, "RemoteTrigger": true,
+	}
+	if outboundNet[input.ToolName] {
+		return map[string]float64{
+			"reversibility": 0.7, "scope": 0.0,
+			"visibility": 0.5, "counterparties": 0.7,
+		}, "outbound-network"
+	}
+
+	// Local file write
+	localWrites := map[string]bool{
+		"Edit": true, "Write": true, "NotebookEdit": true, "TodoWrite": true,
+	}
+	if localWrites[input.ToolName] {
+		scope := 0.2
+		reason := "local-file-write"
+		if regexp.MustCompile(`/(chitin\.yaml|CLAUDE\.md|\.claude/)`).MatchString(filePath) {
+			scope = 0.8
+			reason = "governance-config-write"
+		} else if regexp.MustCompile(`/(node_modules|\.git|dist|build)/`).MatchString(filePath) {
+			scope = 0.9
+			reason = "generated-or-vcs-write"
+		}
+		return map[string]float64{
+			"reversibility": 0.6, "scope": scope,
+			"visibility": 0.0, "counterparties": 0.0,
+		}, reason
+	}
+
+	// Bash — shape by command pattern
+	if input.ToolName == "Bash" {
+		if regexp.MustCompile(`\brm\s+(-[rfRF]+\s+|--recursive\s+)`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.0, "scope": 1.0,
+				"visibility": 0.0, "counterparties": 0.0,
+			}, "recursive-delete"
+		}
+		if regexp.MustCompile(`\bgit\s+push\s+(--force|-f)\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.0, "scope": 0.5,
+				"visibility": 0.9, "counterparties": 0.7,
+			}, "force-push"
+		}
+		if regexp.MustCompile(`\bgit\s+reset\s+--hard\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.0, "scope": 0.4,
+				"visibility": 0.0, "counterparties": 0.0,
+			}, "hard-reset"
+		}
+		if regexp.MustCompile(`\bgit\s+push\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.2, "scope": 0.4,
+				"visibility": 0.7, "counterparties": 0.6,
+			}, "git-push"
+		}
+		if regexp.MustCompile(`\bgh\s+pr\s+(create|merge)\b|\bgh\s+issue\s+close\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.4, "scope": 0.3,
+				"visibility": 0.8, "counterparties": 0.8,
+			}, "github-state-change"
+		}
+		if regexp.MustCompile(`\b(npm|pnpm)\s+publish\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.0, "scope": 0.5,
+				"visibility": 1.0, "counterparties": 1.0,
+			}, "package-publish"
+		}
+		if regexp.MustCompile(`\b(curl|wget)\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 0.7, "scope": 0.0,
+				"visibility": 0.3, "counterparties": 0.5,
+			}, "network-out"
+		}
+		return map[string]float64{
+			"reversibility": 0.5, "scope": 0.3,
+			"visibility": 0.0, "counterparties": 0.0,
+		}, "generic-shell-exec"
+	}
+
+	// Orchestration / scheduling — typically local, reversible
+	orchestration := map[string]bool{
+		"Task": true, "Agent": true, "Skill": true,
+		"TaskCreate": true, "TaskUpdate": true, "TaskStop": true,
+		"CronCreate": true, "CronDelete": true, "CronList": true,
+		"ScheduleWakeup": true, "Monitor": true,
+		"EnterWorktree": true, "ExitWorktree": true,
+	}
+	if orchestration[input.ToolName] {
+		return map[string]float64{
+			"reversibility": 0.5, "scope": 0.3,
+			"visibility": 0.0, "counterparties": 0.0,
+		}, "orchestration-shape"
+	}
+
+	// Unknown tool — moderate caution
+	return map[string]float64{
+		"reversibility": 0.4, "scope": 0.4,
+		"visibility": 0.0, "counterparties": 0.0,
+	}, fmt.Sprintf("unknown-tool:%s", input.ToolName)
+}
+
+// ScoreBlastRadius computes the combined blast-radius score for a hook
+// input. Returns a HeuristicScore with `Fired` set true iff the score
+// meets or exceeds the threshold.
+func ScoreBlastRadius(input HookInput, threshold float64) HeuristicScore {
+	axes, reason := blastRadiusAxes(input)
+	score := (1-axes["reversibility"])*0.4 +
+		axes["scope"]*0.25 +
+		axes["visibility"]*0.2 +
+		axes["counterparties"]*0.15
+	// Round to 3 decimals (matches TS)
+	score = floatRound(score, 3)
+	return HeuristicScore{
+		Score:  score,
+		Fired:  score >= threshold,
+		Reason: reason,
+		Axis:   axes,
+	}
+}
+
+func floatRound(x float64, places int) float64 {
+	mul := 1.0
+	for i := 0; i < places; i++ {
+		mul *= 10
+	}
+	return float64(int64(x*mul+0.5)) / mul
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}

--- a/go/execution-kernel/internal/router/blast_radius_test.go
+++ b/go/execution-kernel/internal/router/blast_radius_test.go
@@ -1,0 +1,99 @@
+package router
+
+import (
+	"math"
+	"testing"
+)
+
+func TestScoreBlastRadius_ReadOnly(t *testing.T) {
+	score := ScoreBlastRadius(HookInput{ToolName: "Read"}, 0.6)
+	if score.Score != 0 {
+		t.Errorf("score=%v want 0", score.Score)
+	}
+	if score.Fired {
+		t.Error("Fired=true; want false for read-only tool")
+	}
+	if score.Reason != "read-only-tool" {
+		t.Errorf("reason=%q want read-only-tool", score.Reason)
+	}
+}
+
+func TestScoreBlastRadius_RecursiveDelete(t *testing.T) {
+	score := ScoreBlastRadius(HookInput{
+		ToolName:  "Bash",
+		ToolInput: map[string]interface{}{"command": "rm -rf /tmp/foo"},
+	}, 0.6)
+	if math.Abs(score.Score-0.65) > 0.01 {
+		t.Errorf("score=%v want ~0.65 (recursive-delete)", score.Score)
+	}
+	if !score.Fired {
+		t.Error("Fired=false; want true (rm-rf is blast)")
+	}
+	if score.Reason != "recursive-delete" {
+		t.Errorf("reason=%q want recursive-delete", score.Reason)
+	}
+}
+
+func TestScoreBlastRadius_ForcePush(t *testing.T) {
+	score := ScoreBlastRadius(HookInput{
+		ToolName:  "Bash",
+		ToolInput: map[string]interface{}{"command": "git push --force origin main"},
+	}, 0.6)
+	if math.Abs(score.Score-0.81) > 0.01 {
+		t.Errorf("score=%v want ~0.81 (force-push)", score.Score)
+	}
+	if !score.Fired {
+		t.Error("Fired=false; want true")
+	}
+	if score.Reason != "force-push" {
+		t.Errorf("reason=%q want force-push", score.Reason)
+	}
+}
+
+func TestScoreBlastRadius_GovernanceWriteFlaggedReason(t *testing.T) {
+	// Score = 0.36 — below default 0.6 threshold.
+	// Kernel's no-governance-self-modification rule denies these
+	// at the deterministic layer, so the heuristic doesn't NEED
+	// to fire. What matters is the REASON tag for telemetry.
+	score := ScoreBlastRadius(HookInput{
+		ToolName:  "Edit",
+		ToolInput: map[string]interface{}{"file_path": "/repo/chitin.yaml"},
+	}, 0.6)
+	if score.Reason != "governance-config-write" {
+		t.Errorf("reason=%q want governance-config-write", score.Reason)
+	}
+	if score.Score < 0.3 {
+		t.Errorf("score=%v want > 0.3", score.Score)
+	}
+	// Lower threshold catches it
+	low := ScoreBlastRadius(HookInput{
+		ToolName:  "Edit",
+		ToolInput: map[string]interface{}{"file_path": "/repo/chitin.yaml"},
+	}, 0.3)
+	if !low.Fired {
+		t.Error("Fired=false at threshold 0.3; want true")
+	}
+}
+
+func TestScoreBlastRadius_PackagePublish(t *testing.T) {
+	score := ScoreBlastRadius(HookInput{
+		ToolName:  "Bash",
+		ToolInput: map[string]interface{}{"command": "pnpm publish --access public"},
+	}, 0.6)
+	if math.Abs(score.Score-0.875) > 0.01 {
+		t.Errorf("score=%v want ~0.875 (package-publish)", score.Score)
+	}
+	if score.Reason != "package-publish" {
+		t.Errorf("reason=%q want package-publish", score.Reason)
+	}
+}
+
+func TestScoreBlastRadius_UnknownTool(t *testing.T) {
+	score := ScoreBlastRadius(HookInput{ToolName: "TotallyMadeUp"}, 0.6)
+	if score.Reason != "unknown-tool:TotallyMadeUp" {
+		t.Errorf("reason=%q want unknown-tool:TotallyMadeUp", score.Reason)
+	}
+	if score.Score <= 0 || score.Score >= 0.6 {
+		t.Errorf("score=%v want > 0 AND < 0.6", score.Score)
+	}
+}

--- a/go/execution-kernel/internal/router/floundering.go
+++ b/go/execution-kernel/internal/router/floundering.go
@@ -1,0 +1,184 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ChainEvent — minimal shape for floundering analysis. Mirrors the
+// kernel's full event.Event but only the fields we need.
+type ChainEvent struct {
+	Ts        string                 `json:"ts"`
+	EventType string                 `json:"event_type"`
+	Payload   map[string]interface{} `json:"payload"`
+}
+
+// FlounderingThresholds holds the operator-tunable cutoffs.
+type FlounderingThresholds struct {
+	MaxLoopCount    int
+	MaxStallSeconds int
+}
+
+// ReadChainEvents loads recent chain events for a session from
+// ~/.chitin/events-<session_id>.jsonl. Returns empty slice (not
+// nil, not error) on missing file — matches the TS behavior.
+func ReadChainEvents(sessionID string) []ChainEvent {
+	if sessionID == "" {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	path := filepath.Join(home, ".chitin", fmt.Sprintf("events-%s.jsonl", sessionID))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var events []ChainEvent
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev ChainEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			// skip malformed lines
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// detectLoop returns (true, reason) if the most recent N tool calls
+// share both tool_name AND non-empty action_target. Same-tool with
+// no target is too loose to flag as a loop.
+func detectLoop(events []ChainEvent, maxLoopCount int) (bool, string) {
+	if len(events) < maxLoopCount {
+		return false, ""
+	}
+	// Filter for decision events with tool_name AND non-empty
+	// action_target — see TS counterpart for rationale.
+	var recent []ChainEvent
+	for _, ev := range events {
+		if ev.EventType != "decision" {
+			continue
+		}
+		toolName, _ := ev.Payload["tool_name"].(string)
+		target, _ := ev.Payload["action_target"].(string)
+		if toolName == "" || target == "" {
+			continue
+		}
+		recent = append(recent, ev)
+	}
+	if len(recent) < maxLoopCount {
+		return false, ""
+	}
+	recent = recent[len(recent)-maxLoopCount:]
+	sig := func(e ChainEvent) string {
+		t, _ := e.Payload["tool_name"].(string)
+		tg, _ := e.Payload["action_target"].(string)
+		return fmt.Sprintf("%s|%s", t, tg)
+	}
+	first := sig(recent[0])
+	for _, e := range recent {
+		if sig(e) != first {
+			return false, ""
+		}
+	}
+	short := first
+	if len(short) > 80 {
+		short = short[:80]
+	}
+	return true, fmt.Sprintf("looping-tool-call:%s-x%d", short, maxLoopCount)
+}
+
+// detectStall returns (true, reason) if no write-shape decisions
+// have been seen in the last maxStallSeconds.
+func detectStall(events []ChainEvent, maxStallSeconds int, now time.Time) (bool, string) {
+	var writeEvents []ChainEvent
+	for _, ev := range events {
+		if ev.EventType != "decision" {
+			continue
+		}
+		dec, _ := ev.Payload["decision"].(string)
+		if dec != "allow" {
+			continue
+		}
+		actionType, _ := ev.Payload["action_type"].(string)
+		if actionType == "file.write" || actionType == "git.commit" || actionType == "git.push" {
+			writeEvents = append(writeEvents, ev)
+		}
+	}
+	if len(writeEvents) == 0 {
+		// No writes ever — only flag if the session has been going long enough
+		if len(events) == 0 {
+			return false, ""
+		}
+		firstTs, err := time.Parse(time.RFC3339, events[0].Ts)
+		if err != nil {
+			return false, ""
+		}
+		elapsed := int(now.Sub(firstTs).Seconds())
+		if elapsed > maxStallSeconds {
+			return true, fmt.Sprintf("no-writes-in-%ds", elapsed)
+		}
+		return false, ""
+	}
+	lastWriteTs, err := time.Parse(time.RFC3339, writeEvents[len(writeEvents)-1].Ts)
+	if err != nil {
+		return false, ""
+	}
+	elapsed := int(now.Sub(lastWriteTs).Seconds())
+	if elapsed > maxStallSeconds {
+		return true, fmt.Sprintf("no-writes-since-%ds-ago", elapsed)
+	}
+	return false, ""
+}
+
+// detectDenialCascade returns (true, reason) if 4+ of the last 5
+// decisions were denied — sign of confusion or floundering.
+func detectDenialCascade(events []ChainEvent) (bool, string) {
+	var recent []ChainEvent
+	for _, ev := range events {
+		if ev.EventType == "decision" {
+			recent = append(recent, ev)
+		}
+	}
+	if len(recent) < 5 {
+		return false, ""
+	}
+	recent = recent[len(recent)-5:]
+	denials := 0
+	for _, e := range recent {
+		dec, _ := e.Payload["decision"].(string)
+		if dec == "deny" {
+			denials++
+		}
+	}
+	if denials >= 4 {
+		return true, fmt.Sprintf("denial-cascade:%d-of-last-5", denials)
+	}
+	return false, ""
+}
+
+// DetectFloundering combines the three signals (loop, stall,
+// denial-cascade) and returns the FIRST signal that fires.
+// Priority: loop > stall > denial-cascade.
+func DetectFloundering(events []ChainEvent, thresholds FlounderingThresholds, now time.Time) HeuristicScore {
+	if fired, reason := detectLoop(events, thresholds.MaxLoopCount); fired {
+		return HeuristicScore{Score: 1.0, Fired: true, Reason: reason}
+	}
+	if fired, reason := detectStall(events, thresholds.MaxStallSeconds, now); fired {
+		return HeuristicScore{Score: 0.85, Fired: true, Reason: reason}
+	}
+	if fired, reason := detectDenialCascade(events); fired {
+		return HeuristicScore{Score: 0.9, Fired: true, Reason: reason}
+	}
+	return HeuristicScore{Score: 0.0, Fired: false, Reason: "no-signals"}
+}

--- a/go/execution-kernel/internal/router/floundering_test.go
+++ b/go/execution-kernel/internal/router/floundering_test.go
@@ -1,0 +1,131 @@
+package router
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDetectFloundering_Empty(t *testing.T) {
+	res := DetectFloundering(nil, FlounderingThresholds{MaxLoopCount: 3, MaxStallSeconds: 600}, time.Now())
+	if res.Fired {
+		t.Errorf("Fired=true on empty events; want false")
+	}
+	if res.Reason != "no-signals" {
+		t.Errorf("reason=%q want no-signals", res.Reason)
+	}
+}
+
+func TestDetectFloundering_Loop(t *testing.T) {
+	ev := func(target string) ChainEvent {
+		return ChainEvent{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":     "Bash",
+				"action_target": target,
+				"decision":      "allow",
+			},
+		}
+	}
+	res := DetectFloundering(
+		[]ChainEvent{ev("rm /tmp/x"), ev("rm /tmp/x"), ev("rm /tmp/x")},
+		FlounderingThresholds{MaxLoopCount: 3, MaxStallSeconds: 600},
+		mustParse("2026-05-03T20:00:30Z"),
+	)
+	if !res.Fired {
+		t.Error("Fired=false; want true (loop detected)")
+	}
+	if res.Score != 1.0 {
+		t.Errorf("score=%v want 1.0", res.Score)
+	}
+}
+
+func TestDetectFloundering_VaryingTargets(t *testing.T) {
+	ev := func(target string) ChainEvent {
+		return ChainEvent{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":     "Bash",
+				"action_target": target,
+				"decision":      "allow",
+			},
+		}
+	}
+	res := DetectFloundering(
+		[]ChainEvent{ev("a"), ev("b"), ev("c")},
+		FlounderingThresholds{MaxLoopCount: 3, MaxStallSeconds: 600},
+		mustParse("2026-05-03T20:00:30Z"),
+	)
+	if res.Fired {
+		t.Errorf("Fired=true on varying targets; want false (reason=%q)", res.Reason)
+	}
+}
+
+func TestDetectFloundering_Stall(t *testing.T) {
+	events := []ChainEvent{
+		{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":   "Read",
+				"action_type": "file.read",
+				"decision":    "allow",
+			},
+		},
+	}
+	// 700s after the only event; max_stall_seconds=600
+	res := DetectFloundering(events,
+		FlounderingThresholds{MaxLoopCount: 3, MaxStallSeconds: 600},
+		mustParse("2026-05-03T20:11:40Z"),
+	)
+	if !res.Fired {
+		t.Error("Fired=false; want true (stall detected)")
+	}
+	if res.Reason[:9] != "no-writes" {
+		t.Errorf("reason=%q want prefix no-writes", res.Reason)
+	}
+}
+
+func TestDetectFloundering_DenialCascade(t *testing.T) {
+	denial := func(target string) ChainEvent {
+		return ChainEvent{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":     "Bash",
+				"action_target": target,
+				"decision":      "deny",
+				"rule_id":       "no-rm-recursive",
+			},
+		}
+	}
+	allow := ChainEvent{
+		Ts:        "2026-05-03T20:00:00Z",
+		EventType: "decision",
+		Payload: map[string]interface{}{
+			"tool_name":     "Read",
+			"action_target": "/tmp/x",
+			"decision":      "allow",
+		},
+	}
+	res := DetectFloundering(
+		[]ChainEvent{allow, denial("c1"), denial("c2"), denial("c3"), denial("c4")},
+		FlounderingThresholds{MaxLoopCount: 3, MaxStallSeconds: 600},
+		mustParse("2026-05-03T20:00:30Z"),
+	)
+	if !res.Fired {
+		t.Error("Fired=false; want true (denial cascade)")
+	}
+	if res.Reason[:15] != "denial-cascade:" {
+		t.Errorf("reason=%q want prefix denial-cascade:", res.Reason)
+	}
+}
+
+func mustParse(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/go/execution-kernel/internal/router/policy.go
+++ b/go/execution-kernel/internal/router/policy.go
@@ -1,0 +1,180 @@
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// FindChitinYaml walks up from startCwd looking for chitin.yaml.
+// Returns the absolute path or "" if not found.
+func FindChitinYaml(startCwd string) string {
+	dir, err := filepath.Abs(startCwd)
+	if err != nil {
+		return ""
+	}
+	for {
+		candidate := filepath.Join(dir, "chitin.yaml")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// extractRouterSection finds the `router:` block in chitin.yaml
+// text and returns its full body (including the heading line).
+// Returns "" if not present.
+func extractRouterSection(yaml string) string {
+	lines := strings.Split(yaml, "\n")
+	startIdx := -1
+	headerRe := regexp.MustCompile(`^router:\s*$`)
+	for i, l := range lines {
+		if headerRe.MatchString(l) {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx < 0 {
+		return ""
+	}
+	out := []string{lines[startIdx]}
+	for i := startIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		if line == "" {
+			out = append(out, line)
+			continue
+		}
+		// End of section: a non-indented, non-comment line at column 0
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") && !strings.HasPrefix(line, "#") {
+			break
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// parseRouterSection parses the router section into a Policy.
+// MVP YAML parser — handles the specific keys we declare in
+// DefaultPolicy. Unknown keys ignored. Type errors fall back to
+// defaults so a malformed config doesn't brick the router.
+func parseRouterSection(routerYaml string) Policy {
+	policy := DefaultPolicy()
+	lines := strings.Split(routerYaml, "\n")
+
+	enabledRe := regexp.MustCompile(`^\s+enabled:\s+(true|false)`)
+	if m := findFirstMatch(lines, enabledRe); m != nil {
+		policy.Enabled = m[1] == "true"
+	}
+
+	section := ""
+	subsection := ""
+	for _, rawLine := range lines {
+		// Section header at 2-space indent + word
+		if matched, _ := regexp.MatchString(`^\s{2}\w`, rawLine); matched {
+			section = strings.TrimSuffix(strings.TrimSpace(rawLine), ":")
+			subsection = ""
+			continue
+		}
+		// Subsection header at 4-space indent + word + colon-EOL
+		if matched, _ := regexp.MatchString(`^\s{4}\w.*:\s*$`, rawLine); matched {
+			subsection = strings.TrimSuffix(strings.TrimSpace(rawLine), ":")
+			continue
+		}
+		// key: value at any indent
+		kvRe := regexp.MustCompile(`^\s+([a-z_]+):\s+(.+)$`)
+		m := kvRe.FindStringSubmatch(rawLine)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		value := strings.TrimSpace(m[2])
+
+		if section == "heuristics" && subsection != "" {
+			h := policy.Heuristics[subsection]
+			switch key {
+			case "enabled":
+				h.Enabled = value == "true"
+			case "threshold":
+				if f, err := strconv.ParseFloat(value, 64); err == nil {
+					h.Threshold = f
+				}
+			case "max_loop_count":
+				if n, err := strconv.Atoi(value); err == nil {
+					h.MaxLoopCount = n
+				}
+			case "max_stall_seconds":
+				if n, err := strconv.Atoi(value); err == nil {
+					h.MaxStallSeconds = n
+				}
+			}
+			policy.Heuristics[subsection] = h
+		} else if section == "advisor" {
+			switch {
+			case key == "enabled":
+				policy.Advisor.Enabled = value == "true"
+			case key == "model":
+				policy.Advisor.Model = strings.Trim(value, `"'`)
+			case key == "when" && strings.HasPrefix(value, "["):
+				inside := strings.Trim(value, "[]")
+				policy.Advisor.When = parseInlineList(inside)
+			case subsection == "chain" && key == "max_depth":
+				if n, err := strconv.Atoi(value); err == nil {
+					policy.Advisor.Chain.MaxDepth = n
+				}
+			case subsection == "chain" && key == "tier_steps" && strings.HasPrefix(value, "["):
+				inside := strings.Trim(value, "[]")
+				policy.Advisor.Chain.TierSteps = parseInlineList(inside)
+			}
+		}
+	}
+
+	return policy
+}
+
+func parseInlineList(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		p = strings.Trim(p, `"'`)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func findFirstMatch(lines []string, re *regexp.Regexp) []string {
+	for _, l := range lines {
+		if m := re.FindStringSubmatch(l); m != nil {
+			return m
+		}
+	}
+	return nil
+}
+
+// LoadPolicy loads chitin.yaml's router section from a starting cwd.
+// Walks up parents to find chitin.yaml; falls back to DefaultPolicy
+// if missing or unreadable.
+func LoadPolicy(cwd string) Policy {
+	path := FindChitinYaml(cwd)
+	if path == "" {
+		return DefaultPolicy()
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return DefaultPolicy()
+	}
+	section := extractRouterSection(string(data))
+	if section == "" {
+		return DefaultPolicy()
+	}
+	return parseRouterSection(section)
+}

--- a/go/execution-kernel/internal/router/types.go
+++ b/go/execution-kernel/internal/router/types.go
@@ -1,0 +1,119 @@
+// Package router implements the heuristic + advisor pipeline that
+// wraps the kernel's deterministic gate. It runs in-process inside
+// chitin-kernel for hot-path speed (~10ms vs the TS implementation's
+// ~500ms cold start).
+//
+// Pipeline:
+//   stdin (Claude Code PreToolUse JSON)
+//     ↓
+//   step 1: kernel verdict (gov.Gate.Evaluate)
+//     ↓ if deny → return deny
+//   step 2: heuristics (BlastRadius, Floundering)
+//     ↓ if none fire → return kernel verdict
+//   step 3: policy.Advisor decides whether to invoke advisor
+//     ↓ if yes → spawn `claude -p` with structured prompt, parse response
+//   step 4: compose final hook output
+//
+// The TS implementation in apps/temporal-worker/src/router/ is the
+// design substrate that informed this port. Test fixtures port
+// directly (see router_test.go).
+package router
+
+// HookInput is the inbound shape from Claude Code's PreToolUse hook.
+type HookInput struct {
+	HookEventName string                 `json:"hook_event_name"`
+	ToolName      string                 `json:"tool_name"`
+	ToolInput     map[string]interface{} `json:"tool_input"`
+	Cwd           string                 `json:"cwd,omitempty"`
+	SessionID     string                 `json:"session_id,omitempty"`
+}
+
+// HookOutput is the outbound shape back to Claude Code.
+type HookOutput struct {
+	Decision string `json:"decision"`          // "allow" | "deny"
+	Message  string `json:"message,omitempty"` // shown to the agent
+	Source   string `json:"source,omitempty"`  // kernel | heuristic-deny | advisor-* | kernel-allow
+}
+
+// HeuristicScore is the result of one heuristic running over a HookInput.
+type HeuristicScore struct {
+	Score  float64            `json:"score"`         // 0.0-1.0
+	Fired  bool               `json:"fired"`         // score >= configured threshold
+	Reason string             `json:"reason"`        // short telemetry tag
+	Axis   map[string]float64 `json:"axis,omitempty"`
+}
+
+// HeuristicOutcome aggregates the heuristic results for one tool call.
+type HeuristicOutcome struct {
+	BlastRadius *HeuristicScore `json:"blast_radius,omitempty"`
+	Floundering *HeuristicScore `json:"floundering,omitempty"`
+	AnyFired    bool            `json:"any_fired"`
+}
+
+// AdvisorRequest is the payload sent to the advisor LLM.
+type AdvisorRequest struct {
+	Question         string           `json:"question"`
+	Context          string           `json:"context"`
+	ProposedAction   HookInput        `json:"proposed_action"`
+	HeuristicOutcome HeuristicOutcome `json:"heuristic_outcome"`
+	CallerTier       string           `json:"caller_tier,omitempty"`
+	ChainDepth       int              `json:"chain_depth"`
+}
+
+// AdvisorResponse is the parsed structured output from the advisor.
+type AdvisorResponse struct {
+	Nudge    string `json:"nudge"`
+	Verdict  string `json:"verdict"`  // "continue" | "takeover"
+	Escalate bool   `json:"escalate"` // true → call next-tier advisor
+}
+
+// HeuristicConfig — per-heuristic policy from chitin.yaml.
+type HeuristicConfig struct {
+	Enabled           bool    `yaml:"enabled" json:"enabled"`
+	Threshold         float64 `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+	MaxLoopCount      int     `yaml:"max_loop_count,omitempty" json:"max_loop_count,omitempty"`
+	MaxStallSeconds   int     `yaml:"max_stall_seconds,omitempty" json:"max_stall_seconds,omitempty"`
+}
+
+// AdvisorConfig — advisor policy from chitin.yaml.
+type AdvisorConfig struct {
+	Enabled bool     `yaml:"enabled" json:"enabled"`
+	When    []string `yaml:"when" json:"when"`
+	Chain   struct {
+		MaxDepth  int      `yaml:"max_depth" json:"max_depth"`
+		TierSteps []string `yaml:"tier_steps" json:"tier_steps"`
+	} `yaml:"chain" json:"chain"`
+	Model string `yaml:"model" json:"model"`
+}
+
+// Policy — full router policy from chitin.yaml `router:` section.
+type Policy struct {
+	Enabled    bool                       `yaml:"enabled" json:"enabled"`
+	Heuristics map[string]HeuristicConfig `yaml:"heuristics" json:"heuristics"`
+	Advisor    AdvisorConfig              `yaml:"advisor" json:"advisor"`
+}
+
+// DefaultPolicy is used when chitin.yaml omits the router section.
+// Off by default — operator opts in.
+func DefaultPolicy() Policy {
+	return Policy{
+		Enabled: false,
+		Heuristics: map[string]HeuristicConfig{
+			"blast_radius": {Enabled: true, Threshold: 0.6},
+			"floundering": {
+				Enabled:         true,
+				MaxLoopCount:    3,
+				MaxStallSeconds: 600,
+			},
+		},
+		Advisor: AdvisorConfig{
+			Enabled: true,
+			When:    []string{"blast_radius_above_threshold", "floundering_detected"},
+			Chain: struct {
+				MaxDepth  int      `yaml:"max_depth" json:"max_depth"`
+				TierSteps []string `yaml:"tier_steps" json:"tier_steps"`
+			}{MaxDepth: 3, TierSteps: []string{"T2", "T3", "T4"}},
+			Model: "claude-code-headless",
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Ports the TS router substrate (PR #230) to Go for the hot path. **Cold-start: 518ms (TS) → 26ms (Go), 20× speedup, measured.** Closes the operator's perf concern from tonight: *"I think for us all that should be in go.. even if we use a go sdk won't node take 500ms to cold start each time?"*

## Architecture

Kernel binary gains a `router` subcommand that runs the SAME pipeline shape as PR #230's TS, but ALL in-process:

```
chitin-kernel router evaluate --hook-stdin --agent=<id>
```

Pipeline:

1. Read stdin (Claude Code PreToolUse JSON)
2. Capture kernel verdict via existing `evalHookStdin` (gov.Gate)
3. Load router policy from `chitin.yaml` `router:` section
4. If policy.enabled=false → emit kernel verdict directly (no extra cost; ~3ms)
5. Run heuristics (Go pure functions):
   - **blast_radius** (4-axis: reversibility / scope / visibility / counterparties)
   - **floundering** (loop / stall / denial-cascade — borrowed from AutoGen v0.4 termination-condition vocabulary)
6. If any heuristic fires AND `policy.advisor.when` triggers match → spawn `claude -p` (sub-billed, no metered API) with structured prompt
7. Compose: kernel decision + advisor nudge if `verdict=continue`, OR override to deny if `verdict=takeover`

## Verified end-to-end

Built kernel binary, installed to `~/.local/bin`, exercised the full pipeline against a live `chitin.yaml` policy:

**Read /tmp/x.txt** (low blast):
- Heuristic: `blast_radius=0` (read-only), `floundering=0.85` (stale chain from earlier today)
- Advisor consulted, returned: `continue` + nudge ("Proceed, but if next 1-2 steps still produce no progress, summarize and ask for direction")
- Result: `allow` with composed nudge in `hookSpecificOutput`

**rm -rf /tmp/test-only** (high blast):
- Kernel: `deny` (no-rm-recursive policy rule)
- Heuristic: `blast_radius=0.65` (recursive-delete, fires)
- Advisor consulted, returned: `continue` + concurring nudge with safer alternatives
- Result: `block` with composed reason (advisor + kernel reason chained)
- Total: 6.7s (LLM latency dominates the call)

**Read in fast-path mode** (sentinel absent):
- Pre-existing behavior — exec to kernel directly, ~3-10ms

## What's in this PR (~1300 LOC across 10 files)

```
go/execution-kernel/internal/router/
  types.go            shared types + DefaultPolicy()
  blast_radius.go     4-axis scorer with reason tags
  floundering.go      loop / stall / denial-cascade detector
                       + ReadChainEvents() for ~/.chitin/events-*.jsonl
  advisor.go          CallAdvisor() — spawns `claude -p`, parses
                       <<<ROUTER_ADVISOR>>>{...} marker
  policy.go           chitin.yaml `router:` section parser
  blast_radius_test.go (6 tests)
  floundering_test.go (5 tests)

go/execution-kernel/cmd/chitin-kernel/router_hook.go
  cmdRouter / cmdRouterEvaluate — subcommand dispatch
  runRouterHookStdin / evalRouterHookStdin — pipeline impl

go/execution-kernel/cmd/chitin-kernel/main.go    + dispatch entry
chitin.yaml                                       + `router:` section
```

## Constraints honored

- **No metered API calls.** Advisor uses `claude -p` headless mode (Claude Code Pro plan; sub-billed). Same constraint as PR #230.
- **Kernel stays deterministic.** Router is post-processing on top of the kernel's verdict — kernel decision is authoritative; advisor adds nudge only.
- **Self-hostable.** No SaaS dependency.
- **Plugin shape.** Heuristics are discrete Go functions with pure interface (`HookInput → HeuristicScore`); plugin-loader extension is a follow-up entry (`router-plugin-loader` in #230).

## Test plan

- [x] `go test ./...` — 100% pass (router: 11 new tests; no regressions across 17 other kernel packages)
- [x] End-to-end smoke: low-blast Read (advisor consulted only because of stale-session floundering)
- [x] End-to-end smoke: high-blast rm-rf (kernel deny + advisor compose)
- [x] Fast-path smoke: sentinel absent → exec kernel directly, ~3-10ms
- [x] Tests port from TS unit tests in PR #230 (`apps/temporal-worker/test/router/heuristics.test.ts`) with identical assertions

## Relationship to PR #230

PR #230 ships the TS substrate as the design spec. This PR ports the hot path to Go. After both merge:
- `chitin.yaml` `router:` section conflict will resolve trivially (identical content)
- TS modules at `apps/temporal-worker/src/router/` remain in the repo as documentation; the bin shim (also updated in #230's branch via a fix-up commit) now calls the Go subcommand for the slow path
- Future plugin-loader work (`router-plugin-loader` entry) lets custom plugins live in either Python or TS — kernel spawns them as subprocesses

## Operator activation (after merge)

```bash
# 1. Rebuild kernel binary (or let chitin-kernel-redeploy.timer pick it up)
~/workspace/chitin/scripts/install-kernel.sh

# 2. Enable router
touch ~/.chitin/router-enabled

# 3. Resume dispatcher
systemctl --user start chitin-dispatcher.timer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)