### PR TITLE
fix(reviewer): cwd-rm regression + 5-bug review-pipeline cascade

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -8,7 +8,29 @@ import type { ActivityResult, HookEventSummary, WorktreeResult } from './activit
 // Bytes of stdout/stderr returned to Temporal in ActivityResult. Buffers
 // during the run are bounded at 2x this value (see runAgentTurn), so
 // chatty drivers can't OOM the 24/7 worker.
-const TAIL_BYTES = 2000;
+//
+// Sized so that the reviewer agent's `<<<REVIEW>>>{...json...}` marker
+// (emitted at the end of the final text message) fits in the captured
+// tail. parseReviewerOutput in reviewer-prompts.ts looks for the
+// marker in the tail; if it's pushed out by trailing stream-json
+// events (Claude Code's result event with usage stats is ~500 bytes
+// of JSON, plus message_stop + a final newline) the parser returns
+// "no <<<REVIEW>>> marker in stdout" and the review-graph escalates
+// one tier — eventually falling through R3 → operator with the
+// "review chain parse-failure cascade" digest.
+//
+// Pre-2026-05-04 default: 2000. That blew past the marker on every
+// reviewer run for PR #274 (260 LOC docs sweep) — the review chain
+// fired R2 → R3 → operator-escalation, both tiers parse-failed.
+// Bumped to 16384 (16 KB) — comfortably absorbs the trailing events.
+//
+// Override via CHITIN_STDOUT_TAIL_BYTES for future tuning.
+const TAIL_BYTES = (() => {
+  const raw = process.env.CHITIN_STDOUT_TAIL_BYTES;
+  if (!raw) return 16384;
+  const n = parseInt(raw.trim(), 10);
+  return Number.isFinite(n) && n > 0 ? n : 16384;
+})();
 
 // Slice 5: where worktrees live when base_ref is set on the request. XDG
 // cache (transient, safe to delete). One sub-dir per workflow_id.
@@ -572,6 +594,17 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
       const agentId = resolveAgent(localDriver as DriverId);
       openclawState = provisionOpenclawState(req, worktreeInfo.path, agentId);
     }
+  } else if (req.role === 'reviewer') {
+    // Reviewers don't write code (write_policy:'none') but DO need
+    // to read the actual repo: `gh pr diff <n>` requires a git
+    // checkout, the prompt instructs them to read the changed files,
+    // etc. Empty-tempdir mode (the slice-1..4 default below)
+    // produced reviewer runs that found `not a git repository` on
+    // the first tool call, escalated with low confidence, and the
+    // gatekeeper cascaded to operator. Run the reviewer in repoRoot
+    // directly — read-only access is governed by the kernel's
+    // policy at the per-tool-call layer, not by isolating the cwd.
+    workDir = repoRoot;
   } else {
     workDir = mkdtempSync(join(tmpdir(), `chitin-worker-${req.workflow_id}-`));
     const policySrc = resolvePolicySrc();
@@ -660,7 +693,10 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     // state and push. Apply-step is responsible for cleanup. If the activity
     // crashes mid-way, the next provisionWorktree() call on the same
     // workflow_id will reclaim the path via best-effort cleanup.
-    if (!useWorktree) {
+    // Tempdir-only cleanup. Reviewer mode runs in repoRoot directly
+    // (write_policy:'none' guarantees read-only); rm-ing it nukes the
+    // monorepo checkout. Worktree mode is owned by the apply-step.
+    if (!useWorktree && workDir !== repoRoot) {
       rmSync(workDir, { recursive: true, force: true });
     }
     // Slice 6b: per-workflow openclaw state dir is transient — clean it

--- a/apps/temporal-worker/src/review-graph-dispatch.ts
+++ b/apps/temporal-worker/src/review-graph-dispatch.ts
@@ -22,7 +22,7 @@ import type { Client } from '@temporalio/client';
 import type { reviewGraphWorkflow } from './review-graph-workflow.ts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 import type { WorktreeResult } from './activity-types.ts';
-import type { PrMeta } from './review-graph.ts';
+import { resolveReviewTierDriver, type PrMeta, type ReviewTier } from './review-graph.ts';
 
 export const REVIEW_GRAPH_WORKFLOW_NAME = 'reviewGraphWorkflow';
 
@@ -151,7 +151,7 @@ export async function enqueueReviewGraph(
   // If a pre-built PrMeta was provided (pr-event-ingester path),
   // thread it through unchanged. Otherwise fall back to the
   // worktree-derived rebuild (programmer-success path).
-  const reviewGraphInput = input.pr_meta
+  const baseInput = input.pr_meta
     ? {
         parent_workflow_id: input.parent_workflow_id,
         pr_meta: input.pr_meta,
@@ -165,6 +165,21 @@ export async function enqueueReviewGraph(
         input.entry,
         input.repo,
       );
+
+  // Resolve per-tier driver+model in regular Node (process.env is
+  // available here) and embed in the workflow input. The workflow
+  // isolate has no `process` global, so it can't run
+  // resolveReviewTierDriver itself — it reads input.tier_config
+  // when present, otherwise the static REVIEW_TIER_DRIVER defaults.
+  // Only R1/R2/R3 are dispatchable; R0/R4 stay null.
+  const tier_config: Record<ReviewTier, { driver: string | null; model: string | null }> = {
+    R0: { driver: null, model: null },
+    R1: resolveReviewTierDriver('R1'),
+    R2: resolveReviewTierDriver('R2'),
+    R3: resolveReviewTierDriver('R3'),
+    R4: { driver: null, model: null },
+  };
+  const reviewGraphInput = { ...baseInput, tier_config };
 
   // Reviewer chain workflow_id derives from the parent. Keep it
   // greppable so the operator can correlate `swarm-<entry>-<ts>` to

--- a/apps/temporal-worker/src/review-graph-workflow.ts
+++ b/apps/temporal-worker/src/review-graph-workflow.ts
@@ -70,6 +70,15 @@ export interface ReviewGraphInput {
   copilot_comments?: string;
   /** Repo slug — needed when we construct reviewer ExecutionRequests. */
   repo: string;
+  /** Per-tier driver+model resolution. Built in regular Node by the
+   *  dispatcher (where `process.env` is readable) so the
+   *  CHITIN_REVIEWER_R<N>_{DRIVER,MODEL} overrides take effect.
+   *  Workflow runs in V8 isolate without `process`, so it can't
+   *  resolve env itself — see review-graph.ts comment on
+   *  resolveReviewTierDriver. When undefined (older callers,
+   *  in-flight workflows from before this rolled out), the workflow
+   *  falls back to the static REVIEW_TIER_DRIVER defaults. */
+  tier_config?: Partial<Record<ReviewTier, { driver: string | null; model: string | null }>>;
 }
 
 /**
@@ -264,7 +273,10 @@ function buildReviewerRequest(
   tier: ReviewTier,
   priorFindings: string | undefined,
 ): ExecutionRequest {
-  const tierConfig = REVIEW_TIER_DRIVER[tier];
+  // Prefer the per-tier config the dispatcher resolved (with env
+  // overrides applied). Fall back to the static defaults for
+  // older callers or in-flight workflows that pre-date the field.
+  const tierConfig = input.tier_config?.[tier] ?? REVIEW_TIER_DRIVER[tier];
   if (!tierConfig.driver) {
     throw new Error(`tier ${tier} is not a dispatchable reviewer tier (R0/R4 are non-dispatchable)`);
   }

--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -55,36 +55,57 @@ function maxTier(a: ReviewTier, b: ReviewTier): ReviewTier {
 // Without this, an accidentally-blank
 // `CHITIN_REVIEWER_R2_DRIVER=` line in chitin.env would override the
 // default to an invalid empty string.
+//
+// CRITICAL: this file is imported by review-graph-workflow.ts which
+// runs in Temporal's V8 workflow isolate where `process` is NOT
+// defined. Reading process.env at module-load (i.e., inside an IIFE
+// like the previous shape) crashes the workflow with
+// `ReferenceError: process is not defined`. Read env lazily (inside
+// the function the activity layer calls), not at module evaluation.
 function envOrDefault(name: string, fallback: string | null): string | null {
+  // typeof guard — workflow isolate has no `process` global at all.
+  if (typeof process === 'undefined' || !process.env) return fallback;
   const raw = process.env[name];
   if (raw === undefined) return fallback;
   const trimmed = raw.trim();
   return trimmed === '' ? fallback : trimmed;
 }
 
-export const REVIEW_TIER_DRIVER: Record<ReviewTier, { driver: string | null; model: string | null }> = (() => {
-  // Operator can override per-tier driver via env. Useful for
-  // running codex (gpt-5.4 on Plus) at R2 instead of copilot/sonnet,
-  // either as a permanent swap or as an A/B comparison. The env
-  // shape is CHITIN_REVIEWER_R<N>_DRIVER (= driver id) +
-  // CHITIN_REVIEWER_R<N>_MODEL (= model name override). When unset
-  // (or whitespace-only), defaults match the historical config below.
-  //
-  // NOTE: this map is module-load evaluated. Tests that need to
-  // exercise default vs override should set the env BEFORE importing
-  // the module, or use the helper directly (envOrDefault).
-  const pick = (tier: string, defaultDriver: string | null, defaultModel: string | null) => ({
-    driver: envOrDefault(`CHITIN_REVIEWER_${tier}_DRIVER`, defaultDriver),
-    model: envOrDefault(`CHITIN_REVIEWER_${tier}_MODEL`, defaultModel),
-  });
+// Default tier→driver mapping (constant; no env reads, safe to
+// evaluate at module load in the workflow isolate).
+const REVIEW_TIER_DRIVER_DEFAULTS: Record<ReviewTier, { driver: string | null; model: string | null }> = {
+  R0: { driver: null, model: null },                                          // GH bot, not dispatched
+  R1: { driver: 'copilot', model: 'gpt-4.1' },
+  R2: { driver: 'copilot', model: 'claude-sonnet-4.6' },
+  R3: { driver: 'claude-code-headless', model: 'claude-opus-4-7' },
+  R4: { driver: null, model: null },                                          // operator, not dispatched
+};
+
+/**
+ * Resolve the driver+model for a review tier, applying the
+ * CHITIN_REVIEWER_R<N>_{DRIVER,MODEL} env override if set.
+ *
+ * Called LAZILY by the activity layer (not the workflow). The
+ * workflow isolate has no `process` so it can't run this; the
+ * activity wraps it instead. The dispatcher / pr-event-ingester
+ * call this directly.
+ */
+export function resolveReviewTierDriver(tier: ReviewTier): { driver: string | null; model: string | null } {
+  const def = REVIEW_TIER_DRIVER_DEFAULTS[tier];
   return {
-    R0: { driver: null, model: null },                                          // GH bot, not dispatched
-    R1: pick('R1', 'copilot', 'gpt-4.1'),
-    R2: pick('R2', 'copilot', 'claude-sonnet-4.6'),
-    R3: pick('R3', 'claude-code-headless', 'claude-opus-4-7'),
-    R4: { driver: null, model: null },                                          // operator, not dispatched
+    driver: envOrDefault(`CHITIN_REVIEWER_${tier}_DRIVER`, def.driver),
+    model: envOrDefault(`CHITIN_REVIEWER_${tier}_MODEL`, def.model),
   };
-})();
+}
+
+/**
+ * Eagerly-resolved table preserved for callers that historically
+ * read REVIEW_TIER_DRIVER as a constant (test fixtures, log lines).
+ * Defaults only — env overrides are NOT applied here because the
+ * workflow isolate import would crash. Callers that need the
+ * override should call `resolveReviewTierDriver(tier)` directly.
+ */
+export const REVIEW_TIER_DRIVER: Record<ReviewTier, { driver: string | null; model: string | null }> = REVIEW_TIER_DRIVER_DEFAULTS;
 
 /**
  * Per-tier resource bounds. R1 is fast + cheap (small diffs go through
@@ -345,7 +366,14 @@ export interface ReviewerFinding {
   severity: '🔴' | '🟡' | '🟢';
   file: string;
   line?: number;
-  category: 'bug' | 'test_gap' | 'design' | 'doc';
+  /** Free-form category. Canonical set is bug/test_gap/design/doc/
+   *  infra/security/perf, but agents in practice invent reasonable
+   *  ones (`infra`, `ops`, `perf`, etc) and rejecting those at the
+   *  schema level cascades the entire review to parse-fail —
+   *  losing the substantive findings. Downstream tooling (debt-
+   *  ledger, etc) should normalize, not require pre-normalization.
+   */
+  category: string;
   summary: string;
   suggested_fix?: string;
 }

--- a/apps/temporal-worker/src/reviewer-prompts.ts
+++ b/apps/temporal-worker/src/reviewer-prompts.ts
@@ -57,7 +57,14 @@ export const ReviewerFindingSchema: z.ZodType<ReviewerFinding> = z.object({
   severity: z.enum(['🔴', '🟡', '🟢']),
   file: z.string().min(1),
   line: z.number().int().positive().optional(),
-  category: z.enum(['bug', 'test_gap', 'design', 'doc']),
+  // Canonical set: bug/test_gap/design/doc/infra/security/perf.
+  // Accept any non-empty string — agents reasonably invent
+  // categories ("infra", "ops") and rejecting them at the schema
+  // level loses the actual finding payload (the gatekeeper digest
+  // shows tier-log "parse-fail" but the marker WAS emitted; only
+  // the category was off-enum). Downstream consumers should
+  // normalize.
+  category: z.string().min(1),
   summary: z.string().min(1),
   suggested_fix: z.string().optional(),
 });
@@ -199,38 +206,185 @@ export function parseReviewerOutput(
     return { ok: false, error: 'no <<<REVIEW>>> marker in stdout' };
   }
   const after = stdoutTail.slice(lastMarker + REVIEW_MARKER.length);
-  // Take everything up to the first newline (the contract is "one
-  // line"). This shields against trailing noise the agent might
-  // emit despite instructions.
-  const lineEnd = after.indexOf('\n');
-  const candidate = (lineEnd >= 0 ? after.slice(0, lineEnd) : after).trim();
-  if (!candidate.startsWith('{')) {
-    return { ok: false, error: `expected JSON object after marker, got: ${truncate(candidate, 200)}` };
+
+  // Two valid forms appear in the wild:
+  //
+  //   raw:        `{"decision":"approve",...}`
+  //   stream-json embedded: `{\"decision\":\"approve\",...}`
+  //
+  // The second arises because Claude Code's --output-format stream-json
+  // wraps the agent's text in JSON-encoded "text" fields and a final
+  // "result" field — both contain the marker line embedded as a
+  // string. So the same `<<<REVIEW>>>{...}` may appear two or three
+  // times in stdout, with different escaping.
+  //
+  // Strategy: walk all occurrences of the marker (newest first via
+  // splitting on the marker) and attempt to parse each candidate as
+  // either raw JSON or JSON-after-unescape. First well-formed +
+  // schema-valid wins.
+  const candidates: string[] = collectCandidates(stdoutTail);
+  if (candidates.length === 0) {
+    return { ok: false, error: `expected JSON object after marker, got: ${truncate(after, 200)}` };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(candidate);
-  } catch (err) {
-    // Include the candidate slice so debugging doesn't require
-    // re-fetching the raw stdout. Truncated to keep error messages
-    // readable in logs (full slice is in stdout_tail anyway).
-    return {
-      ok: false,
-      error:
-        `JSON.parse failed: ${err instanceof Error ? err.message : String(err)} ` +
-        `(candidate: ${truncate(candidate, 200)})`,
-    };
+  let lastParseError = '';
+  for (const cand of candidates) {
+    const tryShapes: string[] = [cand];
+    // Escaped form: candidate contains `\"` or `\\`. JSON-string-decode
+    // by wrapping in quotes and using JSON.parse — that's the standard
+    // way to unescape one level of JSON encoding.
+    if (cand.includes('\\"') || cand.includes('\\\\')) {
+      try {
+        // Wrap the candidate as a JSON string literal then parse to
+        // unescape it. Need to make sure unescaped quotes inside don't
+        // break the wrap — but since the candidate is the escaped form,
+        // any `"` inside should have come from `\"` already (after the
+        // round-trip the inner `"` chars are valid JSON syntax of the
+        // decoded object).
+        const wrapped = `"${cand.replace(/(?<!\\)"/g, '\\"')}"`;
+        const unescaped = JSON.parse(wrapped);
+        if (typeof unescaped === 'string') tryShapes.push(unescaped);
+      } catch {
+        // unescape failed; fall through to direct parse attempt
+      }
+    }
+    for (const shape of tryShapes) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(shape);
+      } catch (err) {
+        lastParseError = `JSON.parse failed: ${err instanceof Error ? err.message : String(err)} (candidate: ${truncate(shape, 200)})`;
+        continue;
+      }
+      const result = ReviewerOutputSchema.safeParse(parsed);
+      if (result.success) {
+        return { ok: true, output: result.data };
+      }
+      lastParseError = `schema validation: ${result.error.message} (candidate: ${truncate(shape, 200)})`;
+    }
   }
+  return { ok: false, error: lastParseError || 'no parseable candidate after any <<<REVIEW>>> marker' };
+}
 
-  const result = ReviewerOutputSchema.safeParse(parsed);
-  if (!result.success) {
-    return {
-      ok: false,
-      error: `schema validation: ${result.error.message} (candidate: ${truncate(candidate, 200)})`,
-    };
+// Walk every occurrence of REVIEW_MARKER in stdout. Two cases:
+//
+//   raw      `<<<REVIEW>>>{"decision":"approve",...}`   (agent printed directly)
+//   escaped  `<<<REVIEW>>>{\"decision\":\"approve\",...}` (marker appears inside
+//                                                          a stream-json
+//                                                          "text" or "result"
+//                                                          field; quotes
+//                                                          backslash-escaped)
+//
+// For each occurrence, derive a candidate JSON string by:
+//   raw     → walk a brace-balanced object from the next `{`
+//   escaped → walk an "escaped-brace-balanced" object treating `\"` as
+//             one logical char, `\{` as the opening, `\}` as the closing
+//
+// Returned newest-first.
+function collectCandidates(stdout: string): string[] {
+  const out: string[] = [];
+  let from = 0;
+  while (true) {
+    const idx = stdout.indexOf(REVIEW_MARKER, from);
+    if (idx < 0) break;
+    const start = idx + REVIEW_MARKER.length;
+    const raw = sliceRawObject(stdout, start);
+    if (raw) out.push(raw);
+    const esc = sliceEscapedObject(stdout, start);
+    if (esc && esc !== raw) out.push(esc);
+    from = start + 1;
   }
-  return { ok: true, output: result.data };
+  return out.reverse();
+}
+
+// Walk from `from` until a `{`, then balanced JSON-aware to the
+// matching `}`. For RAW (unescaped) JSON.
+function sliceRawObject(src: string, from: number): string | null {
+  // Skip whitespace.
+  let i = from;
+  while (i < src.length && /\s/.test(src[i])) i += 1;
+  if (src[i] !== '{') return null;
+
+  let depth = 0;
+  let inStr = false;
+  let escaped = false;
+  for (let j = i; j < src.length; j += 1) {
+    const c = src[j];
+    if (inStr) {
+      if (escaped) { escaped = false; continue; }
+      if (c === '\\') { escaped = true; continue; }
+      if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') { inStr = true; continue; }
+    if (c === '{') depth += 1;
+    else if (c === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(i, j + 1);
+    }
+  }
+  return null;
+}
+
+// Walk from `from` until a `\\{` or `{`, then JSON-string-decode
+// the slice. The "escaped" form has every `"` written as `\"` and
+// every `\` as `\\`; we capture up to the closing `\}` and decode.
+function sliceEscapedObject(src: string, from: number): string | null {
+  // Skip whitespace.
+  let i = from;
+  while (i < src.length && /\s/.test(src[i])) i += 1;
+  // Skip a leading `\` if escape-form; tolerate either `{` or `\{`.
+  let openIdx: number;
+  if (src.slice(i, i + 2) === '\\{') openIdx = i;
+  else if (src[i] === '{') openIdx = i;
+  else return null;
+
+  // Walk forward respecting `\\"` as one logical (escaped) `"` and
+  // `\\\\` as one logical `\`. depth bumps on `{` or `\\{` (treat as
+  // open), drops on `}` or `\\}`. Stop at depth 0.
+  //
+  // The ESCAPED level is tricky because the same `{` might be raw
+  // (depth bump) OR `\{` (still depth bump, but consume two chars).
+  // We treat `\{` and `{` identically for nesting count.
+  let depth = 0;
+  let j = openIdx;
+  let inStr = false;
+  while (j < src.length) {
+    // Look for two-char escape sequences first.
+    if (src[j] === '\\' && j + 1 < src.length) {
+      const next = src[j + 1];
+      if (next === '"') {
+        // `\"` flips inStr (this is the escaped `"` representing the
+        // start/end of a JSON string in the encoded form).
+        inStr = !inStr;
+        j += 2;
+        continue;
+      }
+      if (next === '\\') { j += 2; continue; }
+      if (!inStr && next === '{') { depth += 1; j += 2; continue; }
+      if (!inStr && next === '}') {
+        depth -= 1;
+        if (depth === 0) return src.slice(openIdx, j + 2);
+        j += 2;
+        continue;
+      }
+      // Other `\X` — pass through.
+      j += 2;
+      continue;
+    }
+    const c = src[j];
+    if (!inStr && c === '{') depth += 1;
+    else if (!inStr && c === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(openIdx, j + 1);
+    } else if (!inStr && c === '"') {
+      inStr = true;
+    } else if (inStr && c === '"') {
+      inStr = false;
+    }
+    j += 1;
+  }
+  return null;
 }
 
 function truncate(s: string, max: number): string {

--- a/apps/temporal-worker/test/review-graph-dispatch.test.ts
+++ b/apps/temporal-worker/test/review-graph-dispatch.test.ts
@@ -276,4 +276,46 @@ describe('enqueueReviewGraph', () => {
     expect(arg.entry.id).toBe('arg-shape-test');
     expect(arg.repo).toBe('chitinhq/chitin');
   });
+
+  it('embeds tier_config from CHITIN_REVIEWER_R<N>_{DRIVER,MODEL} env into workflow args', async () => {
+    // The workflow runs in a V8 isolate without `process` — env
+    // override resolution has to happen here in the dispatcher and
+    // be threaded through input. Regression test for Copilot's
+    // catch on PR #280: env overrides were a dead code path.
+    const orig = {
+      r1d: process.env.CHITIN_REVIEWER_R1_DRIVER,
+      r1m: process.env.CHITIN_REVIEWER_R1_MODEL,
+      r3d: process.env.CHITIN_REVIEWER_R3_DRIVER,
+    };
+    process.env.CHITIN_REVIEWER_R1_DRIVER = 'codex-cli';
+    process.env.CHITIN_REVIEWER_R1_MODEL = 'gpt-5.4';
+    process.env.CHITIN_REVIEWER_R3_DRIVER = 'gemini-cli';
+    try {
+      const client = makeMockClient();
+      await enqueueReviewGraph({
+        client: client as unknown as Parameters<typeof enqueueReviewGraph>[0]['client'],
+        taskQueue: 'chitin-worker-q',
+        parent_workflow_id: 'parent-tier-config-1',
+        pr_url: 'https://github.com/chitinhq/chitin/pull/600',
+        worktree: makeWorktree(),
+        entry: makeEntry(),
+        repo: 'chitinhq/chitin',
+      });
+      const [arg] = client.__startCalls[0].args as [
+        { tier_config?: Record<string, { driver: string | null; model: string | null }> },
+      ];
+      expect(arg.tier_config).toBeDefined();
+      expect(arg.tier_config?.R1).toEqual({ driver: 'codex-cli', model: 'gpt-5.4' });
+      expect(arg.tier_config?.R3?.driver).toBe('gemini-cli');
+      // R2 unset → falls back to the static default.
+      expect(arg.tier_config?.R2?.driver).toBe('copilot');
+    } finally {
+      if (orig.r1d === undefined) delete process.env.CHITIN_REVIEWER_R1_DRIVER;
+      else process.env.CHITIN_REVIEWER_R1_DRIVER = orig.r1d;
+      if (orig.r1m === undefined) delete process.env.CHITIN_REVIEWER_R1_MODEL;
+      else process.env.CHITIN_REVIEWER_R1_MODEL = orig.r1m;
+      if (orig.r3d === undefined) delete process.env.CHITIN_REVIEWER_R3_DRIVER;
+      else process.env.CHITIN_REVIEWER_R3_DRIVER = orig.r3d;
+    }
+  });
 });

--- a/apps/temporal-worker/test/reviewer-prompts.test.ts
+++ b/apps/temporal-worker/test/reviewer-prompts.test.ts
@@ -47,8 +47,20 @@ describe('ReviewerFindingSchema', () => {
     expect(() => ReviewerFindingSchema.parse(bad)).toThrow();
   });
 
-  it('rejects an unknown category', () => {
-    const bad = { severity: '🔴', file: 'x.ts', category: 'security', summary: 's' };
+  it('accepts off-canonical category strings (was: rejects "security")', () => {
+    // Updated 2026-05-04: schema was z.enum but agents in practice
+    // invent reasonable categories like "infra"/"security"/"perf"
+    // and rejecting them cascaded the entire review to parse-fail
+    // (PR #277 R3 produced a real findings payload with
+    // category:"infra" and the gatekeeper showed parse-fail because
+    // schema validation threw). Accept any non-empty string;
+    // downstream tooling normalizes.
+    const ok = { severity: '🔴', file: 'x.ts', category: 'security', summary: 's' };
+    expect(() => ReviewerFindingSchema.parse(ok)).not.toThrow();
+  });
+
+  it('rejects empty category string', () => {
+    const bad = { severity: '🔴', file: 'x.ts', category: '', summary: 's' };
     expect(() => ReviewerFindingSchema.parse(bad)).toThrow();
   });
 
@@ -150,6 +162,54 @@ describe('parseReviewerOutput', () => {
     if (r.ok) {
       expect(r.output.findings[0].line).toBe(372);
       expect(r.output.findings[0].suggested_fix).toBe('reorder');
+    }
+  });
+
+
+  it('parses the marker when embedded inside Claude Code stream-json (escaped quotes)', () => {
+    // Real-world tail captured from PR #275 R3 reviewer 2026-05-04.
+    // Claude Code's --output-format stream-json wraps the agent's
+    // text in JSON-encoded fields; the marker shows up with escaped
+    // backslashes inside the wrapper. Pre-fix: parseReviewerOutput
+    // saw the escaped form, JSON.parse threw, every reviewer tier
+    // parse-failed → review chain cascaded to operator. Pin so this
+    // doesn't regress.
+    const streamJsonTail =
+      'some preamble\n' +
+      '{"type":"assistant","message":{"content":[{"type":"text",' +
+      '"text":"clean diff.\\n\\n<<<REVIEW>>>{\\"decision\\":\\"approve\\",\\"confidence\\":\\"high\\",\\"findings\\":[]}"}]}}\n' +
+      '{"type":"result","subtype":"success","result":"... <<<REVIEW>>>{\\"decision\\":\\"approve\\",\\"confidence\\":\\"high\\",\\"findings\\":[]}"}\n';
+    const r = parseReviewerOutput(streamJsonTail);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.output.decision).toBe('approve');
+      expect(r.output.confidence).toBe('high');
+      expect(r.output.findings).toEqual([]);
+    }
+  });
+
+  it('parses the marker when emitted raw (agent printed directly to stdout)', () => {
+    // Plain-text driver path (codex / openclaw / older claude)
+    // emits the marker line without the stream-json wrapper.
+    const rawTail =
+      'reviewing the diff... ok approving.\n' +
+      '<<<REVIEW>>>{"decision":"approve","confidence":"high","findings":[]}\n';
+    const r = parseReviewerOutput(rawTail);
+    expect(r.ok).toBe(true);
+  });
+
+  it('prefers the LATEST valid emit when multiple markers appear (e.g., agent self-corrected)', () => {
+    const tail =
+      '<<<REVIEW>>>{"decision":"approve","confidence":"low","findings":[]}\n' +
+      'on reflection, this is bigger than I thought\n' +
+      '<<<REVIEW>>>{"decision":"request_changes","confidence":"high","findings":[' +
+      '{"severity":"🔴","file":"x","category":"bug","summary":"y"}]}\n';
+    const r = parseReviewerOutput(tail);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.output.decision).toBe('request_changes');
+      expect(r.output.confidence).toBe('high');
+      expect(r.output.findings).toHaveLength(1);
     }
   });
 });


### PR DESCRIPTION
## Summary
- **CRITICAL:** the prior reviewer-cwd fix made `workDir = repoRoot` for reviewers, but the activity's `finally` block runs `rmSync(workDir)` when not in worktree mode. The first reviewer dispatch deleted `/home/red/workspace/chitin` outright; every systemd unit with `WorkingDirectory=%h/workspace/chitin` then failed `200/CHDIR`. This PR adds the `workDir !== repoRoot` guard and ports the four other unmerged review-pipeline fixes.
- Bundles five fixes that were stacked across `chitin-tail-bytes` / `chitin-envelope-rotate` worktrees but never landed because every reviewer parse-failed and gatekeeper auto-merge never fired.

## Fixes
1. **TAIL_BYTES**: 2000 → 16384 (env-overridable via `CHITIN_STDOUT_TAIL_BYTES`). The marker was being truncated by Claude Code's trailing usage-stats events.
2. **Reviewer cwd**: `repoRoot` instead of empty tempdir — `gh pr diff` needs a git checkout.
3. **Cleanup guard**: skip `rmSync(workDir)` when `workDir === repoRoot`. **This is the fix for the directory-deletion incident.**
4. **Marker parser**: raw + JSON-escape-aware brace-balance walkers; iterate every `<<<REVIEW>>>` occurrence. Stream-json embeds the marker inside a `text` field as `\"decision\":\"approve\"`.
5. **Schema**: `ReviewerFinding.category` `z.string().min(1)` (was closed enum). Agents emit `infra`, `safety`, etc.; one non-canonical category was failing the whole envelope.

Plus: workflow-isolate purity in `review-graph.ts` — `REVIEW_TIER_DRIVER` split into static defaults + lazy resolver. The old IIFE read `process.env` at module load and crashed the Temporal V8 isolate.

## Test plan
- [x] 689 vitest cases pass (`nx run temporal-worker:test`)
- [x] `/home/red/workspace/chitin` restored from origin
- [x] Worker re-armed and dispatcher re-enabled after merge
- [ ] Next reviewer dispatch produces parseable R1/R2/R3 envelopes
- [ ] No `200/CHDIR` failures in `journalctl --user -u chitin-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)