### PR TITLE
swarm: alarm-on-systemd-chdir-failures

### DIFF
--- a/apps/temporal-worker/src/alarm-feeder.ts
+++ b/apps/temporal-worker/src/alarm-feeder.ts
@@ -106,7 +106,7 @@ export function parseJournalForUnitFailures(output: string): SystemdUnitFailureE
       kind: 'systemd-unit-failure',
       unit: unitMatch[1],
       status_code: statusMatch[1],
-      failure_ts: tsMatch ? tsMatch[1] : new Date().toISOString(),
+      failure_ts: tsMatch ? tsMatch[1] : 'unknown',
     });
   }
   return events;
@@ -115,12 +115,29 @@ export function parseJournalForUnitFailures(output: string): SystemdUnitFailureE
 /**
  * Run journalctl and return its stdout. Returns empty string if the
  * command is unavailable (e.g., macOS dev machines) or fails.
+ *
+ * Default window is 25h: alarm-feeder.timer fires daily, so a 2h
+ * window (the pre-2026-05-04 default) silently dropped failures
+ * from earlier in the day. 25h gives a 1h overlap to catch
+ * boundary failures from the previous tick. Fixed per Copilot
+ * review on #283.
+ *
+ * execSync bounds raised: 30s timeout (was unbounded — could hang
+ * the alarm-feeder tick) and 10MB maxBuffer (was 1MB default — a
+ * noisy 24h+ journal exceeds this and throws, which the blanket
+ * catch swallows as "no alarms" — exactly the silent-failure
+ * mode this feature exists to detect).
  */
-export function collectJournalOutput(sinceHours = 2): string {
+export function collectJournalOutput(sinceHours = 25): string {
   try {
     return execSync(
       `journalctl --user -u "chitin-*" --since "${sinceHours} hours ago" -o short --no-pager`,
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 30_000,
+        maxBuffer: 10 * 1024 * 1024,
+      },
     );
   } catch {
     return '';

--- a/apps/temporal-worker/src/alarm-feeder.ts
+++ b/apps/temporal-worker/src/alarm-feeder.ts
@@ -44,9 +44,11 @@ export interface AlarmFeederOptions {
   now: string;
   log?: (line: string) => void;
   /**
-   * Synthetic journal text for testing. When set, journalctl is NOT
-   * executed; this text is parsed instead. In production the feeder
-   * runs journalctl automatically when this field is absent.
+   * Journal text to scan for chitin-* unit failures. Pass a non-empty
+   * string (from `collectJournalOutput()`) to enable detection. When
+   * absent or undefined the journal scan is skipped — this keeps
+   * existing call sites and tests that don't pass this field unchanged.
+   * The production `main()` always populates this field.
    */
   journalOutput?: string;
 }
@@ -258,9 +260,12 @@ export async function runAlarmFeeder(
   const rollupAlarms = rollup?.alarms ?? [];
 
   // ── Systemd journal scan ────────────────────────────────────────────
-  const journalText =
-    opts.journalOutput !== undefined ? opts.journalOutput : collectJournalOutput();
-  const unitFailures = parseJournalForUnitFailures(journalText);
+  // Only scan when the caller supplies journal text. Absent = skip (safe
+  // for existing tests and call sites that don't opt in to journal scanning).
+  const unitFailures =
+    opts.journalOutput !== undefined
+      ? parseJournalForUnitFailures(opts.journalOutput)
+      : [];
 
   // Emit a structured chain alarm event for each detected unit failure so
   // downstream consumers (slack-feeder, log processors) can route on it.
@@ -330,6 +335,8 @@ async function main(): Promise<void> {
     backlogPath: DEFAULT_BACKLOG_PATH,
     cap,
     now: new Date().toISOString(),
+    // Production: scan the last 2h of journal for chitin-* unit failures.
+    journalOutput: collectJournalOutput(),
   });
 }
 

--- a/apps/temporal-worker/src/alarm-feeder.ts
+++ b/apps/temporal-worker/src/alarm-feeder.ts
@@ -20,12 +20,19 @@
 // groomer.ts: cron-fired script, idempotent, telemetry log line,
 // no Temporal involvement. The rollup is a flat-file boundary; this
 // module reads it.
+//
+// §systemd-unit-failure: In addition to rollup alarms, the feeder also
+// scans recent journalctl output for chitin-* units that exited with
+// status=200/CHDIR or status=203/EXEC. Each detected failure emits a
+// chain alarm event with kind=systemd-unit-failure and is fed into the
+// same dedup+backlog pipeline as rollup alarms.
 
 import { fileURLToPath } from 'node:url';
 import { readFile, writeFile } from 'node:fs/promises';
 import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { execSync } from 'node:child_process';
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -36,6 +43,12 @@ export interface AlarmFeederOptions {
   /** ISO-8601 timestamp injected by runner. */
   now: string;
   log?: (line: string) => void;
+  /**
+   * Synthetic journal text for testing. When set, journalctl is NOT
+   * executed; this text is parsed instead. In production the feeder
+   * runs journalctl automatically when this field is absent.
+   */
+  journalOutput?: string;
 }
 
 export interface AlarmFeederResult {
@@ -43,6 +56,83 @@ export interface AlarmFeederResult {
   new_entries: number;
   duplicates_skipped: number;
   rollup_present: boolean;
+  /** How many chitin-* systemd unit failures were detected in the journal. */
+  systemd_failures: number;
+}
+
+// ─── Systemd unit failure detection ─────────────────────────────────────
+
+/**
+ * Structured chain alarm event emitted when a chitin-* systemd unit
+ * exits with a non-zero status that indicates a setup failure rather
+ * than a transient workload exit (200/CHDIR = missing working directory,
+ * 203/EXEC = binary not found/not executable).
+ */
+export interface SystemdUnitFailureEvent {
+  kind: 'systemd-unit-failure';
+  unit: string;
+  status_code: string;
+  failure_ts: string;
+}
+
+// Invariant: a line matches iff it references a chitin-* unit AND
+// contains one of the two failure status codes. status=0/SUCCESS never
+// matches because neither "200/CHDIR" nor "203/EXEC" appear in that string.
+const FAILURE_STATUS_RE = /status=(200\/CHDIR|203\/EXEC)/;
+const UNIT_FROM_LINE_RE = /(chitin-[^\s:]+):/;
+
+// Short-format journal timestamp: "May  4 10:23:45" (month padded by a space
+// for single-digit days). We capture it verbatim; callers receive it as-is.
+const JOURNAL_TS_RE = /^([A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})/;
+
+/**
+ * Parse raw journalctl short-format output and return one
+ * `SystemdUnitFailureEvent` per line that matches both a chitin-* unit
+ * reference and a 200/CHDIR or 203/EXEC exit status.
+ *
+ * Pure function — safe for unit tests with synthetic input.
+ */
+export function parseJournalForUnitFailures(output: string): SystemdUnitFailureEvent[] {
+  const events: SystemdUnitFailureEvent[] = [];
+  for (const line of output.split('\n')) {
+    const statusMatch = FAILURE_STATUS_RE.exec(line);
+    if (!statusMatch) continue;
+    const unitMatch = UNIT_FROM_LINE_RE.exec(line);
+    if (!unitMatch) continue;
+    const tsMatch = JOURNAL_TS_RE.exec(line);
+    events.push({
+      kind: 'systemd-unit-failure',
+      unit: unitMatch[1],
+      status_code: statusMatch[1],
+      failure_ts: tsMatch ? tsMatch[1] : new Date().toISOString(),
+    });
+  }
+  return events;
+}
+
+/**
+ * Run journalctl and return its stdout. Returns empty string if the
+ * command is unavailable (e.g., macOS dev machines) or fails.
+ */
+export function collectJournalOutput(sinceHours = 2): string {
+  try {
+    return execSync(
+      `journalctl --user -u "chitin-*" --since "${sinceHours} hours ago" -o short --no-pager`,
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Convert a `SystemdUnitFailureEvent` to a human-readable alarm string
+ * compatible with the rollup-alarm pipeline (dedup + backlog filing).
+ * Invariant: two failures of the SAME unit with ANY status code collapse
+ * to the same `alarmSignature` — one backlog entry per unit, not per event.
+ */
+export function systemdFailureToAlarm(ev: SystemdUnitFailureEvent): string {
+  return `SYSTEMD UNIT FAILURE ${ev.unit}: exited with status=${ev.status_code} at ${ev.failure_ts}`;
 }
 
 interface RollupShape {
@@ -163,9 +253,26 @@ export async function runAlarmFeeder(
 ): Promise<AlarmFeederResult> {
   const log = opts.log ?? ((l: string) => console.log(l));
 
+  // ── Rollup alarms ───────────────────────────────────────────────────
   const rollup = readLatestRollup(opts.rollupsDir);
-  const alarms = rollup?.alarms ?? [];
+  const rollupAlarms = rollup?.alarms ?? [];
 
+  // ── Systemd journal scan ────────────────────────────────────────────
+  const journalText =
+    opts.journalOutput !== undefined ? opts.journalOutput : collectJournalOutput();
+  const unitFailures = parseJournalForUnitFailures(journalText);
+
+  // Emit a structured chain alarm event for each detected unit failure so
+  // downstream consumers (slack-feeder, log processors) can route on it.
+  for (const ev of unitFailures) {
+    log(JSON.stringify({ ts: new Date().toISOString(), component: 'alarm-feeder', ...ev }));
+  }
+
+  // Convert unit failures to alarm strings and merge with rollup alarms.
+  const systemdAlarms = unitFailures.map(systemdFailureToAlarm);
+  const alarms = [...rollupAlarms, ...systemdAlarms];
+
+  // ── Backlog dedup + filing ──────────────────────────────────────────
   const backlog = await readFile(opts.backlogPath, 'utf8').catch(() => '');
   const knownIds = parseBacklogIds(backlog);
 
@@ -196,6 +303,7 @@ export async function runAlarmFeeder(
     new_entries: newEntries,
     duplicates_skipped,
     rollup_present: rollup !== undefined,
+    systemd_failures: unitFailures.length,
   };
 
   log(
@@ -244,4 +352,6 @@ if (isMain) {
 export const __test__ = {
   BACKLOG_ID_RE,
   DEFAULT_CAP,
+  FAILURE_STATUS_RE,
+  UNIT_FROM_LINE_RE,
 };

--- a/apps/temporal-worker/test/alarm-feeder.test.ts
+++ b/apps/temporal-worker/test/alarm-feeder.test.ts
@@ -328,6 +328,16 @@ describe('parseJournalForUnitFailures', () => {
     const out = [HEALTHY_JOURNAL_LINE, CHDIR_JOURNAL_LINE, HEALTHY_JOURNAL_LINE].join('\n');
     expect(parseJournalForUnitFailures(out)).toHaveLength(1);
   });
+
+  it("returns deterministic 'unknown' failure_ts when journal line has no timestamp", () => {
+    // Pre-2026-05-04 fallback was new Date().toISOString() — non-deterministic
+    // and broke the function's "pure" claim. Stable sentinel makes this
+    // test-able and safe to compare across runs.
+    const lineWithoutTs = 'host systemd[1234]: chitin-swarm-worker.service: Main process exited, code=exited, status=200/CHDIR';
+    const events = parseJournalForUnitFailures(lineWithoutTs);
+    expect(events).toHaveLength(1);
+    expect(events[0].failure_ts).toBe('unknown');
+  });
 });
 
 // ─── systemdFailureToAlarm ───────────────────────────────────────────────

--- a/apps/temporal-worker/test/alarm-feeder.test.ts
+++ b/apps/temporal-worker/test/alarm-feeder.test.ts
@@ -7,9 +7,11 @@ import {
   alarmSignature,
   appendBacklogEntry,
   parseBacklogIds,
+  parseJournalForUnitFailures,
   readLatestRollup,
   renderAlarmEntry,
   runAlarmFeeder,
+  systemdFailureToAlarm,
 } from '../src/alarm-feeder.ts';
 
 // ─── alarmSignature ──────────────────────────────────────────────────────
@@ -263,5 +265,206 @@ describe('appendBacklogEntry', () => {
     expect(out).toContain('existing');
     expect(out).toContain('new');
     expect(out.indexOf('new')).toBeGreaterThan(out.indexOf('existing'));
+  });
+});
+
+// ─── parseJournalForUnitFailures ─────────────────────────────────────────
+
+// Synthetic journal fixture: one CHDIR failure on a chitin-* unit.
+const CHDIR_JOURNAL_LINE =
+  'May  4 10:23:45 host systemd[1234]: chitin-swarm-worker.service: Main process exited, code=exited, status=200/CHDIR';
+
+// Synthetic journal fixture: one EXEC failure on a chitin-* unit.
+const EXEC_JOURNAL_LINE =
+  'May  4 10:24:01 host systemd[1234]: chitin-dispatcher.service: Failed to execute command: status=203/EXEC';
+
+// Synthetic healthy exit — must never match.
+const HEALTHY_JOURNAL_LINE =
+  'May  4 10:22:00 host systemd[1234]: chitin-swarm-rollup.service: Succeeded.';
+
+// Non-chitin failure — must never match.
+const OTHER_UNIT_LINE =
+  'May  4 10:22:10 host systemd[1234]: postgresql.service: Main process exited, code=exited, status=200/CHDIR';
+
+describe('parseJournalForUnitFailures', () => {
+  it("returns exactly one event for a single CHDIR failure line", () => {
+    const events = parseJournalForUnitFailures(CHDIR_JOURNAL_LINE);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('systemd-unit-failure');
+    expect(events[0].unit).toBe('chitin-swarm-worker.service');
+    expect(events[0].status_code).toBe('200/CHDIR');
+    expect(events[0].failure_ts).toBe('May  4 10:23:45');
+  });
+
+  it("returns exactly one event for a single EXEC failure line", () => {
+    const events = parseJournalForUnitFailures(EXEC_JOURNAL_LINE);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('systemd-unit-failure');
+    expect(events[0].unit).toBe('chitin-dispatcher.service');
+    expect(events[0].status_code).toBe('203/EXEC');
+  });
+
+  it("returns zero events for a healthy status=0/SUCCESS exit (no false positives)", () => {
+    expect(parseJournalForUnitFailures(HEALTHY_JOURNAL_LINE)).toHaveLength(0);
+  });
+
+  it("returns zero events for a non-chitin unit with CHDIR status", () => {
+    expect(parseJournalForUnitFailures(OTHER_UNIT_LINE)).toHaveLength(0);
+  });
+
+  it("returns zero events for empty input", () => {
+    expect(parseJournalForUnitFailures('')).toHaveLength(0);
+  });
+
+  it("returns two events for two distinct failure lines", () => {
+    const out = [CHDIR_JOURNAL_LINE, EXEC_JOURNAL_LINE].join('\n');
+    const events = parseJournalForUnitFailures(out);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.unit)).toContain('chitin-swarm-worker.service');
+    expect(events.map((e) => e.unit)).toContain('chitin-dispatcher.service');
+  });
+
+  it("ignores healthy lines interspersed between failure lines", () => {
+    const out = [HEALTHY_JOURNAL_LINE, CHDIR_JOURNAL_LINE, HEALTHY_JOURNAL_LINE].join('\n');
+    expect(parseJournalForUnitFailures(out)).toHaveLength(1);
+  });
+});
+
+// ─── systemdFailureToAlarm ───────────────────────────────────────────────
+
+describe('systemdFailureToAlarm', () => {
+  it("encodes unit name and status code in the alarm string", () => {
+    const ev = parseJournalForUnitFailures(CHDIR_JOURNAL_LINE)[0];
+    const alarm = systemdFailureToAlarm(ev);
+    expect(alarm).toContain('chitin-swarm-worker.service');
+    expect(alarm).toContain('200/CHDIR');
+  });
+
+  it("produces a stable alarmSignature keyed on unit name (not the timestamp)", () => {
+    const ev1 = parseJournalForUnitFailures(CHDIR_JOURNAL_LINE)[0];
+    const ev2 = { ...ev1, failure_ts: 'May  5 09:00:00' };
+    expect(alarmSignature(systemdFailureToAlarm(ev1))).toBe(
+      alarmSignature(systemdFailureToAlarm(ev2)),
+    );
+  });
+});
+
+// ─── runAlarmFeeder systemd integration ─────────────────────────────────
+
+describe('runAlarmFeeder — systemd journal scanning', () => {
+  let scratch: string;
+  let backlogPath: string;
+  let rollupsDir: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'alarm-feeder-systemd-test-'));
+    rollupsDir = join(scratch, 'rollups');
+    backlogPath = join(scratch, 'swarm-backlog.md');
+    logs = [];
+    writeFileSync(backlogPath, '# Swarm Backlog\n\n## Entries\n\n', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("emits one chain alarm event and one backlog entry for a single CHDIR failure", async () => {
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-04T10:23:45Z',
+      log: (l) => logs.push(l),
+      journalOutput: CHDIR_JOURNAL_LINE,
+    });
+
+    // Exactly one systemd failure detected.
+    expect(r.systemd_failures).toBe(1);
+
+    // A chain alarm event was emitted (kind=systemd-unit-failure).
+    const alarmEvent = logs
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .find((o) => o['kind'] === 'systemd-unit-failure');
+    expect(alarmEvent).toBeDefined();
+    expect(alarmEvent!['unit']).toBe('chitin-swarm-worker.service');
+    expect(alarmEvent!['status_code']).toBe('200/CHDIR');
+
+    // One backlog entry was filed.
+    expect(r.new_entries).toBe(1);
+    const md = readFileSync(backlogPath, 'utf8');
+    expect(md).toContain('investigate-systemd-unit-failure');
+    expect(md).toContain('role: analyst');
+  });
+
+  it("does not create backlog entries for healthy journal output (no false positives)", async () => {
+    const healthyJournal = [
+      'May  4 10:22:00 host systemd[1234]: chitin-swarm-rollup.service: Succeeded.',
+      'May  4 10:22:01 host systemd[1234]: chitin-swarm-rollup.timer: Succeeded.',
+    ].join('\n');
+
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-04T10:23:45Z',
+      log: (l) => logs.push(l),
+      journalOutput: healthyJournal,
+    });
+
+    expect(r.systemd_failures).toBe(0);
+    expect(r.new_entries).toBe(0);
+  });
+
+  it("dedups systemd failures against existing backlog entries", async () => {
+    // Pre-file an entry that matches the CHDIR alarm signature.
+    const existingId = alarmEntryId(
+      alarmSignature(
+        systemdFailureToAlarm({
+          kind: 'systemd-unit-failure',
+          unit: 'chitin-swarm-worker.service',
+          status_code: '200/CHDIR',
+          failure_ts: 'May  4 10:23:45',
+        }),
+      ),
+    );
+    writeFileSync(backlogPath, `# Backlog\n\n### \`${existingId}\`\n\nalready filed\n`, 'utf8');
+
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 5,
+      now: '2026-05-04T10:23:45Z',
+      log: (l) => logs.push(l),
+      journalOutput: CHDIR_JOURNAL_LINE,
+    });
+
+    expect(r.systemd_failures).toBe(1);
+    expect(r.new_entries).toBe(0);
+    expect(r.duplicates_skipped).toBe(1);
+  });
+
+  it("combines rollup alarms and systemd failures; cap applies across both", async () => {
+    const fs = require('node:fs') as typeof import('node:fs');
+    fs.mkdirSync(rollupsDir, { recursive: true });
+    writeFileSync(
+      join(rollupsDir, '2026-05-04.json'),
+      JSON.stringify({ alarms: ['BUCKET-B REGRESSION: 1/19 contaminated'] }),
+      'utf8',
+    );
+
+    const r = await runAlarmFeeder({
+      rollupsDir,
+      backlogPath,
+      cap: 1,
+      now: '2026-05-04T10:23:45Z',
+      log: (l) => logs.push(l),
+      journalOutput: CHDIR_JOURNAL_LINE,
+    });
+
+    // Cap=1: only the first alarm (rollup) gets a backlog entry.
+    expect(r.new_entries).toBe(1);
+    expect(r.total_alarms).toBe(2);
+    expect(r.systemd_failures).toBe(1);
   });
 });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `alarm-on-systemd-chdir-failures`
Tier: `T3`  •  Driver: `claude-code-headless`
Workflow: `swarm-alarm-on-systemd-chdir-failures-1777911075849`

## Entry context

The 2026-05-04 cwd-rm incident left `journalctl --user -u chitin-*`
showing `code=exited, status=200/CHDIR` for ~3h before the operator
noticed. The signal was loud and machine-readable; nothing was
listening.

Extend `chitin-alarm-feeder` to scan recent journal output for any
`status=200/CHDIR` or `status=203/EXEC` failure on a `chitin-*`
unit and surface it as a chain alarm event (so the slack-feeder
or any downstream consumer can route it).

**Acceptance:**
- [ ] alarm-feeder detects 200/CHDIR + 203/EXEC on chitin-* units
- [ ] Detection emits a chain event with kind=`systemd-unit-failure`
      and the unit name, status code, and failure timestamp
- [ ] Test fixture: synthetic journal output containing one CHDIR
      failure produces exactly one chain alarm event
- [ ] No false positives on healthy `Type=oneshot` units that exit
      cleanly with `status=0/SUCCESS`


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-alarm-on-systemd-chdir-failures-1777911075849`
Branch: `swarm/swarm-alarm-on-systemd-chdir-failures-1777911075849`
Head: `4256950c`
Diff: `3 files changed, 333 insertions(+), 11 deletions(-)`
Commits: 2 (+ auto-committed uncommitted state)