### PR TITLE
swarm: cleanup-ownership-allowlist

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -696,8 +696,21 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     // Tempdir-only cleanup. Reviewer mode runs in repoRoot directly
     // (write_policy:'none' guarantees read-only); rm-ing it nukes the
     // monorepo checkout. Worktree mode is owned by the apply-step.
-    if (!useWorktree && workDir !== repoRoot) {
+    if (!useWorktree && isWorkerOwnedPath(workDir)) {
       rmSync(workDir, { recursive: true, force: true });
+    } else if (!useWorktree && workDir !== repoRoot) {
+      console.warn(`[cleanup] Skipped rmSync on non-owned path: ${workDir}`);
+    }
+
+    /**
+     * Returns true if the given path is unambiguously owned by the worker:
+     * - Starts with os.tmpdir() (tempdir mode)
+     * - Starts with SWARM_WORKTREES_ROOT (per-workflow worktree)
+     * Any other path is considered not owned and will not be removed.
+     */
+    function isWorkerOwnedPath(p: string): boolean {
+      const abs = resolve(p);
+      return abs.startsWith(resolve(tmpdir())) || abs.startsWith(SWARM_WORKTREES_ROOT);
     }
     // Slice 6b: per-workflow openclaw state dir is transient — clean it
     // up unconditionally regardless of activity success/failure. The user's

--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -1,7 +1,7 @@
 import { spawn, execFileSync } from 'node:child_process';
 import { mkdtempSync, copyFileSync, existsSync, readdirSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, relative, isAbsolute } from 'node:path';
 import type { ExecutionRequest, DriverId, Tier } from '@chitin/contracts';
 import type { ActivityResult, HookEventSummary, WorktreeResult } from './activity-types.ts';
 
@@ -35,6 +35,38 @@ const TAIL_BYTES = (() => {
 // Slice 5: where worktrees live when base_ref is set on the request. XDG
 // cache (transient, safe to delete). One sub-dir per workflow_id.
 const SWARM_WORKTREES_ROOT = resolve(homedir(), '.cache/chitin/swarm-worktrees');
+
+/**
+ * Returns true if the given path is unambiguously owned by the worker
+ * and therefore safe to `rmSync`-cleanup:
+ * - Strictly under `os.tmpdir()` (tempdir-mode worker dirs), OR
+ * - Strictly under `SWARM_WORKTREES_ROOT` (per-workflow worktrees).
+ *
+ * Strict containment matters: `startsWith(tmpdir())` raw would also
+ * match a sibling like `${tmpdir()}-backup`. We use `relative()` to
+ * verify the path is genuinely under the base, not just a prefix
+ * match.
+ *
+ * Edge case: when repoRoot itself sits under tmpdir() (test rigs,
+ * CI), the allowlist would match it. Reviewer mode runs in repoRoot
+ * directly (#280); the explicit `abs === repoRoot` short-circuit
+ * preserves the invariant that we never rm the repo checkout.
+ *
+ * Exported so tests can pin the contract without standing up a full
+ * activity context. See review-graph-dispatch.ts pattern.
+ */
+export function isWorkerOwnedPath(p: string, repoRoot: string): boolean {
+  const abs = resolve(p);
+  if (abs === resolve(repoRoot)) return false;
+  return isStrictlyUnder(abs, resolve(tmpdir())) || isStrictlyUnder(abs, SWARM_WORKTREES_ROOT);
+}
+
+function isStrictlyUnder(abs: string, base: string): boolean {
+  const rel = relative(base, abs);
+  // '' = same path; '..' / starts with '..' = outside base.
+  // Anything else = strictly under base.
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
 
 interface DriverInvocation {
   command: string;
@@ -696,21 +728,10 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     // Tempdir-only cleanup. Reviewer mode runs in repoRoot directly
     // (write_policy:'none' guarantees read-only); rm-ing it nukes the
     // monorepo checkout. Worktree mode is owned by the apply-step.
-    if (!useWorktree && isWorkerOwnedPath(workDir)) {
+    if (!useWorktree && isWorkerOwnedPath(workDir, repoRoot)) {
       rmSync(workDir, { recursive: true, force: true });
     } else if (!useWorktree && workDir !== repoRoot) {
       console.warn(`[cleanup] Skipped rmSync on non-owned path: ${workDir}`);
-    }
-
-    /**
-     * Returns true if the given path is unambiguously owned by the worker:
-     * - Starts with os.tmpdir() (tempdir mode)
-     * - Starts with SWARM_WORKTREES_ROOT (per-workflow worktree)
-     * Any other path is considered not owned and will not be removed.
-     */
-    function isWorkerOwnedPath(p: string): boolean {
-      const abs = resolve(p);
-      return abs.startsWith(resolve(tmpdir())) || abs.startsWith(SWARM_WORKTREES_ROOT);
     }
     // Slice 6b: per-workflow openclaw state dir is transient — clean it
     // up unconditionally regardless of activity success/failure. The user's

--- a/apps/temporal-worker/test/activity.test.ts
+++ b/apps/temporal-worker/test/activity.test.ts
@@ -3,7 +3,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ExecutionRequest } from '@chitin/contracts';
-import { __test__ } from '../src/activity.ts';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { __test__, isWorkerOwnedPath } from '../src/activity.ts';
 
 const { planInvocation, resolvePolicySrc, resolveAgent, DRIVER_AGENT_MAP } = __test__;
 
@@ -389,5 +391,62 @@ describe('parseToolSummary', () => {
       tools: ['x'],
       failures: 0,
     });
+  });
+});
+
+// ─── isWorkerOwnedPath ─────────────────────────────────────────────────────
+//
+// Cleanup-cleanup-rmSync gate. The 2026-05-04 cwd-rm incident (#280)
+// established the invariant: never rm a path the worker doesn't
+// unambiguously own. This test pins the contract so a future refactor
+// can't reintroduce the trap.
+
+describe('isWorkerOwnedPath', () => {
+  const repoRoot = '/home/red/workspace/chitin';
+  const swarmRoot = resolve(homedir(), '.cache/chitin/swarm-worktrees');
+
+  it('returns true for paths strictly under tmpdir()', () => {
+    expect(isWorkerOwnedPath('/tmp/chitin-worker-abc-xyz', repoRoot)).toBe(true);
+  });
+
+  it('returns true for paths strictly under SWARM_WORKTREES_ROOT', () => {
+    expect(isWorkerOwnedPath(`${swarmRoot}/wf-test-001`, repoRoot)).toBe(true);
+  });
+
+  it('returns false for repoRoot itself (reviewer mode)', () => {
+    // Reviewer dispatch sets workDir = repoRoot so `gh pr diff` works.
+    // The cleanup must never rm this — that's the #280 incident.
+    expect(isWorkerOwnedPath(repoRoot, repoRoot)).toBe(false);
+  });
+
+  it('returns false for sibling paths that share a prefix with tmpdir()', () => {
+    // The bug Copilot caught: raw startsWith('/tmp') would also match
+    // '/tmp-backup'. Strictly-under check rejects sibling-prefix paths.
+    expect(isWorkerOwnedPath('/tmp-backup/something', repoRoot)).toBe(false);
+  });
+
+  it('returns false for sibling paths that share a prefix with SWARM_WORKTREES_ROOT', () => {
+    expect(isWorkerOwnedPath(`${swarmRoot}-old/wf-x`, repoRoot)).toBe(false);
+  });
+
+  it('returns false for arbitrary paths outside both roots', () => {
+    expect(isWorkerOwnedPath('/etc', repoRoot)).toBe(false);
+    expect(isWorkerOwnedPath('/home/red/workspace', repoRoot)).toBe(false);
+    expect(isWorkerOwnedPath('/var/log/chitin.log', repoRoot)).toBe(false);
+  });
+
+  it('returns false when repoRoot itself is under tmpdir() (test rig edge case)', () => {
+    // CI / test environments sometimes check out the repo into a tempdir.
+    // The allowlist would normally match (path is under tmpdir), but the
+    // explicit repoRoot guard short-circuits to false. Reviewer mode is
+    // protected even on unusual rigs.
+    const repoUnderTmp = '/tmp/chitin-checkout';
+    expect(isWorkerOwnedPath(repoUnderTmp, repoUnderTmp)).toBe(false);
+  });
+
+  it('returns false for the empty path', () => {
+    // resolve('') returns cwd, which is unlikely to be under tmpdir or
+    // swarmRoot — but pin the behaviour so a regression is loud.
+    expect(isWorkerOwnedPath('', repoRoot)).toBe(false);
   });
 });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `cleanup-ownership-allowlist`
Tier: `T1`  •  Driver: `copilot`
Workflow: `swarm-cleanup-ownership-allowlist-1777911720549`

## Entry context

The fix in PR #280 guards the `rmSync(workDir)` cleanup with
`workDir !== repoRoot`. That protects the specific variable name
that bit us, but a future role that sets `workDir = someOtherSharedDir`
would re-introduce the trap. Replace the blacklist with an allowlist:
only rm paths the worker unambiguously owns (`tmpdir()` prefix or
`SWARM_WORKTREES_ROOT` prefix). Any other path → log + skip.

**Acceptance:**
- [ ] Cleanup rm is gated by an `isWorkerOwnedPath(p)` helper that
      returns true only for `tmpdir()` or `SWARM_WORKTREES_ROOT`
      prefixes
- [ ] Reviewer mode (workDir = repoRoot) and any future "run in $X"
      mode are protected without per-mode case statements
- [ ] Unit test covers: tempdir cleanup happens, repoRoot is never
      rm'd, `SWARM_WORKTREES_ROOT/<id>` cleanup paths still work,
      `/etc` (or other arbitrary) paths log + skip


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-cleanup-ownership-allowlist-1777911720549`
Branch: `swarm/swarm-cleanup-ownership-allowlist-1777911720549`
Head: `e6a3cc54`
Diff: `1 file changed, 14 insertions(+), 1 deletion(-)`
Commits: 1