### PR TITLE
feat(router): plugin side-effect gate via opt-in libs (Python + TS)

### DIFF
--- a/libs/router-plugin-api/python/chitin_governance.py
+++ b/libs/router-plugin-api/python/chitin_governance.py
@@ -1,0 +1,166 @@
+"""chitin_governance — opt-in side-effect gate for plugin authors.
+
+When a chitin router plugin needs to perform an action with side
+effects (file write, shell exec, network call), it should route
+that action through this library FIRST. The library shells to
+`chitin-kernel gate evaluate --hook-stdin` and returns the
+deterministic verdict.
+
+Usage:
+
+    from chitin_governance import gate_action, GateBlocked
+
+    # Check before writing a file
+    try:
+        gate_action(
+            tool_name='Write',
+            tool_input={'file_path': '/tmp/output.json'},
+            agent='my-plugin',
+            session_id='router-plugin-foo',
+        )
+    except GateBlocked as e:
+        # Kernel denied — fall back gracefully
+        print(f'Action blocked by chitin: {e}')
+        return
+
+    # If we get here, the kernel allowed the action
+    with open('/tmp/output.json', 'w') as f:
+        f.write(...)
+
+Design notes:
+  - This is OPT-IN. Plugins that don't import this lib aren't
+    gated by chitin's governance. Operator's responsibility to
+    only install trusted plugins (see plugins_trust in chitin.yaml).
+    Hard sandbox enforcement (bubblewrap, seccomp) is a future
+    work item.
+  - Subprocess overhead (~10ms per gate call). Plugin authors
+    should batch related actions when possible.
+  - Returns the kernel's exact decision; allows the plugin to
+    react (retry differently, escalate to operator, etc.).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+
+
+class GateBlocked(Exception):
+    """Raised when chitin-kernel denies the proposed action."""
+
+    def __init__(self, reason: str, rule_id: str | None = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.rule_id = rule_id
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Structured decision returned by chitin-kernel."""
+
+    allowed: bool
+    reason: str | None = None
+    rule_id: str | None = None
+    raw: dict | None = None
+
+
+def gate_action(
+    tool_name: str,
+    tool_input: dict,
+    agent: str = 'plugin',
+    session_id: str | None = None,
+    cwd: str | None = None,
+    raise_on_deny: bool = True,
+    kernel_binary: str = 'chitin-kernel',
+    timeout_s: float = 5.0,
+) -> GateDecision:
+    """Run a hypothetical action through the chitin kernel gate.
+
+    Returns a GateDecision; raises GateBlocked when raise_on_deny=True
+    and the kernel denies. Falls open (allow) if the kernel binary is
+    missing — protects plugins from chitin install errors silently
+    blocking everything.
+    """
+    payload = {
+        'hook_event_name': 'PreToolUse',
+        'tool_name': tool_name,
+        'tool_input': tool_input,
+    }
+    if session_id:
+        payload['session_id'] = session_id
+    if cwd:
+        payload['cwd'] = cwd
+    try:
+        result = subprocess.run(
+            [kernel_binary, 'gate', 'evaluate', '--hook-stdin', f'--agent={agent}'],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except FileNotFoundError:
+        # Kernel binary not on PATH → fail-open (with stderr warning)
+        import sys
+        print(
+            json.dumps({
+                'level': 'warn',
+                'component': 'chitin_governance',
+                'msg': 'kernel-binary-missing-failing-open',
+                'binary': kernel_binary,
+            }),
+            file=sys.stderr,
+        )
+        return GateDecision(allowed=True, reason='kernel-missing-fail-open')
+    except subprocess.TimeoutExpired:
+        return GateDecision(allowed=True, reason='kernel-timeout-fail-open')
+
+    # Exit code 0 + empty stdout = silent allow
+    if result.returncode == 0 and not result.stdout.strip():
+        return GateDecision(allowed=True)
+
+    # Kernel emits JSON on stdout
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return GateDecision(allowed=True, reason='kernel-non-json-fail-open')
+
+    decision_obj = parsed.get('decision')
+    if isinstance(decision_obj, str):
+        # Top-level shape: { decision: "allow"|"deny" }
+        allowed = decision_obj == 'allow' or decision_obj == 'continue'
+        msg = parsed.get('reason') or parsed.get('message')
+    elif isinstance(decision_obj, dict):
+        # Nested shape: { decision: { Allowed: bool, Reason: str } }
+        allowed = bool(decision_obj.get('Allowed'))
+        msg = decision_obj.get('Reason')
+    else:
+        # Block-shape: { decision: "block", reason: "..." }
+        allowed = parsed.get('decision') != 'block'
+        msg = parsed.get('reason') or parsed.get('message')
+
+    rule_id = None
+    if isinstance(decision_obj, dict):
+        rule_id = decision_obj.get('RuleID')
+
+    decision = GateDecision(allowed=allowed, reason=msg, rule_id=rule_id, raw=parsed)
+    if not allowed and raise_on_deny:
+        raise GateBlocked(msg or 'kernel-denied', rule_id=rule_id)
+    return decision
+
+
+# ─── Convenience wrappers for common side effects ─────────────────
+
+
+def gate_file_write(file_path: str, **kw):
+    """Gate a file write before performing it."""
+    return gate_action('Write', {'file_path': file_path}, **kw)
+
+
+def gate_shell_exec(command: str, **kw):
+    """Gate a shell exec before running it."""
+    return gate_action('Bash', {'command': command}, **kw)
+
+
+def gate_http_request(url: str, **kw):
+    """Gate an HTTP request before sending it."""
+    return gate_action('WebFetch', {'url': url}, **kw)

--- a/libs/router-plugin-api/python/chitin_governance.py
+++ b/libs/router-plugin-api/python/chitin_governance.py
@@ -73,8 +73,16 @@ def gate_action(
     raise_on_deny: bool = True,
     kernel_binary: str = 'chitin-kernel',
     timeout_s: float = 5.0,
+    require_policy: bool = False,
 ) -> GateDecision:
     """Run a hypothetical action through the chitin kernel gate.
+
+    Args:
+        require_policy: when True, pass --require-policy to the
+            kernel so that running outside any chitin.yaml-resolved
+            scope is treated as deny (strict mode). Default False
+            preserves the kernel's documented fail-open-on-no-policy
+            behavior, matching the rest of the chitin hook surface.
 
     Returns a GateDecision; raises GateBlocked when raise_on_deny=True
     and the kernel denies. Falls open (allow) if the kernel binary is
@@ -90,9 +98,12 @@ def gate_action(
         payload['session_id'] = session_id
     if cwd:
         payload['cwd'] = cwd
+    cmd = [kernel_binary, 'gate', 'evaluate', '--hook-stdin', f'--agent={agent}']
+    if require_policy:
+        cmd.append('--require-policy')
     try:
         result = subprocess.run(
-            [kernel_binary, 'gate', 'evaluate', '--hook-stdin', f'--agent={agent}'],
+            cmd,
             input=json.dumps(payload),
             capture_output=True,
             text=True,

--- a/libs/router-plugin-api/python/setup.py
+++ b/libs/router-plugin-api/python/setup.py
@@ -1,0 +1,20 @@
+"""Minimal setup for chitin_governance Python lib.
+
+Install for plugin authors:
+
+    pip install -e .
+
+Or vendor directly:
+
+    cp libs/router-plugin-api/python/chitin_governance.py <plugin_dir>/
+"""
+from setuptools import setup
+
+setup(
+    name='chitin-router-plugin-api',
+    version='0.0.1',
+    py_modules=['chitin_governance'],
+    description='Opt-in side-effect gate for chitin router plugin authors.',
+    license='MIT',
+    python_requires='>=3.10',
+)

--- a/libs/router-plugin-api/typescript/index.test.ts
+++ b/libs/router-plugin-api/typescript/index.test.ts
@@ -1,0 +1,154 @@
+// Tests for @chitin/router-plugin-api gateAction() — exercises the
+// branches Copilot flagged as untested: deny parsing, timeout
+// fail-open, missing-binary fail-open, non-JSON fallback,
+// require_policy flag pass-through.
+//
+// We use small shell shims for `kernelBinary` so we can pin exit
+// code + stdout + behavior deterministically without spinning up a
+// real chitin-kernel.
+
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gateAction, GateBlocked } from './index.ts';
+
+function makeShim(stdout: string, exitCode: number, extraScript = ''): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gate-shim-'));
+  const path = join(dir, 'fake-kernel');
+  writeFileSync(
+    path,
+    `#!/bin/bash
+${extraScript}
+echo -n '${stdout.replace(/'/g, "'\\''")}'
+exit ${exitCode}
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+describe('gateAction', () => {
+  it('parses an allow decision (exit 0, JSON allow)', async () => {
+    const bin = makeShim(JSON.stringify({ decision: 'allow' }), 0);
+    const d = await gateAction({
+      toolName: 'Read',
+      toolInput: { file_path: '/tmp/x' },
+      kernelBinary: bin,
+    });
+    expect(d.allowed).toBe(true);
+  });
+
+  it('treats empty stdout + exit 0 as silent allow', async () => {
+    const bin = makeShim('', 0);
+    const d = await gateAction({
+      toolName: 'Read',
+      toolInput: {},
+      kernelBinary: bin,
+    });
+    expect(d.allowed).toBe(true);
+  });
+
+  it('parses a block decision and throws GateBlocked by default', async () => {
+    const bin = makeShim(JSON.stringify({ decision: 'block', reason: 'no rm' }), 2);
+    await expect(
+      gateAction({
+        toolName: 'Bash',
+        toolInput: { command: 'rm -rf /' },
+        kernelBinary: bin,
+      }),
+    ).rejects.toThrow(GateBlocked);
+  });
+
+  it('returns deny instead of throwing when raiseOnDeny=false', async () => {
+    const bin = makeShim(JSON.stringify({ decision: 'block', reason: 'nope' }), 2);
+    const d = await gateAction({
+      toolName: 'Bash',
+      toolInput: { command: 'rm -rf /' },
+      kernelBinary: bin,
+      raiseOnDeny: false,
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe('nope');
+  });
+
+  it('falls open when kernel binary is missing (ENOENT)', async () => {
+    const d = await gateAction({
+      toolName: 'Read',
+      toolInput: {},
+      kernelBinary: '/nonexistent/path/never/exists',
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.reason).toBe('kernel-missing-fail-open');
+  });
+
+  it('falls open when kernel times out', async () => {
+    // Shim sleeps longer than timeoutMs.
+    const bin = makeShim('', 0, 'sleep 10');
+    const d = await gateAction({
+      toolName: 'Read',
+      toolInput: {},
+      kernelBinary: bin,
+      timeoutMs: 100,
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.reason).toBe('kernel-timeout-fail-open');
+  });
+
+  it('falls open when stdout is malformed JSON', async () => {
+    const bin = makeShim('{not json', 0);
+    const d = await gateAction({
+      toolName: 'Read',
+      toolInput: {},
+      kernelBinary: bin,
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.reason).toBe('kernel-non-json-fail-open');
+  });
+
+  it('passes --require-policy when requirePolicy=true', async () => {
+    // Shim that echoes its argv to stderr so we can introspect.
+    const dir = mkdtempSync(join(tmpdir(), 'gate-rp-'));
+    const argLog = join(dir, 'argv.log');
+    const bin = join(dir, 'fake-kernel');
+    writeFileSync(
+      bin,
+      `#!/bin/bash
+echo "$@" > ${argLog}
+echo '{"decision":"allow"}'
+exit 0
+`,
+    );
+    chmodSync(bin, 0o755);
+    await gateAction({
+      toolName: 'Read',
+      toolInput: {},
+      kernelBinary: bin,
+      requirePolicy: true,
+    });
+    const argv = (await import('node:fs')).readFileSync(argLog, 'utf8');
+    expect(argv).toContain('--require-policy');
+  });
+
+  it('omits --require-policy by default', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gate-rp-default-'));
+    const argLog = join(dir, 'argv.log');
+    const bin = join(dir, 'fake-kernel');
+    writeFileSync(
+      bin,
+      `#!/bin/bash
+echo "$@" > ${argLog}
+echo '{"decision":"allow"}'
+exit 0
+`,
+    );
+    chmodSync(bin, 0o755);
+    await gateAction({
+      toolName: 'Read',
+      toolInput: {},
+      kernelBinary: bin,
+    });
+    const argv = (await import('node:fs')).readFileSync(argLog, 'utf8');
+    expect(argv).not.toContain('--require-policy');
+  });
+});

--- a/libs/router-plugin-api/typescript/index.ts
+++ b/libs/router-plugin-api/typescript/index.ts
@@ -67,6 +67,14 @@ export interface GateActionInput {
   raiseOnDeny?: boolean;
   kernelBinary?: string;
   timeoutMs?: number;
+  /**
+   * When true, pass --require-policy to the kernel so that running
+   * outside any chitin.yaml-resolved scope is treated as deny
+   * (strict mode). Default false preserves the kernel's documented
+   * fail-open-on-no-policy behavior, matching the rest of the
+   * chitin hook surface.
+   */
+  requirePolicy?: boolean;
 }
 
 /**
@@ -85,6 +93,7 @@ export async function gateAction(input: GateActionInput): Promise<GateDecision> 
     raiseOnDeny = true,
     kernelBinary = 'chitin-kernel',
     timeoutMs = 5000,
+    requirePolicy = false,
   } = input;
 
   const payload: Record<string, unknown> = {
@@ -107,11 +116,9 @@ export async function gateAction(input: GateActionInput): Promise<GateDecision> 
       }
     };
 
-    const child = spawn(
-      kernelBinary,
-      ['gate', 'evaluate', '--hook-stdin', `--agent=${agent}`],
-      { stdio: ['pipe', 'pipe', 'pipe'] },
-    );
+    const args = ['gate', 'evaluate', '--hook-stdin', `--agent=${agent}`];
+    if (requirePolicy) args.push('--require-policy');
+    const child = spawn(kernelBinary, args, { stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (d: Buffer) => (stdout += d.toString('utf8')));

--- a/libs/router-plugin-api/typescript/index.ts
+++ b/libs/router-plugin-api/typescript/index.ts
@@ -1,0 +1,187 @@
+// chitin-router-plugin-api (TypeScript) — opt-in side-effect gate
+// for plugin authors.
+//
+// When a chitin router plugin needs to perform an action with
+// side effects (file write, shell exec, network call), it should
+// route that action through this library FIRST. The library
+// shells to `chitin-kernel gate evaluate --hook-stdin` and
+// returns the deterministic verdict.
+//
+// Usage:
+//
+//   import { gateAction, GateBlocked } from '@chitin/router-plugin-api';
+//
+//   try {
+//     await gateAction({
+//       toolName: 'Write',
+//       toolInput: { file_path: '/tmp/output.json' },
+//       agent: 'my-plugin',
+//       sessionId: 'router-plugin-foo',
+//     });
+//   } catch (e) {
+//     if (e instanceof GateBlocked) {
+//       console.error(`Action blocked by chitin: ${e.reason}`);
+//       return;
+//     }
+//     throw e;
+//   }
+//
+//   // If we get here, the kernel allowed the action
+//   await fs.writeFile('/tmp/output.json', ...);
+//
+// Design notes (mirrors python/chitin_governance.py):
+//   - This is OPT-IN. Plugins that don't import this aren't gated.
+//     Operator's responsibility to install only trusted plugins
+//     (see plugins_trust in chitin.yaml).
+//   - Subprocess overhead (~10ms per gate call). Plugin authors
+//     should batch related actions when possible.
+//   - Returns the kernel's exact decision; allows the plugin to
+//     react (retry, escalate, fall back).
+
+import { spawn } from 'node:child_process';
+
+export class GateBlocked extends Error {
+  reason: string;
+  ruleId?: string;
+  constructor(reason: string, ruleId?: string) {
+    super(reason);
+    this.name = 'GateBlocked';
+    this.reason = reason;
+    this.ruleId = ruleId;
+  }
+}
+
+export interface GateDecision {
+  allowed: boolean;
+  reason?: string;
+  ruleId?: string;
+  raw?: Record<string, unknown>;
+}
+
+export interface GateActionInput {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  agent?: string;
+  sessionId?: string;
+  cwd?: string;
+  raiseOnDeny?: boolean;
+  kernelBinary?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Run a hypothetical action through the chitin kernel gate.
+ * Returns a GateDecision; throws GateBlocked when raiseOnDeny=true
+ * (default) and the kernel denies. Falls open (allow) if the
+ * kernel binary is missing.
+ */
+export async function gateAction(input: GateActionInput): Promise<GateDecision> {
+  const {
+    toolName,
+    toolInput,
+    agent = 'plugin',
+    sessionId,
+    cwd,
+    raiseOnDeny = true,
+    kernelBinary = 'chitin-kernel',
+    timeoutMs = 5000,
+  } = input;
+
+  const payload: Record<string, unknown> = {
+    hook_event_name: 'PreToolUse',
+    tool_name: toolName,
+    tool_input: toolInput,
+  };
+  if (sessionId) payload.session_id = sessionId;
+  if (cwd) payload.cwd = cwd;
+
+  return new Promise<GateDecision>((resolve, reject) => {
+    let resolved = false;
+    const finish = (val: GateDecision): void => {
+      if (resolved) return;
+      resolved = true;
+      if (!val.allowed && raiseOnDeny) {
+        reject(new GateBlocked(val.reason ?? 'kernel-denied', val.ruleId));
+      } else {
+        resolve(val);
+      }
+    };
+
+    const child = spawn(
+      kernelBinary,
+      ['gate', 'evaluate', '--hook-stdin', `--agent=${agent}`],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => (stdout += d.toString('utf8')));
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString('utf8')));
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish({ allowed: true, reason: 'kernel-timeout-fail-open' });
+    }, timeoutMs);
+
+    child.on('error', (err: Error) => {
+      clearTimeout(timer);
+      // Binary missing — fail open with stderr warning
+      console.error(
+        JSON.stringify({
+          level: 'warn',
+          component: 'router-plugin-api',
+          msg: 'kernel-binary-missing-failing-open',
+          binary: kernelBinary,
+          err: err.message,
+        }),
+      );
+      finish({ allowed: true, reason: 'kernel-missing-fail-open' });
+    });
+
+    child.on('close', (code: number | null) => {
+      clearTimeout(timer);
+      if (code === 0 && !stdout.trim()) {
+        finish({ allowed: true });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout) as Record<string, unknown>;
+        let allowed = true;
+        let reason: string | undefined;
+        let ruleId: string | undefined;
+        const dec = parsed.decision;
+        if (typeof dec === 'string') {
+          allowed = dec === 'allow' || dec === 'continue';
+          reason = (parsed.reason as string) ?? (parsed.message as string);
+        } else if (dec && typeof dec === 'object') {
+          const dObj = dec as Record<string, unknown>;
+          allowed = dObj.Allowed === true;
+          reason = dObj.Reason as string;
+          ruleId = dObj.RuleID as string;
+        } else if (parsed.decision === 'block') {
+          allowed = false;
+          reason = (parsed.reason as string) ?? (parsed.message as string);
+        }
+        finish({ allowed, reason, ruleId, raw: parsed });
+      } catch {
+        finish({ allowed: true, reason: 'kernel-non-json-fail-open' });
+      }
+    });
+
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+// ─── Convenience wrappers ─────────────────────────────────────────
+
+export function gateFileWrite(filePath: string, opts: Partial<GateActionInput> = {}) {
+  return gateAction({ ...opts, toolName: 'Write', toolInput: { file_path: filePath } });
+}
+
+export function gateShellExec(command: string, opts: Partial<GateActionInput> = {}) {
+  return gateAction({ ...opts, toolName: 'Bash', toolInput: { command } });
+}
+
+export function gateHttpRequest(url: string, opts: Partial<GateActionInput> = {}) {
+  return gateAction({ ...opts, toolName: 'WebFetch', toolInput: { url } });
+}

--- a/libs/router-plugin-api/typescript/package.json
+++ b/libs/router-plugin-api/typescript/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@chitin/router-plugin-api",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "description": "Opt-in side-effect gate for chitin router plugin authors. See index.ts for the gateAction() API.",
+  "license": "MIT"
+}

--- a/libs/router-plugin-api/typescript/package.json
+++ b/libs/router-plugin-api/typescript/package.json
@@ -8,5 +8,7 @@
     ".": "./index.ts"
   },
   "description": "Opt-in side-effect gate for chitin router plugin authors. See index.ts for the gateAction() API.",
-  "license": "MIT"
+  "license": "MIT",
+  "$schema-comment-private": "Currently `private: true` because this package isn't yet published to npm. External plugin authors consume it by vendoring the .ts source until the publish pipeline (TS→JS build, dist field, npm prepublish) lands. See PR review on #250 for the deliberate-publish decision.",
+  "$schema-comment-entrypoints": "main + exports point at raw .ts on purpose for monorepo use (Bun + tsx + ts-node + node --experimental-strip-types all handle this). Plain Node from npm install will need .js entrypoints when this package is published — tracked alongside the private:false flip."
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,8 @@ importers:
 
   libs/mcp-chitin: {}
 
+  libs/router-plugin-api/typescript: {}
+
   libs/scheduler:
     dependencies:
       better-sqlite3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'libs/*'
   - 'libs/adapters/*'
+  - 'libs/router-plugin-api/typescript'
   - 'apps/*'
   - 'go/*'
   - 'tools/*'


### PR DESCRIPTION
## Summary

Closes the bulletproofness-checklist row "Router heuristic plugins (their own side effects)" from PR #237's everything-governs entry.

**Principle:** plugins should be subject to the same governance as agents. When a plugin emits a side effect (file write, shell exec, network call), it should route the action through the kernel gate FIRST.

This is **opt-in** — plugin authors import the lib + wrap their actions. Hard sandbox enforcement (bubblewrap, seccomp, namespaces) is a future-work item; this PR ships the API surface + reference implementations.

## Why opt-in vs sandbox tonight

- **Sandboxing requires Linux-namespace work** — significant engineering not realistic tonight
- **Opt-in lib IS the API contract** — plugin authors who care about governance wire it in immediately
- **Future sandboxing reuses the same `gateAction()` API** — when sandboxing lands, it intercepts ALL syscalls and routes them through the same kernel-gate path the lib already wires up
- Operator's responsibility to install only trusted plugins (see `plugins_trust` from PR #237)

## Usage

**Python:**

\`\`\`python
from chitin_governance import gate_file_write, GateBlocked

try:
    gate_file_write('/etc/passwd', agent='my-plugin')
except GateBlocked as e:
    return  # Kernel denied; fall back gracefully

# Allowed — proceed
with open('/etc/passwd', 'w') as f: ...
\`\`\`

**TypeScript:**

\`\`\`ts
import { gateAction, GateBlocked } from '@chitin/router-plugin-api';

try {
  await gateAction({
    toolName: 'Write',
    toolInput: { file_path: '/etc/passwd' },
    agent: 'my-plugin',
  });
} catch (e) {
  if (e instanceof GateBlocked) return;
  throw e;
}
\`\`\`

Convenience wrappers: `gate_file_write`/`gateFileWrite`, `gate_shell_exec`/`gateShellExec`, `gate_http_request`/`gateHttpRequest`.

## Performance

- ~10ms per gate call (subprocess overhead)
- Falls open if kernel binary missing (with stderr warning)
- Plugin authors should batch related actions

## Verified

Smoke against live kernel — `gate_file_write('/etc/passwd')` correctly reaches kernel, returns GateDecision allowed=True (chitin doesn't have a path-based deny rule for /etc/passwd today; would respect operator additions).

## Files (~440 LOC)

```
libs/router-plugin-api/python/
  chitin_governance.py     gate_action + GateBlocked + 3 wrappers
  setup.py                 pip-install-able

libs/router-plugin-api/typescript/
  index.ts                 gateAction + GateBlocked + 3 wrappers
  package.json             @chitin/router-plugin-api
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)