### PR TITLE
feat(replay): replay kernel deny rules, not just heuristics

### DIFF
--- a/go/execution-kernel/internal/replay/replay.go
+++ b/go/execution-kernel/internal/replay/replay.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/router"
 )
 
@@ -32,6 +33,11 @@ type Result struct {
 	Diffs        []DecisionDiff `json:"diffs"`
 	Summary      Summary        `json:"summary"`
 	PolicyPath   string         `json:"policy_path,omitempty"`
+	// GovRuleCount records how many gov.Policy rules were active at
+	// replay time. 0 means no chitin.yaml resolved at policyCwd, so
+	// kernel-rule replay was skipped — operator can spot a misnamed
+	// --policy-cwd flag at a glance.
+	GovRuleCount int `json:"gov_rule_count"`
 }
 
 // DecisionDiff captures one event whose original decision differs
@@ -39,11 +45,17 @@ type Result struct {
 type DecisionDiff struct {
 	Ts             string `json:"ts"`
 	ToolName       string `json:"tool_name"`
+	ActionType     string `json:"action_type,omitempty"`
 	ActionTarget   string `json:"action_target"`
 	OriginalRule   string `json:"original_rule"`
 	OriginalAllow  bool   `json:"original_allow"`
 	ReplayedAllow  bool   `json:"replayed_allow"`
+	ReplayedRule   string `json:"replayed_rule,omitempty"`
 	ReplayedReason string `json:"replayed_reason,omitempty"`
+	// Layer indicates where the difference originated: "kernel" (a
+	// gov.Policy rule changed), "heuristic" (a router heuristic
+	// changed), or "" if both produced the same delta.
+	Layer string `json:"layer,omitempty"`
 }
 
 // Summary aggregates the diff counts.
@@ -56,22 +68,37 @@ type Summary struct {
 // Run replays the chain events for a session against the current
 // policy at policyCwd. Returns the diff result.
 //
-// Note: today's MVP replays HEURISTIC decisions only. Replaying
-// FULL kernel deny rules requires loading gov.Policy + replicating
-// the chain-original action's normalization — left as a
-// follow-up entry. Today's diff catches blast-radius / floundering
-// changes which is the meaningful operator-facing signal.
+// Replays BOTH layers in the order they fire at runtime:
+//  1. Kernel deny rules (gov.Policy.Evaluate) — reconstructs a
+//     gov.Action from chain-recorded action_type+action_target and
+//     evaluates against the current chitin.yaml.
+//  2. Router heuristics (blast-radius today; floundering is per-
+//     window so it's stateful and skipped in single-event replay).
+//
+// Kernel deny short-circuits: if gov.Policy denies, heuristics
+// aren't run for that event — same as the live hook.
+//
+// Falls open on either layer: if chitin.yaml isn't found at
+// policyCwd we skip kernel-rule replay; if router policy is empty
+// we skip heuristic replay. The diff still surfaces whatever layer
+// IS configured.
 func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 	events := router.ReadChainEvents(sessionID)
 	if len(events) == 0 {
 		return nil, fmt.Errorf("replay: no chain events for session %s", sessionID)
 	}
 
-	policy := router.LoadPolicy(policyCwd)
+	routerPolicy := router.LoadPolicy(policyCwd)
+	govPolicy, _, govErr := gov.LoadWithInheritance(policyCwd)
+	govLoaded := govErr == nil
 
 	result := &Result{
 		SessionID:   sessionID,
 		TotalEvents: len(events),
+		PolicyPath:  policyCwd,
+	}
+	if govLoaded {
+		result.GovRuleCount = len(govPolicy.Rules)
 	}
 
 	for _, ev := range events {
@@ -81,6 +108,7 @@ func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 		result.Decisions++
 
 		toolName, _ := ev.Payload["tool_name"].(string)
+		actionType, _ := ev.Payload["action_type"].(string)
 		actionTarget, _ := ev.Payload["action_target"].(string)
 		originalRule, _ := ev.Payload["rule_id"].(string)
 		originalAllow := false
@@ -88,27 +116,49 @@ func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 			originalAllow = true
 		}
 
-		// Replay heuristic decisions: reconstruct a HookInput from
-		// the recorded fields and re-score with current policy.
-		hookInput := router.HookInput{
-			ToolName: toolName,
-			// Best-effort reconstruction — chain doesn't preserve full
-			// tool_input, only the normalized action_type + target.
-			ToolInput: map[string]interface{}{
-				"file_path": actionTarget,
-				"command":   actionTarget,
-			},
-			Cwd:       policyCwd,
-			SessionID: sessionID,
-		}
-
 		replayedAllow := true
 		replayedReason := ""
-		if cfg, ok := policy.Heuristics["blast_radius"]; ok && cfg.Enabled {
-			score := router.ScoreBlastRadius(hookInput, cfg.Threshold)
-			if score.Fired {
+		replayedRule := ""
+		layer := ""
+
+		// Layer 1: kernel deny rules. Best-effort reconstruction —
+		// chain preserves action_type + target, which is exactly
+		// what gov.Policy rules match against.
+		if govLoaded && actionType != "" {
+			act := gov.Action{
+				Type:   gov.ActionType(actionType),
+				Target: actionTarget,
+				Path:   policyCwd,
+			}
+			d := govPolicy.Evaluate(act)
+			if !d.Allowed {
 				replayedAllow = false
-				replayedReason = "blast-radius:" + score.Reason
+				replayedRule = d.RuleID
+				replayedReason = "kernel:" + d.Reason
+				layer = "kernel"
+			}
+		}
+
+		// Layer 2: heuristics. Only runs if kernel allowed (matches
+		// live hook semantics — kernel deny short-circuits).
+		if replayedAllow {
+			hookInput := router.HookInput{
+				ToolName: toolName,
+				ToolInput: map[string]interface{}{
+					"file_path": actionTarget,
+					"command":   actionTarget,
+				},
+				Cwd:       policyCwd,
+				SessionID: sessionID,
+			}
+			if cfg, ok := routerPolicy.Heuristics["blast_radius"]; ok && cfg.Enabled {
+				score := router.ScoreBlastRadius(hookInput, cfg.Threshold)
+				if score.Fired {
+					replayedAllow = false
+					replayedRule = "blast_radius"
+					replayedReason = "blast-radius:" + score.Reason
+					layer = "heuristic"
+				}
 			}
 		}
 
@@ -116,11 +166,14 @@ func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 			result.Diffs = append(result.Diffs, DecisionDiff{
 				Ts:             ev.Ts,
 				ToolName:       toolName,
+				ActionType:     actionType,
 				ActionTarget:   actionTarget,
 				OriginalRule:   originalRule,
 				OriginalAllow:  originalAllow,
 				ReplayedAllow:  replayedAllow,
+				ReplayedRule:   replayedRule,
 				ReplayedReason: replayedReason,
+				Layer:          layer,
 			})
 			if !replayedAllow {
 				result.Summary.NowDenied++
@@ -140,9 +193,13 @@ func WriteHumanReport(w io.Writer, r *Result) {
 	fmt.Fprintf(w, "chitin chain replay — session %s\n", r.SessionID)
 	fmt.Fprintf(w, "  total events:    %d\n", r.TotalEvents)
 	fmt.Fprintf(w, "  decisions:       %d\n", r.Decisions)
+	fmt.Fprintf(w, "  gov rules:       %d\n", r.GovRuleCount)
 	fmt.Fprintf(w, "  unchanged:       %d\n", r.Summary.UnchangedDecisions)
 	fmt.Fprintf(w, "  now-denied:      %d\n", r.Summary.NowDenied)
 	fmt.Fprintf(w, "  now-allowed:     %d\n", r.Summary.NowAllowed)
+	if r.GovRuleCount == 0 {
+		fmt.Fprintf(w, "  note:            no chitin.yaml at %q — kernel-rule replay skipped (heuristic-only)\n", r.PolicyPath)
+	}
 	if len(r.Diffs) == 0 {
 		fmt.Fprintln(w, "\n  No diffs — current policy produces the same decisions as the recorded run.")
 		return
@@ -159,10 +216,14 @@ func WriteHumanReport(w io.Writer, r *Result) {
 		if len(target) > 60 {
 			target = target[:60] + "…"
 		}
-		fmt.Fprintf(w, "    [%s] %s on %q  (orig: %s/%s)  %s  (reason: %s)\n",
+		layerTag := d.Layer
+		if layerTag == "" {
+			layerTag = "-"
+		}
+		fmt.Fprintf(w, "    [%s] %s on %q  (orig: %s/%s)  %s  [%s/%s] %s\n",
 			d.Ts, d.ToolName, target,
 			boolToStr(d.OriginalAllow), d.OriginalRule,
-			dir, d.ReplayedReason,
+			dir, layerTag, d.ReplayedRule, d.ReplayedReason,
 		)
 	}
 }

--- a/go/execution-kernel/internal/replay/replay.go
+++ b/go/execution-kernel/internal/replay/replay.go
@@ -25,6 +25,55 @@ import (
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/router"
 )
 
+// isPolicyAbsentError reports whether the gov.LoadWithInheritance
+// error means "no chitin.yaml in the walk-up chain" (benign — fall
+// open to heuristic-only replay). Any other error means the policy
+// existed but failed to parse / failed strict-mode validation, and
+// must surface to the operator.
+//
+// gov.LoadWithInheritance returns a wrapped error of the form
+// "no_policy_found: ..." for the absent case (see internal/gov/
+// inherit.go). String-match isn't ideal, but the gov package
+// doesn't yet export a sentinel error for this; switching to a
+// sentinel is a separate refactor.
+func isPolicyAbsentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "no_policy_found")
+}
+
+// reverseToolName maps an action_type back to a representative raw
+// tool name, since the chain payload's tool_name is the normalized
+// action_type. ScoreBlastRadius branches on raw names ("Bash",
+// "Edit", "Read") so without this reverse-map heuristic replay
+// would treat every action as unknown-tool.
+//
+// Lossy by design — `file.read` could have been `Read`, `Glob`, or
+// `Grep`; we pick the representative most likely to match policy
+// rules. For replay this is good enough; the alternative (storing
+// the full HookInput on every chain event) would 5x the audit log
+// size for a marginal accuracy gain.
+func reverseToolName(actionType, fallback string) string {
+	switch actionType {
+	case "shell.exec":
+		return "Bash"
+	case "file.write":
+		return "Edit"
+	case "file.read":
+		return "Read"
+	case "http.request":
+		return "WebFetch"
+	case "delegate.task":
+		return "Task"
+	case "git.worktree.add":
+		return "EnterWorktree"
+	case "git.worktree.remove":
+		return "ExitWorktree"
+	}
+	return fallback
+}
+
 // Result is the per-event diff produced by replay.
 type Result struct {
 	SessionID    string         `json:"session_id"`
@@ -90,7 +139,17 @@ func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 
 	routerPolicy := router.LoadPolicy(policyCwd)
 	govPolicy, _, govErr := gov.LoadWithInheritance(policyCwd)
+	// Distinguish "no chitin.yaml found" (fall open, heuristic-only
+	// replay) from "chitin.yaml is malformed" (surface to operator).
+	// Silent fall-open on ANY error would hide a broken policy as
+	// gov_rule_count=0, which is exactly the trap operators run
+	// this command to catch.
 	govLoaded := govErr == nil
+	if govErr != nil && !isPolicyAbsentError(govErr) {
+		// Malformed yaml / strict-mode violation / parse error.
+		// Surface to operator instead of silently degrading.
+		return nil, fmt.Errorf("replay: failed to load policy at %s: %w", policyCwd, govErr)
+	}
 
 	result := &Result{
 		SessionID:   sessionID,
@@ -141,9 +200,21 @@ func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 
 		// Layer 2: heuristics. Only runs if kernel allowed (matches
 		// live hook semantics — kernel deny short-circuits).
+		//
+		// Important caveat: the chain emitter writes
+		// `tool_name = string(action_type)` (see
+		// cmd/chitin-kernel/gate_emit.go) — i.e., chain.tool_name
+		// is the NORMALIZED action_type ("shell.exec"), NOT the
+		// raw Claude Code tool ("Bash"). ScoreBlastRadius matches
+		// on raw tool names. We reverse-map the closed action_type
+		// set to a representative raw tool to keep heuristic replay
+		// approximately faithful to the live router's verdict.
+		// This is lossy by design — the chain doesn't preserve the
+		// full HookInput, so heuristic replay is best-effort.
 		if replayedAllow {
+			rawTool := reverseToolName(actionType, toolName)
 			hookInput := router.HookInput{
-				ToolName: toolName,
+				ToolName: rawTool,
 				ToolInput: map[string]interface{}{
 					"file_path": actionTarget,
 					"command":   actionTarget,
@@ -160,6 +231,15 @@ func Run(ctx context.Context, sessionID, policyCwd string) (*Result, error) {
 					layer = "heuristic"
 				}
 			}
+		}
+
+		// Now-allowed flips: original was deny, replay is allow.
+		// The live deny necessarily came from a kernel rule (today's
+		// router heuristics flag actions but don't issue stand-alone
+		// denies), so attribute the flip to the kernel layer for
+		// operator interpretability.
+		if originalAllow != replayedAllow && replayedAllow && layer == "" {
+			layer = "kernel"
 		}
 
 		if originalAllow != replayedAllow {

--- a/go/execution-kernel/internal/replay/replay_test.go
+++ b/go/execution-kernel/internal/replay/replay_test.go
@@ -134,6 +134,42 @@ rules:
 	}
 }
 
+// TestRun_MalformedPolicySurfaces ensures a chitin.yaml that
+// EXISTS but fails to parse/validate is reported as an error
+// rather than silently falling back to heuristic-only replay.
+// Silent fall-open here would hide a broken policy — exactly the
+// trap operators run replay to catch.
+func TestRun_MalformedPolicySurfaces(t *testing.T) {
+	tmp := t.TempDir()
+	chitinDir := filepath.Join(tmp, ".chitin")
+	if err := os.MkdirAll(chitinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmp)
+
+	sessionID := "malformed-policy-test"
+	chainPath := filepath.Join(chitinDir, "events-"+sessionID+".jsonl")
+	chain := `{"ts":"2026-05-03T10:00:00Z","event_type":"decision","payload":{"tool_name":"shell.exec","action_type":"shell.exec","action_target":"x","decision":"allow","rule_id":"x"}}` + "\n"
+	if err := os.WriteFile(chainPath, []byte(chain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	policyDir := t.TempDir()
+	// Invalid YAML: indentation error → parse failure.
+	bad := []byte("version: 1\nrules:\n  - id: oops\n  effect: deny\n")
+	if err := os.WriteFile(filepath.Join(policyDir, "chitin.yaml"), bad, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Run(context.Background(), sessionID, policyDir)
+	if err == nil {
+		t.Fatal("expected error for malformed chitin.yaml; got nil — silent fall-open hides the broken policy")
+	}
+	if !strings.Contains(err.Error(), "failed to load policy") {
+		t.Errorf("err=%q want to mention 'failed to load policy'", err.Error())
+	}
+}
+
 // TestRun_NoPolicyFallsOpen ensures a missing chitin.yaml at
 // policyCwd is non-fatal — we still run heuristic-only replay, and
 // the report flags GovRuleCount=0 so the operator notices.

--- a/go/execution-kernel/internal/replay/replay_test.go
+++ b/go/execution-kernel/internal/replay/replay_test.go
@@ -75,6 +75,93 @@ func TestWriteHumanReport_NoDiffs(t *testing.T) {
 	}
 }
 
+// TestRun_KernelDenyReplay verifies that gov.Policy deny rules are
+// re-evaluated against the recorded action_type+action_target. We
+// craft a session whose recorded event was originally allowed, then
+// run replay against a chitin.yaml that contains a deny rule
+// matching that action — the diff must surface as a kernel-layer
+// "now denied".
+func TestRun_KernelDenyReplay(t *testing.T) {
+	tmp := t.TempDir()
+	chitinDir := filepath.Join(tmp, ".chitin")
+	if err := os.MkdirAll(chitinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmp)
+
+	sessionID := "kernel-deny-test"
+	chainPath := filepath.Join(chitinDir, "events-"+sessionID+".jsonl")
+	chain := `{"ts":"2026-05-03T10:00:00Z","event_type":"decision","payload":{"tool_name":"Bash","action_type":"shell.exec","action_target":"echo hello","decision":"allow","rule_id":"default-allow-shell"}}` + "\n"
+	if err := os.WriteFile(chainPath, []byte(chain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	policyDir := t.TempDir()
+	policyYAML := `version: 1
+mode: enforce
+rules:
+  - id: deny-all-shell-now
+    effect: deny
+    action: shell.exec
+    reason: post-incident shell lockdown
+`
+	if err := os.WriteFile(filepath.Join(policyDir, "chitin.yaml"), []byte(policyYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Run(context.Background(), sessionID, policyDir)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.GovRuleCount == 0 {
+		t.Fatalf("expected gov policy to load (rules>0); got 0 — chitin.yaml not found at %q?", policyDir)
+	}
+	if r.Summary.NowDenied != 1 {
+		t.Fatalf("expected 1 NowDenied, got %d (diffs=%+v)", r.Summary.NowDenied, r.Diffs)
+	}
+	if len(r.Diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(r.Diffs))
+	}
+	d := r.Diffs[0]
+	if d.Layer != "kernel" {
+		t.Errorf("expected Layer=kernel, got %q", d.Layer)
+	}
+	if d.ReplayedRule != "deny-all-shell-now" {
+		t.Errorf("expected ReplayedRule=deny-all-shell-now, got %q", d.ReplayedRule)
+	}
+	if d.OriginalAllow == d.ReplayedAllow {
+		t.Errorf("expected allow→deny flip, got orig=%v replayed=%v", d.OriginalAllow, d.ReplayedAllow)
+	}
+}
+
+// TestRun_NoPolicyFallsOpen ensures a missing chitin.yaml at
+// policyCwd is non-fatal — we still run heuristic-only replay, and
+// the report flags GovRuleCount=0 so the operator notices.
+func TestRun_NoPolicyFallsOpen(t *testing.T) {
+	tmp := t.TempDir()
+	chitinDir := filepath.Join(tmp, ".chitin")
+	if err := os.MkdirAll(chitinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmp)
+
+	sessionID := "no-policy-test"
+	chainPath := filepath.Join(chitinDir, "events-"+sessionID+".jsonl")
+	chain := `{"ts":"2026-05-03T10:00:00Z","event_type":"decision","payload":{"tool_name":"Read","action_type":"file.read","action_target":"/tmp/x","decision":"allow","rule_id":"default-allow"}}` + "\n"
+	if err := os.WriteFile(chainPath, []byte(chain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyDir := t.TempDir()
+	r, err := Run(context.Background(), sessionID, emptyDir)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.GovRuleCount != 0 {
+		t.Errorf("expected GovRuleCount=0 with no chitin.yaml, got %d", r.GovRuleCount)
+	}
+}
+
 func TestWriteHumanReport_WithDiffs(t *testing.T) {
 	r := &Result{
 		SessionID:   "diff-session",


### PR DESCRIPTION
## Summary
- chain-replay now also runs `gov.Policy.Evaluate` against each recorded event, not just router heuristics
- Reconstructs `gov.Action{Type, Target}` from chain payload (`action_type` + `action_target`) — both already recorded by the live gate emitter
- Kernel deny short-circuits heuristic replay (matches live hook order); diff tags `Layer = "kernel" | "heuristic"` so the operator can see which layer flipped each decision
- Falls open when no `chitin.yaml` resolves at `--policy-cwd`: heuristic replay still runs, report flags `gov_rule_count: 0` + a one-line note

## Why
Operators asking "did my new chitin.yaml rule change break past sessions?" got no signal — the previous replay only re-scored heuristics. Now `chitin-kernel chain replay --session=latest --policy-cwd=/path/with/proposed/chitin.yaml` is a real policy regression test.

## Test plan
- [x] New `TestRun_KernelDenyReplay` flips an originally-allowed `shell.exec` to NOW DENIED via a new deny rule, asserts `Layer="kernel"` and `ReplayedRule="deny-all-shell-now"`
- [x] New `TestRun_NoPolicyFallsOpen` asserts `GovRuleCount=0` when `chitin.yaml` is absent (heuristic-only mode)
- [x] 12/12 tests in `internal/replay`; full module 797 passed across 23 packages
- [ ] Manual: `chitin-kernel chain replay --session=latest` against a real session in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)