### PR TITLE
docs: cwd-rm incident post-mortem + 3 hardening backlog entries

### DIFF
--- a/docs/observations/2026-05-04-reviewer-cwd-rm-incident.md
+++ b/docs/observations/2026-05-04-reviewer-cwd-rm-incident.md
@@ -1,0 +1,156 @@
+---
+date: 2026-05-04
+type: post-mortem
+scope: temporal-worker reviewer cwd-rm regression — checkout deleted, swarm dark ~3h
+active_soul: da Vinci
+related:
+  - apps/temporal-worker/src/activity.ts
+  - https://github.com/chitinhq/chitin/pull/280
+  - docs/observations/2026-05-03-low-success-alarm-investigation.md
+---
+
+# Reviewer cwd-rm incident — post-mortem
+
+## One-sentence summary
+
+A reviewer-cwd fix that ran R1/R2/R3 reviewers in `repoRoot` (so `gh pr
+diff` would work) was paired with the activity's existing
+`finally{ rmSync(workDir) }` cleanup; the first reviewer dispatch
+deleted `/home/red/workspace/chitin` outright, dropping every systemd
+unit with `WorkingDirectory=%h/workspace/chitin` into `200/CHDIR` and
+silencing the autonomous swarm for ~3h until manual recovery.
+
+## Timeline
+
+- **~12:30 UTC** — PR #270 (the original reviewer-cwd fix in a worktree)
+  set `workDir = repoRoot` for `req.role === 'reviewer'`.
+- **~13:00 UTC** — Worker restart picks up the new code. First
+  reviewer dispatch fires.
+- **First reviewer turn ends** — activity `finally` block runs
+  `rmSync(workDir, { recursive: true, force: true })` because
+  `useWorktree=false`. `workDir === repoRoot === /home/red/workspace/chitin`.
+  Entire monorepo checkout deleted.
+- **Subsequent ticks** — `chitin-dispatcher.service`,
+  `chitin-pr-event-ingester.service`, `chitin-envelope-rotate.service`
+  fail with `200/CHDIR` (`WorkingDirectory=%h/workspace/chitin` resolves
+  to a non-existent path). No new programmer dispatches. No new
+  reviewer dispatches. Pre-existing in-flight workflows survive only
+  via Temporal's history; their activities can't run.
+- **~15:00 UTC** — Operator notices "is the swarm in monitor or guard
+  or what mode" and pulls on the thread. `chitin-kernel gate status`
+  returns `no_policy_found: no chitin.yaml from /home/red upward`.
+  `ls /home/red/workspace/chitin` returns `No such file or directory`.
+- **~15:10 UTC** — `git clone https://github.com/chitinhq/chitin.git`
+  restores the checkout at `main` (`021cf38`). Worker stopped to
+  prevent re-deletion.
+- **~15:20 UTC** — Root cause located in
+  `apps/temporal-worker/src/activity.ts:697`. PR #280 opened with
+  `if (!useWorktree && workDir !== repoRoot)` guard plus four other
+  unmerged reviewer-pipeline fixes that were stacked on the deleted
+  worktree.
+- **~15:35 UTC** — PR #280 merged after Copilot review + regression
+  test for env-override pathway (#280 was bundled with workflow-isolate
+  purity changes that broke `process.env` reads at module load).
+- **~15:41 UTC** — Worker + 4 timers restarted. First post-fix tick
+  cleanly enqueues review-graphs for #274 + #277, peer-reviewers for
+  #274/#277/#278, comment-responders for #274/#277. Swarm
+  operational.
+
+## What worked
+
+- **Detection.** Operator caught the silent failure within ~3h via a
+  process-of-elimination question ("is the swarm in monitor or guard
+  mode?"), not via an alarm. The `200/CHDIR` failures were in the
+  journal for hours but not on any dashboard.
+- **Recovery.** Re-cloning from `origin/main` was the correct first
+  move — there was nothing in the deleted worktree we couldn't
+  reconstruct. The orphaned worktree dirs at
+  `/home/red/.cache/chitin/swarm-worktrees/` were unaffected because
+  they don't depend on the parent checkout's `.git`.
+- **Bundle landing.** Five reviewer-pipeline bugs that had been
+  stacked across separate worktrees (`chitin-tail-bytes`,
+  `chitin-envelope-rotate`) were ported into the fresh clone and
+  shipped as one PR (#280). Bundling let CI / Copilot review them
+  together rather than fighting through five rebases.
+
+## What didn't
+
+- **The fix author (me) didn't audit cleanup paths when changing
+  workDir semantics.** Setting `workDir = repoRoot` for reviewer mode
+  was a clean read-side fix. Pairing it with the existing
+  `finally{ rmSync(workDir) }` was a write-side disaster. The
+  cleanup block had been correct under the previous invariant
+  ("workDir is always a tempdir we own"); the new code broke that
+  invariant without touching the consumer.
+- **No alarm on `200/CHDIR`.** The PR-event-ingester failures were
+  visible in `journalctl --user -u chitin-pr-event-ingester` from
+  the moment the deletion happened. There's no alert on systemd
+  unit start failures piped into chain or Slack.
+- **The trap was guard-by-blacklist-friendly.** The fix in #280 is
+  `workDir !== repoRoot`, which protects against the specific
+  variable name. A future developer who adds `workDir = someExternalDir`
+  for a *new* role isn't protected. The structurally-correct fix is
+  `workDir.startsWith(tmpdir())` — only rm paths the worker
+  unambiguously owns.
+
+## Why it bit so hard
+
+Three independent infra components share `WorkingDirectory=%h/workspace/chitin`:
+
+1. **chitin-dispatcher** — the programmer-side tick that picks
+   backlog entries.
+2. **chitin-pr-event-ingester** — the post-PR review-graph trigger.
+3. **chitin-envelope-rotate** — the cost-envelope auto-rotator.
+
+Once the directory was gone, ALL three units were down, which means:
+
+- No new programmer work.
+- No reviewer dispatches even for already-open PRs.
+- No envelope rotation, which would have caused a *second* cascade
+  (envelope-closed deny-cascade) ~5 minutes after the first
+  envelope's TTL.
+
+The blast radius was the entire swarm because the directory is the
+universal anchor for systemd's `%h/workspace/chitin` substitution.
+
+## Action items
+
+1. **Structural fix (PR #280).** `workDir !== repoRoot` guard plus
+   the four bundled fixes. Merged, restored, verified.
+2. **Codify the trap** — saved as feedback memory
+   (`feedback_workdir_repo_root_rm_trap.md`) so future-me / future
+   contributor can grep for it before reaching for `workDir = X`.
+3. **Backlog entry — "alarm on 200/CHDIR systemd failures"** — the
+   journal had the signal for hours, the operator didn't see it.
+   `chitin-alarm-feeder` should detect `code=exited, status=200/CHDIR`
+   and surface it.
+4. **Backlog entry — "tighten cleanup ownership check"** — replace
+   `workDir !== repoRoot` blacklist with `workDir.startsWith(tmpdir())
+   || workDir.startsWith(SWARM_WORKTREES_ROOT)` allowlist. Done as
+   a follow-up by the swarm itself.
+5. **Backlog entry — "agent-lockdown auto-recovery"** — separate from
+   this incident, surfaced by it. The envelope-closed deny-cascade
+   from a *prior* outage left `copilot-cli` lockdown'd; same pattern
+   as the envelope rotator. A `chitin-agent-unlock` timer should
+   age-out stale lockdowns whose denials were infrastructure (cost
+   envelope closed, policy file unreadable) rather than agent
+   misbehavior.
+
+## Empirical lessons
+
+- **Read-side fixes can have write-side consequences.** The
+  `workDir = repoRoot` change was a one-line read-side enabler;
+  the cleanup block 90 lines below silently rewrote it into a
+  destructive operation. Always grep for every consumer of the
+  variable being changed.
+- **`%h/workspace/chitin` is a single point of failure.** Five+
+  systemd units anchor on it. A future hardening pass could either
+  (a) make the path configurable via `Environment=CHITIN_REPO_ROOT=`
+  and have units read from that, so a missing repo can be
+  re-pointed, or (b) auto-clone-on-missing, so the systemd units
+  self-heal.
+- **Recovery automation needs to be tested under failure, not
+  designed under success.** The envelope rotator (PR #277) was
+  designed as "pre-emptively rotate before close." It would not
+  have helped here because the *checkout itself* was the failure
+  mode. The unit's `WorkingDirectory` was the ceiling.

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -5108,6 +5108,117 @@ Fixes:
 - [ ] A single `pnpm validate` (or equivalent) runs Go tests + TS tests + TS typecheck + Python pytest + boundary lint, all of which pass
 - [ ] CI workflow uses the unified target
 
+## Operational hardening — surfaced by 2026-05-04 cwd-rm incident
+
+### `agent-lockdown-auto-recovery`
+
+```yaml
+id: agent-lockdown-auto-recovery
+tier: T2
+status: ready
+estimated_loc: 200
+blocks: []
+file: scripts/chitin-agent-unlock.sh, infra/systemd/chitin-agent-unlock.service, infra/systemd/chitin-agent-unlock.timer, go/execution-kernel/internal/gov/escalation.go (read-side)
+references_finding: docs/observations/2026-05-04-reviewer-cwd-rm-incident.md (action item 5); feedback_sticky_state_needs_recovery_automation.md
+role: programmer
+```
+
+Sticky-state pattern: when an agent racks up 10+ denials it lockdown's
+in `agent_state.locked=1` (escalation.go:87). The 2026-05-04 envelope-
+closed cascade locked `copilot-cli` for 3+ hours before manual reset.
+Same shape as the envelope-rotator (PR #277) — needs an automated
+ager that distinguishes infrastructure denials (envelope-closed,
+policy-load-error) from agent-misbehavior denials (rule violations).
+
+Approach (subject to design tightening — programmer should propose):
+- Read `agent_state` rows where `locked=1`.
+- For each, look at the most recent N denials in `denials` table.
+- If denials are dominated by `envelope-closed` / `policy-load-error`
+  / other infra reasons AND `locked_ts` is older than 1h AND no new
+  denials in last 30m, auto-reset via `chitin-kernel gate reset
+  --agent=<id>`.
+- Emit a chain event for every auto-reset so operators can see the
+  recovery happened.
+- Do NOT auto-reset locks driven by policy violations — those are
+  the signal the lockdown was designed for.
+
+The selection criteria are the design — get them wrong and the
+mechanism papers over real problems. Programmer should propose the
+selection logic in the PR description before the implementation
+lands.
+
+**Acceptance:**
+- [ ] Locked agents whose denials are infra-source get age-out reset
+      after 1h of no new denial activity
+- [ ] Locked agents whose denials include any policy-violation signal
+      do NOT auto-reset (operator-only)
+- [ ] Each auto-reset emits a chain event with kind=`agent-unlock-auto`
+      and the rationale (which denial classes were considered, the
+      counts, the age)
+- [ ] systemd timer runs every 15min; cost: one sqlite read
+
+### `alarm-on-systemd-chdir-failures`
+
+```yaml
+id: alarm-on-systemd-chdir-failures
+tier: T2
+status: ready
+estimated_loc: 150
+blocks: []
+file: apps/temporal-worker/src/alarm-feeder.ts (or co-located new file), infra/systemd/chitin-alarm-feeder.service (env addition only)
+references_finding: docs/observations/2026-05-04-reviewer-cwd-rm-incident.md (action item 3)
+role: programmer
+```
+
+The 2026-05-04 cwd-rm incident left `journalctl --user -u chitin-*`
+showing `code=exited, status=200/CHDIR` for ~3h before the operator
+noticed. The signal was loud and machine-readable; nothing was
+listening.
+
+Extend `chitin-alarm-feeder` to scan recent journal output for any
+`status=200/CHDIR` or `status=203/EXEC` failure on a `chitin-*`
+unit and surface it as a chain alarm event (so the slack-feeder
+or any downstream consumer can route it).
+
+**Acceptance:**
+- [ ] alarm-feeder detects 200/CHDIR + 203/EXEC on chitin-* units
+- [ ] Detection emits a chain event with kind=`systemd-unit-failure`
+      and the unit name, status code, and failure timestamp
+- [ ] Test fixture: synthetic journal output containing one CHDIR
+      failure produces exactly one chain alarm event
+- [ ] No false positives on healthy `Type=oneshot` units that exit
+      cleanly with `status=0/SUCCESS`
+
+### `cleanup-ownership-allowlist`
+
+```yaml
+id: cleanup-ownership-allowlist
+tier: T1
+status: ready
+estimated_loc: 80
+blocks: []
+file: apps/temporal-worker/src/activity.ts
+references_finding: docs/observations/2026-05-04-reviewer-cwd-rm-incident.md (action item 4)
+role: programmer
+```
+
+The fix in PR #280 guards the `rmSync(workDir)` cleanup with
+`workDir !== repoRoot`. That protects the specific variable name
+that bit us, but a future role that sets `workDir = someOtherSharedDir`
+would re-introduce the trap. Replace the blacklist with an allowlist:
+only rm paths the worker unambiguously owns (`tmpdir()` prefix or
+`SWARM_WORKTREES_ROOT` prefix). Any other path → log + skip.
+
+**Acceptance:**
+- [ ] Cleanup rm is gated by an `isWorkerOwnedPath(p)` helper that
+      returns true only for `tmpdir()` or `SWARM_WORKTREES_ROOT`
+      prefixes
+- [ ] Reviewer mode (workDir = repoRoot) and any future "run in $X"
+      mode are protected without per-mode case statements
+- [ ] Unit test covers: tempdir cleanup happens, repoRoot is never
+      rm'd, `SWARM_WORKTREES_ROOT/<id>` cleanup paths still work,
+      `/etc` (or other arbitrary) paths log + skip
+
 ## Ecosystem opportunity — chain as the substrate (filed 2026-05-03 evening)
 
 ### `chitin-ecosystem-opportunity-rollup`


### PR DESCRIPTION
## Summary
- Post-mortem on the 2026-05-04 reviewer cwd-rm regression (PR #270 → directory deletion → ~3h swarm dark) at \`docs/observations/2026-05-04-reviewer-cwd-rm-incident.md\`.
- Three new backlog entries the swarm can self-pick up:
  - \`agent-lockdown-auto-recovery\` (T2) — age-out stale infra-driven lockdowns
  - \`alarm-on-systemd-chdir-failures\` (T2) — alarm-feeder detection
  - \`cleanup-ownership-allowlist\` (T1) — replace #280's blacklist guard with an allowlist

## Test plan
- [x] Backlog parser sees all 3 new entries (\`parseBacklog\` returns 106 entries; all 3 present with correct tier/status/role)
- [x] No code changes; docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)