### PR TITLE
feat(router): pre-action analysis plugins (block flag) + nx-test-before-commit example

### DIFF
--- a/examples/router-plugins/python-nx-test-before-commit/plugin.py
+++ b/examples/router-plugins/python-nx-test-before-commit/plugin.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Pre-action analysis plugin: block git commit when nx-affected tests fail.
+
+Runs `pnpm exec nx affected -t test --base=<base>` against the
+current diff before allowing a `git commit` shell.exec action. If
+any test fails, the plugin returns Block=true and the router
+denies the commit immediately (no advisor consultation — this is
+a deterministic check, not a judgment call).
+
+Operator chitin.yaml:
+
+  router:
+    enabled: true
+    plugins:
+      - name: nx-test-before-commit
+        type: heuristic
+        runtime: python3
+        module: examples/router-plugins/python-nx-test-before-commit/plugin.py
+        config:
+          base_ref: origin/main
+          test_target: test
+        timeout_ms: 120000           # nx affected can take up to 2 min on big repos
+
+  # Trust this plugin (path+hash):
+  plugins_trust:
+    mode: path+hash
+    trusted_paths:
+      - <abs path to plugin.py>
+    trusted_hashes:
+      nx-test-before-commit: <sha256>
+"""
+import json
+import subprocess
+import sys
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"score": 0, "fired": False, "reason": f"plugin-bad-stdin:{e}"}))
+        sys.exit(0)
+
+    hook_input = payload.get("hook_input", {})
+    config = payload.get("config", {})
+    tool_name: str = hook_input.get("tool_name", "")
+    cmd: str = hook_input.get("tool_input", {}).get("command", "") or ""
+    cwd: str = hook_input.get("cwd", "") or "."
+
+    # Only fires on git-commit shell calls
+    if tool_name != "Bash" or "git commit" not in cmd:
+        print(json.dumps({"score": 0, "fired": False, "reason": "not-git-commit"}))
+        return
+
+    base_ref: str = config.get("base_ref", "origin/main")
+    test_target: str = config.get("test_target", "test")
+
+    # Run nx affected (catches: any test for any project that the
+    # current diff touches must pass before commit)
+    try:
+        result = subprocess.run(
+            ["pnpm", "exec", "nx", "affected", "-t", test_target, "--base=" + base_ref],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=110,  # leave headroom inside the plugin's 120s timeout
+        )
+    except FileNotFoundError:
+        # No pnpm/nx available — non-blocking warn
+        print(json.dumps({
+            "score": 0, "fired": False,
+            "reason": "pnpm-or-nx-not-available; commit allowed (operator should configure)",
+        }))
+        return
+    except subprocess.TimeoutExpired:
+        print(json.dumps({
+            "score": 1.0, "fired": True, "block": True,
+            "reason": "nx-affected-timed-out — commit blocked; tests took too long",
+            "axis": {"timeout_s": 110},
+        }))
+        return
+
+    if result.returncode != 0:
+        # nx affected failed — block the commit
+        tail = (result.stderr or result.stdout or "")[-400:]
+        print(json.dumps({
+            "score": 1.0,
+            "fired": True,
+            "block": True,
+            "reason": f"nx-affected-test-failed (target={test_target}, base={base_ref}); commit blocked. Tail of nx output:\n{tail}",
+            "axis": {"exit_code": result.returncode, "test_target": test_target},
+        }))
+        return
+
+    # All tests passed — allow the commit
+    print(json.dumps({
+        "score": 0.0,
+        "fired": False,
+        "reason": f"nx-affected-tests-pass (target={test_target})",
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/go/execution-kernel/cmd/chitin-kernel/router_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook.go
@@ -120,6 +120,25 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 		}
 	}
 
+	// Pre-action analysis short-circuit: if any plugin fired with
+	// block=true, deny immediately with the plugin's reason. The
+	// advisor is NOT consulted — pre-action plugins have
+	// authoritative verdict (e.g., "no commit until tests pass" is
+	// a deterministic check, not a judgment call).
+	for _, r := range pluginResults {
+		if r.Score.Fired && r.Block {
+			composed := map[string]string{
+				"decision": "block",
+				"reason":   "pre-action-analysis (" + r.Name + "): " + r.Score.Reason,
+			}
+			body, _ := json.Marshal(composed)
+			_, _ = out.Write(body)
+			_, _ = out.Write([]byte{'\n'})
+			writeRouterTelemetry(errOut, "pre-action-block", outcome, false)
+			return claudecode.ExitBlock
+		}
+	}
+
 	// Decide whether to invoke the advisor
 	kernelDeny := kernelCode == claudecode.ExitBlock
 	wantAdvisor := false

--- a/go/execution-kernel/internal/router/plugin_runner.go
+++ b/go/execution-kernel/internal/router/plugin_runner.go
@@ -77,8 +77,9 @@ func RunPlugins(ctx context.Context, pluginConfigs []PluginConfig, trust Plugins
 				return
 			}
 			results[idx] = NamedHeuristicScore{
-				Name: p.Name,
-				Type: p.Type,
+				Name:  p.Name,
+				Type:  p.Type,
+				Block: out.Block,
 				Score: HeuristicScore{
 					Score:  out.Score,
 					Fired:  out.Fired,
@@ -100,11 +101,16 @@ func RunPlugins(ctx context.Context, pluginConfigs []PluginConfig, trust Plugins
 }
 
 // NamedHeuristicScore wraps a HeuristicScore with the plugin's
-// name + type so the router can route fired-plugin signals into
-// advisor triggers.
+// name + type + block flag so the router can route fired-plugin
+// signals into advisor triggers OR direct blocks.
 type NamedHeuristicScore struct {
 	Name  string
 	Type  string
+	// Block — when true AND Score.Fired is true, the router denies
+	// the action directly with Score.Reason as the deny message
+	// (pre-action analysis verdict). When false, the firing is a
+	// heuristic signal that may trigger advisor consultation.
+	Block bool
 	Score HeuristicScore
 }
 

--- a/go/execution-kernel/internal/router/plugins/block_test.go
+++ b/go/execution-kernel/internal/router/plugins/block_test.go
@@ -1,0 +1,69 @@
+package plugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRun_BlockFlag verifies a pre-action analysis plugin's
+// block:true flag round-trips through the loader.
+func TestRun_BlockFlag(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "blocker.sh")
+	body := `#!/usr/bin/env bash
+read -r line  # consume stdin
+echo '{"score":1.0,"fired":true,"block":true,"reason":"test-block-fired"}'
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := PluginManifest{
+		Name: "blocker", Type: "heuristic",
+		Runtime: "bash", Module: script, TimeoutMs: 2000,
+	}
+	out, err := Run(context.Background(), manifest, map[string]interface{}{
+		"tool_name": "Bash",
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !out.Block {
+		t.Errorf("Block=%v want true", out.Block)
+	}
+	if !out.Fired {
+		t.Errorf("Fired=%v want true", out.Fired)
+	}
+	if out.Reason != "test-block-fired" {
+		t.Errorf("Reason=%q want test-block-fired", out.Reason)
+	}
+}
+
+// TestRun_NoBlockField — backward compat: plugins emitting the
+// pre-Block schema still work; Block defaults to false.
+func TestRun_NoBlockField(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "legacy.sh")
+	body := `#!/usr/bin/env bash
+read -r line
+echo '{"score":0.7,"fired":true,"reason":"legacy-heuristic"}'
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := PluginManifest{
+		Name: "legacy", Type: "heuristic",
+		Runtime: "bash", Module: script, TimeoutMs: 2000,
+	}
+	out, err := Run(context.Background(), manifest, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Block {
+		t.Errorf("Block=%v want false (no field present)", out.Block)
+	}
+	if !out.Fired {
+		t.Error("Fired=false; want true")
+	}
+}

--- a/go/execution-kernel/internal/router/plugins/loader.go
+++ b/go/execution-kernel/internal/router/plugins/loader.go
@@ -62,11 +62,31 @@ type PluginInput struct {
 }
 
 // PluginOutput is what the plugin writes to stdout.
+//
+// Two plugin shapes are supported:
+//
+//  1. HEURISTIC plugins — score the action; firing flags it for
+//     advisor consultation but doesn't block on its own. Set
+//     Fired but leave Block false.
+//
+//  2. PRE-ACTION ANALYSIS plugins — block the action directly
+//     based on a deterministic check (e.g., "no commit until tests
+//     pass"). Set both Fired AND Block=true. The router emits a
+//     kernel-level deny with the plugin's Reason as the message;
+//     no advisor consultation is needed (plugin verdict is
+//     authoritative).
+//
+// A plugin can switch shape per-invocation: heuristic-fire on
+// one input and block-fire on another.
 type PluginOutput struct {
 	Score  float64                `json:"score"`
 	Fired  bool                   `json:"fired"`
 	Reason string                 `json:"reason"`
 	Axis   map[string]interface{} `json:"axis,omitempty"`
+	// Block — when true AND Fired is true, the router denies the
+	// action directly with Reason as the deny message; advisor
+	// not consulted.
+	Block bool `json:"block,omitempty"`
 }
 
 // runtimeCommand maps a runtime label to the exec.Command shape.


### PR DESCRIPTION
## Summary

Adds a new plugin verdict shape: pre-action plugins can **BLOCK an action directly** without consulting the advisor. Closes the bulletproofness checklist row "Pre-action analysis (e.g., test-before-commit)" from PR #237's strategic entry.

## What this enables

| Heuristic plugin | Pre-action plugin |
|---|---|
| Scores subjectively | Deterministic check |
| Advisor decides verdict | Plugin verdict is authoritative |
| Use when: "this looks risky" | Use when: "tests must pass before commit" |
| Set Fired=true | Set Fired=true AND Block=true |

The two aren't mutually exclusive — a plugin can heuristic-fire on one input and block-fire on another.

## Example: `nx-test-before-commit`

Pure-Python plugin (~80 LOC). Listens for `git commit` shell.exec actions; runs `pnpm exec nx affected -t test --base=<base>`; blocks the commit if any test fails.

\`\`\`yaml
router:
  plugins:
    - name: nx-test-before-commit
      type: heuristic
      runtime: python3
      module: <path>/plugin.py
      config: { base_ref: origin/main, test_target: test }
      timeout_ms: 120000
\`\`\`

Smoke verified:
- `echo hi` → not-git-commit → no fire, no block (fast pass)
- `git commit -m foo` (no pnpm workspace) → block with error tail in deny reason

## Pipeline change

After plugin execution, BEFORE advisor decision:
- Loop over pluginResults
- If any plugin fired with Block=true → emit deny + Reason immediately, skip advisor entirely
- Telemetry: `writeRouterTelemetry "pre-action-block"`

## Files (~223 LOC)

```
go/execution-kernel/internal/router/plugins/
  loader.go               + PluginOutput.Block field
  block_test.go           NEW: 2 tests (block flag + legacy compat)
go/execution-kernel/internal/router/
  plugin_runner.go        + NamedHeuristicScore.Block + mapping
go/execution-kernel/cmd/chitin-kernel/
  router_hook.go          + pre-action short-circuit before advisor
examples/router-plugins/python-nx-test-before-commit/
  plugin.py               example: nx affected → block commit on fail
```

## Test plan

- [x] `go test ./internal/router/...` — pass (2 new tests + existing)
- [x] `go test ./cmd/chitin-kernel/...` — pass, no regressions
- [x] Plugin smoke: not-git-commit case + block case
- [x] Backward compat: pre-existing plugins emitting score+fired only (no block field) continue to work as heuristics

🤖 Generated with [Claude Code](https://claude.com/claude-code)