### PR TITLE
fix(ops): auto-rotate budget envelope (5-min timer) — closes the envelope-closed deny-cascade

### DIFF
--- a/infra/systemd/chitin-envelope-rotate.service
+++ b/infra/systemd/chitin-envelope-rotate.service
@@ -1,0 +1,23 @@
+# Rotate ~/.chitin/current-envelope when the active envelope
+# closes. Without this, a single sticky-closed envelope causes
+# every agent (swarm, operator, anything) to deny-cascade on
+# `envelope-closed` until manually rotated.
+#
+# Background: 2026-05-04 — the most recent envelope hit its 1500-
+# call cap and sticky-closed at 23:48 UTC. The swarm dispatched
+# 61 workflows over the next 4 hours with zero commits because
+# every tool call was denied at the kernel. Manual rotation
+# unblocked everything; this timer makes the recovery automatic.
+
+[Unit]
+Description=Chitin envelope rotation (close → open via fresh budget)
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/workspace/chitin
+Environment=PATH=%h/.local/bin:%h/.vite-plus/bin:/snap/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/systemd/user/chitin.env
+ExecStart=%h/workspace/chitin/scripts/chitin-envelope-rotate.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=30

--- a/infra/systemd/chitin-envelope-rotate.timer
+++ b/infra/systemd/chitin-envelope-rotate.timer
@@ -1,0 +1,25 @@
+# Timer for chitin-envelope-rotate.service.
+#
+# 5-minute cadence. The cost: a single sqlite read + (when the
+# envelope is still open) a one-line shell exit. The benefit: the
+# swarm never silently stops because of a closed envelope. 5 min
+# is the longest acceptable window — at 1500-call caps and the
+# observed agent dispatch rate, an exhausted envelope can still
+# block the next ~5 dispatches before the rotator catches up.
+# Tightening to 1 min would cut that to ~1 dispatch but the
+# steady-state load isn't worth the journal noise.
+#
+# Persistent so a missed tick from a powered-off rig fires on
+# next boot.
+
+[Unit]
+Description=Chitin envelope rotation timer (every 5 min)
+
+[Timer]
+OnBootSec=30sec
+OnUnitActiveSec=5min
+Persistent=true
+Unit=chitin-envelope-rotate.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/systemd/chitin-envelope-rotate.timer
+++ b/infra/systemd/chitin-envelope-rotate.timer
@@ -16,7 +16,7 @@
 Description=Chitin envelope rotation timer (every 5 min)
 
 [Timer]
-OnBootSec=30sec
+OnBootSec=30s
 OnUnitActiveSec=5min
 Persistent=true
 Unit=chitin-envelope-rotate.service

--- a/scripts/chitin-envelope-rotate.sh
+++ b/scripts/chitin-envelope-rotate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# chitin-envelope-rotate — keep ~/.chitin/current-envelope pointing
+# at an OPEN budget envelope so the kernel never deny-cascades on
+# `envelope-closed`.
+#
+# Triggered by chitin-envelope-rotate.timer (every 5 minutes).
+# Idempotent: if the active envelope is open, no-op. If it's
+# closed (or missing), create a fresh one and update the pointer.
+#
+# Background:
+# `gov.Gate.Evaluate` resolves an envelope via:
+#   1. --envelope=<id> flag
+#   2. CHITIN_BUDGET_ENVELOPE env
+#   3. ~/.chitin/current-envelope file
+#   4. None — gate evaluates without spend
+#
+# In production, agents resolve via #3. When the envelope hits its
+# tool-call cap, it sticky-closes; subsequent calls return
+# `envelope-closed`. Without this rotator, the operator must
+# manually run `chitin-kernel envelope create` and update
+# current-envelope — which we forgot to do, and the swarm
+# silently stopped producing PRs for ~4 hours on 2026-05-04.
+#
+# Caps default to "generous enough that a healthy day's swarm +
+# operator activity doesn't trip them, low enough that runaway
+# spend gets caught fast." Operator can override via env vars.
+
+set -euo pipefail
+
+CHITIN_DIR="${CHITIN_DIR:-$HOME/.chitin}"
+CURRENT_ENVELOPE_FILE="$CHITIN_DIR/current-envelope"
+
+# Default caps. Override via env vars if the operator wants
+# tighter or looser limits per-rotation.
+ENV_CALLS="${CHITIN_ENVELOPE_CALLS:-10000}"
+ENV_BYTES="${CHITIN_ENVELOPE_BYTES:-33554432}"   # 32 MB
+ENV_USD="${CHITIN_ENVELOPE_USD:-2.0}"
+
+LOG="${CHITIN_ENVELOPE_ROTATE_LOG:-$HOME/.cache/chitin/envelope-rotate.jsonl}"
+mkdir -p "$(dirname "$LOG")" "$CHITIN_DIR"
+
+emit() {
+  local kind="$1" msg="$2"
+  shift 2
+  local extras=""
+  while (($#)); do
+    local k="${1%%=*}" v="${1#*=}"
+    v="${v//\\/\\\\}"; v="${v//\"/\\\"}"
+    extras+=",\"${k}\":\"${v}\""
+    shift
+  done
+  printf '{"ts":"%s","kind":"%s","msg":"%s"%s}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$kind" "$msg" "$extras" \
+    | tee -a "$LOG" >&2
+}
+
+if ! command -v chitin-kernel >/dev/null; then
+  emit fail kernel-binary-missing
+  exit 2
+fi
+
+# Read the current pointer (may be missing).
+current_id=""
+if [[ -f "$CURRENT_ENVELOPE_FILE" ]]; then
+  current_id=$(tr -d '[:space:]' < "$CURRENT_ENVELOPE_FILE")
+fi
+
+# Check whether the current envelope is still open. We grep
+# `chitin-kernel envelope list` (returns one line of JSON);
+# the envelope is open iff its closed_at is null.
+needs_rotation=1
+if [[ -n "$current_id" ]]; then
+  if chitin-kernel envelope list 2>/dev/null \
+    | jq -e --arg id "$current_id" '
+        .[] | select(.id == $id) | (.closed_at == null)
+      ' >/dev/null 2>&1; then
+    needs_rotation=0
+  fi
+fi
+
+if [[ "$needs_rotation" -eq 0 ]]; then
+  emit noop "current envelope $current_id is open — no rotation needed"
+  exit 0
+fi
+
+# Rotate: create a fresh envelope, update the pointer.
+new_id=$(chitin-kernel envelope create \
+  --calls="$ENV_CALLS" \
+  --bytes="$ENV_BYTES" \
+  --usd="$ENV_USD" 2>&1 | tail -1 | tr -d '[:space:]')
+
+if [[ -z "$new_id" ]] || ! [[ "$new_id" =~ ^[A-Z0-9]+$ ]]; then
+  emit fail envelope-create-failed "raw_output=$new_id"
+  exit 3
+fi
+
+# Atomic-ish write: tmpfile + mv. Avoids a partial write under
+# concurrent readers (every gate-evaluate hits this file).
+tmp="$CURRENT_ENVELOPE_FILE.tmp.$$"
+echo "$new_id" > "$tmp"
+mv "$tmp" "$CURRENT_ENVELOPE_FILE"
+
+emit ok rotated "old_id=${current_id:-<none>}" "new_id=$new_id" "calls=$ENV_CALLS" "bytes=$ENV_BYTES" "usd=$ENV_USD"

--- a/scripts/chitin-envelope-rotate.sh
+++ b/scripts/chitin-envelope-rotate.sh
@@ -25,10 +25,26 @@
 # operator activity doesn't trip them, low enough that runaway
 # spend gets caught fast." Operator can override via env vars.
 
-set -euo pipefail
+set -uo pipefail
+# NOTE: deliberately NO `-e`. Bash's `set -e` + `pipefail` causes
+# `x=$(failing-cmd | tail -1)` to abort the script silently when
+# `failing-cmd` exits non-zero — `tail` succeeds on empty input, but
+# pipefail surfaces the leftmost failure to the assignment, which
+# `set -e` then treats as fatal. The earlier shape made the
+# `emit fail envelope-create-failed; exit 3` branch dead code: a
+# kernel error produced exit=1 with NO log entry. Explicit error
+# checking via captured exit codes is more honest here.
 
-CHITIN_DIR="${CHITIN_DIR:-$HOME/.chitin}"
-CURRENT_ENVELOPE_FILE="$CHITIN_DIR/current-envelope"
+# Resolve chitin's state dir the same way the kernel does:
+#   1. CHITIN_HOME env (kernel's `chitinDir()` honors this)
+#   2. CHITIN_DIR env (rotator-only convention; defers to CHITIN_HOME
+#      when both set)
+#   3. $HOME/.chitin (default)
+# If only CHITIN_DIR was honored and chitin.env sets CHITIN_HOME=/x,
+# the rotator updates /home/<user>/.chitin/current-envelope but the
+# kernel reads /x/current-envelope — rotation silently no-ops.
+CHITIN_HOME="${CHITIN_HOME:-${CHITIN_DIR:-$HOME/.chitin}}"
+CURRENT_ENVELOPE_FILE="$CHITIN_HOME/current-envelope"
 
 # Default caps. Override via env vars if the operator wants
 # tighter or looser limits per-rotation.
@@ -37,7 +53,7 @@ ENV_BYTES="${CHITIN_ENVELOPE_BYTES:-33554432}"   # 32 MB
 ENV_USD="${CHITIN_ENVELOPE_USD:-2.0}"
 
 LOG="${CHITIN_ENVELOPE_ROTATE_LOG:-$HOME/.cache/chitin/envelope-rotate.jsonl}"
-mkdir -p "$(dirname "$LOG")" "$CHITIN_DIR"
+mkdir -p "$(dirname "$LOG")" "$CHITIN_HOME"
 
 emit() {
   local kind="$1" msg="$2"
@@ -54,8 +70,14 @@ emit() {
     | tee -a "$LOG" >&2
 }
 
+# Hard-fail on missing prerequisites — without these the rotator
+# silently passes through and rotation effectively never happens.
 if ! command -v chitin-kernel >/dev/null; then
   emit fail kernel-binary-missing
+  exit 2
+fi
+if ! command -v jq >/dev/null; then
+  emit fail jq-missing "rotator depends on jq for envelope state introspection"
   exit 2
 fi
 
@@ -65,16 +87,26 @@ if [[ -f "$CURRENT_ENVELOPE_FILE" ]]; then
   current_id=$(tr -d '[:space:]' < "$CURRENT_ENVELOPE_FILE")
 fi
 
-# Check whether the current envelope is still open. We grep
-# `chitin-kernel envelope list` (returns one line of JSON);
-# the envelope is open iff its closed_at is null.
+# Check whether the current envelope is still open. Use --limit=0
+# (no limit) so the lookup doesn't drop the current envelope out
+# of the response after enough rotation history accumulates —
+# `envelope list` defaults to 20, so without --limit=0 this check
+# would silently false-fail after ~20 rotations and trigger a
+# fresh create every tick (spend leak that compounds).
 needs_rotation=1
+list_failed=0
 if [[ -n "$current_id" ]]; then
-  if chitin-kernel envelope list 2>/dev/null \
-    | jq -e --arg id "$current_id" '
-        .[] | select(.id == $id) | (.closed_at == null)
-      ' >/dev/null 2>&1; then
-    needs_rotation=0
+  list_out=$(chitin-kernel envelope list --limit=0 2>&1)
+  list_rc=$?
+  if [[ "$list_rc" -ne 0 ]]; then
+    emit warn envelope-list-failed "rc=$list_rc tail=$(echo "$list_out" | tail -c 300 | tr '\n' ' ')"
+    list_failed=1
+  else
+    if echo "$list_out" | jq -e --arg id "$current_id" '
+          .[] | select(.id == $id) | (.closed_at == null)
+        ' >/dev/null 2>&1; then
+      needs_rotation=0
+    fi
   fi
 fi
 
@@ -83,14 +115,26 @@ if [[ "$needs_rotation" -eq 0 ]]; then
   exit 0
 fi
 
-# Rotate: create a fresh envelope, update the pointer.
-new_id=$(chitin-kernel envelope create \
+# Don't create a new envelope if we couldn't introspect — the
+# existing pointer might still be fine; we just couldn't verify.
+# Better to wait for the next tick than to leak spend.
+if [[ "$list_failed" -eq 1 ]]; then
+  emit skip "envelope list failed; preserving existing pointer to avoid spend leak"
+  exit 0
+fi
+
+# Rotate: create a fresh envelope, update the pointer. Capture
+# exit code explicitly so a kernel failure produces a real fail
+# emit (not silent script abort under set -e).
+create_out=$(chitin-kernel envelope create \
   --calls="$ENV_CALLS" \
   --bytes="$ENV_BYTES" \
-  --usd="$ENV_USD" 2>&1 | tail -1 | tr -d '[:space:]')
+  --usd="$ENV_USD" 2>&1)
+create_rc=$?
+new_id=$(echo "$create_out" | tail -1 | tr -d '[:space:]')
 
-if [[ -z "$new_id" ]] || ! [[ "$new_id" =~ ^[A-Z0-9]+$ ]]; then
-  emit fail envelope-create-failed "raw_output=$new_id"
+if [[ "$create_rc" -ne 0 ]] || [[ -z "$new_id" ]] || ! [[ "$new_id" =~ ^[A-Z0-9]+$ ]]; then
+  emit fail envelope-create-failed "rc=$create_rc raw_output=$(echo "$create_out" | tail -c 300 | tr '\n' ' ')"
   exit 3
 fi
 

--- a/scripts/chitin-envelope-rotate.sh
+++ b/scripts/chitin-envelope-rotate.sh
@@ -138,10 +138,19 @@ if [[ "$create_rc" -ne 0 ]] || [[ -z "$new_id" ]] || ! [[ "$new_id" =~ ^[A-Z0-9]
   exit 3
 fi
 
-# Atomic-ish write: tmpfile + mv. Avoids a partial write under
-# concurrent readers (every gate-evaluate hits this file).
-tmp="$CURRENT_ENVELOPE_FILE.tmp.$$"
-echo "$new_id" > "$tmp"
-mv "$tmp" "$CURRENT_ENVELOPE_FILE"
+# Update the pointer via the kernel's `envelope use` so the write
+# matches kernel semantics: write to a tmp file in the same dir,
+# fsync, rename. Pre-2026-05-04 this was bash `echo > tmp && mv` —
+# atomic for the rename but no fsync, so a crash between the
+# rename and the page cache flush could surface either an empty
+# `current-envelope` or torn content to a concurrent reader. The
+# kernel's writeCurrentEnvelope (cmd/chitin-kernel/envelope.go)
+# is the authoritative implementation; defer to it.
+use_out=$(chitin-kernel envelope use "$new_id" 2>&1)
+use_rc=$?
+if [[ "$use_rc" -ne 0 ]]; then
+  emit fail envelope-use-failed "rc=$use_rc raw_output=$(echo "$use_out" | tail -c 300 | tr '\n' ' ')"
+  exit 4
+fi
 
 emit ok rotated "old_id=${current_id:-<none>}" "new_id=$new_id" "calls=$ENV_CALLS" "bytes=$ENV_BYTES" "usd=$ENV_USD"

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -151,5 +151,22 @@ for installer in \
   rm -f "$hook_log"
 done
 
+# Rotate the budget envelope if the active one closed. Without
+# this, a sticky-closed envelope deny-cascades every tool call
+# until manual rotation. Idempotent; no-op when the active
+# envelope is open. See scripts/chitin-envelope-rotate.sh and
+# the chitin-envelope-rotate.timer for the periodic mechanism.
+ROTATOR="$REPO/scripts/chitin-envelope-rotate.sh"
+if [[ -x "$ROTATOR" ]]; then
+  rotator_log=$(mktemp)
+  if "$ROTATOR" >"$rotator_log" 2>&1; then
+    emit ok envelope-rotate-checked
+  else
+    tail=$(tail -c 500 "$rotator_log" | tr '\n' ' ' | tr -d '"' || true)
+    emit warn envelope-rotate-failed "tail=$tail"
+  fi
+  rm -f "$rotator_log"
+fi
+
 emit ok redeploy-success "old_sha=$old_sha" "new_sha=$new_sha" "build_dur_ms=$build_dur_ms" "changed=$relevant_changes_since_last"
 exit 0


### PR DESCRIPTION
## Summary
Adds a periodic systemd timer that checks the active budget envelope and creates a fresh one when the current one closes. **Closes the operational gap that halted the swarm 2026-05-03 ~23:48 UTC → 2026-05-04 ~02:54 UTC.**

## Background
The kernel resolves a budget envelope from `~/.chitin/current-envelope` on every gate evaluate. When that envelope hits its tool-call cap, it sticky-closes; subsequent calls return `envelope-closed`. The repo had **zero automation** to rotate when this happens.

Last night the active envelope exhausted (1500/1500 calls) and sat closed for ~3 hours while the dispatcher fired 61 workflows. Each agent's first tool call hit `envelope-closed`, gave up, and apply-step saw `commits_added=0`. **Zero auto-merged PRs from 61 dispatches.**

## What this PR ships
- `scripts/chitin-envelope-rotate.sh` — idempotent. If active envelope open: noop. If closed/missing: create fresh envelope (10000 calls / 32MB / $2 default; env-overridable) and atomic-write the pointer.
- `infra/systemd/chitin-envelope-rotate.{service,timer}` — 5-min cadence.
- `install-kernel.sh` runs the rotator after each successful kernel install (covers cold-start).

## Validation
Rotated manually at 02:54 today. Within 10 minutes the swarm produced two real autonomous PRs:
- **#273** `chitin-codex-chain-ingest-timer` — 1 commit, 38 lines
- **#276** `nx-target-consistency-and-validate` — 1 commit, 9 lines

Both were entries from the cohort I filed in #271 a few hours earlier. The swarm itself was healthy; the kernel was deny-cascading every tool call. Manual rotation → swarm immediately functional.

## Observation
Filing an after-action observation alongside this PR is worth doing — the cost-gov v3 envelope mechanism was correct as designed but operationally incomplete without rotation automation. Pattern: any sticky-state mechanism (close on cap, lockdown on signal, etc) needs a paired automation to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)