### PR TITLE
feat(budget): universal usage-feed schema + codex render

### DIFF
--- a/docs/runbooks/usage-feeds.md
+++ b/docs/runbooks/usage-feeds.md
@@ -1,0 +1,133 @@
+# Usage feeds — driver quota visibility
+
+Status: shipped (codex). Roadmap: gemini, ollama-cloud.
+
+## Why
+
+`chitin-budget` historically tracked $-spend from the swarm-rollup JSONs (Anthropic API per-token billing). That works for paid APIs but not for:
+
+- **Subscription CLIs** (codex, gemini): no per-call dollar cost; flat-rate monthly with rate limits as the soft ceiling
+- **Self-hosted with cloud bursting** (ollama-cloud): quota is rpm/tpm, not $
+- **Rate-limited free tiers** generally
+
+A unified "usage" surface lets the operator see all of these in one dashboard alongside $-spend.
+
+## Where feeds live
+
+`~/.cache/chitin/usage/<driver>.json` — one file per driver. Override the directory with `CHITIN_USAGE_FEED_DIR`.
+
+## Schema
+
+```json
+{
+  "driver": "codex",
+  "axis": "quota_percent",
+  "plan_type": "plus",
+  "last_observed": "2026-05-04T00:43:39.125Z",
+  "warnings": [],
+  "calls_total": 41,
+  "windows": [
+    {
+      "label": "primary",
+      "used_percent": 1.0,
+      "window_minutes": 300,
+      "resets_at": 1777872638
+    },
+    {
+      "label": "secondary",
+      "used_percent": 0.0,
+      "window_minutes": 10080,
+      "resets_at": 1778459438
+    }
+  ]
+}
+```
+
+Required fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `driver` | string | Canonical driver name (matches the `--agent=` flag and chain payload) |
+| `axis` | string | One of `quota_percent`, `calls_count`, `rpm_tpm`, `usd` (existing $ rows; not used by feeds today) |
+| `plan_type` | string | Vendor plan label (`plus`, `pro`, free, etc). Empty when irrelevant |
+| `last_observed` | iso8601 | When the feed was last refreshed; used by chitin-status to flag stale feeds |
+| `warnings` | array | Non-empty list = soft signal an operator should see; one element = one warning. `chitin-budget --check` exits 1 if any feed has a warning. |
+| `windows` | array | Per-window axis-specific metrics. See per-axis sections below. |
+
+### `axis: quota_percent` (codex)
+
+```json
+"windows": [
+  {"label": "primary", "used_percent": 1.0, "window_minutes": 300, "resets_at": 1777872638},
+  {"label": "secondary", "used_percent": 0.0, "window_minutes": 10080, "resets_at": 1778459438}
+]
+```
+
+`window_minutes` documents the rolling-window length the vendor enforces (300 = 5h for codex Plus). `resets_at` is unix seconds; chitin-budget renders it as "in 4h06m" or "passed".
+
+### `axis: calls_count` (gemini, future)
+
+```json
+"windows": [
+  {"label": "primary", "used_count": 47, "cap": 100, "window_minutes": 300, "resets_at": 0}
+]
+```
+
+When the vendor publishes the cap, populate `cap`. When `resets_at` is 0/unknown, chitin-budget shows "—".
+
+### `axis: rpm_tpm` (ollama-cloud, future)
+
+```json
+"windows": [
+  {"label": "rpm", "used_percent": 18.0, "window_minutes": 1, "resets_at": 0},
+  {"label": "tpm", "used_percent": 35.0, "window_minutes": 1, "resets_at": 0}
+]
+```
+
+Per-minute rolling windows. `used_percent` of the cap is the most useful render.
+
+## Producers
+
+| Driver | Source | Producer |
+|---|---|---|
+| `codex` | `~/.codex/sessions/**/*.jsonl` (rate_limits in token_count events) | `python -m analysis.codex_mine usage --write-feed ~/.cache/chitin/usage/codex.json` |
+| `gemini` | TBD — gemini doesn't publish quota in its session logs today; may scrape stderr for rate-limit signals | TODO |
+| `ollama-cloud` | response headers (`X-RateLimit-Remaining` etc.) captured at the activity layer | TODO — activity stderr scraper proposed |
+
+## Consumers
+
+- `chitin-budget` renders the "Quota / usage" section after the $-spend table; `--check` exits 1 on any warning
+- `chitin-status` (future) — surfaces top-line usage % per driver in the operator dashboard
+- `chitin-kernel chain stats` (future) — joins call_total across feeds with per-action stats from the chain
+
+## Refresh cadence
+
+Producers are designed to be runnable from a systemd timer:
+
+```ini
+# infra/systemd/chitin-codex-usage-feed.timer (TODO)
+[Unit]
+Description=Refresh codex usage feed every 10 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+
+[Install]
+WantedBy=timers.target
+```
+
+The codex feed is cheap to refresh (reads ~1MB of JSONL, writes ~1KB). Gemini scrape will be similar; ollama-cloud capture is per-request at the activity layer.
+
+## Operator quickstart
+
+```bash
+# Refresh the codex feed manually
+mkdir -p ~/.cache/chitin/usage
+python -m analysis.codex_mine usage --write-feed ~/.cache/chitin/usage/codex.json
+
+# Then chitin-budget shows it
+chitin-budget
+chitin-budget --json
+chitin-budget --check    # exit 1 if any rate-limit hit
+```

--- a/infra/systemd/chitin-codex-usage-feed.service
+++ b/infra/systemd/chitin-codex-usage-feed.service
@@ -1,0 +1,24 @@
+# One-shot service fired by chitin-codex-usage-feed.timer.
+# Re-mines ~/.codex/sessions/**/*.jsonl into the universal usage
+# feed at ~/.cache/chitin/usage/codex.json. chitin-budget reads
+# this for the Quota/usage section; chitin-status will read it
+# for the per-driver dashboard row.
+#
+# Cheap: reads ~1MB of JSONL, writes ~1KB. Safe to run frequently.
+
+[Unit]
+Description=Refresh codex usage feed (rate_limits + call counts)
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=/bin/sh -c '\
+  mkdir -p %h/.cache/chitin/usage && \
+  cd %h/workspace/chitin/python/analysis && \
+  uv run --project . python -m analysis.codex_mine usage \
+    --write-feed=%h/.cache/chitin/usage/codex.json'
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=30

--- a/infra/systemd/chitin-codex-usage-feed.timer
+++ b/infra/systemd/chitin-codex-usage-feed.timer
@@ -1,0 +1,17 @@
+# Timer for chitin-codex-usage-feed.service.
+# 10-minute cadence — fast enough that operators see usage drift
+# in something close to real time, slow enough that we don't
+# pound on the codex sessions dir. Persistent so a missed tick
+# from a powered-off rig fires on the next boot.
+
+[Unit]
+Description=Refresh codex usage feed every 10 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Persistent=true
+Unit=chitin-codex-usage-feed.service
+
+[Install]
+WantedBy=timers.target

--- a/python/analysis/codex_mine.py
+++ b/python/analysis/codex_mine.py
@@ -283,6 +283,56 @@ def usage_to_dict(u: Usage) -> dict:
     }
 
 
+def usage_to_feed(u: Usage) -> dict:
+    """Render Usage in the universal usage-feed schema that
+    chitin-budget reads. The schema is shared across drivers:
+
+      {
+        driver:         <name>,
+        axis:           "quota_percent" | "calls_count" | "rpm_tpm" | "usd",
+        plan_type:      <vendor plan label, optional>,
+        last_observed:  <iso8601>,
+        warnings:       [<rate-limit-hit indicators>],
+        calls_total:    <int>,
+        windows: [
+          {label, used_percent, window_minutes, resets_at}
+        ]
+      }
+
+    Different drivers populate different `axis` shapes; chitin-budget
+    branches on `axis` for rendering. This function emits the codex
+    flavor (axis=quota_percent, two windows: 5h primary + 1w
+    secondary). Other drivers (gemini, ollama-cloud, anthropic) get
+    sibling functions that emit the same envelope shape so the
+    reader stays vendor-neutral.
+    """
+    warnings = []
+    if u.rate_limit_reached_type:
+        warnings.append(f"rate_limit_reached:{u.rate_limit_reached_type}")
+    return {
+        "driver": u.driver,
+        "axis": "quota_percent",
+        "plan_type": u.plan_type,
+        "last_observed": u.last_observed_ts,
+        "warnings": warnings,
+        "calls_total": u.function_calls_total,
+        "windows": [
+            {
+                "label": "primary",
+                "used_percent": u.primary_used_percent,
+                "window_minutes": u.primary_window_minutes,
+                "resets_at": u.primary_resets_at,
+            },
+            {
+                "label": "secondary",
+                "used_percent": u.secondary_used_percent,
+                "window_minutes": u.secondary_window_minutes,
+                "resets_at": u.secondary_resets_at,
+            },
+        ],
+    }
+
+
 # ──────────────────────────────────────────────────────────────────
 # CLI
 # ──────────────────────────────────────────────────────────────────
@@ -303,6 +353,13 @@ def _cli_usage(args: argparse.Namespace) -> int:
     root = Path(args.sessions_dir).expanduser()
     paths = sessions_in(root)
     u = extract_usage(paths)
+    if args.write_feed:
+        feed_path = Path(args.write_feed).expanduser()
+        feed_path.parent.mkdir(parents=True, exist_ok=True)
+        feed_path.write_text(json.dumps(usage_to_feed(u), indent=2) + "\n")
+        sys.stderr.write(f"wrote usage feed to {feed_path}\n")
+        # Also emit the human (or JSON) summary so the timer log
+        # captures something useful.
     if args.json:
         print(json.dumps(usage_to_dict(u), indent=2))
         return 0
@@ -384,6 +441,12 @@ def main(argv: list[str] | None = None) -> int:
     pu = sub.add_parser("usage", help="summarize codex quota state")
     pu.add_argument("--sessions-dir", default=str(CODEX_SESSIONS_ROOT))
     pu.add_argument("--json", action="store_true")
+    pu.add_argument(
+        "--write-feed",
+        metavar="PATH",
+        default="",
+        help="also write the usage-feed JSON (universal schema chitin-budget reads) to PATH; ~/.cache/chitin/usage/codex.json is the conventional location",
+    )
     pu.set_defaults(func=_cli_usage)
 
     pi = sub.add_parser("ingest", help="project codex function_calls into chitin events JSONL")

--- a/python/analysis/tests/test_codex_mine.py
+++ b/python/analysis/tests/test_codex_mine.py
@@ -10,6 +10,7 @@ from analysis.codex_mine import (
     iter_session_events,
     sessions_in,
     _safe_chain_id_basename,
+    usage_to_feed,
     _to_action_type,
     _extract_target,
 )
@@ -257,3 +258,45 @@ def test_cli_ingest_sanitizes_malicious_chain_id(tmp_path: Path) -> None:
     assert len(files) == 1
     assert "escape" in files[0].name
     assert "/" not in files[0].name
+
+
+def test_usage_to_feed_codex_shape() -> None:
+    """The usage-feed schema chitin-budget reads must be stable.
+    Pin the field set + axis label so a future refactor doesn't
+    silently break the budget script."""
+    u = Usage(
+        driver="codex",
+        plan_type="plus",
+        primary_used_percent=12.5,
+        primary_window_minutes=300,
+        primary_resets_at=1777872999,
+        secondary_used_percent=1.2,
+        secondary_window_minutes=10080,
+        secondary_resets_at=1778459438,
+        rate_limit_reached_type=None,
+        last_observed_ts="2026-05-04T01:00:01Z",
+        sessions_observed=2,
+        function_calls_total=3,
+    )
+    feed = usage_to_feed(u)
+    assert feed["driver"] == "codex"
+    assert feed["axis"] == "quota_percent"
+    assert feed["plan_type"] == "plus"
+    assert feed["last_observed"] == "2026-05-04T01:00:01Z"
+    assert feed["calls_total"] == 3
+    assert feed["warnings"] == []  # not hit
+    assert len(feed["windows"]) == 2
+    primary = feed["windows"][0]
+    assert primary["label"] == "primary"
+    assert primary["used_percent"] == 12.5
+    assert primary["window_minutes"] == 300
+    assert primary["resets_at"] == 1777872999
+
+
+def test_usage_to_feed_emits_warning_on_rate_limit_hit() -> None:
+    """When rate_limit_reached_type is set, the feed must include
+    a warning so chitin-budget --check exits 1."""
+    u = Usage(driver="codex", rate_limit_reached_type="primary")
+    feed = usage_to_feed(u)
+    assert len(feed["warnings"]) == 1
+    assert "rate_limit_reached:primary" in feed["warnings"][0]

--- a/scripts/chitin-budget
+++ b/scripts/chitin-budget
@@ -24,6 +24,14 @@ set -euo pipefail
 
 ROLLUP_DIR="${CHITIN_SWARM_ROLLUP_DIR:-$HOME/.cache/chitin/swarm-rollups}"
 BUDGETS_FILE="${CHITIN_BUDGETS_FILE:-$HOME/.chitin/budgets.json}"
+# Usage feeds: per-driver JSON files in this directory. Schema
+# documented at scripts/chitin-budget-usage-schema.md. Each file
+# carries one of: axis=quota_percent (codex), axis=calls_count
+# (gemini), axis=rpm_tpm (ollama-cloud). chitin-budget reads
+# them into a "Quota / usage" section after the $-spend table
+# so subscription and rate-limited drivers have first-class
+# visibility alongside per-token-billed APIs.
+USAGE_FEED_DIR="${CHITIN_USAGE_FEED_DIR:-$HOME/.cache/chitin/usage}"
 
 mode="human"
 for arg in "$@"; do
@@ -127,13 +135,39 @@ build_data=$(jq -n \
 
 case "$mode" in
   json)
-    echo "$build_data"
+    # Merge $-spend rows + usage feeds into one envelope so
+    # programmatic consumers see both axes at once.
+    feeds_array='[]'
+    if [[ -d "$USAGE_FEED_DIR" ]] && compgen -G "$USAGE_FEED_DIR/*.json" >/dev/null 2>&1; then
+      feeds_array=$(jq -s '.' "$USAGE_FEED_DIR"/*.json 2>/dev/null || echo '[]')
+    fi
+    jq -n \
+      --argjson spend "$build_data" \
+      --argjson feeds "$feeds_array" \
+      '{spend: $spend, usage_feeds: $feeds}'
     ;;
   check)
     over_count=$(echo "$build_data" | jq '[.[] | select(.over_cap)] | length')
     if [[ "$over_count" -gt 0 ]]; then
       echo "$build_data" | jq -r '.[] | select(.over_cap) | "[OVER CAP] \(.driver): today=$\(.today_usd) (cap $\(.cap_daily // "—")), week=$\(.week_usd) (cap $\(.cap_weekly // "—"))"' >&2
       exit 1
+    fi
+    # Also fail if any usage feed reports a rate-limit-reached
+    # warning. Subscription drivers can be over their soft ceiling
+    # without an explicit $ cap; this catches that case.
+    if [[ -d "$USAGE_FEED_DIR" ]]; then
+      rl_hits=0
+      for feed in "$USAGE_FEED_DIR"/*.json; do
+        [[ -f "$feed" ]] || continue
+        warns=$(jq -r '(.warnings // []) | length' "$feed" 2>/dev/null || echo 0)
+        if [[ "$warns" -gt 0 ]]; then
+          driver=$(jq -r '.driver // "?"' "$feed")
+          warn_text=$(jq -r '.warnings | join(",")' "$feed")
+          echo "[RATE LIMIT] $driver: $warn_text" >&2
+          rl_hits=$((rl_hits + 1))
+        fi
+      done
+      [[ "$rl_hits" -gt 0 ]] && exit 1
     fi
     exit 0
     ;;
@@ -159,6 +193,51 @@ case "$mode" in
       printf "  %-25s %10s %10s %12s %12s %s\n" "$driver" "$today" "$week" "$capd" "$capw" "$status"
     done
     echo
+
+    # Quota / usage section — subscription drivers (codex, gemini),
+    # rate-limited drivers (ollama-cloud). Each driver's usage-feed
+    # JSON lives at $USAGE_FEED_DIR/<driver>.json and carries a
+    # normalized {axis, windows, warnings, ...} envelope.
+    if [[ -d "$USAGE_FEED_DIR" ]] && compgen -G "$USAGE_FEED_DIR/*.json" >/dev/null 2>&1; then
+      echo "  quota / usage (subscription + rate-limited drivers):"
+      for feed in "$USAGE_FEED_DIR"/*.json; do
+        [[ -f "$feed" ]] || continue
+        driver=$(jq -r '.driver // "?"' "$feed" 2>/dev/null)
+        axis=$(jq -r '.axis // "?"' "$feed" 2>/dev/null)
+        plan=$(jq -r '.plan_type // ""' "$feed" 2>/dev/null)
+        warns=$(jq -r '(.warnings // []) | join(",")' "$feed" 2>/dev/null)
+        case "$axis" in
+          quota_percent)
+            jq -r '.windows // [] | map("\(.label) " + (.used_percent | tostring) + "%") | join(", ")' "$feed" 2>/dev/null \
+              | while IFS= read -r summary; do
+                  marker=" "
+                  [[ -n "$warns" ]] && marker="⚠"
+                  printf "    %s %-22s %-7s %s\n" "$marker" "$driver" "$plan" "$summary"
+                done
+            ;;
+          calls_count)
+            count=$(jq -r '.calls_total // 0' "$feed" 2>/dev/null)
+            cap=$(jq -r '(.windows // [] | map(select(.cap)) | first | .cap // "—")' "$feed" 2>/dev/null)
+            marker=" "
+            [[ -n "$warns" ]] && marker="⚠"
+            printf "    %s %-22s %-7s calls=%s cap=%s\n" "$marker" "$driver" "$plan" "$count" "$cap"
+            ;;
+          rpm_tpm)
+            rpm=$(jq -r '.windows // [] | map(select(.label=="rpm")) | first.used_percent // 0' "$feed" 2>/dev/null)
+            tpm=$(jq -r '.windows // [] | map(select(.label=="tpm")) | first.used_percent // 0' "$feed" 2>/dev/null)
+            marker=" "
+            [[ -n "$warns" ]] && marker="⚠"
+            printf "    %s %-22s %-7s rpm=%s%% tpm=%s%%\n" "$marker" "$driver" "$plan" "$rpm" "$tpm"
+            ;;
+          *)
+            printf "    ? %-22s %-7s (unknown axis: %s)\n" "$driver" "$plan" "$axis"
+            ;;
+        esac
+        [[ -n "$warns" ]] && echo "      ⚠ $warns"
+      done
+      echo
+    fi
+
     if [[ ! -f "$BUDGETS_FILE" ]]; then
       echo "  (no caps configured; create $BUDGETS_FILE to set per-driver limits)"
     fi


### PR DESCRIPTION
## Summary
Stacked on #268. Establishes a vendor-neutral usage feed schema so subscription drivers (codex/gemini) and rate-limited drivers (ollama-cloud) show up in `chitin-budget` alongside per-token-billed APIs.

## Schema (`docs/runbooks/usage-feeds.md`)
```json
{
  "driver": "codex", "axis": "quota_percent", "plan_type": "plus",
  "last_observed": "...", "warnings": [], "calls_total": 41,
  "windows": [{"label":"primary", "used_percent":1.0, "window_minutes":300, "resets_at":1777872638}]
}
```
`axis` branches: `quota_percent` (codex), `calls_count` (gemini), `rpm_tpm` (ollama-cloud).

## What's in this PR
- `analysis.codex_mine usage --write-feed PATH` writes the feed
- `chitin-budget` renders a "Quota / usage" section + `--json` envelope `{spend, usage_feeds}` + `--check` exits 1 on rate-limit warnings
- `chitin-codex-usage-feed.{service,timer}` refreshes the feed every 10 min
- Runbook doc covers the schema, the producers, the consumers, and operator quickstart

## Live smoke
```
$ chitin-budget
  ...
  quota / usage (subscription + rate-limited drivers):
      codex                  plus    primary 1.0%, secondary 0.0%
```

## What's NOT in this PR (deliberate scope)
- gemini producer — gemini doesn't expose quota in its session JSONL today; needs stderr scrape (separate PR)
- ollama-cloud producer — needs activity-layer response-header capture (separate PR)
- chitin-status integration — once feeds are common, status surfaces top-line %

## Test plan
- [x] 10/10 in test_codex_mine.py (8 existing + 2 new for `usage_to_feed`)
- [x] Live render verified against real codex sessions
- [x] `--check` exits 1 on simulated rate-limit warning
- [ ] Operator: install timer, watch feed refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)