### PR TITLE
feat(driver): gemini-cli governance — chitin gates BeforeTool hooks

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/cost"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/gemini"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/tier"
 )
@@ -106,9 +107,28 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 	// stderr stream so operators see malformed payloads explicitly
 	// rather than via a silent default-deny.
 	claudecode.SetWarnSink(errOut)
+	gemini.SetWarnSink(errOut)
 	defer claudecode.SetWarnSink(nil)
+	defer gemini.SetWarnSink(nil)
 
-	action, err := claudecode.Normalize(payload)
+	// Dispatch by agent: gemini uses different tool names than
+	// Claude Code (run_shell_command vs Bash, etc.), so the
+	// normalizer differs. Wire shape on stdin is identical between
+	// the two — the same payload struct works for both.
+	var action gov.Action
+	if agent == "gemini" {
+		gPayload := gemini.HookInput{
+			SessionID:      payload.SessionID,
+			TranscriptPath: payload.TranscriptPath,
+			Cwd:            payload.Cwd,
+			HookEventName:  payload.HookEventName,
+			ToolName:       payload.ToolName,
+			ToolInput:      payload.ToolInput,
+		}
+		action, err = gemini.Normalize(gPayload)
+	} else {
+		action, err = claudecode.Normalize(payload)
+	}
 	if err != nil {
 		writeJSONLine(errOut, map[string]string{"error": "hook_normalize", "message": err.Error()})
 		return claudecode.ExitNonBlockError

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -199,7 +199,15 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 		hookChainID = newChainID()
 	}
 	if hookChainID != "" {
-		de, deClose, deErr := newDecisionEmitter(cdir, hookChainID, "claude-code", func() string { return hookChainID })
+		// Surface label tracks the dispatched driver so chain
+		// telemetry doesn't mislabel gemini events as claude-code.
+		// The agent flag drives this — claude-code is the default
+		// when the flag is empty (single-driver legacy behavior).
+		surface := agent
+		if surface == "" {
+			surface = "claude-code"
+		}
+		de, deClose, deErr := newDecisionEmitter(cdir, hookChainID, surface, func() string { return hookChainID })
 		if deErr == nil {
 			defer deClose()
 			gate.OnDecision = de.emitDecision

--- a/go/execution-kernel/internal/driver/gemini/normalize.go
+++ b/go/execution-kernel/internal/driver/gemini/normalize.go
@@ -1,0 +1,227 @@
+// Package gemini normalizes Gemini CLI BeforeTool hook payloads
+// to canonical gov.Action values. Sibling of internal/driver/
+// claudecode; same wire shape as Claude Code's PreToolUse hook
+// (the hook stdin protocol is byte-identical), but with
+// gemini-specific tool names that must be re-mapped.
+//
+// Wire stability: gemini-cli emits BeforeTool with the same
+// {session_id, cwd, hook_event_name, tool_name, tool_input}
+// shape that Claude Code's PreToolUse uses. The router-hook
+// shim already speaks that protocol — only the per-tool
+// normalization differs.
+//
+// Source for the closed enum: gemini-cli's bundled tool registry
+// at @google/gemini-cli/bundle/chunk-*.js. Last verified against
+// 0.40.1 (2026-05-04). Unknown tools fall through to ActUnknown,
+// which the policy default-deny-unknown rule will catch in
+// enforce mode — same fail-closed posture as the claudecode driver.
+package gemini
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// HookInput mirrors the wire-format gemini-cli sends on the
+// BeforeTool hook's stdin. Identical to claudecode.HookInput
+// modulo the field set; we keep the struct local to this driver
+// so the two normalizers can evolve independently as vendors
+// diverge.
+type HookInput struct {
+	SessionID      string         `json:"session_id"`
+	TranscriptPath string         `json:"transcript_path"`
+	Cwd            string         `json:"cwd"`
+	HookEventName  string         `json:"hook_event_name"`
+	Timestamp      string         `json:"timestamp"`
+	ToolName       string         `json:"tool_name"`
+	ToolInput      map[string]any `json:"tool_input"`
+}
+
+// warnSink mirrors the claudecode pattern — wrong-type fields
+// emit a structured warning via this io.Writer. nil → silent.
+var warnSink io.Writer
+
+// SetWarnSink directs Normalize's non-fatal warnings to w. Pass
+// nil to silence.
+func SetWarnSink(w io.Writer) { warnSink = w }
+
+// Normalize maps a Gemini CLI BeforeTool payload to a gov.Action.
+//
+// Tool-name mapping (as of gemini-cli 0.40.1):
+//
+//	run_shell_command                    → shell.exec (re-classified
+//	                                       via gov.Normalize for rm,
+//	                                       git push, etc.)
+//	read_file, read_many_files,
+//	  list_directory, glob,
+//	  search_file_content,
+//	  list_background_processes,
+//	  read_background_output             → file.read
+//	edit, replace, write_file            → file.write
+//	web_fetch, google_web_search         → http.request
+//	save_memory                          → file.write target="memory"
+//	update_topic                         → file.write target="topic"
+//	                                       (gemini's internal plan/
+//	                                       summary; treat as write-
+//	                                       shaped so policy rules
+//	                                       stay simple)
+//	<unknown>                            → ActUnknown (fail-closed)
+func Normalize(in HookInput) (gov.Action, error) {
+	switch in.ToolName {
+	case "run_shell_command":
+		cmd := stringField(in.ToolInput, "command")
+		a, err := gov.Normalize("terminal", map[string]any{"command": cmd})
+		if err != nil {
+			return gov.Action{}, fmt.Errorf("normalize run_shell_command: %w", err)
+		}
+		a.Path = in.Cwd
+		return a, nil
+
+	case "read_file":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "file_path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "read_many_files":
+		// gemini accepts a list of paths/globs under "paths"; pick
+		// the first as a representative target — the action_type
+		// is what policy matches against, not the full input.
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: firstStringInList(in.ToolInput, "paths"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "list_directory":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "glob":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "pattern"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "search_file_content":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "pattern"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "list_background_processes", "read_background_output":
+		// Browse-shaped — no host side effect.
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: in.ToolName,
+			Path:   in.Cwd,
+		}, nil
+
+	case "edit", "replace":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: stringField(in.ToolInput, "file_path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "write_file":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: stringField(in.ToolInput, "file_path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "web_fetch":
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: stringField(in.ToolInput, "url"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "google_web_search":
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: "google_web_search:" + stringField(in.ToolInput, "query"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "save_memory":
+		// Internal memory artifact — write-shaped but target=memory
+		// so a single "allow if target=memory" rule covers it.
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "memory",
+			Path:   in.Cwd,
+		}, nil
+
+	case "update_topic":
+		// Gemini's per-turn plan/summary update. No host side effect
+		// but treat as write-shaped at target="topic" to match the
+		// claudecode TodoWrite convention (Target=todo) so policy
+		// rules need only one entry per artifact kind.
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "topic",
+			Path:   in.Cwd,
+		}, nil
+	}
+
+	// Forward-compat: unknown tools fail-closed. Operator gets a
+	// clear "default-deny-unknown" verdict and can add a rule if
+	// the tool turns out to be benign.
+	return gov.Action{
+		Type:   gov.ActUnknown,
+		Target: in.ToolName,
+		Path:   in.Cwd,
+		Params: in.ToolInput,
+	}, nil
+}
+
+// stringField extracts a string field. Same shape as
+// claudecode.stringField — wrong-type values warn (operator
+// telemetry), missing keys silent (caller decides if required).
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if warnSink != nil {
+		fmt.Fprintf(warnSink, `{"warning":"tool_input_wrong_type","key":%q,"actual":%q}`+"\n", key, fmt.Sprintf("%T", v))
+	}
+	return ""
+}
+
+// firstStringInList returns the first string entry in
+// tool_input[key]. Used for read_many_files where the target
+// shape is a list of paths.
+func firstStringInList(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	list, ok := v.([]any)
+	if !ok || len(list) == 0 {
+		return ""
+	}
+	if s, ok := list[0].(string); ok {
+		return s
+	}
+	return ""
+}

--- a/go/execution-kernel/internal/driver/gemini/normalize_test.go
+++ b/go/execution-kernel/internal/driver/gemini/normalize_test.go
@@ -1,0 +1,146 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+func TestNormalize_ShellExecReclassifies(t *testing.T) {
+	a, err := Normalize(HookInput{
+		ToolName:  "run_shell_command",
+		ToolInput: map[string]any{"command": "rm -rf /tmp/foo"},
+		Cwd:       "/work",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Type == gov.ActUnknown {
+		t.Errorf("rm -rf should reclassify, got %s", a.Type)
+	}
+	if a.Path != "/work" {
+		t.Errorf("Path=%q want /work", a.Path)
+	}
+}
+
+func TestNormalize_FileRead(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolName   string
+		input      map[string]any
+		wantTarget string
+	}{
+		{"read_file", "read_file", map[string]any{"file_path": "/tmp/x"}, "/tmp/x"},
+		{"list_directory", "list_directory", map[string]any{"path": "/tmp"}, "/tmp"},
+		{"glob", "glob", map[string]any{"pattern": "**/*.go"}, "**/*.go"},
+		{"search_file_content", "search_file_content", map[string]any{"pattern": "TODO"}, "TODO"},
+		{"list_background_processes", "list_background_processes", map[string]any{}, "list_background_processes"},
+		{"read_background_output", "read_background_output", map[string]any{}, "read_background_output"},
+	}
+	for _, tc := range cases {
+		a, err := Normalize(HookInput{ToolName: tc.toolName, ToolInput: tc.input})
+		if err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		if a.Type != gov.ActFileRead {
+			t.Errorf("%s: type=%s want file.read", tc.name, a.Type)
+		}
+		if a.Target != tc.wantTarget {
+			t.Errorf("%s: target=%q want %q", tc.name, a.Target, tc.wantTarget)
+		}
+	}
+}
+
+func TestNormalize_ReadManyFilesPicksFirst(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName:  "read_many_files",
+		ToolInput: map[string]any{"paths": []any{"/tmp/a", "/tmp/b", "/tmp/c"}},
+	})
+	if a.Type != gov.ActFileRead {
+		t.Fatalf("type=%s want file.read", a.Type)
+	}
+	if a.Target != "/tmp/a" {
+		t.Errorf("target=%q want first path /tmp/a", a.Target)
+	}
+}
+
+func TestNormalize_FileWrite(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolName   string
+		input      map[string]any
+		wantTarget string
+	}{
+		{"edit", "edit", map[string]any{"file_path": "/tmp/x.go"}, "/tmp/x.go"},
+		{"replace", "replace", map[string]any{"file_path": "/tmp/y"}, "/tmp/y"},
+		{"write_file", "write_file", map[string]any{"file_path": "/tmp/z"}, "/tmp/z"},
+	}
+	for _, tc := range cases {
+		a, _ := Normalize(HookInput{ToolName: tc.toolName, ToolInput: tc.input})
+		if a.Type != gov.ActFileWrite {
+			t.Errorf("%s: type=%s want file.write", tc.name, a.Type)
+		}
+		if a.Target != tc.wantTarget {
+			t.Errorf("%s: target=%q want %q", tc.name, a.Target, tc.wantTarget)
+		}
+	}
+}
+
+func TestNormalize_HTTP(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName:  "web_fetch",
+		ToolInput: map[string]any{"url": "https://example.com"},
+	})
+	if a.Type != gov.ActHTTPRequest {
+		t.Errorf("type=%s want http.request", a.Type)
+	}
+	if a.Target != "https://example.com" {
+		t.Errorf("target=%q want url", a.Target)
+	}
+	b, _ := Normalize(HookInput{
+		ToolName:  "google_web_search",
+		ToolInput: map[string]any{"query": "chitin governance"},
+	})
+	if b.Type != gov.ActHTTPRequest {
+		t.Errorf("type=%s want http.request", b.Type)
+	}
+	if b.Target != "google_web_search:chitin governance" {
+		t.Errorf("target=%q does not include query", b.Target)
+	}
+}
+
+func TestNormalize_SaveMemoryAndUpdateTopic(t *testing.T) {
+	a, _ := Normalize(HookInput{ToolName: "save_memory", ToolInput: map[string]any{"content": "..."}})
+	if a.Type != gov.ActFileWrite || a.Target != "memory" {
+		t.Errorf("save_memory: %+v want type=file.write target=memory", a)
+	}
+	b, _ := Normalize(HookInput{ToolName: "update_topic", ToolInput: map[string]any{"summary": "..."}})
+	if b.Type != gov.ActFileWrite || b.Target != "topic" {
+		t.Errorf("update_topic: %+v want type=file.write target=topic", b)
+	}
+}
+
+func TestNormalize_UnknownToolFailsClosed(t *testing.T) {
+	a, _ := Normalize(HookInput{
+		ToolName:  "future_unreleased_gemini_tool",
+		ToolInput: map[string]any{"x": 1},
+	})
+	if a.Type != gov.ActUnknown {
+		t.Fatalf("type=%s want ActUnknown", a.Type)
+	}
+	// Params preserved so the audit log captures what we couldn't classify.
+	if a.Params == nil {
+		t.Errorf("Params should preserve raw input")
+	}
+}
+
+func TestNormalize_MissingFieldYieldsEmptyTarget(t *testing.T) {
+	a, _ := Normalize(HookInput{ToolName: "read_file", ToolInput: map[string]any{}})
+	if a.Type != gov.ActFileRead {
+		t.Fatalf("type=%s want file.read", a.Type)
+	}
+	if a.Target != "" {
+		t.Errorf("target=%q want empty", a.Target)
+	}
+}

--- a/scripts/install-gemini-hook.sh
+++ b/scripts/install-gemini-hook.sh
@@ -18,7 +18,26 @@
 set -euo pipefail
 
 SETTINGS_PATH="${GEMINI_SETTINGS_PATH:-$HOME/.gemini/settings.json}"
-HOOK_BIN="${CHITIN_ROUTER_HOOK_BIN:-/home/red/workspace/chitin/bin/chitin-router-hook}"
+
+# Resolve the hook binary path. Priority order:
+#   1. CHITIN_ROUTER_HOOK_BIN env override (operator-driven)
+#   2. <this-script-dir>/../bin/chitin-router-hook (in-repo, the
+#      common case for chitin-kernel-redeploy.timer which calls
+#      this script from the chitin checkout root)
+#   3. `command -v chitin-router-hook` (PATH lookup, for cases
+#      where the operator installed the shim into ~/.local/bin)
+#
+# Fail with a clear message if none resolve, rather than writing
+# a hardcoded /home/red path into the operator's gemini config.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK_BIN="${CHITIN_ROUTER_HOOK_BIN:-}"
+if [[ -z "$HOOK_BIN" ]]; then
+  if [[ -x "$SCRIPT_DIR/../bin/chitin-router-hook" ]]; then
+    HOOK_BIN="$SCRIPT_DIR/../bin/chitin-router-hook"
+  elif command -v chitin-router-hook >/dev/null; then
+    HOOK_BIN=$(command -v chitin-router-hook)
+  fi
+fi
 
 if ! command -v jq >/dev/null; then
   echo "install-gemini-hook: jq is required (apt install jq)" >&2

--- a/scripts/install-gemini-hook.sh
+++ b/scripts/install-gemini-hook.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# install-gemini-hook.sh — wire chitin governance into Gemini CLI.
+#
+# Gemini CLI fires a BeforeTool hook whose stdin shape is byte-
+# identical to Claude Code's PreToolUse (only the event name +
+# tool names differ). The kernel's gemini driver remaps the tool
+# names; this script installs the hook block into
+# ~/.gemini/settings.json so the kernel actually gets called.
+#
+# Idempotent: runs the merge through jq so re-running adds no
+# duplicates; can be invoked from chitin-kernel-redeploy.timer
+# alongside the kernel rebuild.
+#
+# Falls open: if jq is missing or ~/.gemini/settings.json is
+# unparseable, prints a clear error and exits non-zero rather
+# than overwriting the operator's config.
+
+set -euo pipefail
+
+SETTINGS_PATH="${GEMINI_SETTINGS_PATH:-$HOME/.gemini/settings.json}"
+HOOK_BIN="${CHITIN_ROUTER_HOOK_BIN:-/home/red/workspace/chitin/bin/chitin-router-hook}"
+
+if ! command -v jq >/dev/null; then
+  echo "install-gemini-hook: jq is required (apt install jq)" >&2
+  exit 2
+fi
+
+if [[ ! -x "$HOOK_BIN" ]]; then
+  echo "install-gemini-hook: hook binary not found at $HOOK_BIN" >&2
+  echo "  set CHITIN_ROUTER_HOOK_BIN to override the default path." >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$SETTINGS_PATH")"
+
+# Seed an empty settings file if absent.
+if [[ ! -f "$SETTINGS_PATH" ]]; then
+  echo '{}' > "$SETTINGS_PATH"
+fi
+
+# Validate parseability before mutation — never clobber a config
+# we can't read.
+if ! jq empty "$SETTINGS_PATH" 2>/dev/null; then
+  echo "install-gemini-hook: $SETTINGS_PATH is not valid JSON; refusing to overwrite" >&2
+  exit 3
+fi
+
+# Build the hook block. Idempotency: jq merges, then we drop
+# duplicates by command path so re-running this script doesn't
+# add the chitin hook twice.
+HOOK_BLOCK=$(jq -n --arg cmd "$HOOK_BIN --agent=gemini" '
+  {
+    matcher: "",
+    hooks: [
+      { type: "command", command: $cmd }
+    ]
+  }')
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+jq --argjson hookBlock "$HOOK_BLOCK" --arg cmd "$HOOK_BIN --agent=gemini" '
+  .hooks //= {} |
+  .hooks.BeforeTool //= [] |
+  # Drop any existing entry whose hook command matches ours, then add.
+  .hooks.BeforeTool |= (
+    map(select(
+      [.hooks[]? | select(.type=="command" and .command==$cmd)] | length == 0
+    )) + [$hookBlock]
+  )
+' "$SETTINGS_PATH" > "$TMP"
+
+mv "$TMP" "$SETTINGS_PATH"
+
+echo "install-gemini-hook: wired $HOOK_BIN --agent=gemini into $SETTINGS_PATH"
+echo
+echo "Verify with:"
+echo "  jq '.hooks.BeforeTool' $SETTINGS_PATH"

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -138,11 +138,19 @@ fi
 # dependencies, so failures here are non-fatal — log + continue.
 GEMINI_HOOK_INSTALLER="$REPO/scripts/install-gemini-hook.sh"
 if [[ -x "$GEMINI_HOOK_INSTALLER" ]]; then
-  if "$GEMINI_HOOK_INSTALLER" >/dev/null 2>&1; then
+  # Capture output so a failure surface is actually inspectable.
+  # On success, output is discarded (just the structured emit
+  # below). On failure, both stdout + stderr are tail-truncated
+  # and threaded into the structured log so operators can diagnose
+  # without spelunking through journal entries.
+  gemini_log=$(mktemp)
+  if "$GEMINI_HOOK_INSTALLER" >"$gemini_log" 2>&1; then
     emit ok gemini-hook-installed
   else
-    emit warn gemini-hook-install-failed "see install-gemini-hook output"
+    tail=$(tail -c 500 "$gemini_log" | tr '\n' ' ' | tr -d '"' || true)
+    emit warn gemini-hook-install-failed "tail=$tail"
   fi
+  rm -f "$gemini_log"
 fi
 
 emit ok redeploy-success "old_sha=$old_sha" "new_sha=$new_sha" "build_dur_ms=$build_dur_ms" "changed=$relevant_changes_since_last"

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -132,5 +132,18 @@ if ! echo "$smoke_payload" | timeout 2 "$BIN" gate evaluate --hook-stdin --agent
   fi
 fi
 
+# Refresh per-agent hook wiring. The kernel binary is now current;
+# wire it (or re-wire it) into agent CLIs that support hooks. Each
+# hook installer is idempotent and falls open on missing
+# dependencies, so failures here are non-fatal — log + continue.
+GEMINI_HOOK_INSTALLER="$REPO/scripts/install-gemini-hook.sh"
+if [[ -x "$GEMINI_HOOK_INSTALLER" ]]; then
+  if "$GEMINI_HOOK_INSTALLER" >/dev/null 2>&1; then
+    emit ok gemini-hook-installed
+  else
+    emit warn gemini-hook-install-failed "see install-gemini-hook output"
+  fi
+fi
+
 emit ok redeploy-success "old_sha=$old_sha" "new_sha=$new_sha" "build_dur_ms=$build_dur_ms" "changed=$relevant_changes_since_last"
 exit 0


### PR DESCRIPTION
## Summary
- Adds `internal/driver/gemini/normalize.go` mapping gemini-cli's tool registry (run_shell_command, read_file, edit, web_fetch, etc.) to canonical `gov.Action` values
- Dispatch in `evalHookStdin` selects normalizer by `--agent` flag (`gemini` vs `claude-code`); the JSON wire shape is shared between the two
- `scripts/install-gemini-hook.sh` injects `chitin-router-hook --agent=gemini` into `~/.gemini/settings.json` (BeforeTool event) idempotently via jq; no-clobber on parse failure
- `install-kernel.sh` now refreshes the gemini hook wiring on each kernel redeploy

## Why
Gemini CLI's BeforeTool hook is byte-identical to Claude Code's PreToolUse on the wire (they even set `CLAUDE_PROJECT_DIR` / `CLAUDE_CODE_ENTRYPOINT` envvars for compatibility). Only the tool names differ. Reusing the existing hook pipeline + a per-vendor normalizer means chitin gates gemini sessions with no new daemon, no new sockets, no new auth surface.

## Smoke
```
$ echo '{"hook_event_name":"BeforeTool","tool_name":"run_shell_command","tool_input":{"command":"rm -rf /tmp/foo"},"cwd":"/home/red/workspace/chitin"}' \
  | chitin-kernel gate evaluate --hook-stdin --agent=gemini
{"decision":"block","reason":"chitin: Recursive delete is blocked — use targeted file operations | suggest: ..."}
exit=2
```

End-to-end through real `gemini -p` works the same way once the hook is installed via the script.

## Test plan
- [x] 8 unit tests on the normalizer
- [x] 822 pass across 24 packages (full kernel suite)
- [x] Manual: install script smoke-tested + idempotency confirmed (running twice doesn't duplicate)
- [ ] Manual: `gemini -p "edit /tmp/x to add hello"` while in a chitin.yaml-governed dir; verify the block fires

## Future
- Codex governance (separate PR — codex has no hook surface but emits OTEL into a sqlite we can mine)
- Universal usage tracking (extend chitin-budget with calls/RL axes for subscription drivers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)