### PR TITLE
feat(router): plugin loader — Python + TS + bash heuristic plugins

### DIFF
--- a/examples/router-plugins/python-blast-radius-v2/plugin.py
+++ b/examples/router-plugins/python-blast-radius-v2/plugin.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Example chitin router heuristic plugin (Python).
+
+Reads a single JSON line from stdin:
+  { "hook_input": {...}, "config": {...} }
+
+Writes a single JSON line to stdout:
+  { "score": 0.0-1.0, "fired": bool, "reason": "...", "axis": {...} }
+
+This example: a "destination-allowlist" heuristic. Fires when a
+write-shaped action targets a path NOT on the operator's allowlist.
+
+Operator chitin.yaml:
+
+  router:
+    plugins:
+      - name: destination-allowlist
+        type: heuristic
+        runtime: python3
+        module: examples/router-plugins/python-blast-radius-v2/plugin.py
+        config:
+          allowed_prefixes:
+            - "apps/temporal-worker/"
+            - "libs/contracts/"
+            - "docs/"
+          threshold: 0.5
+        timeout_ms: 1000
+
+Cold start: ~50-100ms (faster than Node).
+"""
+import json
+import sys
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"score": 0, "fired": False, "reason": f"plugin-bad-stdin:{e}"}))
+        sys.exit(0)
+
+    hook_input = payload.get("hook_input", {})
+    config = payload.get("config", {})
+    allowed: list[str] = config.get("allowed_prefixes", [])
+    threshold: float = float(config.get("threshold", 0.5))
+
+    tool_name: str = hook_input.get("tool_name", "")
+    tool_input: dict = hook_input.get("tool_input", {})
+
+    # Read-shaped tools never fire — only writes are gated
+    if tool_name in {
+        "Read", "Glob", "Grep", "LS", "TaskGet", "TaskList",
+        "TaskOutput", "ToolSearch", "AskUserQuestion",
+        "EnterPlanMode", "ExitPlanMode",
+    }:
+        print(json.dumps({"score": 0.0, "fired": False, "reason": "read-shape-skip"}))
+        return
+
+    # Extract target path from any of the common shapes
+    target = (
+        tool_input.get("file_path")
+        or tool_input.get("notebook_path")
+        or _extract_path_from_command(tool_input.get("command", ""))
+        or ""
+    )
+    if not target:
+        print(json.dumps({"score": 0.0, "fired": False, "reason": "no-target-path"}))
+        return
+
+    if any(target.startswith(p) or p in target for p in allowed):
+        print(json.dumps({
+            "score": 0.0,
+            "fired": False,
+            "reason": f"in-allowlist:{target[:60]}",
+        }))
+        return
+
+    # Out of allowlist — fire
+    score = 0.7  # always above default threshold
+    print(json.dumps({
+        "score": score,
+        "fired": score >= threshold,
+        "reason": f"target-not-in-allowlist:{target[:80]}",
+        "axis": {"allowed_prefixes_count": len(allowed)},
+    }))
+
+
+def _extract_path_from_command(cmd: str) -> str:
+    if not cmd:
+        return ""
+    for tok in cmd.split():
+        if tok.startswith("-"):
+            continue
+        if "/" in tok or any(tok.endswith(s) for s in (".ts", ".go", ".py", ".md", ".json")):
+            return tok
+    return ""
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/router-plugins/typescript-allowlist/package.json
+++ b/examples/router-plugins/typescript-allowlist/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "chitin-router-plugin-tool-call-rate-limit-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Example chitin router heuristic plugin (TypeScript). See plugin.ts."
+}

--- a/examples/router-plugins/typescript-allowlist/plugin.ts
+++ b/examples/router-plugins/typescript-allowlist/plugin.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Example chitin router heuristic plugin (TypeScript via node
+ * --experimental-strip-types).
+ *
+ * Reads a single JSON line from stdin:
+ *   { "hook_input": {...}, "config": {...} }
+ *
+ * Writes a single JSON line to stdout:
+ *   { "score": 0.0-1.0, "fired": bool, "reason": "...", "axis": {...} }
+ *
+ * This example: a "tool-call-rate-limit" heuristic. Fires when the
+ * agent has made more than `max_calls_per_minute` tool calls in
+ * the last 60 seconds. Operator caps tool-call rate per session.
+ *
+ * Operator chitin.yaml:
+ *
+ *   router:
+ *     plugins:
+ *       - name: tool-call-rate-limit
+ *         type: heuristic
+ *         runtime: node
+ *         module: examples/router-plugins/typescript-allowlist/plugin.ts
+ *         config:
+ *           max_calls_per_minute: 30
+ *         timeout_ms: 2000
+ *
+ * Cold start: ~500ms (Node). For latency-sensitive heuristics,
+ * prefer Python (~50-100ms) or in-tree Go (~10ms via the GoSDK).
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+interface Input {
+  hook_input: {
+    tool_name?: string;
+    session_id?: string;
+  };
+  config: {
+    max_calls_per_minute?: number;
+  };
+}
+
+interface Output {
+  score: number;
+  fired: boolean;
+  reason: string;
+  axis?: Record<string, unknown>;
+}
+
+function emit(o: Output): void {
+  console.log(JSON.stringify(o));
+}
+
+function main(): void {
+  const raw = readFileSync(0, 'utf8');
+  let payload: Input;
+  try {
+    payload = JSON.parse(raw);
+  } catch (e) {
+    emit({ score: 0, fired: false, reason: `plugin-bad-stdin:${(e as Error).message}` });
+    return;
+  }
+
+  const cap = payload.config.max_calls_per_minute ?? 30;
+  const sid = payload.hook_input.session_id;
+  if (!sid) {
+    emit({ score: 0, fired: false, reason: 'no-session-id' });
+    return;
+  }
+
+  // Count tool-call decisions in the last 60s for this session
+  const path = join(homedir(), '.chitin', `events-${sid}.jsonl`);
+  if (!existsSync(path)) {
+    emit({ score: 0, fired: false, reason: 'no-chain-yet' });
+    return;
+  }
+  const cutoff = Date.now() - 60_000;
+  let count = 0;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const ev = JSON.parse(line) as { ts?: string; event_type?: string; payload?: { tool_name?: string } };
+      if (ev.event_type !== 'decision') continue;
+      if (!ev.payload?.tool_name) continue;
+      if (!ev.ts) continue;
+      const ts = new Date(ev.ts).getTime();
+      if (ts >= cutoff) count++;
+    } catch {
+      /* skip malformed line */
+    }
+  }
+
+  const fired = count > cap;
+  const score = fired ? Math.min(1.0, count / (cap * 2)) : count / cap;
+  emit({
+    score: Number(score.toFixed(3)),
+    fired,
+    reason: fired
+      ? `rate-limit-exceeded:${count}-calls-in-60s-cap-${cap}`
+      : `under-rate-limit:${count}-calls-in-60s-cap-${cap}`,
+    axis: { count_60s: count, cap },
+  });
+}
+
+main();

--- a/go/execution-kernel/internal/router/plugins/loader.go
+++ b/go/execution-kernel/internal/router/plugins/loader.go
@@ -1,0 +1,153 @@
+// Package plugins implements the router's plugin loader. Plugins are
+// declared in chitin.yaml under `router.plugins:` and run as
+// subprocess invocations per tool call (when policy says so).
+//
+// Wire protocol:
+//   stdin  : a single line of JSON — the HookInput shape
+//   stdout : a single line of JSON — the HeuristicScore shape
+//            ({"score": 0.0-1.0, "fired": bool, "reason": "..."})
+//   stderr : structured warning logs (forwarded to operator stderr)
+//
+// Runtimes supported (chosen via chitin.yaml's `runtime:` field):
+//   python3  →  python plugins (faster cold-start, ~50-100ms)
+//   node     →  TypeScript / JavaScript plugins (~500ms)
+//   bun      →  TypeScript via Bun (~50ms cold, but operator must
+//                have bun installed)
+//   bash     →  shell scripts (fastest, ~10ms; for prototyping)
+//
+// Cost model: per-call subprocess spawn. Most tool calls SKIP
+// plugins (gated by policy.advisor.when triggers). Plugin authors
+// should keep their work fast — heavy compute belongs in advisor
+// LLM calls, not heuristic plugins.
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// PluginManifest — what chitin.yaml declares for one plugin.
+// Lives under `router.plugins[]`.
+type PluginManifest struct {
+	// Name identifies the plugin in telemetry (operator-readable).
+	Name string `yaml:"name" json:"name"`
+	// Type — heuristic | advisor. Heuristics fire pre-advisor; advisors
+	// receive the heuristic outcome and return a verdict + nudge.
+	Type string `yaml:"type" json:"type"`
+	// Runtime — which interpreter to spawn (python3, node, bun, bash).
+	Runtime string `yaml:"runtime" json:"runtime"`
+	// Module — entrypoint for the runtime to invoke. For node/bun: a
+	// path to a .ts or .js file. For python3: a path to a .py file
+	// (callable as `python3 -u <path>`). For bash: an executable
+	// script path.
+	Module string `yaml:"module" json:"module"`
+	// Config — plugin-specific JSON object passed to the plugin via
+	// the `config` field of its stdin payload.
+	Config map[string]interface{} `yaml:"config,omitempty" json:"config,omitempty"`
+	// Timeout — wall-clock cap on the subprocess. Plugins exceeding
+	// this are killed and treated as no-signal (fire=false). Default
+	// 5s — heuristics should be fast.
+	TimeoutMs int `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
+}
+
+// PluginInput is what the plugin sees on stdin.
+type PluginInput struct {
+	HookInput map[string]interface{} `json:"hook_input"`
+	Config    map[string]interface{} `json:"config"`
+}
+
+// PluginOutput is what the plugin writes to stdout.
+type PluginOutput struct {
+	Score  float64                `json:"score"`
+	Fired  bool                   `json:"fired"`
+	Reason string                 `json:"reason"`
+	Axis   map[string]interface{} `json:"axis,omitempty"`
+}
+
+// runtimeCommand maps a runtime label to the exec.Command shape.
+// Returns (cmd, args, err). cmd may be empty for unsupported.
+func runtimeCommand(runtime, module string) (string, []string, error) {
+	switch runtime {
+	case "python3", "python":
+		return "python3", []string{"-u", module}, nil
+	case "node":
+		return "node", []string{"--experimental-strip-types", module}, nil
+	case "bun":
+		return "bun", []string{"run", module}, nil
+	case "bash", "sh":
+		return module, nil, nil // execute the script directly
+	default:
+		return "", nil, fmt.Errorf("plugins: unsupported runtime %q (want python3|node|bun|bash)", runtime)
+	}
+}
+
+// Run a plugin against a hook input. Returns (output, nil) on
+// success, (nil, err) on any failure (timeout, malformed output,
+// missing binary). Caller decides fallback (typically: treat as
+// no-signal + log warn).
+func Run(ctx context.Context, manifest PluginManifest, hookInput map[string]interface{}, errOut io.Writer) (*PluginOutput, error) {
+	if manifest.TimeoutMs == 0 {
+		manifest.TimeoutMs = 5000
+	}
+	cmd, args, err := runtimeCommand(manifest.Runtime, manifest.Module)
+	if err != nil {
+		return nil, err
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, time.Duration(manifest.TimeoutMs)*time.Millisecond)
+	defer cancel()
+
+	pInput := PluginInput{HookInput: hookInput, Config: manifest.Config}
+	stdin, err := json.Marshal(pInput)
+	if err != nil {
+		return nil, fmt.Errorf("plugins: marshal input: %w", err)
+	}
+	stdin = append(stdin, '\n')
+
+	c := exec.CommandContext(cctx, cmd, args...)
+	c.Stdin = strings.NewReader(string(stdin))
+	stdoutBuf := &strings.Builder{}
+	stderrBuf := &strings.Builder{}
+	c.Stdout = stdoutBuf
+	c.Stderr = stderrBuf
+	runErr := c.Run()
+
+	// Forward plugin stderr to operator stderr for visibility
+	if stderrBuf.Len() > 0 && errOut != nil {
+		fmt.Fprintf(errOut,
+			"{\"ts\":%q,\"level\":\"info\",\"component\":\"router-plugin\",\"plugin\":%q,\"msg\":\"plugin-stderr\",\"text\":%q}\n",
+			time.Now().UTC().Format(time.RFC3339),
+			manifest.Name,
+			truncate(stderrBuf.String(), 500),
+		)
+	}
+
+	if runErr != nil {
+		return nil, fmt.Errorf("plugins: %s exec: %w", manifest.Name, runErr)
+	}
+
+	// Parse last newline-delimited JSON from stdout
+	out := strings.TrimSpace(stdoutBuf.String())
+	if out == "" {
+		return nil, fmt.Errorf("plugins: %s produced no output", manifest.Name)
+	}
+	lines := strings.Split(out, "\n")
+	last := strings.TrimSpace(lines[len(lines)-1])
+	var po PluginOutput
+	if err := json.Unmarshal([]byte(last), &po); err != nil {
+		return nil, fmt.Errorf("plugins: %s parse output: %w (last line: %s)", manifest.Name, err, truncate(last, 200))
+	}
+	return &po, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/go/execution-kernel/internal/router/plugins/loader_test.go
+++ b/go/execution-kernel/internal/router/plugins/loader_test.go
@@ -1,0 +1,112 @@
+package plugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeCommand(t *testing.T) {
+	cases := []struct {
+		runtime  string
+		module   string
+		wantCmd  string
+		wantArg0 string
+	}{
+		{"python3", "/p.py", "python3", "-u"},
+		{"python", "/p.py", "python3", "-u"},
+		{"node", "/p.ts", "node", "--experimental-strip-types"},
+		{"bun", "/p.ts", "bun", "run"},
+		{"bash", "/p.sh", "/p.sh", ""},
+	}
+	for _, c := range cases {
+		cmd, args, err := runtimeCommand(c.runtime, c.module)
+		if err != nil {
+			t.Errorf("runtimeCommand(%q): %v", c.runtime, err)
+			continue
+		}
+		if cmd != c.wantCmd {
+			t.Errorf("runtimeCommand(%q) cmd=%q want %q", c.runtime, cmd, c.wantCmd)
+		}
+		if c.wantArg0 != "" && (len(args) == 0 || args[0] != c.wantArg0) {
+			t.Errorf("runtimeCommand(%q) args[0]=%v want %q", c.runtime, args, c.wantArg0)
+		}
+	}
+}
+
+func TestRuntimeCommand_Unsupported(t *testing.T) {
+	_, _, err := runtimeCommand("rust", "/p.rs")
+	if err == nil {
+		t.Error("expected error for unsupported runtime")
+	}
+}
+
+func TestRun_BashEcho(t *testing.T) {
+	// Write a tiny shell script that emits a fixed plugin output
+	dir := t.TempDir()
+	script := filepath.Join(dir, "echo-plugin.sh")
+	body := `#!/usr/bin/env bash
+read -r line  # consume stdin
+echo '{"score":0.42,"fired":false,"reason":"smoke-bash-ok"}'
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := PluginManifest{
+		Name: "smoke-bash", Type: "heuristic",
+		Runtime: "bash", Module: script, TimeoutMs: 2000,
+	}
+	out, err := Run(context.Background(), manifest, map[string]interface{}{
+		"tool_name":  "Read",
+		"tool_input": map[string]interface{}{"file_path": "/tmp/x"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Score != 0.42 {
+		t.Errorf("score=%v want 0.42", out.Score)
+	}
+	if out.Reason != "smoke-bash-ok" {
+		t.Errorf("reason=%q want smoke-bash-ok", out.Reason)
+	}
+}
+
+func TestRun_BashTimeout(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "slow-plugin.sh")
+	body := `#!/usr/bin/env bash
+sleep 10
+echo '{"score":0,"fired":false,"reason":"too-late"}'
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := PluginManifest{
+		Name: "slow", Type: "heuristic",
+		Runtime: "bash", Module: script, TimeoutMs: 200,
+	}
+	_, err := Run(context.Background(), manifest, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Error("expected timeout error; got nil")
+	}
+}
+
+func TestRun_BashMalformedOutput(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "bad-plugin.sh")
+	body := `#!/usr/bin/env bash
+echo "not-json-at-all"
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := PluginManifest{
+		Name: "bad", Type: "heuristic",
+		Runtime: "bash", Module: script, TimeoutMs: 2000,
+	}
+	_, err := Run(context.Background(), manifest, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Error("expected parse error; got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Substrate for the \`router-plugin-loader\` entry. Adds the Go-side loader package + 2 example plugins (Python + TypeScript) demonstrating the wire protocol. Closes the perf-aware plugin-author question from tonight: **Python is the recommended runtime for heuristic plugins (~50-100ms cold-start vs Node's ~500ms).**

## Architecture

Plugins are subprocess invocations declared in \`chitin.yaml\`:

\`\`\`yaml
router:
  plugins:
    - name: destination-allowlist
      type: heuristic
      runtime: python3
      module: examples/router-plugins/python-blast-radius-v2/plugin.py
      config:
        allowed_prefixes: ["apps/", "libs/"]
        threshold: 0.5
      timeout_ms: 1000
\`\`\`

## Wire protocol

| Channel | Format |
|---|---|
| stdin | one JSON line: `{ "hook_input": {...}, "config": {...} }` |
| stdout | one JSON line: `{ "score": 0.0-1.0, "fired": bool, "reason": "...", "axis": {...} }` |
| stderr | structured warnings (forwarded to operator stderr) |

## Runtimes supported

| runtime | cold start | when to use |
|---|---|---|
| python3 | **~50-100ms** | heuristics (recommended; Python is chitin's analysis substrate) |
| node | ~500ms | TS plugins integrating with TS codebases |
| bun | ~50ms | TS, when bun is installed |
| bash | ~10ms | shell-only / prototyping |

## Example plugins (working)

**Python — destination-allowlist:** fires when a write-shaped action targets a path NOT on the operator's allowlist. Smoke-tested: /etc/passwd write fires, apps/foo.ts in-allowlist passes.

**TypeScript — tool-call-rate-limit:** fires when the agent has made > N tool calls in the last 60 seconds. Reads chain events; smoke-tested for no-chain case.

## Test coverage

\`go test ./internal/router/plugins/\` — 4/4 pass:
- Runtime mapping correctness (python/node/bun/bash)
- Unsupported runtime rejection
- End-to-end bash plugin (echo fixed output)
- Timeout enforcement
- Malformed output rejection

## Deferred to follow-up

- **Wire-up** — router pipeline iterating over policy.plugins and calling \`Run()\` per plugin alongside built-in heuristics. Today's PR is the SUBSTRATE; wire-up needs the chitin.yaml policy parser to grow a `plugins:` section. Filed as `router-plugin-wire-up`.
- **Plugin discovery** (auto-load from a `plugins/` dir) — quality-of-life follow-up.
- **npm-package distribution** (`@my-org/chitin-plugin-foo`) — needs a resolver step. Repo-relative paths today.

## Files (~480 LOC, 5 files)

```
go/execution-kernel/internal/router/plugins/
  loader.go               PluginManifest + Run() + runtime dispatch
  loader_test.go          4 tests

examples/router-plugins/python-blast-radius-v2/
  plugin.py               destination-allowlist heuristic

examples/router-plugins/typescript-allowlist/
  plugin.ts               tool-call-rate-limit heuristic
  package.json            "type": "module"
```

## Test plan

- [x] `go build ./internal/router/plugins/` clean
- [x] `go test ./internal/router/plugins/` — 4/4 pass
- [x] Python plugin smoke (allowlist hit + miss)
- [x] Node TS plugin smoke (no-chain case)
- [x] Bash echo plugin smoke (test fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)