### PR TITLE
swarm: pr-event-ingester-extract-decision-helper

### DIFF
--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -58,6 +58,31 @@ const TASK_QUEUE = 'chitin-worker-q';
 /**
  * Pure: decide which agents to dispatch for a PR, given running agents and options.
  * Mirrors the per-PR agent dispatch logic in runIngesterTick.
+ *
+ * Two agents may be dispatched per PR:
+ *
+ *   - peer-reviewer: a higher-tier reviewer that re-evaluates the PR
+ *     beyond what GitHub's Copilot bot already produced. Always
+ *     dispatched on each tick UNLESS its workflow id is already in
+ *     runningAgents (Temporal-side dedup; the workflow id is stable
+ *     per PR number, so a re-tick won't double-dispatch).
+ *
+ *   - comment-responder: redrafts patches in response to inline
+ *     review comments. Dispatched only when copilotCommentCount
+ *     EXCEEDS the threshold (`>` not `>=`). Important caveat: today's
+ *     `copilotCommentCount` is the TOTAL comment count, NOT the
+ *     unresolved-only count. That means a PR that's already been
+ *     iterated on (with resolved threads) can still trip the
+ *     threshold and re-dispatch the responder, which then noops or
+ *     applies a redundant patch. Filed as backlog entry
+ *     `pr-event-ingester-comment-count-is-unresolved`. Until that
+ *     lands, the dedup via runningAgents is the only thing keeping
+ *     the responder from spinning on an already-handled PR — which
+ *     is why the runningAgents check fires BEFORE the threshold check.
+ *
+ * Decisions are returned as bools + a reasons map so callers can
+ * distinguish "skipped because of dedup" from "skipped because below
+ * threshold" in telemetry.
  */
 export function decideAgentDispatches(
   pr: OpenPrSummary,

--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -56,6 +56,53 @@ const TASK_QUEUE = 'chitin-worker-q';
 // ── Pure logic ──────────────────────────────────────────────────────
 
 /**
+ * Pure: decide which agents to dispatch for a PR, given running agents and options.
+ * Mirrors the per-PR agent dispatch logic in runIngesterTick.
+ */
+export function decideAgentDispatches(
+  pr: OpenPrSummary,
+  runningAgents: ReadonlySet<string>,
+  opts?: { commentResponderThreshold?: number }
+): {
+  dispatchPeerReviewer: boolean;
+  dispatchCommentResponder: boolean;
+  reasons: {
+    skip_peer_reviewer?: string;
+    skip_comment_responder?: string;
+  };
+} {
+  const peerWorkflowId = peerReviewerWorkflowIdForPr(pr.number);
+  const responderWorkflowId = commentResponderWorkflowIdForPr(pr.number);
+  const commentCount = pr.copilotCommentCount ?? 0;
+  const threshold = opts?.commentResponderThreshold ?? COMMENT_RESPONDER_THRESHOLD;
+  const reasons: { skip_peer_reviewer?: string; skip_comment_responder?: string } = {};
+
+  let dispatchPeerReviewer = true;
+  if (runningAgents.has(peerWorkflowId)) {
+    dispatchPeerReviewer = false;
+    reasons.skip_peer_reviewer = 'peer-reviewer already running';
+  }
+
+  let dispatchCommentResponder = false;
+  if (runningAgents.has(responderWorkflowId)) {
+    dispatchCommentResponder = false;
+    reasons.skip_comment_responder = 'comment-responder already running';
+  } else if (commentCount > threshold) {
+    dispatchCommentResponder = true;
+  } else {
+    dispatchCommentResponder = false;
+    reasons.skip_comment_responder = `comment count (${commentCount}) <= threshold (${threshold})`;
+  }
+
+  return {
+    dispatchPeerReviewer,
+    dispatchCommentResponder,
+    reasons,
+  };
+}
+
+
+/**
  * Stable parent_workflow_id for an ingester-spawned review-graph.
  * The review-graph workflow id derives from this as
  * `${parent_workflow_id}-review-graph` (matches review-graph-dispatch.ts).
@@ -490,11 +537,10 @@ export async function runIngesterTick(opts: {
   for (const decision of decisions) {
     if (decision.kind === 'skip') continue;
     const pr = decision.pr;
+    const agentDecision = decideAgentDispatches(pr, runningAgents);
 
-    // Peer-reviewer fires per-PR — independent second opinion. Skip
-    // if one is already running for this PR.
-    const peerWorkflowId = peerReviewerWorkflowIdForPr(pr.number);
-    if (!runningAgents.has(peerWorkflowId)) {
+    // Peer-reviewer
+    if (agentDecision.dispatchPeerReviewer) {
       if (opts.dryRun) {
         log(JSON.stringify({
           component: 'pr-event-ingester',
@@ -515,31 +561,14 @@ export async function runIngesterTick(opts: {
       }
     }
 
-    // Comment-responder fires when the PR has more than
-    // COMMENT_RESPONDER_THRESHOLD raw Copilot inline review
-    // comments. NOTE: the count is total inline comments returned
-    // by `/pulls/{n}/comments` — it does NOT distinguish resolved
-    // vs unresolved threads, so once a responder run completes the
-    // count remains above threshold and the next ingester tick
-    // will redispatch. That respawn is gated by the
-    // `runningAgents` check (one in flight blocks the next), but
-    // not by a "previously responded" check. Both gaps are
-    // tracked as backlog follow-ups
-    // (`pr-event-ingester-comment-count-is-unresolved` +
-    // `pr-event-ingester-dedup-against-completed-workflows`,
-    // PR #223).
-    // Same threshold as the §5 matrix's R1 escalation (>2
-    // comments) so the responder fires on roughly the same PRs
-    // that get an R1 reviewer.
-    const responderWorkflowId = commentResponderWorkflowIdForPr(pr.number);
-    const commentCount = pr.copilotCommentCount ?? 0;
-    if (commentCount > COMMENT_RESPONDER_THRESHOLD && !runningAgents.has(responderWorkflowId)) {
+    // Comment-responder
+    if (agentDecision.dispatchCommentResponder) {
       if (opts.dryRun) {
         log(JSON.stringify({
           component: 'pr-event-ingester',
           msg: 'would-enqueue-comment-responder',
           pr: pr.number,
-          comment_count: commentCount,
+          comment_count: pr.copilotCommentCount ?? 0,
         }));
         result.comment_responders_enqueued += 1;
       } else {

--- a/apps/temporal-worker/test/pr-event-ingester.test.ts
+++ b/apps/temporal-worker/test/pr-event-ingester.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
+  decideAgentDispatches,
   parentWorkflowIdForPr,
   pickPrsToIngest,
   reviewGraphWorkflowIdForPr,
   synthesizeBacklogEntry,
   type OpenPrSummary,
 } from '../src/pr-event-ingester.ts';
+
+// peerReviewer + commentResponder workflow id helpers — same
+// modules pr-event-ingester imports them from. Keeps test
+// indirection one level shallow.
+import { peerReviewerWorkflowIdForPr } from '../src/peer-reviewer/dispatch.ts';
+import { commentResponderWorkflowIdForPr } from '../src/comment-responder/dispatch.ts';
 
 function pr(overrides: Partial<OpenPrSummary> & { number: number }): OpenPrSummary {
   return {
@@ -164,5 +171,95 @@ describe('pickPrsToIngest — mixed batch', () => {
       'ingest',
       'ingest',
     ]);
+  });
+});
+
+
+describe('decideAgentDispatches — peer-reviewer + comment-responder gating', () => {
+  // Per Copilot review on PR #264: matrix coverage for the new
+  // refactored helper. Tests the three branches called out:
+  // runningAgents dedup, threshold boundary, skip reasons.
+
+  const basePr = (overrides: Partial<OpenPrSummary>): OpenPrSummary => pr({ number: 100, ...overrides });
+
+  it('dispatches both when nothing is running and comments exceed threshold', () => {
+    const d = decideAgentDispatches(
+      basePr({ copilotCommentCount: 5 }),
+      new Set<string>(),
+      { commentResponderThreshold: 2 },
+    );
+    expect(d.dispatchPeerReviewer).toBe(true);
+    expect(d.dispatchCommentResponder).toBe(true);
+    expect(d.reasons).toEqual({});
+  });
+
+  it('skips peer-reviewer when its workflow is already running', () => {
+    const running = new Set<string>([peerReviewerWorkflowIdForPr(100)]);
+    const d = decideAgentDispatches(
+      basePr({ copilotCommentCount: 5 }),
+      running,
+      { commentResponderThreshold: 2 },
+    );
+    expect(d.dispatchPeerReviewer).toBe(false);
+    expect(d.reasons.skip_peer_reviewer).toContain('peer-reviewer already running');
+    expect(d.dispatchCommentResponder).toBe(true);
+  });
+
+  it('skips comment-responder when its workflow is already running, even with comments above threshold', () => {
+    const running = new Set<string>([commentResponderWorkflowIdForPr(100)]);
+    const d = decideAgentDispatches(
+      basePr({ copilotCommentCount: 5 }),
+      running,
+      { commentResponderThreshold: 2 },
+    );
+    expect(d.dispatchCommentResponder).toBe(false);
+    expect(d.reasons.skip_comment_responder).toContain('comment-responder already running');
+    // peer-reviewer still gets dispatched
+    expect(d.dispatchPeerReviewer).toBe(true);
+  });
+
+  it('skips comment-responder at the threshold boundary (count <= threshold)', () => {
+    // count == threshold → skip (the gate is `>` not `>=`)
+    const d = decideAgentDispatches(
+      basePr({ copilotCommentCount: 2 }),
+      new Set<string>(),
+      { commentResponderThreshold: 2 },
+    );
+    expect(d.dispatchCommentResponder).toBe(false);
+    expect(d.reasons.skip_comment_responder).toMatch(/<= threshold/);
+  });
+
+  it('dispatches comment-responder one above the threshold boundary', () => {
+    const d = decideAgentDispatches(
+      basePr({ copilotCommentCount: 3 }),
+      new Set<string>(),
+      { commentResponderThreshold: 2 },
+    );
+    expect(d.dispatchCommentResponder).toBe(true);
+    expect(d.reasons.skip_comment_responder).toBeUndefined();
+  });
+
+  it('uses default threshold when opts is omitted', () => {
+    // The default threshold is whatever the module exports —
+    // we assert behavior, not the number: a low comment count
+    // (0) below any reasonable default must skip.
+    const d = decideAgentDispatches(basePr({ copilotCommentCount: 0 }), new Set<string>());
+    expect(d.dispatchCommentResponder).toBe(false);
+  });
+
+  it('dedups both agents simultaneously when both are already running', () => {
+    const running = new Set<string>([
+      peerReviewerWorkflowIdForPr(100),
+      commentResponderWorkflowIdForPr(100),
+    ]);
+    const d = decideAgentDispatches(
+      basePr({ copilotCommentCount: 10 }),
+      running,
+      { commentResponderThreshold: 2 },
+    );
+    expect(d.dispatchPeerReviewer).toBe(false);
+    expect(d.dispatchCommentResponder).toBe(false);
+    expect(d.reasons.skip_peer_reviewer).toBeDefined();
+    expect(d.reasons.skip_comment_responder).toBeDefined();
   });
 });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `pr-event-ingester-extract-decision-helper`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-pr-event-ingester-extract-decision-helper-1777855646615`

## Entry context

The new per-PR agent dispatch logic in `pr-event-ingester.ts`
(always enqueue peer-reviewer; enqueue comment-responder when
`copilotCommentCount > COMMENT_RESPONDER_THRESHOLD`; dedup against
`runningAgents`) is not exercised by tests. The existing test suite
covers only `pickPrsToIngest` (the pure classification helper).
The dispatch decision branching includes:

- threshold check on `copilotCommentCount`
- dedup check against `runningAgents` set (workflow_id presence)
- per-decision counter accounting (`peer_reviewers_enqueued`,
  `comment_responders_enqueued`)
- error accounting on individual dispatch failure (the loop
  shouldn't break the whole tick)

Steps:

1. Extract the per-PR dispatch decision into a pure helper
   `decideAgentDispatches(pr, runningAgents, opts):
   { dispatchPeerReviewer: boolean, dispatchCommentResponder: boolean,
     reasons: { skip_peer_reviewer?: string, skip_comment_responder?: string } }`.
   Mirror the shape of `pickPrsToIngest`'s return: structured
   decisions, not booleans.

2. Ingester's main loop calls the helper, then maps decisions to
   dispatch + counter increments.

3. Tests for the helper (in the existing `pr-event-ingester.test.ts`):
   - peer-reviewer always proposed when no run is running
   - peer-reviewer skipped when its workflow_id is in runningAgents
   - comment-responder skipped below threshold
   - comment-responder proposed at + above threshold
   - comment-responder skipped when its workflow_id is in
     runningAgents (regardless of comment count)
   - reasons match expectations on each skip

**Acceptance:**
- [ ] `decideAgentDispatches` is a pure function with no
      Temporal-client dependency
- [ ] Existing ingester behavior is observably identical
      (`pickPrsToIngest` tests still pass)
- [ ] Six new helper tests cover the matrix above
- [ ] CI green


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-pr-event-ingester-extract-decision-helper-1777855646615`
Branch: `swarm/swarm-pr-event-ingester-extract-decision-helper-1777855646615`
Head: `eb22033b`
Diff: `1 file changed, 53 insertions(+), 24 deletions(-)`
Commits: 1