### PR TITLE
docs(readme): separate kernel from reference consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@
 
 > Principle: real execution before policy. Policy before automation. Automation gated by the same kernel.
 
-## Where chitin is today
+## What chitin is today
+
+The kernel and the contract it enforces:
 
 - **Kernel + governance** — Go binary fires on every PreToolUse hook, evaluates `chitin.yaml`, writes a hash-linked JSONL chain. Gate decisions are auditable; chain integrity is SHA-256-verified.
 - **OTEL emit (F4, 2026-05-02)** — kernel projects every chain event onto an OTLP/HTTP JSON span after the canonical write succeeds. One-way bridge: chain authoritative, OTEL non-authoritative. Opt-in via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
-- **Autonomous swarm runtime** — Temporal-backed dispatcher + worker that picks ready backlog entries, dispatches role-typed agents (programmer, reviewer, researcher, analyst, …), runs the §5 review-tier escalation chain (R1→R2→R3→operator), and (with `CHITIN_GATEKEEPER_AUTO_MERGE=1`) auto-merges PRs that pass the §6 gate matrix. The factory's design lives in [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md).
-- **Self-feeding telemetry loop** — periodic scripts (researcher, lessons, debt-curator, groomer, alarm-feeder, stale-doc detector) keep the backlog hydrated from external signals + internal alarms; the analyst role runs deterministic Python recipes against the chain to investigate regressions automatically.
+
+Chitin is *not* a tick-loop, not an agent runner, not an OTEL ingest target, not a cloud product — see [`docs/thesis.md`](./docs/thesis.md) for the full set of refusals.
+
+## Reference consumers (hosted in the monorepo for dogfooding)
+
+These are downstream consumers of the kernel — they run *on* chitin, they aren't chitin. Hosted in the same repo so they share `libs/contracts/` schemas and the Nx project graph; gated from the outside via the openclaw plugin like any other agent surface.
+
+- **Autonomous swarm runtime** (`apps/temporal-worker/`) — Temporal-backed dispatcher + worker that picks ready backlog entries, dispatches role-typed agents (programmer, reviewer, researcher, analyst, …), runs the §5 review-tier escalation chain (R1→R2→R3→operator), and (with `CHITIN_GATEKEEPER_AUTO_MERGE=1`) auto-merges PRs that pass the §6 gate matrix. Design: [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md).
+- **Self-feeding telemetry loop** (cron scripts under `apps/temporal-worker/`) — periodic researcher / lessons / debt-curator / groomer / alarm-feeder / stale-doc detector keep the backlog hydrated from external signals + internal alarms; the analyst role runs deterministic Python recipes against the chain to investigate regressions.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 
 The kernel and the contract it enforces:
 
-- **Kernel + governance** — Go binary fires on every PreToolUse hook, evaluates `chitin.yaml`, writes a hash-linked JSONL chain. Gate decisions are auditable; chain integrity is SHA-256-verified.
+- **Kernel + governance** — Go binary that adjudicates every tool call across the integration points it's wired into: Claude Code / Codex / Gemini PreToolUse hooks (`--agent=<id>`), the Copilot CLI driver (`chitin-kernel drive copilot`), and the OpenClaw `before_tool_call` plugin path. Each evaluates `chitin.yaml` and writes a hash-linked JSONL chain. Gate decisions are auditable; chain integrity is SHA-256-verified.
 - **OTEL emit (F4, 2026-05-02)** — kernel projects every chain event onto an OTLP/HTTP JSON span after the canonical write succeeds. One-way bridge: chain authoritative, OTEL non-authoritative. Opt-in via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
 
 Chitin is *not* a tick-loop, not an agent runner, not an OTEL ingest target, not a cloud product — see [`docs/thesis.md`](./docs/thesis.md) for the full set of refusals.
 
 ## Reference consumers (hosted in the monorepo for dogfooding)
 
-These are downstream consumers of the kernel — they run *on* chitin, they aren't chitin. Hosted in the same repo so they share `libs/contracts/` schemas and the Nx project graph; gated from the outside via the openclaw plugin like any other agent surface.
+These are downstream consumers of the kernel — they run *on* chitin, they aren't chitin. Hosted in the same repo so they share `libs/contracts/` schemas and the Nx project graph; governed by the same kernel via the per-driver integration points (Claude Code PreToolUse for `claude-code-headless`, the Copilot CLI driver for `copilot`, the OpenClaw plugin for the `local-*` drivers, the Codex/Gemini PreToolUse hooks where applicable).
 
 - **Autonomous swarm runtime** (`apps/temporal-worker/`) — Temporal-backed dispatcher + worker that picks ready backlog entries, dispatches role-typed agents (programmer, reviewer, researcher, analyst, …), runs the §5 review-tier escalation chain (R1→R2→R3→operator), and (with `CHITIN_GATEKEEPER_AUTO_MERGE=1`) auto-merges PRs that pass the §6 gate matrix. Design: [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md).
 - **Self-feeding telemetry loop** (cron scripts under `apps/temporal-worker/`) — periodic researcher / lessons / debt-curator / groomer / alarm-feeder / stale-doc detector keep the backlog hydrated from external signals + internal alarms; the analyst role runs deterministic Python recipes against the chain to investigate regressions.


### PR DESCRIPTION
## Summary

Restructures the README's first descriptive section so the kernel and its dogfood consumers don't sit at the same level.

- Renames **\"Where chitin is today\"** → **\"What chitin is today\"** and trims it to the kernel + governance + OTEL emit.
- Adds an explicit refusals one-liner pointing at \`docs/thesis.md\` (\"not a tick-loop, not an agent runner, not an OTEL ingest target, not a cloud product\").
- Moves the autonomous swarm runtime and the self-feeding telemetry loop into a new **\"Reference consumers (hosted in the monorepo for dogfooding)\"** section, framed as downstream of the kernel — they run *on* chitin, they aren't chitin. Same code, different framing.

## Why

The prior framing listed swarm + self-feeding loop in the same bullet group as the kernel itself. That reads as \"chitin = kernel + swarm + telemetry loop\" — the marketing-level shape of chitin-archive's scope-creep failure mode, even though the artifact boundaries here are structurally clean (Nx project graph, Go-owns-side-effects, kernel doesn't import from \`apps/\`).

A1 (agent framework builders) landing on the README should see the kernel first; the swarm should read as a reference consumer of that kernel that happens to share the monorepo for dogfooding and contract reuse.

thesis.md is already disciplined here (\"What chitin is not\" section); README.md was the gap.

## Test plan

- [ ] Render README on GitHub, confirm headings and bullet groupings read correctly
- [ ] Confirm both internal links resolve (\`docs/thesis.md\`, \`docs/design/2026-05-02-swarm-as-software-factory.md\`)
- [ ] Confirm no other doc cross-references the old \"Where chitin is today\" heading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)