### PR TITLE
docs: post-codex-gemini sweep — five vendor surfaces, real-time gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chitin
 
-**Execution kernel for AI coding agents.** Every tool call across Claude Code, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript + Python). MIT licensed.
+**Execution kernel for AI coding agents.** Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript + Python). MIT licensed.
 
 > Principle: real execution before policy. Policy before automation. Automation gated by the same kernel.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,22 +5,25 @@ Chitin is a small Go kernel with thin TypeScript adapters per surface. The kerne
 ## System diagram
 
 ```
-              Agent Surfaces (drivers)
-   ┌────────────┐ ┌──────────────┐ ┌─────────────┐
-   │ Claude Code│ │ Copilot CLI  │ │ openclaw    │
-   │ PR #66 hook│ │ PR #51 SDK   │ │ acpx config │
-   └─────┬──────┘ └──────┬───────┘ └──────┬──────┘
-         │ tool call     │                │
-         └───────────────┴────────┬───────┘
-                                  ▼
-                       ┌──────────────────────┐
-                       │  gov.Gate.Evaluate   │  ←── chitin.yaml
-                       │  (Go kernel; only    │      (closed-enum
-                       │   side-effect layer) │       action vocab)
-                       └──────────┬───────────┘
-                                  │ Decision: allow / deny / guide
-                  ┌───────────────┼───────────────┐
-                  ▼               ▼               ▼
+                          Agent Surfaces (drivers)
+   ┌──────────┐ ┌────────┐ ┌──────────┐ ┌────────┐ ┌──────────┐ ┌─────────┐
+   │ Claude   │ │ Codex  │ │ Gemini   │ │Copilot │ │ openclaw │ │ MCP     │
+   │ Code     │ │ CLI    │ │ CLI      │ │ CLI    │ │ (local-*)│ │ servers │
+   │ PreToolU │ │ PreToo │ │ BeforeT  │ │ SDK    │ │ before_  │ │ via     │
+   │ hook     │ │ hook   │ │ hook     │ │ wrap   │ │tool_call │ │ above   │
+   └────┬─────┘ └───┬────┘ └────┬─────┘ └───┬────┘ └────┬─────┘ └────┬────┘
+        │           │           │           │           │            │
+        └───────────┴───────────┴────┬──────┴───────────┴────────────┘
+                                     │ tool call
+                                     ▼
+                        ┌──────────────────────────┐
+                        │  gov.Gate.Evaluate       │ ←── chitin.yaml
+                        │  (Go kernel; only        │     (closed-enum
+                        │   side-effect layer)     │      action vocab)
+                        └──────────┬───────────────┘
+                                   │ Decision: allow / deny / guide
+                  ┌────────────────┼────────────────┐
+                  ▼                ▼                ▼
         ┌──────────────────┐ ┌──────────┐ ┌─────────────────┐
         │   event chain    │ │ gov.db   │ │ OTEL emit       │
         │  hash-linked,    │ │ envelope │ │ projection only │
@@ -28,9 +31,24 @@ Chitin is a small Go kernel with thin TypeScript adapters per surface. The kerne
         └────────┬─────────┘ └──────────┘ └─────────────────┘
                  │
                  ▼ on disk (kernel single-writer)
-   .chitin/events-<run_id>.jsonl + flow_events.jsonl
-   ~/.chitin/gov-decisions-YYYY-MM-DD.jsonl, gov.db
+   ~/.chitin/events-<run_id>.jsonl
+   ~/.chitin/gov-decisions-YYYY-MM-DD.jsonl
+   ~/.chitin/gov.db (envelope counters + budgets)
+   ~/.chitin/usage/<driver>.json (universal usage feed; PR #269)
 ```
+
+**Per-vendor integration matrix.** Same kernel, different integration points:
+
+| Driver | Integration | Wire shape | Real-time gating? |
+|---|---|---|---|
+| `claude-code-headless` | PreToolUse hook (settings.json) | claudecode.HookInput | yes |
+| `codex` | PreToolUse hook (~/.codex/config.toml) | codex.HookInput (byte-compatible w/ Claude Code; hooks/list RPC) | yes |
+| `gemini` | BeforeTool hook (~/.gemini/settings.json) | gemini.HookInput (byte-compatible w/ Claude Code) | yes |
+| `copilot` | wrapping orchestrator (`chitin-kernel drive copilot`) | Copilot SDK PermissionRequest | yes |
+| `local-qwen`/`-glm`/`-deepseek` | openclaw `before_tool_call` plugin | openclaw plugin context | yes |
+| MCP tools | flow through whichever agent dispatched | parent driver's hook | yes (via parent) |
+
+Codex + gemini both speak the Claude Code PreToolUse wire format byte-for-byte; only the per-tool name set differs (`Bash`/`apply_patch` for codex, `run_shell_command`/`edit`/`replace` for gemini). The `chitin-router-hook` shim is shared across all three; `internal/driver/<vendor>/normalize.go` does the per-vendor translation.
 
 ## Layers
 
@@ -49,6 +67,12 @@ The Go kernel exposes these subcommands:
 chitin-kernel init                  # initialize a .chitin/ state dir
 chitin-kernel emit                  # append a canonical event to the chain
 chitin-kernel chain-info            # inspect chain state
+chitin-kernel chain replay          # re-evaluate a session against current policy (kernel + heuristic layers)
+chitin-kernel chain summarize       # compact markdown summary suitable for next-agent prompt injection
+chitin-kernel chain related         # find sessions touching the same entry/files
+chitin-kernel chain stats           # aggregate decisions by tool/action/rule/decision/agent
+chitin-kernel chain recommend-tier  # data-driven starting-tier per action_type
+chitin-kernel chain snapshot        # immutable hash-linked session export (sigstore-shape)
 chitin-kernel ingest-transcript     # post-hoc audit of a Claude Code transcript
 chitin-kernel ingest-otel           # post-hoc audit of OTEL spans (legacy ingest path)
 chitin-kernel sweep-transcripts     # batch transcript ingest
@@ -57,8 +81,21 @@ chitin-kernel uninstall-hook
 chitin-kernel install / uninstall   # surface-aware install (`--surface claude-code --global`)
 chitin-kernel health                # report on resolved .chitin/ state
 chitin-kernel gate <evaluate|status|lockdown|reset>
+chitin-kernel router evaluate       # router pipeline (kernel verdict → heuristics → optional advisor → composed verdict)
+chitin-kernel simulate              # what-if a single hook input without executing
 chitin-kernel envelope <…>          # cost-gov v3 envelope (cross-process, sqlite WAL)
 chitin-kernel drive copilot         # in-kernel Copilot CLI driver
+```
+
+Operator-side scripts (under `scripts/`):
+
+```
+chitin-status                 # dashboard: timers + chain + router + spend + tier-recs
+chitin-budget                 # per-driver $-spend + universal usage feeds (codex 5h/weekly, etc)
+chitin-router-hook            # bash shim that all PreToolUse hooks point at
+install-kernel.sh             # idempotent rebuild/install + per-vendor hook refresh
+install-gemini-hook.sh        # writes hooks block into ~/.gemini/settings.json
+install-codex-hook.sh         # writes [features] codex_hooks=true + [[hooks.PreToolUse]] into ~/.codex/config.toml
 ```
 
 ## Layer Contracts v1
@@ -76,12 +113,15 @@ These are non-negotiable. New code, specs, and plans must respect them. See [`ar
 
 **Why:** Forensic fidelity of captured events depends on a single write path. Multiple writers = non-deterministic replay + contract drift. Canonicalization and emission are co-located in Go so the shell-parse and JSONL-append cannot disagree.
 
-## Two-driver pattern (open vs closed vendor)
+## Vendor integration patterns (open vs closed vendor)
 
 Per-vendor integration shape varies by vendor posture; the `gov.Gate` API is shared.
 
-- **Open vendors → in-process extension.** Vendor ships a documented extensibility API; chitin runs as a forked child via that API and gates tool calls via the vendor's own hook. Example: openclaw `acpx` config-override; Copilot CLI v2 (post-talk).
-- **Closed vendors → wrapping orchestrator.** Vendor ships a closed binary; chitin spawns the agent as a child of a chitin-driven harness. Example: Copilot CLI v1 (`chitin-kernel drive copilot`); Claude Code likely fits here.
+- **Open vendors with native hook surface → in-process extension.** Vendor ships a PreToolUse-style hook config; chitin's router-hook shim is wired in via the vendor's config, kernel does normalization. Examples: Claude Code (`~/.claude/settings.json` PreToolUse), Codex (`~/.codex/config.toml` [features] codex_hooks=true + [[hooks.PreToolUse]]), Gemini (`~/.gemini/settings.json` BeforeTool — same wire shape, different event name).
+- **Open vendors with plugin runtime → openclaw plugin.** openclaw's `before_tool_call` plugin path. Examples: local-qwen / local-glm / local-glm-flash / local-deepseek.
+- **Closed vendors → wrapping orchestrator.** Vendor ships a closed binary; chitin spawns the agent as a child of a chitin-driven harness. Example: Copilot CLI (`chitin-kernel drive copilot`).
+
+Codex + gemini both ship native PreToolUse hook systems that are byte-compatible with Claude Code's wire shape — gemini's `gemini hooks migrate --from-claude` is explicit about the equivalence. That's why all three slot into the same `chitin-router-hook` pipeline; the only per-vendor work is the tool-name normalizer in `internal/driver/<vendor>/normalize.go`.
 
 Classify the vendor first; let the classification pick the integration shape, not the other way around.
 

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -19,7 +19,7 @@ Every event is `{envelope, payload}`. The envelope is surface-neutral; the paylo
     "seq": 12,
     "prev_hash": "sha256:…",
     "this_hash": "sha256:…",
-    "surface": "claude-code | copilot-cli | openclaw | ollama-local | …",
+    "surface": "claude-code | codex | gemini | copilot | openclaw | local-* | …",
     "driver": "string",
     "agent_id": "string",
     "soul_id": "davinci | knuth | curie | … | null",
@@ -56,8 +56,8 @@ Adapters emit whichever subset their surface can observe. Today's payloads:
 | `event_type` | Emitter | Payload (shape) |
 |---|---|---|
 | `session_start` | every adapter | `agent_id, soul_id, soul_hash, machine_fingerprint, env` |
-| `user_prompt` | claude-code, copilot-cli | `prompt_text, prompt_id` |
-| `pre_tool_use` | claude-code, copilot-cli, openclaw | `tool_name, raw_input, canonical_form, action_type` |
+| `user_prompt` | claude-code, codex, copilot | `prompt_text, prompt_id` |
+| `pre_tool_use` | claude-code, codex, gemini, copilot, openclaw | `tool_name, raw_input, canonical_form, action_type` |
 | `decision` | gov.Gate | `decision (allow/deny/guide), reason, suggestion, corrected_command` |
 | `post_tool_use` | every adapter | `tool_name, result (success/error/denied), duration_ms, output_summary` |
 | `pre_compact` | claude-code | `tokens_in, tokens_out` |

--- a/docs/governance-setup.md
+++ b/docs/governance-setup.md
@@ -1,35 +1,35 @@
 # Chitin Governance Setup
 
-The `gov.Gate.Evaluate(action, agent) → Decision` API is the single enforcement point. Every tool call across every driver evaluates against `chitin.yaml`. Three install paths — one per supported driver — wire this API into the driver's tool-call lifecycle.
+The `gov.Gate.Evaluate(action, agent) → Decision` API is the single enforcement point. Every tool call across every driver evaluates against `chitin.yaml`. Five install paths — one per supported vendor surface — wire this API into the driver's tool-call lifecycle.
 
 ## Install paths by driver
 
 ```
-   chitin.yaml (single policy)
-          │
-          ▼
-   gov.Gate.Evaluate ◄─────────┐
-     ▲       ▲       ▲          │
-     │       │       │          │
-     │       │       │          │
- Claude    Copilot  openclaw    │
-  Code      CLI      acpx       │
- PR #66    PR #51    config     │
- hook     SDK driver override   │
-     │       │       │          │
-     ▼       ▼       ▼          │
-        tool calls  ────────────┘
+                 chitin.yaml (single policy)
+                          │
+                          ▼
+                  gov.Gate.Evaluate ◄──────────────┐
+       ▲       ▲      ▲       ▲       ▲             │
+       │       │      │       │       │             │
+   Claude   Codex  Gemini   Copilot  openclaw       │
+    Code     CLI    CLI      CLI      plugin        │
+   PreToo  PreToo  BeforeT   SDK      before_       │
+   Use     Use     ool       wrap     tool_call     │
+   hook    hook    hook                             │
+       │       │      │       │       │             │
+       ▼       ▼      ▼       ▼       ▼             │
+                   tool calls  ───────────────────  │
 ```
 
-### 1. Claude Code (PreToolUse hook — PR #66)
+### 1. Claude Code (PreToolUse hook)
 
 ```bash
 chitin-kernel install --surface claude-code --global
 ```
 
 Writes a `PreToolUse` entry to `~/.claude/settings.json` matching the nested
-`{matcher, hooks:[{type, command}]}` schema. The hook execs the kernel binary
-with the hook payload on stdin.
+`{matcher, hooks:[{type, command}]}` schema. The hook execs the router-hook
+shim with the hook payload on stdin.
 
 To uninstall:
 
@@ -37,28 +37,42 @@ To uninstall:
 chitin-kernel uninstall --surface claude-code --global
 ```
 
-### 2. Copilot CLI (in-kernel driver — PR #51)
+### 2. Codex CLI (PreToolUse hook — codex 0.128.0+)
+
+```bash
+bash scripts/install-codex-hook.sh
+```
+
+Writes a `[features] codex_hooks=true` block + `[[hooks.PreToolUse]]` entry into `~/.codex/config.toml`. Wire shape is byte-compatible with Claude Code's PreToolUse — only the per-tool name set differs (codex emits `Bash`, `apply_patch`, MCP tool names). The router-hook shim handles the protocol; per-tool normalization in `internal/driver/codex/normalize.go`.
+
+### 3. Gemini CLI (BeforeTool hook — same wire shape, different event name)
+
+```bash
+bash scripts/install-gemini-hook.sh
+```
+
+Writes a `BeforeTool` block to `~/.gemini/settings.json`. Stdin payload is byte-identical to Claude Code's PreToolUse (gemini even sets `CLAUDE_PROJECT_DIR`/`CLAUDE_CODE_ENTRYPOINT` envvars for compatibility); only the per-tool name set differs (`run_shell_command`, `read_file`, `edit`, `replace`, `write_file`, `web_fetch`, `google_web_search`, etc.). Per-tool normalization in `internal/driver/gemini/normalize.go`.
+
+Both `install-codex-hook.sh` and `install-gemini-hook.sh` are idempotent and refused-on-malformed-config; they run after each `install-kernel.sh` invocation so kernel rebuilds refresh the hook wiring automatically.
+
+### 4. Copilot CLI (in-kernel driver — wrapping orchestrator)
 
 ```bash
 chitin-kernel drive copilot "<prompt>"
 ```
 
-The kernel spawns Copilot CLI as a child of a chitin-driven harness (closed-vendor pattern: see [architecture.md](./architecture.md#two-driver-pattern-open-vs-closed-vendor)). Tool calls are gated via the SDK; chitin enforces the same `gov.Gate` policy.
+The kernel spawns Copilot CLI as a child of a chitin-driven harness (closed-vendor pattern: see [architecture.md](./architecture.md#vendor-integration-patterns-open-vs-closed-vendor)). Tool calls are gated via the SDK; chitin enforces the same `gov.Gate` policy.
 
-This is the v1 path used in the 2026-05-07 talk demo. v2 (in-process extension via Copilot SDK `joinSession({tools, hooks})`) starts post-talk.
-
-### 3. openclaw (acpx config-override)
-
-One-line install — no chitin-side wrapper code:
+### 5. openclaw (`local-*` drivers via `before_tool_call` plugin)
 
 ```yaml
-# ~/.config/openclaw/acpx.yaml
-preToolUse:
-  command: chitin-kernel
-  args: ["gate", "evaluate", "--hook-stdin", "--agent=openclaw"]
+# ~/.config/openclaw/openclaw.json
+plugins:
+  allow:
+    - chitin-governance     # ships with chitin; loaded at openclaw startup
 ```
 
-openclaw forwards each tool call to chitin-kernel via the configured pre-tool-use hook. Same `gov.Gate` API, same policy file.
+The plugin is loaded by openclaw at startup; every tool call dispatched by openclaw-managed agents (qwen / glm / glm-flash / deepseek) passes through `before_tool_call` → `chitin-kernel gate evaluate`. Same policy file.
 
 ## Build the kernel
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -7,36 +7,49 @@ How chitin actually runs today, and what each subsystem owns.
 Single-box. One Linux workstation with an RTX 3090 hosts the entire dev + dogfood loop.
 
 ```
-                  ┌─────────────────────────────────────────────┐
-                  │  Local workstation (RTX 3090, this machine) │
-                  │                                             │
-   Anthropic ─────┤── Claude Code ──┐                           │
-   (cloud)        │                  │                          │
-                  │                  ├──► chitin-kernel ──► .chitin/
-   GitHub ────────┤── Copilot CLI ──┤    (gov.Gate gates       │
-   (cloud)        │                  │     every tool call)    │
-                  │                  │                          │
-   local Ollama ──┤── openclaw ─────┘                           │
-   (3090 GPU)     │                                             │
-                  └─────────────────────────────────────────────┘
+                  ┌──────────────────────────────────────────────────────┐
+                  │  Local workstation (RTX 3090, this machine)          │
+                  │                                                      │
+   Anthropic ─────┤── Claude Code ──┐                                    │
+   OpenAI    ─────┤── Codex CLI  ───┤                                    │
+   Google    ─────┤── Gemini CLI ───┼──► chitin-kernel ──► ~/.chitin/    │
+   GitHub    ─────┤── Copilot CLI ──┤    (gov.Gate gates                 │
+                  │                  │     every tool call,               │
+                  │                  │     PreToolUse hooks               │
+   local Ollama ──┤── openclaw ─────┘     for the CLIs;                  │
+   (3090 GPU)     │                       drive copilot for              │
+                  │                       the closed CLI;                │
+                  │                       openclaw plugin                │
+                  │                       for local-*)                   │
+                  └──────────────────────────────────────────────────────┘
 ```
 
 - **No Hetzner box.** Multi-machine observability was a Phase 3 framing in older docs; the box is dead. Collapse any "cross-machine" reading into single-box.
 - **Murphy's Mac** is separate — chitin is not installed there. Out of scope for current dogfooding.
-- **Ollama Cloud Pro + Anthropic + GitHub Copilot** are cloud reasoning surfaces; they are not chitin's scope. Chitin only sees what the local CLI/driver does on this box.
+- **Cloud reasoning surfaces** (Anthropic, OpenAI, Google, GitHub) are accessed via their CLIs; chitin governs the tool calls those CLIs make on this box. The cloud reasoning itself is out of scope; the local effects are not.
 
 ## Subsystem ownership
 
 | Subsystem | Owner | Live? |
 |-----------|-------|-------|
 | Capture (event chain) | Go kernel `emit` | ✅ shipped Phase 1.5, 2026-04-19 |
-| Replay | TS `libs/telemetry` + `apps/cli` | ✅ shipped Phase 1 |
+| Replay (kernel + heuristic layers) | Go kernel `internal/replay` + `chain replay` | ✅ shipped 2026-05-03 (#240, #253) |
+| Chain analytics (stats / recommend-tier / snapshot / simulate / summarize / related) | Go kernel `internal/replay` | ✅ shipped 2026-05-03/04 (#240, #245, #246, #247, #249) |
+| Skill mining (n-gram surface from chain) | Python `analysis/skill_mine.py` | ✅ shipped 2026-05-03 (#259) |
+| Predictive model (chain-predict-outcome) | Python `analysis/predict.py` | ✅ shipped 2026-05-03 (#256) |
 | Governance (`gov.Gate`) | Go kernel `internal/gov` | ✅ shipped 2026-04-28 (PR #45 + #51) |
-| Cost envelope (cross-process) | Go kernel `internal/envelope` | 🔄 cost-gov v3 in flight (committed 2026-04-29, c1ecbf9) |
-| Drivers — Claude Code hook | `libs/adapters/claude-code` + kernel install path | ✅ shipped (PR #66) |
-| Drivers — Copilot CLI (v1, wrapping) | Kernel `drive copilot` | ✅ shipped (PR #51) |
-| Drivers — openclaw (acpx config) | One-line config; no chitin code | ✅ shipped |
-| OTEL emit (projection) | Go kernel `internal/emit` (TBD) | 🔄 F4 — ships before 2026-05-07 talk |
+| Cost envelope (cross-process) | Go kernel `internal/envelope` | ✅ cost-gov v3 |
+| Universal usage feed (codex 5h/weekly, gemini calls, ollama-cloud rpm/tpm) | `chitin-budget` + `~/.cache/chitin/usage/` | ✅ schema + codex producer shipped 2026-05-04 (#269); gemini/ollama producers in backlog |
+| Drivers — Claude Code hook | `internal/driver/claudecode/normalize.go` + kernel install path | ✅ shipped (PR #66) |
+| Drivers — Codex CLI (PreToolUse) | `internal/driver/codex/normalize.go` + `scripts/install-codex-hook.sh` | ✅ shipped 2026-05-04 (#272) |
+| Drivers — Gemini CLI (BeforeTool) | `internal/driver/gemini/normalize.go` + `scripts/install-gemini-hook.sh` | ✅ shipped 2026-05-04 (#267) |
+| Drivers — Codex as activity-spawned reviewer (env-overridable per tier) | `apps/temporal-worker` `planInvocation` + `REVIEW_TIER_DRIVER` | ✅ shipped 2026-05-04 (#270) |
+| Drivers — Copilot CLI (wrapping) | Kernel `drive copilot` | ✅ shipped (PR #51) |
+| Drivers — openclaw (`local-*`) | openclaw `before_tool_call` plugin | ✅ shipped |
+| Plugin runtime (Python + TS heuristic plugins) | `internal/router/plugins` + opt-in side-effect gate libs | ✅ shipped (#235, #237, #241, #250) |
+| Plugin sandbox (bubblewrap, opt-in) | `internal/router/plugins/sandbox.go` | ✅ shipped 2026-05-03 (#255) |
+| OTEL emit (projection) | Go kernel `internal/emit` | ✅ F4 shipped before 2026-05-07 talk |
+| Worktree index (dispatcher writes `WORKTREE_INDEX.md`) | `apps/temporal-worker/src/activity.ts` | ✅ shipped 2026-05-03 (#261) |
 | Souls library | `souls/canonical/` + `souls/experimental/` | ✅ shipped Phase 1.5 |
 
 ## Order of operations (current, not aspirational)

--- a/docs/runbooks/chitin-router.md
+++ b/docs/runbooks/chitin-router.md
@@ -9,6 +9,24 @@
 > **Off by default** — operator opts in via a sentinel file. Hot
 > path stays fast (kernel only) until then.
 
+## Supported agents
+
+The router-hook shim works for any agent whose hook surface speaks
+the Claude Code PreToolUse wire shape (or one byte-compatible with
+it). As of 2026-05-04 that's all of:
+
+| Driver | Hook event | Config file | Installer |
+|---|---|---|---|
+| `claude-code-headless` | `PreToolUse` | `~/.claude/settings.json` | `chitin-kernel install --surface claude-code` |
+| `codex` | `PreToolUse` (codex 0.128.0+) | `~/.codex/config.toml` (`[features] codex_hooks=true`) | `scripts/install-codex-hook.sh` |
+| `gemini` | `BeforeTool` (same wire shape; renamed event) | `~/.gemini/settings.json` | `scripts/install-gemini-hook.sh` |
+| `copilot` | n/a — wrapping driver | (in-kernel) | `chitin-kernel drive copilot` |
+| `local-*` (qwen/glm/glm-flash/deepseek) | `before_tool_call` plugin | openclaw plugin config | openclaw-side |
+
+The `chitin-router-hook` shim is the same binary across all hook-
+surface drivers; per-vendor tool-name normalization lives in
+`internal/driver/<vendor>/normalize.go` (claudecode, codex, gemini).
+
 ## What it does
 
 For each `PreToolUse` hook call from any chitin-governed agent:
@@ -143,12 +161,14 @@ Two reasons:
 1. **Instant disable** — `rm ~/.chitin/router-enabled` doesn't
    require restarting a worker or reloading config. The next hook
    call sees no sentinel → fast path.
-2. **Hot-path performance** — if disabled, the bash shim never
-   spawns `pnpm tsx`, saving ~500ms-1s per tool call.
+2. **Hot-path performance** — if disabled, the bash shim short-
+   circuits to the kernel directly (microsecond cost).
 
-A future Go SDK (see backlog: `router-heuristics-go-sdk`) will move
-the heuristics into the kernel binary itself; at that point the
-sentinel becomes redundant and the policy flag is enough.
+The Go SDK port shipped (PR #231) — heuristics now run in-process
+in the kernel binary at ~26ms cold start instead of ~500ms via
+`pnpm tsx`. The sentinel still exists because it's the operator-
+side instant-disable; the slow-path performance just isn't a
+reason to keep it anymore.
 
 ## Related
 

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -1,21 +1,24 @@
 # Thesis
 
-> Chitin is an execution kernel for AI coding agents. Every tool call across Claude Code, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack.
+> Chitin is an execution kernel for AI coding agents. Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack.
 
 ## What chitin is
 
-A small Go kernel that sits between AI coding agents and the operating system. Three patterns are gated through it today:
+A small Go kernel that sits between AI coding agents and the operating system. Five vendor surfaces are gated through it today:
 
-- **Claude Code** — via a `PreToolUse` hook installed into `~/.claude/settings.json`.
-- **Copilot CLI** — via the in-kernel SDK driver (`chitin-kernel drive copilot`).
-- **openclaw** — via an `acpx` config-override (one-line install, no chitin-side wrapper code).
+- **Claude Code** — `PreToolUse` hook in `~/.claude/settings.json`.
+- **Codex CLI** — `PreToolUse` hook in `~/.codex/config.toml` (`[features] codex_hooks=true` + `[[hooks.PreToolUse]]`); same wire shape as Claude Code.
+- **Gemini CLI** — `BeforeTool` hook in `~/.gemini/settings.json`; same wire shape as Claude Code (renamed event).
+- **Copilot CLI** — in-kernel SDK driver (`chitin-kernel drive copilot`); wrapping orchestrator pattern (closed vendor).
+- **openclaw** (`local-*` drivers: qwen / glm / glm-flash / deepseek) — `before_tool_call` plugin path.
 
-Same `gov.Gate` API across all three. Same canonical event chain on disk. Same OTEL projection out the back.
+Same `gov.Gate` API across all five. Same canonical event chain on disk. Same OTEL projection out the back. Vendor-specific normalization lives in `internal/driver/<vendor>/normalize.go`.
 
 ## What chitin is not
 
 - Not a tick-loop / agent-runner. Hermes is dead (2026-04-23). Drivers run on their own surfaces; chitin gates their tool calls.
 - Not an OTEL ingest target. Chitin **emits** spans as a projection of its canonical chain. The chain is the source of truth; OTEL is one-way out.
+- Not an LLM provider abstraction. Chitin doesn't proxy or re-call models. Each vendor's CLI talks to its own backend (codex → OpenAI under your ChatGPT Plus auth; gemini → Google under Pro auth; etc.); chitin governs the actions those CLIs take.
 - Not a cloud product (yet). Phase 1 is local-only. Cloud is the monetization step on the strategic arc — it follows ecosystem distribution, not the other way around.
 
 ## The closed loop


### PR DESCRIPTION
## Summary
Catches the docs up to today's merged reality. Today's batch (#247-#272) expanded chitin's governance surface in a way the docs didn't reflect — they still said "Claude Code + Copilot + openclaw" everywhere.

Five-vendor matrix now consistent across README, thesis, architecture, runbook, operating-model, event-model, governance-setup:

| Driver | Integration | Wire shape |
|---|---|---|
| Claude Code | PreToolUse hook (`~/.claude/settings.json`) | claudecode.HookInput |
| Codex CLI 0.128.0+ | PreToolUse hook (`~/.codex/config.toml`) | byte-compatible w/ Claude Code |
| Gemini CLI | BeforeTool hook (`~/.gemini/settings.json`) | byte-compatible w/ Claude Code |
| Copilot CLI | wrapping orchestrator (`chitin-kernel drive copilot`) | Copilot SDK PermissionRequest |
| openclaw (local-*) | `before_tool_call` plugin | openclaw plugin context |

## What changed by file

- `README.md` — top-line scope mention adds Codex + Gemini
- `docs/thesis.md` — five-vendor enumeration; adds "not an LLM provider abstraction" disclaimer
- `docs/architecture.md` — system diagram redrawn; per-vendor integration matrix; subcommand list extended (chain replay/summarize/related/stats/recommend-tier/snapshot, router evaluate, simulate); operator-side scripts section; two-driver-pattern → three-pattern (open-with-hook, openclaw-plugin, closed-wrap)
- `docs/runbooks/chitin-router.md` — supported-agents matrix; Go SDK shipped (sentinel still useful as instant-disable, no longer the perf reason)
- `docs/operating-model.md` — topology diagram includes all 4 cloud reasoning sources; subsystem-ownership table refreshed for everything shipped 2026-04-30 → 2026-05-04
- `docs/event-model.md` — surface enum + per-event emitter columns include codex + gemini
- `docs/governance-setup.md` — install-paths section becomes five-driver

## What did NOT change
- The strategic narrative (closed loop, three analysis streams, dogfooding posture) — already current
- `docs/architecture/layer-contracts.md` — refers to "drivers" generically, no enumeration drift
- `docs/toolchain.md` — no driver-specific content

🤖 Generated with [Claude Code](https://claude.com/claude-code)