### PR TITLE
swarm: nx-generator-app

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,8 @@ importers:
         specifier: '*'
         version: 12.9.0
 
+  tools/generators: {}
+
   tools/lint:
     dependencies:
       '@chitin/contracts':

--- a/tools/generators/app/index.ts
+++ b/tools/generators/app/index.ts
@@ -1,0 +1,186 @@
+import { type Tree } from '@nx/devkit';
+import type { AppGeneratorSchema } from './schema.js';
+
+export default async function appGenerator(
+  tree: Tree,
+  options: AppGeneratorSchema,
+): Promise<void> {
+  const { name, daemon = false } = options;
+  const appRoot = `apps/${name}`;
+
+  tree.write(`${appRoot}/package.json`, packageJson(name));
+  tree.write(`${appRoot}/tsconfig.json`, tsconfig(name));
+  tree.write(`${appRoot}/tsconfig.spec.json`, tsconfigSpec(name));
+  tree.write(`${appRoot}/src/main.ts`, mainTs(name));
+  tree.write(`${appRoot}/tests/${name}.test.ts`, testTs(name));
+  tree.write(`${appRoot}/README.md`, readme(name));
+
+  if (daemon) {
+    tree.write(
+      `${appRoot}/systemd/chitin-${name}.service`,
+      systemdService(name),
+    );
+    tree.write(
+      `${appRoot}/systemd/chitin-${name}.timer`,
+      systemdTimer(name),
+    );
+  }
+}
+
+function packageJson(name: string): string {
+  return (
+    JSON.stringify(
+      {
+        name: `@chitin/${name}`,
+        version: '0.0.1',
+        private: true,
+        type: 'module',
+        main: './src/main.ts',
+        nx: {
+          tags: ['layer:app'],
+          targets: {
+            run: {
+              executor: 'nx:run-commands',
+              options: {
+                command: `pnpm exec tsx apps/${name}/src/main.ts`,
+                cwd: '{workspaceRoot}',
+              },
+            },
+            test: {
+              executor: 'nx:run-commands',
+              options: {
+                command: `pnpm exec vitest run apps/${name}/tests`,
+                cwd: '{workspaceRoot}',
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+function tsconfig(name: string): string {
+  return (
+    JSON.stringify(
+      {
+        extends: '../../tsconfig.base.json',
+        compilerOptions: {
+          outDir: `../../dist/apps/${name}`,
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          allowImportingTsExtensions: true,
+          noEmit: true,
+        },
+        include: ['src/**/*', 'tests/**/*'],
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+function tsconfigSpec(name: string): string {
+  return (
+    JSON.stringify(
+      {
+        extends: '../../tsconfig.base.json',
+        compilerOptions: {
+          outDir: `../../dist/apps/${name}`,
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          allowImportingTsExtensions: true,
+          noEmit: true,
+        },
+        include: ['tests/**/*'],
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+function mainTs(name: string): string {
+  return `// ${name} entry point\n\nconsole.log('${name} started');\n`;
+}
+
+function testTs(name: string): string {
+  return [
+    `import { describe, it, expect } from 'vitest';`,
+    ``,
+    `describe('${name}', () => {`,
+    `  it('placeholder', () => {`,
+    `    expect(true).toBe(true);`,
+    `  });`,
+    `});`,
+    ``,
+  ].join('\n');
+}
+
+function readme(name: string): string {
+  return [
+    `# @chitin/${name}`,
+    ``,
+    `Scaffolded by \`nx g @chitin/generators:app ${name}\`.`,
+    ``,
+    `## Run`,
+    ``,
+    `\`\`\`bash`,
+    `nx run @chitin/${name}:run`,
+    `\`\`\``,
+    ``,
+    `## Test`,
+    ``,
+    `\`\`\`bash`,
+    `nx run @chitin/${name}:test`,
+    `\`\`\``,
+    ``,
+  ].join('\n');
+}
+
+function systemdService(name: string): string {
+  return [
+    `# One-shot service for chitin-${name}, fired by chitin-${name}.timer.`,
+    `#`,
+    `# Install:`,
+    `#   cp apps/${name}/systemd/chitin-${name}.{service,timer} ~/.config/systemd/user/`,
+    `#   systemctl --user daemon-reload`,
+    `#   systemctl --user enable --now chitin-${name}.timer`,
+    ``,
+    `[Unit]`,
+    `Description=Chitin ${name}`,
+    ``,
+    `[Service]`,
+    `Type=oneshot`,
+    `WorkingDirectory=%h/workspace/chitin`,
+    `Environment=CHITIN_REPO_ROOT=%h/workspace/chitin`,
+    `Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin`,
+    `EnvironmentFile=-%h/.config/systemd/user/chitin.env`,
+    `ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/${name}/src/main.ts`,
+    `StandardOutput=journal`,
+    `StandardError=journal`,
+    `TimeoutStartSec=1200`,
+    ``,
+  ].join('\n');
+}
+
+function systemdTimer(name: string): string {
+  return [
+    `# Timer for chitin-${name}.service.`,
+    ``,
+    `[Unit]`,
+    `Description=Chitin ${name} periodic timer`,
+    ``,
+    `[Timer]`,
+    `OnBootSec=5min`,
+    `OnUnitActiveSec=1h`,
+    `Persistent=false`,
+    `Unit=chitin-${name}.service`,
+    ``,
+    `[Install]`,
+    `WantedBy=timers.target`,
+    ``,
+  ].join('\n');
+}

--- a/tools/generators/app/index.ts
+++ b/tools/generators/app/index.ts
@@ -1,12 +1,44 @@
 import { type Tree } from '@nx/devkit';
 import type { AppGeneratorSchema } from './schema.js';
 
+// Lockdown for app names: kebab-case alphanumerics only. Without
+// this, a name like `../foo` would write outside `apps/`, and
+// names with quotes/newlines would generate invalid TS sources.
+const APP_NAME_RE = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+
+function validateName(name: string): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('appGenerator: name is required');
+  }
+  if (name.length > 64) {
+    throw new Error(`appGenerator: name too long (${name.length} > 64): ${JSON.stringify(name)}`);
+  }
+  if (!APP_NAME_RE.test(name)) {
+    throw new Error(
+      `appGenerator: name must match /^[a-z][a-z0-9-]*[a-z0-9]$/ ` +
+        `(kebab-case, no path separators, no quotes/newlines). got: ${JSON.stringify(name)}`,
+    );
+  }
+}
+
 export default async function appGenerator(
   tree: Tree,
   options: AppGeneratorSchema,
 ): Promise<void> {
   const { name, daemon = false } = options;
+  validateName(name);
+
   const appRoot = `apps/${name}`;
+
+  // Refuse to silently overwrite an existing app. The Nx Tree's
+  // exists() returns true for any path the tree knows about
+  // (already-on-disk OR pending-write); both are reasons to bail.
+  if (tree.exists(appRoot)) {
+    throw new Error(
+      `appGenerator: refusing to overwrite existing path ${appRoot}. ` +
+        `Pick a different name, or remove the existing directory first.`,
+    );
+  }
 
   tree.write(`${appRoot}/package.json`, packageJson(name));
   tree.write(`${appRoot}/tsconfig.json`, tsconfig(name));
@@ -158,7 +190,11 @@ function systemdService(name: string): string {
     `Environment=CHITIN_REPO_ROOT=%h/workspace/chitin`,
     `Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin`,
     `EnvironmentFile=-%h/.config/systemd/user/chitin.env`,
-    `ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/${name}/src/main.ts`,
+    // ExecStart relies on the unit's PATH (set above to include
+    // %h/.vite-plus/bin) rather than hardcoding /home/<operator>/...
+    // — the latter breaks the moment another operator or CI runs
+    // the unit.
+    `ExecStart=pnpm exec tsx apps/${name}/src/main.ts`,
     `StandardOutput=journal`,
     `StandardError=journal`,
     `TimeoutStartSec=1200`,

--- a/tools/generators/app/schema.d.ts
+++ b/tools/generators/app/schema.d.ts
@@ -1,0 +1,4 @@
+export interface AppGeneratorSchema {
+  name: string;
+  daemon?: boolean;
+}

--- a/tools/generators/app/schema.json
+++ b/tools/generators/app/schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "chitin-app",
+  "title": "Generate a Chitin App",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "App name (kebab-case) — becomes apps/<name>/ and @chitin/<name>",
+      "$default": { "$source": "argv", "index": 0 }
+    },
+    "daemon": {
+      "type": "boolean",
+      "description": "Emit systemd .service + .timer templates under apps/<name>/systemd/",
+      "default": false
+    }
+  },
+  "required": ["name"]
+}

--- a/tools/generators/generators.json
+++ b/tools/generators/generators.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "name": "chitin",
+  "version": "0.0.1",
+  "generators": {
+    "app": {
+      "factory": "./app/index",
+      "schema": "./app/schema.json",
+      "description": "Scaffold a new chitin app with run + test targets (--daemon adds systemd units)"
+    }
+  }
+}

--- a/tools/generators/package.json
+++ b/tools/generators/package.json
@@ -2,6 +2,7 @@
   "name": "@chitin/generators",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "generators": "./generators.json",
   "nx": {
     "tags": ["layer:tooling"]

--- a/tools/generators/package.json
+++ b/tools/generators/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@chitin/generators",
+  "version": "0.0.1",
+  "private": true,
+  "generators": "./generators.json",
+  "nx": {
+    "tags": ["layer:tooling"]
+  }
+}


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `nx-generator-app`
Tier: `T3`  •  Driver: `claude-code-headless`
Workflow: `swarm-nx-generator-app-1777845954620`

## Entry context

`nx g @chitin/app <name> [--daemon]` scaffolds an app shape:
package.json with `nx:run-commands` run + test targets,
tsconfig.json + tsconfig.spec.json (extending base), src/main.ts
stub, tests/, README. With `--daemon`: also emits
systemd .service + .timer templates under `apps/<name>/systemd/`
following the `chitin-<name>.{service,timer}` convention used by
dispatcher/researcher/groomer/etc.

Same layer-tag depConstraint update as the workspace-lib generator.

**Acceptance:**
- [ ] Generated app boots via `nx run @chitin/<name>:run`
- [ ] --daemon variant produces working systemd units
- [ ] lint-layer-tag-coverage passes


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-nx-generator-app-1777845954620`
Branch: `swarm/swarm-nx-generator-app-1777845954620`
Head: `a89c0ed0`
Diff: `6 files changed, 242 insertions(+), 10 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)