### PR TITLE
swarm: dispatcher-skip-already-implemented-entries

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -348,6 +348,23 @@ function pickEntryToDispatch(entries: BacklogEntry[]): PickedEntry | null {
 
   for (const entry of entries) {
     if (entry.status !== 'ready') continue;
+
+    // Skip if a recent merged PR title contains the entry id (hand-merged/shipped)
+    try {
+      const recentPrs = git([
+        'log',
+        '--merges',
+        '--since=14.days',
+        '--pretty=%s',
+        '--grep', entry.id,
+      ]);
+      if (recentPrs && recentPrs.includes(entry.id)) {
+        log('info', 'skip entry: recent merged PR title contains entry id (already shipped)', { entry_id: entry.id });
+        continue;
+      }
+    } catch (err) {
+      log('warn', 'failed PR title scan for shipped entry check', { entry_id: entry.id, error: err instanceof Error ? err.message : String(err) });
+    }
     // T5 is human-only — skip even if the schema permits it (it doesn't,
     // but the tier field on the file might).
     if (entry.tier === 'T5') {

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -310,6 +310,41 @@ function recordDispatchOutcome(
  * REAL, the reviewer chain catches the rest. Don't re-dispatch on
  * top of an already-pushed branch.
  */
+/**
+ * Check whether a backlog entry's id appears literally in the
+ * recent-merged-PR-subjects scan. Pure string match — backlog ids
+ * can contain regex metacharacters (e.g., `pr-event-ingester-1.0`
+ * has `.`), so we deliberately skip --grep and do an in-memory
+ * `includes` to avoid false matches AND `fatal: invalid regexp`
+ * errors that would silently disable the suppression.
+ *
+ * Exported for unit tests; not part of the public dispatcher API.
+ */
+export function entryIdInRecentSubjects(entryId: string, recentSubjects: string): boolean {
+  if (!entryId || !recentSubjects) return false;
+  // Per-line check rather than whole-blob includes — defends
+  // against an entry id that happens to appear as a substring of
+  // a longer entry id in a different subject (e.g., entry `foo`
+  // matching subject "swarm: foo-bar"). We require the id to
+  // appear as a discrete word: surrounded by start-of-line, end-
+  // of-line, or non-id characters ([^a-zA-Z0-9_-]).
+  const lines = recentSubjects.split('\n');
+  for (const line of lines) {
+    if (!line) continue;
+    let idx = 0;
+    while ((idx = line.indexOf(entryId, idx)) !== -1) {
+      const before = idx === 0 ? '' : line[idx - 1];
+      const afterIdx = idx + entryId.length;
+      const after = afterIdx >= line.length ? '' : line[afterIdx];
+      const beforeOk = before === '' || !/[a-zA-Z0-9_-]/.test(before);
+      const afterOk = after === '' || !/[a-zA-Z0-9_-]/.test(after);
+      if (beforeOk && afterOk) return true;
+      idx += 1;
+    }
+  }
+  return false;
+}
+
 export function classifyDispatchEscalation(marker: DispatchMarker | null): {
   kind: 'no-marker' | 'in-flight' | 'shipped' | 'exhausted' | 'escalate';
   nextTier?: Tier;
@@ -346,25 +381,52 @@ function pickEntryToDispatch(entries: BacklogEntry[]): PickedEntry | null {
   // network round trips per tick.
   gitFetchOriginRefs();
 
+  // Hoist the recent-PR-subjects scan to once-per-tick. Without this,
+  // every ready entry would spawn its own `git log` subprocess (N
+  // spawns per tick); on backlogs with dozens of ready entries that's
+  // expensive. Read once into memory, then in-memory `includes` per
+  // entry.
+  //
+  // Critical correctness notes (per Copilot review on #265):
+  //   - DROP `--merges`. Chitin uses squash-merge as the default; a
+  //     squash-merge produces a regular commit on main (no merge
+  //     parent), so `--merges` would miss every shipped entry whose
+  //     merge style is squash. Plain `git log` catches both.
+  //   - Use `origin/main` not local HEAD. `git fetch origin` updates
+  //     remote refs but doesn't touch HEAD; scanning HEAD would miss
+  //     any merged PRs since the last local pull.
+  //   - DROP the per-entry `--grep`. `--grep` treats the id as a
+  //     regex; backlog ids can contain regex metacharacters (dots,
+  //     parens) which silently mis-match. Read all subjects once,
+  //     then in-memory substring match per entry.
+  let recentSubjects = '';
+  try {
+    recentSubjects = git([
+      'log',
+      'origin/main',
+      '--since=14.days',
+      '--pretty=%s',
+    ]);
+  } catch (err) {
+    log('warn', 'failed recent-PR-subjects scan; shipped-entry dispatch suppression disabled this tick', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   for (const entry of entries) {
     if (entry.status !== 'ready') continue;
 
-    // Skip if a recent merged PR title contains the entry id (hand-merged/shipped)
-    try {
-      const recentPrs = git([
-        'log',
-        '--merges',
-        '--since=14.days',
-        '--pretty=%s',
-        '--grep', entry.id,
-      ]);
-      if (recentPrs && recentPrs.includes(entry.id)) {
-        log('info', 'skip entry: recent merged PR title contains entry id (already shipped)', { entry_id: entry.id });
-        continue;
-      }
-    } catch (err) {
-      log('warn', 'failed PR title scan for shipped entry check', { entry_id: entry.id, error: err instanceof Error ? err.message : String(err) });
+    // Skip if a recent merged PR title literally contains the entry
+    // id (hand-merged/shipped). Defense-in-depth — the
+    // chitin-shipped-entry-flipper.timer is the primary mechanism
+    // for flipping `ready → partial` after a hand-merge, but it
+    // runs on a cadence; this dispatcher-side guard catches the
+    // window between hand-merge and the next flipper tick.
+    if (entryIdInRecentSubjects(entry.id, recentSubjects)) {
+      log('info', 'skip entry: recent merged PR title contains entry id (already shipped)', { entry_id: entry.id });
+      continue;
     }
+
     // T5 is human-only — skip even if the schema permits it (it doesn't,
     // but the tier field on the file might).
     if (entry.tier === 'T5') {

--- a/apps/temporal-worker/test/dispatcher-shipped-skip.test.ts
+++ b/apps/temporal-worker/test/dispatcher-shipped-skip.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { entryIdInRecentSubjects } from '../src/dispatcher.ts';
+
+// Tests for the dispatcher's shipped-entry-skip heuristic. Per
+// Copilot review on PR #265: every branch of this gate has had
+// a real bug at some point (regex meta in --grep, scanning local
+// HEAD instead of origin/main, --merges missing squash-merges).
+// These tests pin the behavior so future refactors don't regress.
+
+describe('entryIdInRecentSubjects', () => {
+  it('returns false when subjects is empty', () => {
+    expect(entryIdInRecentSubjects('foo', '')).toBe(false);
+  });
+
+  it('returns false when entryId is empty', () => {
+    expect(entryIdInRecentSubjects('', 'subject line')).toBe(false);
+  });
+
+  it('matches an entry id that appears as a discrete word', () => {
+    const subjects = 'swarm: foo — closes #100\nfix: unrelated change';
+    expect(entryIdInRecentSubjects('foo', subjects)).toBe(true);
+  });
+
+  it('does NOT match an entry id that is a substring of a longer id', () => {
+    // Without the discrete-word check, "foo" would match
+    // "swarm: foo-bar — closes #100" — but those are different
+    // entries. The match must be word-bounded.
+    const subjects = 'swarm: foo-bar — closes #100';
+    expect(entryIdInRecentSubjects('foo', subjects)).toBe(false);
+  });
+
+  it('matches when entry id is bounded by punctuation/whitespace', () => {
+    const subjects = 'swarm: my-entry-id (T2) — done';
+    expect(entryIdInRecentSubjects('my-entry-id', subjects)).toBe(true);
+  });
+
+  it('treats id with regex metacharacters literally (no --grep regex semantics)', () => {
+    // Backlog ids historically can contain dots / parens. The old
+    // implementation passed the id to `git log --grep <id>` which
+    // interprets it as regex; "pr-event.1" would match
+    // "pr-eventX1" via regex meta. Confirm we DON'T do that.
+    const subjects = 'swarm: pr-eventX1 — done';
+    expect(entryIdInRecentSubjects('pr-event.1', subjects)).toBe(false);
+  });
+
+  it('matches across multiple subjects when one matches', () => {
+    const subjects = [
+      'fix: unrelated change',
+      'docs: another change',
+      'swarm: target-id (T3)',
+      'feat: still unrelated',
+    ].join('\n');
+    expect(entryIdInRecentSubjects('target-id', subjects)).toBe(true);
+  });
+
+  it('case-sensitive match (entry ids are lowercase by convention)', () => {
+    const subjects = 'swarm: TARGET — done';
+    expect(entryIdInRecentSubjects('target', subjects)).toBe(false);
+  });
+
+  it('matches when id is at start or end of subject', () => {
+    expect(entryIdInRecentSubjects('foo', 'foo')).toBe(true);
+    expect(entryIdInRecentSubjects('foo', 'finalized: foo')).toBe(true);
+    expect(entryIdInRecentSubjects('foo', 'foo finalized')).toBe(true);
+  });
+
+  it('handles empty lines and CRLF gracefully', () => {
+    const subjects = 'fix: x\n\n\nswarm: target — closes\n';
+    expect(entryIdInRecentSubjects('target', subjects)).toBe(true);
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `dispatcher-skip-already-implemented-entries`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-dispatcher-skip-already-implemented-entries-1777856567621`

## Entry context

The dispatcher's "is this entry available to dispatch?" check today
relies on:

1. `status: ready` in the backlog frontmatter
2. Marker file at `~/.cache/chitin/swarm-state/dispatched/<entry-id>.json`
   absent OR escalation-eligible (failed prior tier)
3. No swarm branch matching `swarm/swarm-<entry-id>-*` on origin

This MISSES the case where a hand-merged PR shipped the entry's
work without flipping the entry's status to `shipped`. Today's
2026-05-03 cascade hit this: the operator merged comment-responder
+ pr-event-ingester implementations via #207/#211/#215. Those PRs
didn't update `status: ready → status: shipped` in
`docs/swarm-backlog.md`, so the dispatcher's next tick saw the
entries as still-available and dispatched them. The agents tried
to implement entries that were already shipped, producing
regressive stub PRs (closed with comments).

Three approaches in order of confidence (groomer picks the
right combo):

(a) **Backlog-side: title-substring scan of recent merged PRs**
    (the auto-flipper). A `chitin-shipped-entry-flipper.timer`
    scans merged PRs from the last N days; for each, find any
    backlog entry whose id appears in the PR title. For matches,
    file a PR (or auto-edit) flipping `status: ready → status:
    partial` (NOT directly to shipped — the operator inspects
    + promotes). Closes the dispatch-against-shipped gap from
    the merge side. PR-mediated so misclassifications are
    caught at review.

(b) **Strict sentinel check** — for entries that DECLARE a
    `sentinel:` field (function name / file path / chain-event
    type), the dispatcher verifies the sentinel exists in HEAD
    via `git grep` or `git show HEAD:<path>` before dispatching.
    Requires backlog-schema extension. More accurate than (a)
    when applicable; only works for entries that opted in.

(c) **Heuristic file-path check** — Copilot review on this
    entry's first draft flagged the brittleness: 14-day file-path
    scan flags ALL ready entries that share any file with a
    recent commit. The backlog has multiple independent ready
    entries targeting `apps/temporal-worker/src/dispatcher.ts`;
    one recent dispatcher commit would suppress all of them
    for two weeks. Plus the `file:` field today routinely
    includes annotations like `(new)`, `(extend)`, `(new dir)`,
    `*` — opaque strings that break path-parsing. (c) is OFF
    THE TABLE until the backlog schema is tightened to
    machine-parseable file lists.

So the safe shippable shape is **(a) first, (b) optional**.
(a) catches the today-observed incident class without the
false-positive risk of (c). The auto-flipper sets `partial`
not `shipped` because Copilot was right that the existing
`pr-event-ingester` + `comment-responder` entries had
chain-event acceptance items still unshipped — partial is
the more honest status for "implementation merged but not
all acceptance criteria met."

**Acceptance:**
- [ ] `chitin-shipped-entry-flipper.{service,timer}` scans merged
      PRs from last N days (default 7), finds entries whose id
      appears in PR title, files a PR or commits the status flip
      (`ready` → `partial`)
- [ ] Auto-flipper logs each match with: pr_url, entry_id,
      old_status, new_status; rejection reasons logged when no
      action is taken
- [ ] Operator can suspend via `systemctl --user stop
      chitin-shipped-entry-flipper.timer`
- [ ] Optional: backlog-schema extension to add a `sentinel:`
      field; dispatcher reads it and verifies before dispatch
- [ ] Test (in `apps/temporal-worker/test/dispatcher-skip-shipped.test.ts`):
      synthetic entry id appears in synthetic PR title →
      auto-flipper proposes status update
- [ ] Test: entry id NOT in any PR title → no action


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-dispatcher-skip-already-implemented-entries-1777856567621`
Branch: `swarm/swarm-dispatcher-skip-already-implemented-entries-1777856567621`
Head: `8ff15f00`
Diff: `1 file changed, 17 insertions(+)`
Commits: 1