### PR TITLE
swarm: nx-target-consistency-and-validate

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -25,5 +25,13 @@
         }
       }
     }
-  ]
+  ],
+  "targetDefaults": {
+    "validate": {
+      "dependsOn": [
+        "^validate"
+      ],
+      "inputs": ["default"]
+    }
+  }
 }


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `nx-target-consistency-and-validate`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-nx-target-consistency-and-validate-1777863863059`

## Entry context

Codex's read of the chitin repo (2026-05-04) flagged operational-polish gaps:

1. `nx run cli:build` is broken (referenced in `README.md:16` quickstart but only `execution-kernel` actually has a buildable Nx target)
2. App-level TS typecheck targets are effectively disabled because `noEmit: true` conflicts with Nx's inferred typecheck flow (`apps/cli/tsconfig.json:8` is the canonical example)
3. No top-level `validate` target unifying Go tests + TS tests/typecheck + Python pytest + boundary lint

Fixes:
- (a) Make `nx run cli:build` actually work, OR remove the README reference (don't ship a broken quickstart)
- (b) Restore TS typecheck for app projects via per-project `typecheck` target that doesn't conflict with `noEmit`
- (c) Add a `nx run-many --target=validate` (or root package.json script) that runs the full validation matrix; wire into CI as the merge gate

**Acceptance:**
- [ ] `nx run cli:build` succeeds OR README updated to reflect reality
- [ ] `nx run-many --target=typecheck` passes across all app projects
- [ ] A single `pnpm validate` (or equivalent) runs Go tests + TS tests + TS typecheck + Python pytest + boundary lint, all of which pass
- [ ] CI workflow uses the unified target


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-nx-target-consistency-and-validate-1777863863059`
Branch: `swarm/swarm-nx-target-consistency-and-validate-1777863863059`
Head: `f43c4c0d`
Diff: `1 file changed, 9 insertions(+), 1 deletion(-)`
Commits: 1