### PR TITLE
feat(chain): chitin-kernel chain stats — aggregate analytics by axis

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/replay_cmd.go
+++ b/go/execution-kernel/cmd/chitin-kernel/replay_cmd.go
@@ -182,7 +182,9 @@ Default: tool_name.`)
 	if jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(stats)
+		if err := enc.Encode(stats); err != nil {
+			exitErr("chain_stats_json", err.Error())
+		}
 		return
 	}
 	fmt.Printf("chitin chain stats — by %s\n", axis)

--- a/go/execution-kernel/cmd/chitin-kernel/replay_cmd.go
+++ b/go/execution-kernel/cmd/chitin-kernel/replay_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -133,7 +134,7 @@ func cmdChainRelated(args []string) {
 // `replay`, `summarize`, and `related` are wired here.
 func cmdChain(args []string) {
 	if len(args) < 1 {
-		exitErr("chain_no_subcommand", "usage: chitin-kernel chain <replay|summarize|related> [flags]")
+		exitErr("chain_no_subcommand", "usage: chitin-kernel chain <replay|summarize|related|snapshot|stats> [flags]")
 	}
 	switch args[0] {
 	case "replay":
@@ -144,7 +145,58 @@ func cmdChain(args []string) {
 		cmdChainRelated(args[1:])
 	case "snapshot":
 		cmdChainSnapshot(args[1:])
+	case "stats":
+		cmdChainStats(args[1:])
 	default:
 		exitErr("chain_unknown_subcommand", args[0])
+	}
+}
+
+// cmdChainStats — chitin-kernel chain stats [--by=<axis>] [--json]
+// Aggregates decisions across all chain JSONLs; outputs per-bucket
+// counts + success rates. Foundation for tier-router-by-data.
+func cmdChainStats(args []string) {
+	axis := "tool_name"
+	jsonOut := false
+	for _, a := range args {
+		switch {
+		case strings.HasPrefix(a, "--by="):
+			axis = a[len("--by="):]
+		case a == "--json":
+			jsonOut = true
+		case a == "--help" || a == "-h":
+			fmt.Fprintln(os.Stderr, `Usage: chitin-kernel chain stats [--by=<axis>] [--json]
+
+Aggregate decision events across all sessions; output per-bucket
+counts + success rates.
+
+Axes: tool_name | action_type | rule_id | decision | agent
+Default: tool_name.`)
+			os.Exit(0)
+		}
+	}
+	stats, err := replay.ComputeStats(axis)
+	if err != nil {
+		exitErr("chain_stats_failed", err.Error())
+	}
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(stats)
+		return
+	}
+	fmt.Printf("chitin chain stats — by %s\n", axis)
+	fmt.Printf("  total decisions: %d\n\n", stats.Total)
+	fmt.Printf("  %-30s %10s %10s %10s %10s\n", "bucket", "decisions", "allows", "denies", "success%")
+	fmt.Printf("  %-30s %10s %10s %10s %10s\n", "------", "---------", "------", "------", "--------")
+	for _, k := range stats.SortedBucketKeys() {
+		b := stats.Buckets[k]
+		key := k
+		if len(key) > 30 {
+			key = key[:27] + "..."
+		}
+		fmt.Printf("  %-30s %10d %10d %10d %9.1f%%\n",
+			key, b.Decisions, b.Allows, b.Denies, b.SuccessRate*100,
+		)
 	}
 }

--- a/go/execution-kernel/internal/replay/stats.go
+++ b/go/execution-kernel/internal/replay/stats.go
@@ -1,0 +1,129 @@
+package replay
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Stats — aggregate chain analytics keyed by an axis.
+type Stats struct {
+	Axis    string                 `json:"axis"`
+	Buckets map[string]BucketStats `json:"buckets"`
+	Total   int                    `json:"total_decisions"`
+	Window  string                 `json:"window,omitempty"`
+}
+
+// BucketStats — per-axis-bucket counts.
+type BucketStats struct {
+	Decisions int `json:"decisions"`
+	Allows    int `json:"allows"`
+	Denies    int `json:"denies"`
+	// SuccessRate is allows / decisions (0.0-1.0). NaN-safe: 0
+	// when decisions=0.
+	SuccessRate float64 `json:"success_rate"`
+}
+
+// ComputeStats reads all chain JSONL files in ~/.chitin/ and
+// aggregates decisions by axis. Axis can be:
+//   - tool_name      (which Claude Code tool)
+//   - action_type    (which gov action)
+//   - rule_id        (which policy rule)
+//   - decision       (allow/deny — pivot for sanity-check)
+//   - agent          (agent_instance_id)
+func ComputeStats(axis string) (*Stats, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	pattern := filepath.Join(home, ".chitin", "events-*.jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	stats := &Stats{
+		Axis:    axis,
+		Buckets: make(map[string]BucketStats),
+	}
+	for _, p := range matches {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var ev map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				continue
+			}
+			etype, _ := ev["event_type"].(string)
+			if etype != "decision" {
+				continue
+			}
+			payload, _ := ev["payload"].(map[string]interface{})
+			if payload == nil {
+				continue
+			}
+			bucket := extractAxis(ev, payload, axis)
+			if bucket == "" {
+				continue
+			}
+			stats.Total++
+			b := stats.Buckets[bucket]
+			b.Decisions++
+			if dec, _ := payload["decision"].(string); dec == "allow" {
+				b.Allows++
+			} else if dec == "deny" {
+				b.Denies++
+			}
+			stats.Buckets[bucket] = b
+		}
+	}
+	// Compute success rates
+	for k, b := range stats.Buckets {
+		if b.Decisions > 0 {
+			b.SuccessRate = float64(b.Allows) / float64(b.Decisions)
+		}
+		stats.Buckets[k] = b
+	}
+	return stats, nil
+}
+
+func extractAxis(ev, payload map[string]interface{}, axis string) string {
+	switch axis {
+	case "tool_name":
+		s, _ := payload["tool_name"].(string)
+		return s
+	case "action_type":
+		s, _ := payload["action_type"].(string)
+		return s
+	case "rule_id":
+		s, _ := payload["rule_id"].(string)
+		return s
+	case "decision":
+		s, _ := payload["decision"].(string)
+		return s
+	case "agent":
+		s, _ := ev["agent_instance_id"].(string)
+		return s
+	}
+	return ""
+}
+
+// SortedBucketKeys returns bucket keys sorted by decision count
+// descending (most-frequent first).
+func (s *Stats) SortedBucketKeys() []string {
+	keys := make([]string, 0, len(s.Buckets))
+	for k := range s.Buckets {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return s.Buckets[keys[i]].Decisions > s.Buckets[keys[j]].Decisions
+	})
+	return keys
+}

--- a/go/execution-kernel/internal/replay/stats.go
+++ b/go/execution-kernel/internal/replay/stats.go
@@ -2,6 +2,7 @@ package replay
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,19 +27,54 @@ type BucketStats struct {
 	SuccessRate float64 `json:"success_rate"`
 }
 
+// SupportedAxes is the closed set of axis labels accepted by
+// ComputeStats. Exposed so the CLI can validate `--by=...` up
+// front and produce a useful error instead of silently returning
+// an empty bucket map.
+var SupportedAxes = []string{"tool_name", "action_type", "rule_id", "decision", "agent"}
+
+// IsSupportedAxis reports whether a is a known axis label.
+func IsSupportedAxis(a string) bool {
+	for _, s := range SupportedAxes {
+		if s == a {
+			return true
+		}
+	}
+	return false
+}
+
 // ComputeStats reads all chain JSONL files in ~/.chitin/ and
-// aggregates decisions by axis. Axis can be:
+// aggregates decisions by axis. Axis must be one of SupportedAxes;
+// an unknown axis returns an explicit error rather than silently
+// returning empty results (which would mask CLI typos).
+//
+// Axis labels:
 //   - tool_name      (which Claude Code tool)
 //   - action_type    (which gov action)
 //   - rule_id        (which policy rule)
 //   - decision       (allow/deny — pivot for sanity-check)
 //   - agent          (agent_instance_id)
 func ComputeStats(axis string) (*Stats, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	return ComputeStatsIn(axis, "")
+}
+
+// ComputeStatsIn is ComputeStats with an explicit chain dir. Empty
+// chitinDir resolves to ~/.chitin (the default). The override
+// path exists for tests + advanced operator scenarios; production
+// CLI use should call ComputeStats.
+func ComputeStatsIn(axis, chitinDir string) (*Stats, error) {
+	if !IsSupportedAxis(axis) {
+		return nil, fmt.Errorf("unsupported axis %q (want one of: %s)",
+			axis, strings.Join(SupportedAxes, ", "))
 	}
-	pattern := filepath.Join(home, ".chitin", "events-*.jsonl")
+	if chitinDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		chitinDir = filepath.Join(home, ".chitin")
+	}
+	pattern := filepath.Join(chitinDir, "events-*.jsonl")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, err
@@ -48,6 +84,12 @@ func ComputeStats(axis string) (*Stats, error) {
 		Buckets: make(map[string]BucketStats),
 	}
 	for _, p := range matches {
+		// Note: we read the whole file and split on newlines for
+		// simplicity. For typical chain logs this is well under 5MB
+		// per file. Streaming via bufio.Scanner would help if a
+		// long-running install accumulates >100MB per session,
+		// which is not the current regime — measure before
+		// switching.
 		data, err := os.ReadFile(p)
 		if err != nil {
 			continue
@@ -116,14 +158,22 @@ func extractAxis(ev, payload map[string]interface{}, axis string) string {
 }
 
 // SortedBucketKeys returns bucket keys sorted by decision count
-// descending (most-frequent first).
+// descending (most-frequent first), with bucket-name lexicographic
+// as the tie-breaker. The named tie-breaker matters because two
+// runs over the same data must produce identical CLI output —
+// without it, ties resolve via Go map iteration order, which is
+// randomized.
 func (s *Stats) SortedBucketKeys() []string {
 	keys := make([]string, 0, len(s.Buckets))
 	for k := range s.Buckets {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
-		return s.Buckets[keys[i]].Decisions > s.Buckets[keys[j]].Decisions
+		bi, bj := s.Buckets[keys[i]], s.Buckets[keys[j]]
+		if bi.Decisions != bj.Decisions {
+			return bi.Decisions > bj.Decisions
+		}
+		return keys[i] < keys[j]
 	})
 	return keys
 }

--- a/go/execution-kernel/internal/replay/stats_test.go
+++ b/go/execution-kernel/internal/replay/stats_test.go
@@ -1,0 +1,127 @@
+package replay
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeChain materializes a synthetic events-*.jsonl in dir with
+// the given decision events. Each event is a one-line JSON object
+// shaped like the kernel's chain emitter.
+func writeChain(t *testing.T, dir, sessionID string, events string) {
+	t.Helper()
+	path := filepath.Join(dir, "events-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestComputeStatsIn_BucketCountsAndSuccessRate(t *testing.T) {
+	tmp := t.TempDir()
+	writeChain(t, tmp, "s1",
+		`{"event_type":"decision","payload":{"tool_name":"Bash","action_type":"shell.exec","decision":"allow","rule_id":"default-allow-shell"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"Bash","action_type":"shell.exec","decision":"allow","rule_id":"default-allow-shell"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"Bash","action_type":"shell.exec","decision":"deny","rule_id":"no-rm-recursive"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"Read","action_type":"file.read","decision":"allow","rule_id":"default-allow-reads"}}`+"\n",
+	)
+
+	s, err := ComputeStatsIn("tool_name", tmp)
+	if err != nil {
+		t.Fatalf("ComputeStatsIn: %v", err)
+	}
+	if s.Total != 4 {
+		t.Errorf("Total=%d want 4", s.Total)
+	}
+	bash := s.Buckets["Bash"]
+	if bash.Decisions != 3 || bash.Allows != 2 || bash.Denies != 1 {
+		t.Errorf("Bash bucket=%+v want decisions=3 allows=2 denies=1", bash)
+	}
+	wantRate := 2.0 / 3.0
+	if bash.SuccessRate < wantRate-1e-9 || bash.SuccessRate > wantRate+1e-9 {
+		t.Errorf("Bash.SuccessRate=%v want ≈%v", bash.SuccessRate, wantRate)
+	}
+	read := s.Buckets["Read"]
+	if read.Decisions != 1 || read.Allows != 1 {
+		t.Errorf("Read bucket=%+v", read)
+	}
+}
+
+func TestComputeStatsIn_UnknownAxisErrors(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := ComputeStatsIn("not_a_real_axis", tmp)
+	if err == nil {
+		t.Fatal("expected error for unsupported axis; got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported axis") {
+		t.Errorf("error text=%q want to mention unsupported axis", err.Error())
+	}
+}
+
+func TestComputeStatsIn_SkipsNonDecisionEvents(t *testing.T) {
+	tmp := t.TempDir()
+	writeChain(t, tmp, "s1",
+		`{"event_type":"audit","payload":{"tool_name":"Bash"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"Bash","decision":"allow"}}`+"\n",
+	)
+	s, err := ComputeStatsIn("tool_name", tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Total != 1 {
+		t.Errorf("Total=%d want 1 (audit event must be skipped)", s.Total)
+	}
+}
+
+func TestComputeStatsIn_EmptyDirYieldsEmptyStats(t *testing.T) {
+	tmp := t.TempDir()
+	s, err := ComputeStatsIn("tool_name", tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Total != 0 || len(s.Buckets) != 0 {
+		t.Errorf("expected empty stats, got %+v", s)
+	}
+}
+
+// TestSortedBucketKeys_TieBreakerIsLexicographic pins the tie-breaker
+// promised by the doc comment. Without it, two runs over the same
+// data produce different orderings via map iteration randomness,
+// which breaks operator dashboards + test fixtures.
+func TestSortedBucketKeys_TieBreakerIsLexicographic(t *testing.T) {
+	s := &Stats{
+		Buckets: map[string]BucketStats{
+			"zebra": {Decisions: 5},
+			"apple": {Decisions: 5},
+			"mango": {Decisions: 5},
+			"baby":  {Decisions: 10},
+		},
+	}
+	// Run 100 times to defeat randomness — lexicographic tie-breaker
+	// must yield the same order every time.
+	want := []string{"baby", "apple", "mango", "zebra"}
+	for i := 0; i < 100; i++ {
+		got := s.SortedBucketKeys()
+		if len(got) != len(want) {
+			t.Fatalf("len=%d want %d", len(got), len(want))
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Errorf("iter %d: got[%d]=%q want %q", i, j, got[j], want[j])
+				return
+			}
+		}
+	}
+}
+
+func TestIsSupportedAxis(t *testing.T) {
+	for _, a := range SupportedAxes {
+		if !IsSupportedAxis(a) {
+			t.Errorf("expected %q to be supported", a)
+		}
+	}
+	if IsSupportedAxis("garbage") {
+		t.Error("expected 'garbage' to be unsupported")
+	}
+}


### PR DESCRIPTION
## Summary

Aggregates decision events across all chain sessions; outputs per-bucket counts + success rates. Foundation for tier-router-by-data and predictive modeling (from PR #239's ecosystem entry).

## CLI

\`\`\`bash
chitin-kernel chain stats [--by=<axis>] [--json]
\`\`\`

Axes: \`tool_name\` (default) | \`action_type\` | \`rule_id\` | \`decision\` | \`agent\`

## Live output

Tonight's accumulated chain (1035 decisions across all sessions):

\`\`\`
chitin chain stats — by rule_id
  total decisions: 1035

  bucket                          decisions  allows  denies  success%
  default-allow-shell                   470     470       0    100.0%
  default-allow-reads                   327     327       0    100.0%
  default-allow-file-write              141     141       0    100.0%
  lockdown                               22       0      22      0.0%
  default-allow-git-read                 21      21       0    100.0%
  default-deny-unknown                    7       0       7      0.0%
  no-governance-self-modification         3       0       3      0.0%
  ...
\`\`\`

The lockdown rows are real telemetry from earlier today's denial cascade (now closed by the auto-redeploy + reset).

## Use cases

- **"Which tools are denied most?"** — `chain stats --by=rule_id`
- **"Which agent has highest success rate?"** — `chain stats --by=agent`
- **tier-router-by-data input** — success_rate per (action_type, agent) feeds a future tier-recommendation primitive
- **Operator dashboarding** — `chain stats --json` piped into grafana for trends

## Files (~190 LOC)

```
go/execution-kernel/internal/replay/stats.go   ComputeStats + types
go/execution-kernel/cmd/chitin-kernel/
  replay_cmd.go                                + cmdChainStats + dispatch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)