### PR TITLE
auto: flip 4 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -3100,7 +3100,7 @@ Steps:
 ```yaml
 id: nx-generator-app
 tier: T2
-status: ready
+status: partial
 estimated_loc: 300
 blocks: []
 file: tools/generators/app/*
@@ -3156,7 +3156,7 @@ nx g @chitin/doc observation <id>  → docs/observations/<date>-<id>.md
 ```yaml
 id: systemd-unit-generator
 tier: T1
-status: ready
+status: partial
 estimated_loc: 150
 blocks: []
 file: tools/generators/systemd-unit/*, scripts/install-systemd-units.sh (refresh)
@@ -4112,7 +4112,7 @@ individually.
 ```yaml
 id: pr-event-ingester-extract-decision-helper
 tier: T2
-status: ready
+status: partial
 estimated_loc: 100
 blocks: []
 file: apps/temporal-worker/src/pr-event-ingester.ts, apps/temporal-worker/test/pr-event-ingester.test.ts
@@ -4440,7 +4440,7 @@ T4 only when the heuristic flags ambiguity.
 ```yaml
 id: dispatcher-skip-already-implemented-entries
 tier: T2
-status: ready
+status: partial
 estimated_loc: 250
 blocks: []
 file: apps/temporal-worker/src/dispatcher.ts, apps/temporal-worker/test/dispatcher-skip-shipped.test.ts, apps/temporal-worker/src/grooming/parse-backlog.ts


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- dispatcher-skip-already-implemented-entries (#265)
- pr-event-ingester-extract-decision-helper (#264)
- systemd-unit-generator (#251)
- nx-generator-app (#238)

If any of these are wrong, revert + investigate why the title matched without the work shipping.