### PR TITLE
feat(analysis): codex_mine — quota visibility + session ingest

### DIFF
--- a/python/analysis/__main__.py
+++ b/python/analysis/__main__.py
@@ -6,7 +6,9 @@ print(
     "  python -m analysis.decisions   # repeated-deny pattern detection\n"
     "  python -m analysis.predict     # chain-predict-outcome model (train + predict)\n"
     "  python -m analysis.debt        # debt-ledger draft\n"
-    "  python -m analysis.souls       # soul-routing decisions",
+    "  python -m analysis.souls       # soul-routing decisions\n"
+    "  python -m analysis.skill_mine  # workflow n-gram surface from chain telemetry\n"
+    "  python -m analysis.codex_mine  # codex session ingest + quota usage",
     file=sys.stderr,
 )
 sys.exit(2)

--- a/python/analysis/codex_mine.py
+++ b/python/analysis/codex_mine.py
@@ -1,0 +1,367 @@
+"""Mine ~/.codex/sessions/**/*.jsonl into chitin-shaped chain events
+and a per-session usage rollup.
+
+Codex doesn't have a PreToolUse hook, so chitin can't gate codex
+calls in real time. But codex DOES emit a structured session
+JSONL with everything we need post-hoc:
+
+  - session_meta:        cwd, model_provider, cli_version
+  - event_msg.task_started:   turn_id, started_at, model_context_window
+  - response_item.function_call:  tool name + arguments
+  - event_msg.exec_command_end:   exit code, duration, stdout/stderr
+  - event_msg.token_count:        rate_limits with used_percent,
+                                  resets_at, window_minutes, plan_type
+                                  ← THIS IS THE BUDGET API
+  - event_msg.task_complete
+
+This module projects each function_call into a chitin chain
+decision event (action_type/action_target shape) and rolls up
+the rate_limits into a per-driver usage record.
+
+Public API:
+    iter_session_events(path) -> list[ChainEvent]
+    extract_usage(path) -> Usage
+    sessions_in(dir) -> list[Path]
+
+CLI:
+    python -m analysis.codex_mine usage      # summarize quota
+    python -m analysis.codex_mine ingest     # write chain JSONL
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+CODEX_SESSIONS_ROOT = Path.home() / ".codex" / "sessions"
+
+
+# ──────────────────────────────────────────────────────────────────
+# Shapes
+# ──────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ChainEvent:
+    """Subset of chitin chain.event.Event needed for ingest. The Go
+    kernel writes the full envelope; this Python projection carries
+    just enough to drive analytics + usage tracking."""
+    ts: str
+    chain_id: str
+    event_type: str  # "decision" | "exec_result" | "task_start"
+    payload: dict
+
+
+@dataclass
+class Usage:
+    """Per-driver usage rollup. Codex's rate_limits structure
+    exposes percent + reset times for two windows (primary 5h,
+    secondary 1w). chitin-budget reads this to render a unified
+    "% of cap" per driver across vendors."""
+    driver: str = "codex"
+    plan_type: str = ""
+    primary_used_percent: float = 0.0
+    primary_window_minutes: int = 0
+    primary_resets_at: int = 0  # unix seconds
+    secondary_used_percent: float = 0.0
+    secondary_window_minutes: int = 0
+    secondary_resets_at: int = 0
+    rate_limit_reached_type: str | None = None
+    last_observed_ts: str = ""
+    sessions_observed: int = 0
+    function_calls_total: int = 0
+    function_calls_by_name: dict[str, int] = field(default_factory=dict)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Loaders
+# ──────────────────────────────────────────────────────────────────
+
+def sessions_in(root: Path) -> list[Path]:
+    """Return all rollout-*.jsonl session files under root."""
+    if not root.exists():
+        return []
+    return sorted(root.rglob("rollout-*.jsonl"))
+
+
+def _parse_session_meta(line_obj: dict) -> tuple[str, str]:
+    """Returns (chain_id, cwd) from a session_meta event."""
+    p = line_obj.get("payload") or {}
+    return p.get("id", ""), p.get("cwd", "")
+
+
+def iter_session_events(path: Path) -> Iterable[ChainEvent]:
+    """Project each codex function_call into a chitin chain
+    decision event. Yields events in source order."""
+    if not path.exists():
+        return
+    chain_id = ""
+    cwd = ""
+    try:
+        data = path.read_text(errors="replace")
+    except OSError:
+        return
+    for line in data.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        ts = ev.get("timestamp", "")
+        ev_type = ev.get("type", "")
+        payload = ev.get("payload") or {}
+        ptype = payload.get("type", "")
+
+        if ev_type == "session_meta":
+            chain_id, cwd = _parse_session_meta(ev)
+            yield ChainEvent(
+                ts=ts,
+                chain_id=chain_id,
+                event_type="task_start",
+                payload={
+                    "tool_name": "codex.session_start",
+                    "action_type": "delegate.task",
+                    "action_target": payload.get("cli_version", ""),
+                    "decision": "allow",
+                    "rule_id": "codex-post-hoc",
+                    "cwd": cwd,
+                    "model_provider": payload.get("model_provider", ""),
+                },
+            )
+            continue
+
+        if ev_type == "response_item" and ptype == "function_call":
+            name = payload.get("name") or "unknown"
+            args = payload.get("arguments") or ""
+            target = _extract_target(name, args)
+            yield ChainEvent(
+                ts=ts,
+                chain_id=chain_id,
+                event_type="decision",
+                payload={
+                    "tool_name": name,
+                    "action_type": _to_action_type(name),
+                    "action_target": target,
+                    "decision": "allow",
+                    "rule_id": "codex-post-hoc",
+                },
+            )
+            continue
+
+        if ev_type == "event_msg" and ptype == "exec_command_end":
+            yield ChainEvent(
+                ts=ts,
+                chain_id=chain_id,
+                event_type="exec_result",
+                payload={
+                    "tool_name": "exec_command",
+                    "exit_code": payload.get("exit_code", -1),
+                    "duration_ms": payload.get("duration_ms"),
+                    "session_id": chain_id,
+                },
+            )
+
+
+def _to_action_type(name: str) -> str:
+    """Codex tool names → chitin action types. Mirror of
+    internal/driver/gemini/normalize.go but in Python because the
+    miner runs post-hoc, not in the kernel hot path."""
+    mapping = {
+        "exec_command": "shell.exec",
+        "shell": "shell.exec",
+        "write_stdin": "shell.exec",
+        "read_file": "file.read",
+        "apply_patch": "file.write",
+        "edit_file": "file.write",
+        "search_replace": "file.write",
+        "fetch": "http.request",
+        "web_search": "http.request",
+    }
+    return mapping.get(name, "unknown")
+
+
+def _extract_target(name: str, args: str) -> str:
+    """Best-effort: parse the first relevant field out of the
+    function_call arguments JSON. Codex's args are a JSON-encoded
+    string; we don't fail on parse errors (post-hoc, not safety-
+    critical)."""
+    try:
+        a = json.loads(args) if isinstance(args, str) else args or {}
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(a, dict):
+        return ""
+    for key in ("command", "file_path", "path", "url", "query", "pattern"):
+        v = a.get(key)
+        if isinstance(v, list) and v:
+            v = v[0]
+        if isinstance(v, str):
+            return v
+    return ""
+
+
+# ──────────────────────────────────────────────────────────────────
+# Usage rollup
+# ──────────────────────────────────────────────────────────────────
+
+def extract_usage(paths: Iterable[Path]) -> Usage:
+    """Walk all sessions; pull the latest rate_limits + sum
+    function_call counts. Returns a Usage record suitable for
+    chitin-budget's multi-axis schema."""
+    u = Usage()
+    latest_ts = ""
+    for path in paths:
+        if not path.exists():
+            continue
+        u.sessions_observed += 1
+        try:
+            data = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in data.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            payload = ev.get("payload") or {}
+            ptype = payload.get("type", "")
+            if ev.get("type") == "response_item" and ptype == "function_call":
+                u.function_calls_total += 1
+                name = payload.get("name") or "?"
+                u.function_calls_by_name[name] = u.function_calls_by_name.get(name, 0) + 1
+            if ev.get("type") == "event_msg" and ptype == "token_count":
+                rl = payload.get("rate_limits") or {}
+                ts = ev.get("timestamp", "")
+                if ts and ts > latest_ts:
+                    latest_ts = ts
+                    u.last_observed_ts = ts
+                    u.plan_type = rl.get("plan_type", u.plan_type)
+                    u.rate_limit_reached_type = rl.get("rate_limit_reached_type")
+                    primary = rl.get("primary") or {}
+                    u.primary_used_percent = float(primary.get("used_percent", u.primary_used_percent))
+                    u.primary_window_minutes = int(primary.get("window_minutes", u.primary_window_minutes))
+                    u.primary_resets_at = int(primary.get("resets_at", u.primary_resets_at))
+                    secondary = rl.get("secondary") or {}
+                    u.secondary_used_percent = float(secondary.get("used_percent", u.secondary_used_percent))
+                    u.secondary_window_minutes = int(secondary.get("window_minutes", u.secondary_window_minutes))
+                    u.secondary_resets_at = int(secondary.get("resets_at", u.secondary_resets_at))
+    return u
+
+
+def usage_to_dict(u: Usage) -> dict:
+    return {
+        "driver": u.driver,
+        "plan_type": u.plan_type,
+        "primary": {
+            "used_percent": u.primary_used_percent,
+            "window_minutes": u.primary_window_minutes,
+            "resets_at": u.primary_resets_at,
+        },
+        "secondary": {
+            "used_percent": u.secondary_used_percent,
+            "window_minutes": u.secondary_window_minutes,
+            "resets_at": u.secondary_resets_at,
+        },
+        "rate_limit_reached_type": u.rate_limit_reached_type,
+        "last_observed_ts": u.last_observed_ts,
+        "sessions_observed": u.sessions_observed,
+        "function_calls_total": u.function_calls_total,
+        "function_calls_by_name": u.function_calls_by_name,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────
+
+def _humanize_resets_at(ts: int) -> str:
+    if not ts:
+        return "?"
+    delta = ts - int(datetime.now(timezone.utc).timestamp())
+    if delta <= 0:
+        return "passed"
+    h, m = divmod(delta // 60, 60)
+    if h:
+        return f"in {h}h{m:02d}m"
+    return f"in {m}m"
+
+
+def _cli_usage(args: argparse.Namespace) -> int:
+    root = Path(args.sessions_dir).expanduser()
+    paths = sessions_in(root)
+    u = extract_usage(paths)
+    if args.json:
+        print(json.dumps(usage_to_dict(u), indent=2))
+        return 0
+    print(f"codex usage — {u.sessions_observed} sessions observed")
+    print(f"  plan:                  {u.plan_type or '?'}")
+    print(f"  primary  (5h):         {u.primary_used_percent:5.1f}% used, resets {_humanize_resets_at(u.primary_resets_at)}")
+    print(f"  secondary (weekly):    {u.secondary_used_percent:5.1f}% used, resets {_humanize_resets_at(u.secondary_resets_at)}")
+    if u.rate_limit_reached_type:
+        print(f"  ⚠  rate-limit hit:     {u.rate_limit_reached_type}")
+    print(f"  function calls total:  {u.function_calls_total}")
+    if u.function_calls_by_name:
+        print("  by tool:")
+        for name, n in sorted(u.function_calls_by_name.items(), key=lambda kv: -kv[1]):
+            print(f"    {n:5}  {name}")
+    return 0
+
+
+def _cli_ingest(args: argparse.Namespace) -> int:
+    """Project codex function_calls into chitin events JSONL.
+    Default output: ~/.chitin/codex-events-<chain_id>.jsonl per
+    session (matches the kernel's per-chain file convention)."""
+    root = Path(args.sessions_dir).expanduser()
+    out_dir = Path(args.out_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = sessions_in(root)
+    written = 0
+    for path in paths:
+        events = list(iter_session_events(path))
+        if not events:
+            continue
+        chain_id = events[0].chain_id or path.stem
+        out_path = out_dir / f"codex-events-{chain_id}.jsonl"
+        with out_path.open("w") as fh:
+            for ev in events:
+                fh.write(json.dumps({
+                    "ts": ev.ts,
+                    "chain_id": ev.chain_id,
+                    "event_type": ev.event_type,
+                    "payload": ev.payload,
+                }) + "\n")
+        written += 1
+    print(f"wrote {written} session(s) to {out_dir}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="analysis.codex_mine")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pu = sub.add_parser("usage", help="summarize codex quota state")
+    pu.add_argument("--sessions-dir", default=str(CODEX_SESSIONS_ROOT))
+    pu.add_argument("--json", action="store_true")
+    pu.set_defaults(func=_cli_usage)
+
+    pi = sub.add_parser("ingest", help="project codex function_calls into chitin events JSONL")
+    pi.add_argument("--sessions-dir", default=str(CODEX_SESSIONS_ROOT))
+    pi.add_argument("--out-dir", default="~/.chitin")
+    pi.set_defaults(func=_cli_ingest)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/analysis/codex_mine.py
+++ b/python/analysis/codex_mine.py
@@ -19,8 +19,8 @@ decision event (action_type/action_target shape) and rolls up
 the rate_limits into a per-driver usage record.
 
 Public API:
-    iter_session_events(path) -> list[ChainEvent]
-    extract_usage(path) -> Usage
+    iter_session_events(path) -> Iterable[ChainEvent]
+    extract_usage(paths: Iterable[Path]) -> Usage
     sessions_in(dir) -> list[Path]
 
 CLI:
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -81,8 +81,12 @@ class Usage:
 # ──────────────────────────────────────────────────────────────────
 
 def sessions_in(root: Path) -> list[Path]:
-    """Return all rollout-*.jsonl session files under root."""
-    if not root.exists():
+    """Return all rollout-*.jsonl session files under root.
+
+    Returns empty list when root is missing OR is a non-directory
+    path (file, broken symlink, etc.). rglob() on a non-directory
+    raises; defensive check keeps the function call-safe."""
+    if not root.exists() or not root.is_dir():
         return []
     return sorted(root.rglob("rollout-*.jsonl"))
 
@@ -316,10 +320,38 @@ def _cli_usage(args: argparse.Namespace) -> int:
     return 0
 
 
+_SAFE_CHAIN_ID_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _safe_chain_id_basename(chain_id: str, fallback: str) -> str:
+    """Sanitize chain_id for use as a filename component.
+
+    Codex's session payload.id is normally a UUID, but a malformed
+    or hostile session JSONL could contain path separators / `..`
+    which would let _cli_ingest write outside out_dir. Replace
+    anything outside [a-zA-Z0-9_-] with `_`; fall back to the
+    file stem if the input is empty OR contains no allowlist chars
+    (e.g., "///" → all-underscore, no real id signal — use the
+    file stem instead so nothing gets written under an opaque name).
+    """
+    if not chain_id or not any(c.isalnum() or c in "_-" for c in chain_id):
+        return fallback
+    return _SAFE_CHAIN_ID_RE.sub("_", chain_id)
+
+
 def _cli_ingest(args: argparse.Namespace) -> int:
     """Project codex function_calls into chitin events JSONL.
-    Default output: ~/.chitin/codex-events-<chain_id>.jsonl per
-    session (matches the kernel's per-chain file convention)."""
+
+    Note: output files are named codex-events-<chain_id>.jsonl
+    in a SUBDIR (default: ~/.chitin/codex-ingest/) — NOT the
+    kernel's main events-*.jsonl convention. The kernel writes
+    full v2 envelopes; this projection is post-hoc and lighter
+    weight. Existing chitin telemetry tools (events list/tree/
+    replay) only scan the canonical events-*.jsonl pattern, so
+    keeping codex-events in a subdir avoids confusion + accidental
+    indexing of incomplete records. Future: emit through the
+    kernel's event API directly.
+    """
     root = Path(args.sessions_dir).expanduser()
     out_dir = Path(args.out_dir).expanduser()
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -330,7 +362,7 @@ def _cli_ingest(args: argparse.Namespace) -> int:
         events = list(iter_session_events(path))
         if not events:
             continue
-        chain_id = events[0].chain_id or path.stem
+        chain_id = _safe_chain_id_basename(events[0].chain_id, path.stem)
         out_path = out_dir / f"codex-events-{chain_id}.jsonl"
         with out_path.open("w") as fh:
             for ev in events:
@@ -356,7 +388,9 @@ def main(argv: list[str] | None = None) -> int:
 
     pi = sub.add_parser("ingest", help="project codex function_calls into chitin events JSONL")
     pi.add_argument("--sessions-dir", default=str(CODEX_SESSIONS_ROOT))
-    pi.add_argument("--out-dir", default="~/.chitin")
+    # Subdir keeps codex-events-*.jsonl out of the canonical
+    # events-*.jsonl namespace that chitin telemetry walks.
+    pi.add_argument("--out-dir", default="~/.chitin/codex-ingest")
     pi.set_defaults(func=_cli_ingest)
 
     args = p.parse_args(argv)

--- a/python/analysis/tests/test_codex_mine.py
+++ b/python/analysis/tests/test_codex_mine.py
@@ -1,0 +1,164 @@
+"""Tests for analysis.codex_mine — codex session JSONL ingest."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from analysis.codex_mine import (
+    Usage,
+    extract_usage,
+    iter_session_events,
+    sessions_in,
+    _to_action_type,
+    _extract_target,
+)
+
+
+def _write_session(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev) + "\n")
+
+
+def test_to_action_type_known_tools() -> None:
+    assert _to_action_type("exec_command") == "shell.exec"
+    assert _to_action_type("write_stdin") == "shell.exec"
+    assert _to_action_type("read_file") == "file.read"
+    assert _to_action_type("apply_patch") == "file.write"
+    assert _to_action_type("fetch") == "http.request"
+    assert _to_action_type("future_unknown_tool") == "unknown"
+
+
+def test_extract_target_first_match() -> None:
+    args = json.dumps({"command": "ls /tmp", "extra": "ignored"})
+    assert _extract_target("exec_command", args) == "ls /tmp"
+    args = json.dumps({"file_path": "/tmp/x", "content": "hi"})
+    assert _extract_target("write_file", args) == "/tmp/x"
+    # malformed JSON returns empty, doesn't raise
+    assert _extract_target("?", "{not json") == ""
+
+
+def test_iter_session_events_function_calls(tmp_path: Path) -> None:
+    p = tmp_path / "rollout-test.jsonl"
+    _write_session(p, [
+        {"timestamp": "2026-05-04T00:30:37Z", "type": "session_meta",
+         "payload": {"id": "chain-A", "cwd": "/work", "cli_version": "0.128.0", "model_provider": "openai"}},
+        {"timestamp": "2026-05-04T00:30:38Z", "type": "response_item",
+         "payload": {"type": "function_call", "name": "exec_command",
+                     "arguments": json.dumps({"command": "ls /tmp"})}},
+        {"timestamp": "2026-05-04T00:30:39Z", "type": "response_item",
+         "payload": {"type": "function_call", "name": "exec_command",
+                     "arguments": json.dumps({"command": "rm /tmp/x"})}},
+        # non-decision events are still surfaced where applicable
+        {"timestamp": "2026-05-04T00:30:40Z", "type": "event_msg",
+         "payload": {"type": "exec_command_end", "exit_code": 0, "duration_ms": 12}},
+    ])
+    events = list(iter_session_events(p))
+    # 1 task_start + 2 decision + 1 exec_result
+    assert len(events) == 4
+    assert events[0].event_type == "task_start"
+    assert events[0].chain_id == "chain-A"
+    decisions = [e for e in events if e.event_type == "decision"]
+    assert len(decisions) == 2
+    assert decisions[0].payload["action_type"] == "shell.exec"
+    assert decisions[0].payload["action_target"] == "ls /tmp"
+    assert decisions[0].chain_id == "chain-A"
+    exec_result = [e for e in events if e.event_type == "exec_result"]
+    assert len(exec_result) == 1
+    assert exec_result[0].payload["exit_code"] == 0
+    assert exec_result[0].payload["duration_ms"] == 12
+
+
+def test_extract_usage_aggregates_rate_limits(tmp_path: Path) -> None:
+    p1 = tmp_path / "session1.jsonl"
+    _write_session(p1, [
+        {"timestamp": "2026-05-04T00:30:37Z", "type": "session_meta",
+         "payload": {"id": "chain-A", "cwd": "/", "cli_version": "0.128.0"}},
+        {"timestamp": "2026-05-04T00:30:38Z", "type": "response_item",
+         "payload": {"type": "function_call", "name": "exec_command", "arguments": "{}"}},
+        {"timestamp": "2026-05-04T00:30:39Z", "type": "event_msg",
+         "payload": {"type": "token_count", "rate_limits": {
+             "plan_type": "plus",
+             "rate_limit_reached_type": None,
+             "primary": {"used_percent": 5.0, "window_minutes": 300, "resets_at": 1777872638},
+             "secondary": {"used_percent": 0.5, "window_minutes": 10080, "resets_at": 1778459438},
+         }}},
+    ])
+    p2 = tmp_path / "session2.jsonl"
+    _write_session(p2, [
+        {"timestamp": "2026-05-04T01:00:00Z", "type": "session_meta",
+         "payload": {"id": "chain-B", "cwd": "/", "cli_version": "0.128.0"}},
+        # later token_count should win
+        {"timestamp": "2026-05-04T01:00:01Z", "type": "event_msg",
+         "payload": {"type": "token_count", "rate_limits": {
+             "plan_type": "plus",
+             "rate_limit_reached_type": None,
+             "primary": {"used_percent": 12.5, "window_minutes": 300, "resets_at": 1777872999},
+             "secondary": {"used_percent": 1.2, "window_minutes": 10080, "resets_at": 1778459438},
+         }}},
+        {"timestamp": "2026-05-04T01:00:02Z", "type": "response_item",
+         "payload": {"type": "function_call", "name": "read_file", "arguments": "{}"}},
+        {"timestamp": "2026-05-04T01:00:03Z", "type": "response_item",
+         "payload": {"type": "function_call", "name": "exec_command", "arguments": "{}"}},
+    ])
+
+    u = extract_usage([p1, p2])
+    assert u.sessions_observed == 2
+    assert u.plan_type == "plus"
+    # latest by timestamp: session 2's 12.5%
+    assert u.primary_used_percent == 12.5
+    assert u.primary_window_minutes == 300
+    assert u.secondary_used_percent == 1.2
+    assert u.last_observed_ts == "2026-05-04T01:00:01Z"
+    # function calls aggregate across sessions
+    assert u.function_calls_total == 3
+    assert u.function_calls_by_name == {"exec_command": 2, "read_file": 1}
+
+
+def test_extract_usage_handles_missing_rate_limits(tmp_path: Path) -> None:
+    """A session without token_count events leaves Usage at defaults
+    rather than crashing."""
+    p = tmp_path / "session.jsonl"
+    _write_session(p, [
+        {"timestamp": "2026-05-04T00:30:37Z", "type": "session_meta",
+         "payload": {"id": "x", "cwd": "/"}},
+        {"timestamp": "2026-05-04T00:30:38Z", "type": "response_item",
+         "payload": {"type": "function_call", "name": "exec_command", "arguments": "{}"}},
+    ])
+    u = extract_usage([p])
+    assert u.sessions_observed == 1
+    assert u.primary_used_percent == 0.0
+    assert u.function_calls_total == 1
+
+
+def test_sessions_in_returns_sorted(tmp_path: Path) -> None:
+    (tmp_path / "2026" / "05").mkdir(parents=True)
+    (tmp_path / "2026" / "05" / "rollout-b.jsonl").write_text("{}\n")
+    (tmp_path / "2026" / "05" / "rollout-a.jsonl").write_text("{}\n")
+    (tmp_path / "2026" / "05" / "ignored.txt").write_text("nope")
+    paths = sessions_in(tmp_path)
+    assert len(paths) == 2
+    assert paths[0].name == "rollout-a.jsonl"
+    assert paths[1].name == "rollout-b.jsonl"
+
+
+def test_sessions_in_missing_dir_returns_empty(tmp_path: Path) -> None:
+    nonexistent = tmp_path / "not-here"
+    assert sessions_in(nonexistent) == []
+
+
+def test_iter_session_events_handles_corrupt_lines(tmp_path: Path) -> None:
+    p = tmp_path / "session.jsonl"
+    p.write_text(
+        json.dumps({"timestamp": "2026-05-04T00:30:37Z", "type": "session_meta",
+                    "payload": {"id": "chain-A", "cwd": "/"}}) + "\n"
+        "this is not JSON\n"
+        + json.dumps({"timestamp": "2026-05-04T00:30:39Z", "type": "response_item",
+                      "payload": {"type": "function_call", "name": "exec_command",
+                                  "arguments": "{}"}}) + "\n"
+    )
+    events = list(iter_session_events(p))
+    # corrupt line skipped, others survive
+    assert len(events) == 2  # task_start + 1 decision
+    assert events[0].chain_id == "chain-A"

--- a/python/analysis/tests/test_codex_mine.py
+++ b/python/analysis/tests/test_codex_mine.py
@@ -9,6 +9,7 @@ from analysis.codex_mine import (
     extract_usage,
     iter_session_events,
     sessions_in,
+    _safe_chain_id_basename,
     _to_action_type,
     _extract_target,
 )
@@ -162,3 +163,97 @@ def test_iter_session_events_handles_corrupt_lines(tmp_path: Path) -> None:
     # corrupt line skipped, others survive
     assert len(events) == 2  # task_start + 1 decision
     assert events[0].chain_id == "chain-A"
+
+
+def test_safe_chain_id_basename_strips_path_separators() -> None:
+    """Hostile or malformed session JSONL could have a payload.id
+    containing path separators or .. — basename must not let
+    that escape the configured out_dir."""
+    # 6 chars in "../../" → 6 underscores, plus 1 each for / between segments
+    assert _safe_chain_id_basename("../../etc/passwd", "fallback") == "______etc_passwd"
+    assert _safe_chain_id_basename("a/b/c", "fallback") == "a_b_c"
+    assert _safe_chain_id_basename("normal-uuid-123", "fallback") == "normal-uuid-123"
+    # All-bad → fallback
+    assert _safe_chain_id_basename("///", "fallback") == "fallback"
+    assert _safe_chain_id_basename("", "fallback") == "fallback"
+
+
+def test_sessions_in_rejects_non_directory(tmp_path: Path) -> None:
+    """If --sessions-dir points at a file (or other non-dir),
+    rglob would raise. sessions_in must defensively return []."""
+    f = tmp_path / "not-a-dir"
+    f.write_text("hi")
+    assert sessions_in(f) == []
+
+
+def test_cli_ingest_writes_codex_events(tmp_path: Path) -> None:
+    """End-to-end smoke for _cli_ingest: synthetic session in
+    sessions_dir → output file appears in out_dir with the
+    expected naming convention. Pins the CLI contract Copilot
+    flagged as untested."""
+    import subprocess
+    import sys
+
+    sessions_dir = tmp_path / "sessions" / "2026" / "05"
+    sessions_dir.mkdir(parents=True)
+    chain_id = "abc-123"
+    fixture = sessions_dir / f"rollout-test-{chain_id}.jsonl"
+    fixture.write_text(
+        json.dumps({"timestamp": "2026-05-04T00:30:37Z", "type": "session_meta",
+                    "payload": {"id": chain_id, "cwd": "/", "cli_version": "0.128.0"}}) + "\n"
+        + json.dumps({"timestamp": "2026-05-04T00:30:38Z", "type": "response_item",
+                      "payload": {"type": "function_call", "name": "exec_command",
+                                  "arguments": json.dumps({"command": "ls /tmp"})}}) + "\n"
+    )
+
+    out_dir = tmp_path / "out"
+    proc = subprocess.run(
+        [sys.executable, "-m", "analysis.codex_mine", "ingest",
+         f"--sessions-dir={tmp_path / 'sessions'}",
+         f"--out-dir={out_dir}"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"ingest failed: {proc.stderr}"
+
+    out_file = out_dir / f"codex-events-{chain_id}.jsonl"
+    assert out_file.exists(), f"expected {out_file}; saw {list(out_dir.glob('*'))}"
+    lines = [l for l in out_file.read_text().splitlines() if l.strip()]
+    assert len(lines) == 2  # task_start + 1 decision
+    decoded = [json.loads(l) for l in lines]
+    assert decoded[0]["chain_id"] == chain_id
+    assert decoded[1]["payload"]["action_type"] == "shell.exec"
+
+
+def test_cli_ingest_sanitizes_malicious_chain_id(tmp_path: Path) -> None:
+    """A session whose payload.id contains path separators must
+    NOT cause _cli_ingest to write outside out_dir."""
+    import subprocess
+    import sys
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    fixture = sessions_dir / "rollout-malicious.jsonl"
+    fixture.write_text(
+        json.dumps({"timestamp": "2026-05-04T00:30:37Z", "type": "session_meta",
+                    "payload": {"id": "../../escape", "cwd": "/"}}) + "\n"
+        + json.dumps({"timestamp": "2026-05-04T00:30:38Z", "type": "response_item",
+                      "payload": {"type": "function_call", "name": "exec_command",
+                                  "arguments": "{}"}}) + "\n"
+    )
+
+    out_dir = tmp_path / "out"
+    proc = subprocess.run(
+        [sys.executable, "-m", "analysis.codex_mine", "ingest",
+         f"--sessions-dir={sessions_dir}",
+         f"--out-dir={out_dir}"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"ingest failed: {proc.stderr}"
+    # The escape attempt must not have created files outside out_dir
+    parent = tmp_path
+    assert not (parent / "escape").exists()
+    # The file should land in out_dir with sanitized name
+    files = list(out_dir.iterdir())
+    assert len(files) == 1
+    assert "escape" in files[0].name
+    assert "/" not in files[0].name


### PR DESCRIPTION
## Summary
- New `python/analysis/codex_mine.py` ingests `~/.codex/sessions/**/*.jsonl` into chitin chain events + a per-driver usage rollup
- **Big win for the budget question:** codex's `event_msg.token_count.rate_limits` IS a quota API — exposes `used_percent` + `resets_at` for both 5h and weekly windows, plus `plan_type` and a `rate_limit_reached_type` flag
- CLI: `python -m analysis.codex_mine usage` (human or --json), `... ingest` to write per-session events JSONL into ~/.chitin

## Why
Codex has no PreToolUse hook so chitin can't gate its calls in real time, but it emits everything we need post-hoc — function names + arguments, exec_command_end exit codes + duration, and the rate_limits structure that gives us proper quota visibility (the thing operators actually want to see).

## Smoke
```
$ python -m analysis.codex_mine usage
codex usage — 1 sessions observed
  plan:                  plus
  primary  (5h):           1.0% used, resets in 4h06m
  secondary (weekly):      0.0% used, resets in 167h06m
  function calls total:  41
  by tool:
       40  exec_command
        1  write_stdin
```

## Test plan
- [x] 8 unit tests (action-type mapping, target extraction, aggregation, latest-wins, missing rate_limits, sorted discovery, corrupt-line tolerance)
- [x] Live smoke against this box's real codex session

## Future
- Universal usage schema PR: feeds this Usage record (alongside Anthropic $ + Gemini calls + Ollama Cloud rpm/tpm) into a unified chitin-budget multi-axis dashboard
- Periodic ingest timer: systemd unit that runs `codex_mine ingest` every N minutes so chain stats include codex traffic alongside Claude Code and gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)