### PR TITLE
feat(analysis): chain-predict-outcome — stdlib logistic regression

### DIFF
--- a/python/analysis/__main__.py
+++ b/python/analysis/__main__.py
@@ -1,5 +1,12 @@
 """`python -m analysis` — guide users to the right submodule."""
 import sys
 
-print("Use: python -m analysis.decisions", file=sys.stderr)
+print(
+    "Use one of:\n"
+    "  python -m analysis.decisions   # repeated-deny pattern detection\n"
+    "  python -m analysis.predict     # chain-predict-outcome model (train + predict)\n"
+    "  python -m analysis.debt        # debt-ledger draft\n"
+    "  python -m analysis.souls       # soul-routing decisions",
+    file=sys.stderr,
+)
 sys.exit(2)

--- a/python/analysis/predict.py
+++ b/python/analysis/predict.py
@@ -12,12 +12,12 @@ expanded to ~30 stdlib lines; readability stays.
 
 Public API:
     extract_features(decisions) -> X, y, vocab
-    train(X, y, ...) -> Model
-    predict(model, vocab, action_type, agent, hour) -> float
+    train(X, y, vocab, ...) -> Model         # vocab is a positional
+    predict(model, action_type, agent, hour) -> float
 
 CLI:
-    python -m analysis predict \\
-        --decisions-dir=$HOME/.chitin/decisions \\
+    python -m analysis.predict train --decisions-dir=$HOME/.chitin
+    python -m analysis.predict predict \\
         --action-type=shell.exec --agent=claude-code --hour=14
 """
 from __future__ import annotations
@@ -27,7 +27,7 @@ import json
 import math
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -253,8 +253,11 @@ def from_dict(d: dict) -> Model:
 def _cli_train(args: argparse.Namespace) -> int:
     decisions_dir = Path(args.decisions_dir).expanduser()
     now = datetime.now(timezone.utc)
+    # 1-year lookback. timedelta(days=365) handles Feb 29 cleanly;
+    # now.replace(year=now.year - 1) crashes on leap day because
+    # the prior year has no Feb 29.
     window = Window(
-        since=now.replace(year=now.year - 1),  # 1y window — predictor wants depth
+        since=now - timedelta(days=365),
         until=now,
     )
     result = load_gov_decisions(decisions_dir, window)
@@ -306,7 +309,10 @@ def main(argv: list[str] | None = None) -> int:
     sub = p.add_subparsers(dest="cmd", required=True)
 
     pt = sub.add_parser("train", help="train + persist a model from gov-decisions JSONL")
-    pt.add_argument("--decisions-dir", default="~/.chitin/decisions")
+    # gov-decisions-*.jsonl files live at the top of ~/.chitin (alongside
+    # events-*.jsonl), not in a sub-directory. The default below matches
+    # the kernel's actual layout.
+    pt.add_argument("--decisions-dir", default="~/.chitin")
     pt.add_argument("--out", default="~/.chitin/predict-model.json")
     pt.add_argument("--iterations", type=int, default=200)
     pt.add_argument("--lr", type=float, default=0.05)
@@ -317,7 +323,11 @@ def main(argv: list[str] | None = None) -> int:
     pp.add_argument("--model", default="~/.chitin/predict-model.json")
     pp.add_argument("--action-type", required=True)
     pp.add_argument("--agent", default="")
-    pp.add_argument("--hour", type=int, default=datetime.now().hour)
+    # Use UTC for the default hour: training timestamps come from the
+    # kernel in UTC, so a local-time default (datetime.now().hour) on
+    # a non-UTC host would bucket the same action into a different
+    # time-of-day feature than the model was trained on.
+    pp.add_argument("--hour", type=int, default=datetime.now(timezone.utc).hour)
     pp.set_defaults(func=_cli_predict)
 
     args = p.parse_args(argv)

--- a/python/analysis/predict.py
+++ b/python/analysis/predict.py
@@ -1,0 +1,328 @@
+"""Predict whether a future action will be denied, given chain history.
+
+Trains on `gov-decisions-*.jsonl` rows: features = (action_type,
+agent, hour-of-day); label = `not allowed` (deny / interrupt). Uses
+a stdlib-only logistic regression — no numpy / sklearn dep. Intended
+for the kernel's advisor.when=predicted_failure_above_threshold gate.
+
+Why no numpy: the analysis layer already ships across machines (CI,
+operator boxes) and adding a heavy dep for a sub-second classifier
+on hundreds of rows is a bad trade. The math here is one numpy line
+expanded to ~30 stdlib lines; readability stays.
+
+Public API:
+    extract_features(decisions) -> X, y, vocab
+    train(X, y, ...) -> Model
+    predict(model, vocab, action_type, agent, hour) -> float
+
+CLI:
+    python -m analysis predict \\
+        --decisions-dir=$HOME/.chitin/decisions \\
+        --action-type=shell.exec --agent=claude-code --hour=14
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from analysis.loaders import Window, load_gov_decisions
+from analysis.models import Decision
+
+
+# ──────────────────────────────────────────────────────────────────
+# Feature engineering
+# ──────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class Vocab:
+    """Categorical -> column index. Built from training data; reused
+    at prediction time so unseen categories map to the dedicated
+    "<unk>" column instead of crashing."""
+    action_types: dict[str, int]
+    agents: dict[str, int]
+
+    @property
+    def n_features(self) -> int:
+        # action_type one-hot + agent one-hot + hour-bucket (4) + bias
+        return len(self.action_types) + len(self.agents) + 4 + 1
+
+
+def _build_vocab(decisions: Iterable[Decision]) -> Vocab:
+    at_set: set[str] = {"<unk>"}
+    ag_set: set[str] = {"<unk>"}
+    for d in decisions:
+        if d.action_type:
+            at_set.add(d.action_type)
+        if d.agent:
+            ag_set.add(d.agent)
+    action_types = {a: i for i, a in enumerate(sorted(at_set))}
+    agents = {a: i for i, a in enumerate(sorted(ag_set))}
+    return Vocab(action_types=action_types, agents=agents)
+
+
+def _hour_bucket(hour: int) -> int:
+    # Crude diurnal bucket: morning/afternoon/evening/night. The
+    # signal is whether some action_types skew unsafe at certain
+    # hours (e.g., 3am git pushes from a flaky agent). Tighter
+    # buckets without more data just memorize noise.
+    if 6 <= hour < 12:
+        return 0  # morning
+    if 12 <= hour < 18:
+        return 1  # afternoon
+    if 18 <= hour < 22:
+        return 2  # evening
+    return 3      # night
+
+
+def _featurize_row(
+    vocab: Vocab,
+    action_type: str | None,
+    agent: str | None,
+    hour: int,
+) -> list[float]:
+    n = vocab.n_features
+    x = [0.0] * n
+
+    at = action_type or "<unk>"
+    at_idx = vocab.action_types.get(at, vocab.action_types["<unk>"])
+    x[at_idx] = 1.0
+
+    ag = agent or "<unk>"
+    ag_offset = len(vocab.action_types)
+    ag_idx = vocab.agents.get(ag, vocab.agents["<unk>"])
+    x[ag_offset + ag_idx] = 1.0
+
+    hour_offset = ag_offset + len(vocab.agents)
+    x[hour_offset + _hour_bucket(hour)] = 1.0
+
+    # Bias term — last column.
+    x[-1] = 1.0
+    return x
+
+
+def extract_features(
+    decisions: list[Decision],
+) -> tuple[list[list[float]], list[int], Vocab]:
+    """Returns (X, y, vocab). y[i] = 1 if decision was DENIED (the
+    failure label). Empty inputs return empty arrays + a vocab
+    containing only "<unk>" so prediction still runs."""
+    vocab = _build_vocab(decisions)
+    X: list[list[float]] = []
+    y: list[int] = []
+    for d in decisions:
+        X.append(_featurize_row(vocab, d.action_type, d.agent, d.ts.hour))
+        y.append(0 if d.allowed else 1)
+    return X, y, vocab
+
+
+# ──────────────────────────────────────────────────────────────────
+# Logistic regression (stdlib)
+# ──────────────────────────────────────────────────────────────────
+
+@dataclass
+class Model:
+    """Trained logistic regression weights + the vocab they require."""
+    weights: list[float]
+    vocab: Vocab
+    n_samples: int
+    iterations: int
+    final_loss: float
+    # Class balance — useful for the "insufficient signal" hint.
+    base_rate: float = field(default=0.0)
+
+
+def _sigmoid(z: float) -> float:
+    if z >= 0:
+        ez = math.exp(-z)
+        return 1.0 / (1.0 + ez)
+    ez = math.exp(z)
+    return ez / (1.0 + ez)
+
+
+def _dot(w: list[float], x: list[float]) -> float:
+    return sum(wi * xi for wi, xi in zip(w, x))
+
+
+def train(
+    X: list[list[float]],
+    y: list[int],
+    vocab: Vocab,
+    *,
+    learning_rate: float = 0.05,
+    iterations: int = 200,
+    l2: float = 0.01,
+) -> Model:
+    """Stdlib batch-gradient-descent logistic regression with L2.
+
+    Empty input → returns a degenerate model whose predict() returns
+    the base rate (0.0). Caller gets a usable predictor; the
+    insufficient_signal flag is set via base_rate proximity to 0.5.
+    """
+    n_features = vocab.n_features
+    weights = [0.0] * n_features
+
+    if not X:
+        return Model(weights=weights, vocab=vocab, n_samples=0, iterations=0, final_loss=0.0)
+
+    n = len(X)
+    base_rate = sum(y) / n
+
+    final_loss = 0.0
+    for it in range(iterations):
+        grad = [0.0] * n_features
+        loss = 0.0
+        for xi, yi in zip(X, y):
+            z = _dot(weights, xi)
+            p = _sigmoid(z)
+            err = p - yi
+            for j, x_val in enumerate(xi):
+                grad[j] += err * x_val
+            # binary cross-entropy
+            eps = 1e-12
+            loss += -(yi * math.log(p + eps) + (1 - yi) * math.log(1 - p + eps))
+
+        for j in range(n_features):
+            grad[j] = grad[j] / n + l2 * weights[j]
+            weights[j] -= learning_rate * grad[j]
+
+        final_loss = loss / n
+
+    return Model(
+        weights=weights,
+        vocab=vocab,
+        n_samples=n,
+        iterations=iterations,
+        final_loss=final_loss,
+        base_rate=base_rate,
+    )
+
+
+def predict(model: Model, action_type: str | None, agent: str | None, hour: int) -> float:
+    """Returns P(deny) ∈ [0, 1] for the given (action_type, agent, hour)."""
+    if model.n_samples == 0:
+        # No training data — fall back to base rate (which is 0.0
+        # when no rows seen). Caller treats predict==0 as "no signal".
+        return model.base_rate
+    x = _featurize_row(model.vocab, action_type, agent, hour)
+    return _sigmoid(_dot(model.weights, x))
+
+
+# ──────────────────────────────────────────────────────────────────
+# Persistence
+# ──────────────────────────────────────────────────────────────────
+
+def to_dict(model: Model) -> dict:
+    return {
+        "weights": model.weights,
+        "vocab": {
+            "action_types": model.vocab.action_types,
+            "agents": model.vocab.agents,
+        },
+        "n_samples": model.n_samples,
+        "iterations": model.iterations,
+        "final_loss": model.final_loss,
+        "base_rate": model.base_rate,
+    }
+
+
+def from_dict(d: dict) -> Model:
+    vocab = Vocab(
+        action_types=dict(d["vocab"]["action_types"]),
+        agents=dict(d["vocab"]["agents"]),
+    )
+    return Model(
+        weights=list(d["weights"]),
+        vocab=vocab,
+        n_samples=int(d["n_samples"]),
+        iterations=int(d["iterations"]),
+        final_loss=float(d["final_loss"]),
+        base_rate=float(d.get("base_rate", 0.0)),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────
+
+def _cli_train(args: argparse.Namespace) -> int:
+    decisions_dir = Path(args.decisions_dir).expanduser()
+    now = datetime.now(timezone.utc)
+    window = Window(
+        since=now.replace(year=now.year - 1),  # 1y window — predictor wants depth
+        until=now,
+    )
+    result = load_gov_decisions(decisions_dir, window)
+    if not result.decisions:
+        sys.stderr.write(f"no decisions found in {decisions_dir}\n")
+        return 2
+    X, y, vocab = extract_features(result.decisions)
+    model = train(X, y, vocab, iterations=args.iterations, learning_rate=args.lr, l2=args.l2)
+    out_path = Path(args.out).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(to_dict(model), indent=2))
+    summary = {
+        "trained_on": result.files_read,
+        "samples": model.n_samples,
+        "deny_rate": model.base_rate,
+        "final_loss": model.final_loss,
+        "out": str(out_path),
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+def _cli_predict(args: argparse.Namespace) -> int:
+    model_path = Path(args.model).expanduser()
+    if not model_path.exists():
+        sys.stderr.write(f"model not found: {model_path}\n")
+        return 2
+    model = from_dict(json.loads(model_path.read_text()))
+    p_deny = predict(model, args.action_type, args.agent, args.hour)
+    insufficient = (
+        model.n_samples < 50
+        or abs(model.base_rate - 0.5) < 0.05
+    )
+    out = {
+        "action_type": args.action_type,
+        "agent": args.agent,
+        "hour": args.hour,
+        "predicted_deny_probability": p_deny,
+        "model_n_samples": model.n_samples,
+        "insufficient_signal": insufficient,
+        "base_rate": model.base_rate,
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="analysis predict", description=__doc__.split("\n")[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pt = sub.add_parser("train", help="train + persist a model from gov-decisions JSONL")
+    pt.add_argument("--decisions-dir", default="~/.chitin/decisions")
+    pt.add_argument("--out", default="~/.chitin/predict-model.json")
+    pt.add_argument("--iterations", type=int, default=200)
+    pt.add_argument("--lr", type=float, default=0.05)
+    pt.add_argument("--l2", type=float, default=0.01)
+    pt.set_defaults(func=_cli_train)
+
+    pp = sub.add_parser("predict", help="emit P(deny) for a single action shape")
+    pp.add_argument("--model", default="~/.chitin/predict-model.json")
+    pp.add_argument("--action-type", required=True)
+    pp.add_argument("--agent", default="")
+    pp.add_argument("--hour", type=int, default=datetime.now().hour)
+    pp.set_defaults(func=_cli_predict)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/analysis/tests/test_predict.py
+++ b/python/analysis/tests/test_predict.py
@@ -1,0 +1,129 @@
+"""Tests for analysis.predict — stdlib logistic regression."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from analysis.models import Decision
+from analysis.predict import (
+    Vocab,
+    extract_features,
+    from_dict,
+    predict,
+    to_dict,
+    train,
+)
+
+
+def _ts(hour: int = 12) -> datetime:
+    return datetime(2026, 5, 3, hour, 0, 0, tzinfo=timezone.utc)
+
+
+def _decision(*, action_type: str, agent: str, allowed: bool, hour: int = 12) -> Decision:
+    return Decision(
+        ts=_ts(hour),
+        allowed=allowed,
+        action_type=action_type,
+        agent=agent,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+# Feature extraction
+# ──────────────────────────────────────────────────────────────────
+
+def test_extract_features_empty() -> None:
+    X, y, vocab = extract_features([])
+    assert X == []
+    assert y == []
+    assert "<unk>" in vocab.action_types
+    assert "<unk>" in vocab.agents
+
+
+def test_extract_features_single_row() -> None:
+    decisions = [_decision(action_type="shell.exec", agent="claude-code", allowed=True)]
+    X, y, vocab = extract_features(decisions)
+    assert len(X) == 1
+    assert len(y) == 1
+    assert y[0] == 0  # allowed → not denied
+    # one row, all columns wired
+    assert len(X[0]) == vocab.n_features
+    # bias column is the last one
+    assert X[0][-1] == 1.0
+
+
+def test_extract_features_label_is_deny() -> None:
+    decisions = [
+        _decision(action_type="shell.exec", agent="claude-code", allowed=False),
+        _decision(action_type="shell.exec", agent="claude-code", allowed=True),
+    ]
+    _, y, _ = extract_features(decisions)
+    assert y == [1, 0]
+
+
+# ──────────────────────────────────────────────────────────────────
+# Training behavior
+# ──────────────────────────────────────────────────────────────────
+
+def test_train_empty_returns_degenerate() -> None:
+    vocab = Vocab(action_types={"<unk>": 0}, agents={"<unk>": 0})
+    model = train([], [], vocab, iterations=10)
+    assert model.n_samples == 0
+    # predict against degenerate model returns base_rate (0.0)
+    p = predict(model, "shell.exec", "claude-code", 12)
+    assert p == 0.0
+
+
+def test_train_separable_classes_converges() -> None:
+    """When deny is perfectly correlated with action_type, predict
+    should give P(deny) significantly above 0.5 for the bad type
+    and significantly below for the good one."""
+    decisions = (
+        [_decision(action_type="rm.recursive", agent="a", allowed=False)] * 30
+        + [_decision(action_type="file.read", agent="a", allowed=True)] * 30
+    )
+    X, y, vocab = extract_features(decisions)
+    model = train(X, y, vocab, iterations=300, learning_rate=0.1)
+    p_bad = predict(model, "rm.recursive", "a", 12)
+    p_good = predict(model, "file.read", "a", 12)
+    assert p_bad > 0.7, f"expected high deny prob for bad type, got {p_bad}"
+    assert p_good < 0.3, f"expected low deny prob for good type, got {p_good}"
+
+
+def test_predict_unknown_category_falls_to_unk() -> None:
+    decisions = [_decision(action_type="shell.exec", agent="a", allowed=True)] * 10
+    X, y, vocab = extract_features(decisions)
+    model = train(X, y, vocab, iterations=50)
+    # Never seen this action_type in training — must not raise
+    p = predict(model, "novel.action", "a", 12)
+    assert 0.0 <= p <= 1.0
+
+
+# ──────────────────────────────────────────────────────────────────
+# Persistence round-trip
+# ──────────────────────────────────────────────────────────────────
+
+def test_persistence_roundtrip_preserves_predictions() -> None:
+    decisions = (
+        [_decision(action_type="rm.recursive", agent="a", allowed=False)] * 20
+        + [_decision(action_type="file.read", agent="a", allowed=True)] * 20
+    )
+    X, y, vocab = extract_features(decisions)
+    model = train(X, y, vocab, iterations=100)
+    blob = to_dict(model)
+    restored = from_dict(blob)
+    p_orig = predict(model, "rm.recursive", "a", 12)
+    p_rest = predict(restored, "rm.recursive", "a", 12)
+    assert abs(p_orig - p_rest) < 1e-9
+
+
+def test_base_rate_recorded() -> None:
+    decisions = (
+        [_decision(action_type="x", agent="a", allowed=False)] * 10
+        + [_decision(action_type="x", agent="a", allowed=True)] * 30
+    )
+    X, y, vocab = extract_features(decisions)
+    model = train(X, y, vocab, iterations=10)
+    # 10 deny / 40 total = 0.25
+    assert pytest.approx(model.base_rate, abs=1e-9) == 0.25

--- a/python/analysis/tests/test_predict.py
+++ b/python/analysis/tests/test_predict.py
@@ -1,6 +1,7 @@
 """Tests for analysis.predict — stdlib logistic regression."""
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -116,6 +117,55 @@ def test_persistence_roundtrip_preserves_predictions() -> None:
     p_orig = predict(model, "rm.recursive", "a", 12)
     p_rest = predict(restored, "rm.recursive", "a", 12)
     assert abs(p_orig - p_rest) < 1e-9
+
+
+# ──────────────────────────────────────────────────────────────────
+# CLI end-to-end
+# ──────────────────────────────────────────────────────────────────
+
+def test_cli_train_then_predict_roundtrip(tmp_path) -> None:
+    """End-to-end: spawn the CLI to train against synthetic
+    gov-decisions JSONL, then spawn it again to predict. Catches
+    regressions like the wrong-default-decisions-path bug Copilot
+    surfaced on PR #256."""
+    import subprocess
+    import sys
+
+    decisions_dir = tmp_path / "chitin"
+    decisions_dir.mkdir()
+    fixture = decisions_dir / "gov-decisions-2026-05-03.jsonl"
+    rows = []
+    for i in range(40):
+        ok = "true" if i % 4 != 0 else "false"
+        rows.append(
+            f'{{"ts":"2026-05-03T10:{i:02d}:00Z","allowed":{ok},'
+            f'"action_type":"shell.exec","agent":"claude-code"}}'
+        )
+    fixture.write_text("\n".join(rows) + "\n")
+
+    model_path = tmp_path / "model.json"
+    train_proc = subprocess.run(
+        [sys.executable, "-m", "analysis.predict", "train",
+         f"--decisions-dir={decisions_dir}",
+         f"--out={model_path}",
+         "--iterations=50"],
+        capture_output=True, text=True,
+    )
+    assert train_proc.returncode == 0, f"train failed: {train_proc.stderr}"
+    assert model_path.exists()
+
+    predict_proc = subprocess.run(
+        [sys.executable, "-m", "analysis.predict", "predict",
+         f"--model={model_path}",
+         "--action-type=shell.exec",
+         "--agent=claude-code",
+         "--hour=10"],
+        capture_output=True, text=True,
+    )
+    assert predict_proc.returncode == 0, f"predict failed: {predict_proc.stderr}"
+    out = json.loads(predict_proc.stdout)
+    assert "predicted_deny_probability" in out
+    assert 0.0 <= out["predicted_deny_probability"] <= 1.0
 
 
 def test_base_rate_recorded() -> None:


### PR DESCRIPTION
## Summary
- New `analysis.predict` module: trains a logistic-regression classifier on `gov-decisions-*.jsonl` (features = action_type, agent, hour-bucket; label = denied)
- Stdlib-only — no numpy/sklearn dep. Hundreds-of-rows regime is well within stdlib reach; readability stays high
- CLI: `train` persists model JSON; `predict` emits P(deny) for a single action shape
- Foundation for the `advisor.when = predicted_failure_above_threshold` gate

## Why
The kernel's strategic roadmap calls for data-driven gating: don't escalate by static rule — escalate when the model says this action shape historically fails. This PR ships the model + CLI; kernel integration is the follow-up so it can be reviewed alone.

## Smoke
On this box's 3777 real decisions, deny rate 3.6%:
- `mcp.call` → 10.2% predicted deny
- `git.commit` → 10.0%
- `shell.exec` → 7.2%
- `file.read` → 7.6%

The model differentiates across action_types and converges in <1s.

## Test plan
- [x] 8 new unit tests (empty input, separable classes, persistence round-trip, unknown-category fallback, base-rate recording)
- [x] 150/150 in the analysis test suite
- [x] Manual end-to-end `train → predict` against ~/.chitin gov-decisions

## Future work (out of scope)
- Kernel integration: `advisor.when = predicted_failure_above_threshold`
- Online updates (re-train nightly via systemd timer)
- More features: blast_radius_score, recent-failure-streak, day-of-week

🤖 Generated with [Claude Code](https://claude.com/claude-code)