### PR TITLE
feat(ops): re-ship install-kernel.sh + redeploy timer (PR #222 dropped files)

### DIFF
--- a/infra/systemd/chitin-kernel-redeploy.service
+++ b/infra/systemd/chitin-kernel-redeploy.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Rebuild + reinstall chitin-kernel from main
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/workspace/chitin/scripts/install-kernel.sh
+
+# Resource caps
+MemoryMax=2G
+CPUQuota=200%
+TimeoutStartSec=300
+
+# Don't auto-restart — a build failure wants operator attention
+Restart=no
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/chitin-kernel-redeploy.timer
+++ b/infra/systemd/chitin-kernel-redeploy.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Trigger chitin-kernel-redeploy every 15 min
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+Persistent=true
+
+Unit=chitin-kernel-redeploy.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Idempotent rebuild + reinstall of chitin-kernel. Designed to be
+# triggered by chitin-kernel-redeploy.timer every 15 minutes, but
+# safe to run manually at any time.
+#
+# Closes the deploy-lag pattern documented in
+# docs/observations/2026-05-03-low-success-alarm-investigation.md:
+# kernel/policy fixes can sit in `main` for hours-to-days because
+# nobody manually rebuilds, and the swarm runs against a stale
+# binary. This script narrows the window to ~15 minutes.
+#
+# (Re-shipping after PR #222's merge dropped the implementation
+# files; only the docs landed. This PR ships the actual code.)
+#
+# Decision tree:
+#   1. fetch origin/main; if behind, pull.
+#   2. if either (a) the new commits touch go/ or chitin.yaml OR
+#      (b) the binary is older than tracked sources → rebuild.
+#   3. smoke-test the freshly-built binary; on failure, roll back
+#      to the prior binary (saved aside in $BIN.prev) and exit
+#      non-zero so the systemd unit reports failure.
+#   4. log structured JSON to ~/.cache/chitin/install-kernel.jsonl
+#      (one line per run) for grep-ability.
+#
+# Exit codes:
+#   0  no-op (no relevant changes since last run)
+#   0  successful rebuild + smoke pass
+#   1  pull conflict — operator must resolve manually
+#   2  build failure — operator must investigate; rollback attempted
+#   3  smoke failure, rollback succeeded — fix in main is bad; revert
+#   4  smoke failure AND rollback failed — binary in undefined state
+
+set -euo pipefail
+
+REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+BIN="${CHITIN_KERNEL_BIN:-$HOME/.local/bin/chitin-kernel}"
+PREV="$BIN.prev"
+LOG="${CHITIN_INSTALL_KERNEL_LOG:-$HOME/.cache/chitin/install-kernel.jsonl}"
+
+mkdir -p "$(dirname "$LOG")" "$(dirname "$BIN")"
+
+emit() {
+  local kind="$1" msg="$2"
+  shift 2
+  local extras=""
+  while (($#)); do
+    local k="${1%%=*}" v="${1#*=}"
+    v="${v//\\/\\\\}"
+    v="${v//\"/\\\"}"
+    extras+=",\"${k}\":\"${v}\""
+    shift
+  done
+  local line
+  line=$(printf '{"ts":"%s","kind":"%s","msg":"%s"%s}' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$kind" "$msg" "$extras")
+  printf '%s\n' "$line" | tee -a "$LOG" >&2
+}
+
+cd "$REPO"
+
+old_sha=$(git rev-parse HEAD)
+if ! git fetch --quiet origin main; then
+  emit fail fetch-failed "old_sha=$old_sha"
+  exit 1
+fi
+new_sha=$(git rev-parse origin/main)
+
+need_rebuild=0
+relevant_changes_since_last="(none)"
+
+if [[ "$old_sha" != "$new_sha" ]]; then
+  if git diff --quiet "$old_sha" "$new_sha" -- go/ chitin.yaml; then
+    if ! git pull --ff-only --quiet origin main; then
+      emit fail pull-conflict "old_sha=$old_sha" "new_sha=$new_sha"
+      exit 1
+    fi
+    emit noop "no kernel-relevant changes" "old_sha=$old_sha" "new_sha=$new_sha"
+    exit 0
+  else
+    if ! git pull --ff-only --quiet origin main; then
+      emit fail pull-conflict "old_sha=$old_sha" "new_sha=$new_sha"
+      exit 1
+    fi
+    need_rebuild=1
+    relevant_changes_since_last=$(git diff --name-only "$old_sha" "$new_sha" -- go/ chitin.yaml | tr '\n' ',' | sed 's/,$//')
+  fi
+fi
+
+if [[ $need_rebuild -eq 0 ]]; then
+  if [[ ! -x "$BIN" ]]; then
+    need_rebuild=1
+    relevant_changes_since_last="binary-missing"
+  elif find go chitin.yaml -newer "$BIN" -print -quit 2>/dev/null | grep -q .; then
+    need_rebuild=1
+    relevant_changes_since_last="binary-stale-relative-to-source"
+  fi
+fi
+
+if [[ $need_rebuild -eq 0 ]]; then
+  emit noop "no rebuild needed" "old_sha=$old_sha"
+  exit 0
+fi
+
+# Save prev binary for rollback
+if [[ -x "$BIN" ]]; then
+  cp -a "$BIN" "$PREV"
+fi
+
+# Build. Chitin's go module is nested at go/execution-kernel/go.mod
+# (no top-level go.mod), so `go build` runs from inside that module.
+build_start_ns=$(date +%s%N)
+if ! ( cd "$REPO/go/execution-kernel" && go build -o "$BIN" ./cmd/chitin-kernel ) 2>&1; then
+  emit fail build-failed "old_sha=$old_sha" "new_sha=$new_sha"
+  if [[ -x "$PREV" ]]; then
+    cp -a "$PREV" "$BIN"
+    emit rollback build-fail-rollback-success "restored_from=$PREV"
+  fi
+  exit 2
+fi
+build_dur_ms=$(( ($(date +%s%N) - build_start_ns) / 1000000 ))
+
+# Smoke-test: a `Task` PreToolUse evaluate must exit 0.
+smoke_payload=$(printf '{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":{"description":"redeploy-smoke"},"cwd":"%s","session_id":"redeploy-smoke"}' "$REPO")
+if ! echo "$smoke_payload" | timeout 2 "$BIN" gate evaluate --hook-stdin --agent=redeploy-smoke >/dev/null 2>&1; then
+  emit fail smoke-failed "new_sha=$new_sha" "build_dur_ms=$build_dur_ms"
+  if [[ -x "$PREV" ]] && cp -a "$PREV" "$BIN"; then
+    emit rollback smoke-rollback-success "restored_from=$PREV"
+    exit 3
+  else
+    emit fail smoke-rollback-failed-binary-undefined "expected_prev=$PREV"
+    exit 4
+  fi
+fi
+
+emit ok redeploy-success "old_sha=$old_sha" "new_sha=$new_sha" "build_dur_ms=$build_dur_ms" "changed=$relevant_changes_since_last"
+exit 0


### PR DESCRIPTION
## Summary

Re-ships the kernel auto-rebuild scripts that PR #222 (auto-rebuild kernel timer) was supposed to merge — discovered tonight while activating the router that only the BACKLOG entry made it; the actual code was dropped during the rebase conflicts.

## Why this matters

Without auto-rebuild, kernel/policy fixes sit in main for hours-to-days until someone manually rebuilds. The 2026-05-03 low-success alarm was caused by exactly this: binary 20h behind PR #171's normalizer fix.

This timer narrows the deploy-lag window to ~15 minutes.

## Files

```
scripts/install-kernel.sh                    Idempotent rebuild + smoke + rollback
infra/systemd/chitin-kernel-redeploy.service User-level oneshot
infra/systemd/chitin-kernel-redeploy.timer   15-min cadence
```

## Operator install (after merge)

\`\`\`bash
ln -sf /home/red/workspace/chitin/infra/systemd/chitin-kernel-redeploy.service \\
       ~/.config/systemd/user/
ln -sf /home/red/workspace/chitin/infra/systemd/chitin-kernel-redeploy.timer \\
       ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now chitin-kernel-redeploy.timer
\`\`\`

## Verified

- `bash -n scripts/install-kernel.sh` — syntax OK
- `systemd-analyze --user verify infra/systemd/chitin-kernel-redeploy.{service,timer}` — clean

## Test plan

- [x] Script syntax valid
- [x] systemd unit syntax valid
- [x] Five exit codes documented (0 noop / 0 ok / 1 pull-conflict / 2 build-fail / 3 smoke-fail-rollback / 4 smoke-fail-rollback-failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)