### PR TITLE
swarm: shift-left routing reshuffle — every account in rotation

### DIFF
--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../libs/telemetry"
     },
     {
+      "path": "../../libs/scheduler"
+    },
+    {
       "path": "../../libs/contracts"
     }
   ]

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -7,5 +7,10 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../libs/mcp-chitin"
+    }
+  ]
 }

--- a/apps/openclaw-plugin-governance/test/subagent-gate.test.ts
+++ b/apps/openclaw-plugin-governance/test/subagent-gate.test.ts
@@ -20,9 +20,9 @@ describe('isClaudeCodeAgent (ToS denylist)', () => {
 
   it.each([
     'copilot',
-    'local-qwen',
-    'local-glm',
-    'local-deepseek',
+    'openclaw-glm-flash',
+    'openclaw-glm-cloud',
+    'openclaw-deepseek',
     'main',
     'qwen-agent',
     'claudia', // partial substring of "claude" only — must not match

--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -42,20 +42,23 @@ interface DriverInvocation {
   env?: Record<string, string>;
 }
 
-// Per-driver openclaw agent mapping (slice 3). Each local-* driver routes to
-// a distinct openclaw agent so reasoning and mechanical models can be
-// configured independently — the spec calls for qwen3-coder for mechanical
-// (local-qwen), glm-5.1:cloud for reasoning (local-glm), glm-4.7-flash for
-// local mechanical (local-glm-flash, added 2026-05-03 to replace copilot at
-// T0 once the model is hot on the 3090), deepseek for code (local-deepseek).
-// Override per driver via env var, e.g. CHITIN_AGENT_LOCAL_QWEN=my-agent.
-// Falls back to `main` if neither env var nor the default mapping resolves
-// the driver — `main` always exists.
+// Per-driver openclaw agent mapping. Each openclaw-* driver routes to a
+// distinct openclaw agent in ~/.openclaw/openclaw.json so each tier can
+// run its own model.
+//
+// 2026-05-04 rename: local-* → openclaw-*. The `local` prefix was
+// misleading — `local-glm` actually pointed at glm-5.1:cloud (Ollama
+// Cloud sub, not on-box). The new prefix is accurate: every entry here
+// dispatches through openclaw, model-residency is in the suffix
+// (-flash = 3090 on-box, -cloud = Ollama Cloud sub).
+//
+// Override per driver via env var, e.g. CHITIN_AGENT_OPENCLAW_GLM_FLASH=my-agent.
+// Falls back to `main` if neither env var nor the default mapping
+// resolves the driver — `main` always exists.
 const DRIVER_AGENT_MAP: Record<string, string> = {
-  'local-qwen': 'qwen-agent',
-  'local-glm': 'glm-agent',
-  'local-glm-flash': 'glm-flash-agent',
-  'local-deepseek': 'deepseek-agent',
+  'openclaw-glm-flash': 'glm-flash-agent',  // 3090: glm-4.7-flash:latest (~30B)
+  'openclaw-glm-cloud': 'glm-agent',        // Ollama Cloud sub: glm-5.1:cloud (opus-light)
+  'openclaw-deepseek': 'deepseek-agent',    // 3090: deepseek (kept; not in defaults)
 };
 
 function resolveAgent(driver: DriverId): string {
@@ -72,11 +75,27 @@ function resolveAgent(driver: DriverId): string {
 // a tighter scope (e.g., 'Read,Edit' only).
 const DEFAULT_CLAUDE_ALLOWED_TOOLS = 'Read,Edit,Write,Bash,Glob,Grep';
 
-// Slice 6c: tier → model maps per driver. T0/T1 use the cheap fast
-// models; T4 uses the strongest. Drivers that route via a per-agent
-// configured model (the local-* tier through openclaw) ignore the tier
-// — its model is set at agent-creation time, not per call. Override by
+// Tier → model maps per driver. Drivers that route via a per-agent
+// configured model (openclaw-* through openclaw) ignore the tier — its
+// model is set at agent-creation time, not per call. Override by
 // setting CHITIN_MODEL_<DRIVER>_<TIER> for tactical experimentation.
+//
+// 2026-05-04 rebalance, driven by Copilot Pro premium-request multipliers
+// the operator measured directly:
+//
+//   gpt-5-mini       0×    free, unlimited
+//   gpt-5.4-mini     0.33×
+//   claude-haiku-4-5 0.33×
+//   claude-sonnet-4-6 1×
+//   gpt-5.4          1×
+//   claude-opus-4-6  3×
+//   gpt-5.5          7.5×
+//
+// Rule on Copilot: never premium-tier-and-up by default (no sonnet, no
+// opus, no gpt-5.5). They burn the Pro premium-request budget too fast.
+// Default to gpt-5-mini for free/unlimited tiers; haiku-4-5 (0.33×) for
+// any tier that needs more reasoning. Anthropic models go via
+// claude-code-headless (Max plan) — never through Copilot.
 const CLAUDE_TIER_MODEL: Record<Tier, string> = {
   T0: 'claude-haiku-4-5',
   T1: 'claude-haiku-4-5',
@@ -85,18 +104,12 @@ const CLAUDE_TIER_MODEL: Record<Tier, string> = {
   T4: 'claude-opus-4-7',
 };
 
-// 2026-05-02: T2 bumped from haiku → sonnet on copilot. Pairs with the
-// dispatcher.ts T2 reroute (claude-code-headless → copilot) so the model
-// class is preserved (was claude-sonnet-4-6 via CCH, now claude-sonnet-4.6
-// via copilot — same family). Without this bump the reroute would silently
-// downgrade T2 reasoning to haiku. Cost is still $0 under the Copilot Pro
-// plan.
 const COPILOT_TIER_MODEL: Record<Tier, string> = {
-  T0: 'gpt-4.1',
-  T1: 'gpt-4.1',
-  T2: 'claude-sonnet-4.6',           // (was claude-haiku-4.5; bumped to preserve T2 reasoning quality)
-  T3: 'claude-sonnet-4.6',
-  T4: 'claude-opus-4.7',
+  T0: 'gpt-5-mini',                  // 0× free unlimited
+  T1: 'gpt-5-mini',                  // 0× free unlimited
+  T2: 'claude-haiku-4-5',            // 0.33× — bulk programmer (Copilot routes to haiku via Anthropic provider)
+  T3: 'claude-haiku-4-5',            // 0.33× — escalation cascade still cheap if T3 falls back to copilot
+  T4: 'claude-haiku-4-5',            // 0.33× — never opus (3×) or gpt-5.5 (7.5×) on Copilot
 };
 
 function envOverride(driverEnvKey: string, tier: Tier): string | undefined {
@@ -182,16 +195,31 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
         args,
       };
     }
-    case 'local-qwen':
-    case 'local-glm':
-    case 'local-glm-flash':
-    case 'local-deepseek':
+    case 'gemini': {
+      // Gemini CLI on Google AI Pro plan. PreToolUse hook is wired via
+      // ~/.gemini/settings.json BeforeTool — same wire shape as Claude
+      // Code's PreToolUse, just a renamed event. Model selection via -m;
+      // CHITIN_MODEL_GEMINI env override picks the per-call model
+      // (defaults to whatever ~/.gemini/settings.json picks if unset).
+      const args = ['-p', req.prompt];
+      const model = (process.env.CHITIN_MODEL_GEMINI ?? '').trim();
+      if (model) {
+        args.push('-m', model);
+      }
+      return {
+        command: 'gemini',
+        args,
+      };
+    }
+    case 'openclaw-glm-flash':
+    case 'openclaw-glm-cloud':
+    case 'openclaw-deepseek':
       // Dispatch through openclaw + chitin-governance plugin. The plugin
       // is loaded at openclaw startup (~/.openclaw/openclaw.json plugins.allow
       // includes "chitin-governance"); every tool call the local agent
       // dispatches passes through before_tool_call → chitin gate. The per-
-      // driver agent mapping (slice 3) routes to distinct openclaw agents so
-      // each local tier runs its own model.
+      // driver agent mapping routes to distinct openclaw agents so each
+      // tier runs its own model.
       return {
         command: 'openclaw',
         args: [
@@ -583,15 +611,15 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     if (req.allowed_drivers.includes('claude-code-headless')) {
       writeWorktreeClaudeSettings(worktreeInfo.path);
     }
-    // Slice 6b: openclaw-driven local-* drivers need the agent's workspace
-    // pointed at the worktree so the agent's read/edit tools see the right
-    // files. We provision a per-workflow OPENCLAW_STATE_DIR with a remapped
+    // openclaw-driven drivers need the agent's workspace pointed at
+    // the worktree so the agent's read/edit tools see the right files.
+    // We provision a per-workflow OPENCLAW_STATE_DIR with a remapped
     // openclaw.json instead of mutating the user's global config.
-    const localDriver = req.allowed_drivers.find((d) =>
-      d === 'local-qwen' || d === 'local-glm' || d === 'local-glm-flash' || d === 'local-deepseek',
+    const openclawDriver = req.allowed_drivers.find((d) =>
+      d === 'openclaw-glm-flash' || d === 'openclaw-glm-cloud' || d === 'openclaw-deepseek',
     );
-    if (localDriver) {
-      const agentId = resolveAgent(localDriver as DriverId);
+    if (openclawDriver) {
+      const agentId = resolveAgent(openclawDriver as DriverId);
       openclawState = provisionOpenclawState(req, worktreeInfo.path, agentId);
     }
   } else if (req.role === 'reviewer') {

--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -59,33 +59,45 @@ const TMP_DIR = resolve(process.cwd(), 'tmp');
 // marker to allow re-dispatch.
 const STATE_DIR = resolve(homedir(), '.cache/chitin/swarm-state/dispatched');
 
-// Tier → driver routing. The cheapest reliable driver capable of the
-// work. local-qwen is architecturally the right T0 driver (free, on-
-// the-3090, mechanical) but qwen3-coder:30b on this rig was unstable
-// (ollama stream crashes mid-generation; agent misinterprets relative
-// paths as absolute; scope drift onto files outside the entry). T0
-// routed to copilot through 2026-05-02. As of 2026-05-03, T0 routes
-// to local-glm-flash (glm-4.7-flash:latest, hot on the 3090, 32K
-// context, 19 GB on disk). Operator can revert to copilot via env
-// override CHITIN_TIER_DRIVER_T0=copilot if local model regresses.
+// Tier → driver routing. Goal: every flat-rate / free account in
+// rotation, Anthropic Max plan reserved for actual escalation.
 //
-// 2026-05-02: T2 temporarily routed to copilot. The overnight 2026-05-02
-// run produced 4/4 bucket-B contaminated PRs on T2/T3 claude-code-
-// headless (and 1/5 successes total). Root cause: the worker's
-// writeWorktreeClaudeSettings overwrites the worktree's
-// .claude/settings.json, and the apply step's "tracked diff" heuristic
-// auto-commits + ships the modification as task work whenever the
-// agent declined to commit real edits. The apply-step revert in
-// apply-workflow-result.revertWorktreeSettingsArtifact closes the
-// auto-commit path; once it's been live for a swarm cycle and the
-// rate stays at 0, flip T2 (and T3) back to claude-code-headless.
-// See docs/observations/2026-05-02-bucket-b-after-action.md.
+// 2026-05-04 reshuffle, driven by measured Copilot Pro premium-request
+// multipliers + the realization that each subscription has its own
+// independent rate-limit budget. Spreading T1-T3 across them prevents
+// any single sub from blowing through its quota.
+//
+//   T0 → openclaw-glm-flash     3090, glm-4.7-flash (~30B), free unlimited
+//   T1 → openclaw-glm-flash     3090, same model — exercises the GPU on
+//                                bulk simple-write work; cascades to copilot
+//                                free-tier (gpt-5-mini, 0×) on failure
+//   T2 → copilot                Copilot Pro, model defaults to claude-haiku-4-5
+//                                (0.33× — bulk, ~900/mo budget)
+//   T3 → openclaw-glm-cloud     Ollama Cloud sub, glm-5.1:cloud (opus-light);
+//                                heavy reasoning that doesn't need Anthropic
+//   T4 → claude-code-headless   Anthropic Max, opus-4-7 — escalation only
+//
+// Operator can override per-tier via CHITIN_TIER_DRIVER_T<N> env at
+// runtime without a code change. The autonomous swarm picks up the
+// new mapping on next dispatcher tick.
+//
+// Pre-2026-05-04 mapping had T2 and T3 on claude-code-headless directly,
+// which made the swarm's bulk programmer tier dependent on the metered
+// Anthropic plan. The reshuffle moves bulk to Copilot's haiku-4-5 (cheap-
+// multiplier) and shifts the GPU-resident glm-flash from T0-only to
+// T0+T1 so the 3090 actually does work.
+//
+// Historical bucket-B fix (2026-05-02): T2 routed to copilot to sidestep
+// the writeWorktreeClaudeSettings auto-commit issue. apply-workflow-result
+// .revertWorktreeSettingsArtifact closed that path; T2 remains on copilot
+// for the cost-multiplier reasons above. See docs/observations/
+// 2026-05-02-bucket-b-after-action.md.
 const TIER_DRIVER_DEFAULTS: Record<Tier, DriverId> = {
-  T0: 'local-glm-flash',             // glm-4.7-flash:latest on the 3090 via ollama
-  T1: 'copilot',                     // Copilot GPT-4.1 free
-  T2: 'copilot',                     // (was claude-code-headless — see comment above)
-  T3: 'claude-code-headless',        // claude-sonnet-4-6
-  T4: 'claude-code-headless',        // claude-opus-4-7
+  T0: 'openclaw-glm-flash',          // 3090: glm-4.7-flash:latest (~30B)
+  T1: 'openclaw-glm-flash',          // 3090: same model — bulk simple write on the GPU
+  T2: 'copilot',                     // Copilot Pro: claude-haiku-4-5 (0.33×) — bulk programmer
+  T3: 'openclaw-glm-cloud',          // Ollama Cloud sub: glm-5.1:cloud (opus-light) — heavy reasoning
+  T4: 'claude-code-headless',        // Anthropic Max: claude-opus-4-7 — escalation only
 };
 
 // Operator can override per-tier driver routing via env:
@@ -115,7 +127,7 @@ const TIER_DRIVER: Record<Tier, DriverId> = (Object.keys(TIER_DRIVER_DEFAULTS) a
 //
 // Slice 7-tuning history:
 //   180s (slice 7) — too short, even healthy runs hit it
-//   480s (first tuning) — productive for copilot but local-qwen still
+//   480s (first tuning) — productive for copilot but the small 30B local still
 //                         couldn't finish stable runs
 //   1200s/1800s (this tuning) — give complex T2+ work real room. The
 //                         SIGKILL fix means stuck = killed-at-budget,

--- a/apps/temporal-worker/src/grooming/prompt.ts
+++ b/apps/temporal-worker/src/grooming/prompt.ts
@@ -13,11 +13,11 @@ decide whether it's now ready for a tier to claim, and if not, propose what
 needs to change.
 
 ## Tier definitions
-- **T0** local-qwen (qwen3-coder:30b on 3090): mechanical, single-file, <100 LOC. Free, fast.
-- **T1** copilot (GPT-4.1 free or Haiku): moderate, multi-file, clear pattern.
-- **T2** local-glm (rate-limited) or copilot-mid: specialized reasoning. Use sparingly.
-- **T3** copilot (GPT-5.4): heavy, cross-cutting, architectural.
-- **T4** Claude Code interactive (with Jared): strategy, ambiguous scope, irreversible.
+- **T0** openclaw-glm-flash (glm-4.7-flash on 3090, ~30B): mechanical, single-file, <100 LOC. Free, fast.
+- **T1** openclaw-glm-flash (same 3090 model): moderate, multi-file, clear pattern. Free.
+- **T2** copilot (claude-haiku-4-5, 0.33× premium): bulk programmer tier. Cheap.
+- **T3** openclaw-glm-cloud (glm-5.1:cloud via Ollama Cloud sub): heavy reasoning, cross-cutting. Flat-rate.
+- **T4** claude-code-headless (claude-opus-4-7, Anthropic Max): escalation only — irreversible / strategic.
 
 ## Status meanings
 - **ready** — sized correctly, scope clear, claimable as-is.

--- a/apps/temporal-worker/src/review-graph.ts
+++ b/apps/temporal-worker/src/review-graph.ts
@@ -73,11 +73,19 @@ function envOrDefault(name: string, fallback: string | null): string | null {
 
 // Default tier→driver mapping (constant; no env reads, safe to
 // evaluate at module load in the workflow isolate).
+//
+// 2026-05-04 reshuffle, driven by Copilot Pro premium-request multipliers:
+//   R1: gpt-5-mini    (0× free, was gpt-4.1 also free; gpt-5-mini is newer)
+//   R2: haiku-4-5     (0.33× — was sonnet-4.6 at 1×; haiku is the bulk-reviewer
+//                       capability tier and 3× cheaper per dispatch)
+//   R3: opus-4-7      (Anthropic Max plan, unchanged — escalation only)
+//
+// Operator can override per-tier with CHITIN_REVIEWER_R<N>_{DRIVER,MODEL}.
 const REVIEW_TIER_DRIVER_DEFAULTS: Record<ReviewTier, { driver: string | null; model: string | null }> = {
   R0: { driver: null, model: null },                                          // GH bot, not dispatched
-  R1: { driver: 'copilot', model: 'gpt-4.1' },
-  R2: { driver: 'copilot', model: 'claude-sonnet-4.6' },
-  R3: { driver: 'claude-code-headless', model: 'claude-opus-4-7' },
+  R1: { driver: 'copilot', model: 'gpt-5-mini' },                             // 0× free
+  R2: { driver: 'copilot', model: 'claude-haiku-4-5' },                       // 0.33× — bulk reviewer
+  R3: { driver: 'claude-code-headless', model: 'claude-opus-4-7' },           // metered, escalation
   R4: { driver: null, model: null },                                          // operator, not dispatched
 };
 

--- a/apps/temporal-worker/src/router/types.ts
+++ b/apps/temporal-worker/src/router/types.ts
@@ -91,7 +91,7 @@ export interface RouterPolicy {
       | 'kernel_denied'
     >;
     chain: { max_depth: number; tier_steps: string[] };
-    /** Model id (e.g., 'claude-code-headless', 'gemini-cli', 'local-glm-flash'). */
+    /** Model id (e.g., 'claude-code-headless', 'gemini-cli', 'openclaw-glm-flash'). */
     model: string;
   };
 }

--- a/apps/temporal-worker/src/submit.ts
+++ b/apps/temporal-worker/src/submit.ts
@@ -23,7 +23,7 @@ async function main() {
     repo: 'chitinhq/chitin',
     task_class: 'exploration',
     risk_level: 'low',
-    allowed_drivers: [(process.env.DRIVER ?? 'copilot') as 'copilot' | 'local-qwen' | 'local-glm' | 'local-deepseek'],
+    allowed_drivers: [(process.env.DRIVER ?? 'copilot') as 'copilot' | 'openclaw-glm-flash' | 'openclaw-glm-cloud' | 'openclaw-deepseek'],
     network_policy: 'allowlist',
     write_policy: 'none',
     bounds: {

--- a/apps/temporal-worker/test/activity.test.ts
+++ b/apps/temporal-worker/test/activity.test.ts
@@ -28,8 +28,8 @@ describe('planInvocation', () => {
     expect(plan.args).toEqual(['drive', 'copilot', baseReq.prompt]);
   });
 
-  it('dispatches local-qwen through openclaw with the prompt and timeout', () => {
-    const plan = planInvocation({ ...baseReq, allowed_drivers: ['local-qwen'] });
+  it('dispatches openclaw-glm-flash through openclaw with the prompt and timeout', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['openclaw-glm-flash'] });
     expect(plan.command).toBe('openclaw');
     expect(plan.args).toContain('--message');
     expect(plan.args).toContain(baseReq.prompt);
@@ -37,21 +37,42 @@ describe('planInvocation', () => {
     expect(plan.args).toContain(String(baseReq.bounds.wall_timeout_s));
   });
 
-  it('dispatches local-glm and local-deepseek through openclaw (each to their own agent)', () => {
-    const glm = planInvocation({ ...baseReq, allowed_drivers: ['local-glm'] });
-    const ds = planInvocation({ ...baseReq, allowed_drivers: ['local-deepseek'] });
+  it('dispatches openclaw-glm-cloud and openclaw-deepseek through openclaw (each to its own agent)', () => {
+    const glm = planInvocation({ ...baseReq, allowed_drivers: ['openclaw-glm-cloud'] });
+    const ds = planInvocation({ ...baseReq, allowed_drivers: ['openclaw-deepseek'] });
     expect(glm.command).toBe('openclaw');
     expect(ds.command).toBe('openclaw');
-    // Slice 3: each driver goes to its own agent so models can differ.
+    // Each driver goes to its own openclaw agent so models can differ.
     expect(glm.args).toContain('glm-agent');
     expect(ds.args).toContain('deepseek-agent');
     expect(glm.args).not.toEqual(ds.args);
   });
 
-  it('routes local-qwen to qwen-agent (not main) post-slice-3', () => {
-    const plan = planInvocation({ ...baseReq, allowed_drivers: ['local-qwen'] });
-    expect(plan.args).toContain('qwen-agent');
+  it('routes openclaw-glm-flash to glm-flash-agent (not main)', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['openclaw-glm-flash'] });
+    expect(plan.args).toContain('glm-flash-agent');
     expect(plan.args).not.toContain('main');
+  });
+
+  it('dispatches gemini via the `gemini` CLI with -p prompt', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['gemini'] });
+    expect(plan.command).toBe('gemini');
+    expect(plan.args).toContain('-p');
+    expect(plan.args).toContain(baseReq.prompt);
+  });
+
+  it('gemini respects CHITIN_MODEL_GEMINI env override', () => {
+    const orig = process.env.CHITIN_MODEL_GEMINI;
+    try {
+      process.env.CHITIN_MODEL_GEMINI = 'gemini-3.0-pro';
+      const plan = planInvocation({ ...baseReq, allowed_drivers: ['gemini'] });
+      const idx = plan.args.indexOf('-m');
+      expect(idx).toBeGreaterThan(-1);
+      expect(plan.args[idx + 1]).toBe('gemini-3.0-pro');
+    } finally {
+      if (orig === undefined) delete process.env.CHITIN_MODEL_GEMINI;
+      else process.env.CHITIN_MODEL_GEMINI = orig;
+    }
   });
 
   it('dispatches codex via `codex exec --json` without --cd (req.repo is a slug, spawn cwd handles dir)', () => {
@@ -143,8 +164,8 @@ describe('planInvocation', () => {
     expect(plan.args).toContain('--include-hook-events');
   });
 
-  it('local-* (openclaw) drivers include --include-hook-events for chain visibility', () => {
-    for (const driver of ['local-qwen', 'local-glm', 'local-deepseek'] as const) {
+  it('openclaw-* drivers include --include-hook-events for chain visibility', () => {
+    for (const driver of ['openclaw-glm-flash', 'openclaw-glm-cloud', 'openclaw-deepseek'] as const) {
       const plan = planInvocation({ ...baseReq, allowed_drivers: [driver] });
       expect(plan.command).toBe('openclaw');
       expect(plan.args).toContain('--include-hook-events');
@@ -246,9 +267,9 @@ describe('resolvePolicySrc', () => {
 
 describe('resolveAgent', () => {
   const envKeys = [
-    'CHITIN_AGENT_LOCAL_QWEN',
-    'CHITIN_AGENT_LOCAL_GLM',
-    'CHITIN_AGENT_LOCAL_DEEPSEEK',
+    'CHITIN_AGENT_OPENCLAW_GLM_FLASH',
+    'CHITIN_AGENT_OPENCLAW_GLM_CLOUD',
+    'CHITIN_AGENT_OPENCLAW_DEEPSEEK',
     'CHITIN_AGENT_COPILOT',
   ];
   const saved: Record<string, string | undefined> = {};
@@ -267,10 +288,10 @@ describe('resolveAgent', () => {
     }
   });
 
-  it('routes each local-* driver to its dedicated agent by default', () => {
-    expect(resolveAgent('local-qwen')).toBe('qwen-agent');
-    expect(resolveAgent('local-glm')).toBe('glm-agent');
-    expect(resolveAgent('local-deepseek')).toBe('deepseek-agent');
+  it('routes each openclaw-* driver to its dedicated agent by default', () => {
+    expect(resolveAgent('openclaw-glm-flash')).toBe('glm-flash-agent');
+    expect(resolveAgent('openclaw-glm-cloud')).toBe('glm-agent');
+    expect(resolveAgent('openclaw-deepseek')).toBe('deepseek-agent');
   });
 
   it('falls back to main for any driver not in the map', () => {
@@ -281,34 +302,34 @@ describe('resolveAgent', () => {
     expect(resolveAgent('copilot')).toBe('main');
   });
 
-  it('honors CHITIN_AGENT_LOCAL_QWEN env override', () => {
-    process.env.CHITIN_AGENT_LOCAL_QWEN = 'custom-qwen-agent';
-    expect(resolveAgent('local-qwen')).toBe('custom-qwen-agent');
+  it('honors CHITIN_AGENT_OPENCLAW_GLM_FLASH env override', () => {
+    process.env.CHITIN_AGENT_OPENCLAW_GLM_FLASH = 'custom-flash-agent';
+    expect(resolveAgent('openclaw-glm-flash')).toBe('custom-flash-agent');
   });
 
   it('treats whitespace-only env override as unset', () => {
-    process.env.CHITIN_AGENT_LOCAL_QWEN = '   ';
-    expect(resolveAgent('local-qwen')).toBe('qwen-agent');
+    process.env.CHITIN_AGENT_OPENCLAW_GLM_FLASH = '   ';
+    expect(resolveAgent('openclaw-glm-flash')).toBe('glm-flash-agent');
   });
 
   it('trims env override value', () => {
-    process.env.CHITIN_AGENT_LOCAL_QWEN = '  trimmed-agent  ';
-    expect(resolveAgent('local-qwen')).toBe('trimmed-agent');
+    process.env.CHITIN_AGENT_OPENCLAW_GLM_FLASH = '  trimmed-agent  ';
+    expect(resolveAgent('openclaw-glm-flash')).toBe('trimmed-agent');
   });
 
-  it('does not return the same agent for different local-* drivers (no model collision)', () => {
+  it('does not return the same agent for different openclaw-* drivers (no model collision)', () => {
     const agents = new Set([
-      resolveAgent('local-qwen'),
-      resolveAgent('local-glm'),
-      resolveAgent('local-deepseek'),
+      resolveAgent('openclaw-glm-flash'),
+      resolveAgent('openclaw-glm-cloud'),
+      resolveAgent('openclaw-deepseek'),
     ]);
     expect(agents.size).toBe(3);
   });
 
   it('exports DRIVER_AGENT_MAP with the expected default routes', () => {
-    expect(DRIVER_AGENT_MAP['local-qwen']).toBe('qwen-agent');
-    expect(DRIVER_AGENT_MAP['local-glm']).toBe('glm-agent');
-    expect(DRIVER_AGENT_MAP['local-deepseek']).toBe('deepseek-agent');
+    expect(DRIVER_AGENT_MAP['openclaw-glm-flash']).toBe('glm-flash-agent');
+    expect(DRIVER_AGENT_MAP['openclaw-glm-cloud']).toBe('glm-agent');
+    expect(DRIVER_AGENT_MAP['openclaw-deepseek']).toBe('deepseek-agent');
   });
 });
 

--- a/apps/temporal-worker/test/slice6.test.ts
+++ b/apps/temporal-worker/test/slice6.test.ts
@@ -76,10 +76,16 @@ describe('slice 6c — tier → model resolution', () => {
     expect(resolveClaudeModel('T4' as Tier)).toBe('claude-opus-4-7'); // unaffected
   });
 
-  it('resolveCopilotModel maps T0/T1 to free GPT-4.1 and T4 to opus', () => {
-    expect(resolveCopilotModel('T0' as Tier)).toBe('gpt-4.1');
-    expect(resolveCopilotModel('T1' as Tier)).toBe('gpt-4.1');
-    expect(resolveCopilotModel('T4' as Tier)).toBe('claude-opus-4.7');
+  it('resolveCopilotModel maps T0/T1 to free gpt-5-mini and T2-T4 to haiku-4-5 (cheap multipliers)', () => {
+    // 2026-05-04 reshuffle: Copilot bulk tier defaults bound by premium-
+    // request multipliers measured by the operator. gpt-5-mini = 0× free
+    // unlimited; haiku-4-5 = 0.33× cheap. Sonnet (1×) and Opus (3×) are
+    // never default — operator opts in via env override only.
+    expect(resolveCopilotModel('T0' as Tier)).toBe('gpt-5-mini');
+    expect(resolveCopilotModel('T1' as Tier)).toBe('gpt-5-mini');
+    expect(resolveCopilotModel('T2' as Tier)).toBe('claude-haiku-4-5');
+    expect(resolveCopilotModel('T3' as Tier)).toBe('claude-haiku-4-5');
+    expect(resolveCopilotModel('T4' as Tier)).toBe('claude-haiku-4-5');
   });
 
   it('resolveCopilotModel honors per-tier env override', () => {
@@ -112,7 +118,7 @@ describe('slice 6c — planInvocation tier wiring', () => {
     expect(planT4.args[planT4.args.indexOf('--model') + 1]).toBe('claude-opus-4-7');
   });
 
-  it('copilot without tier omits --model (driver default = gpt-4.1)', () => {
+  it('copilot without tier omits --model (Copilot CLI picks its own default)', () => {
     const plan = planInvocation({ ...baseReq, allowed_drivers: ['copilot'] });
     expect(plan.args).not.toContain('--model');
   });
@@ -120,10 +126,11 @@ describe('slice 6c — planInvocation tier wiring', () => {
   it('copilot with tier appends --model into the chitin-kernel shim args', () => {
     const planT2 = planInvocation({ ...baseReq, allowed_drivers: ['copilot'], tier: 'T2' as Tier });
     expect(planT2.args).toContain('--model');
-    // 2026-05-02: T2 copilot model bumped to claude-sonnet-4.6 to preserve
-    // T2 reasoning quality after the dispatcher reroute (TIER_DRIVER[T2]
-    // changed from claude-code-headless → copilot in PR #123).
-    expect(planT2.args[planT2.args.indexOf('--model') + 1]).toBe('claude-sonnet-4.6');
+    // 2026-05-04 reshuffle: T2 Copilot model defaults to claude-haiku-4-5
+    // (0.33× premium multiplier — the cheap-bulk reviewer/programmer tier).
+    // Pre-2026-05-04 this was claude-sonnet-4.6 (1×) which burned the Pro
+    // premium-request budget too aggressively for the bulk tier.
+    expect(planT2.args[planT2.args.indexOf('--model') + 1]).toBe('claude-haiku-4-5');
   });
 });
 
@@ -220,13 +227,13 @@ describe('slice 6b — provisionOpenclawState', () => {
 
   it('returns null when no openclaw.json exists in $HOME/.openclaw', () => {
     rmSync(join(fakeOpenclaw, 'openclaw.json'));
-    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const req = { ...baseReq, allowed_drivers: ['openclaw-glm-flash'] as const };
     const result = provisionOpenclawState(req, scratch, 'qwen-agent');
     expect(result).toBeNull();
   });
 
   it('writes a state dir with openclaw.json that remaps the named agent workspace', () => {
-    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const req = { ...baseReq, allowed_drivers: ['openclaw-glm-flash'] as const };
     const result = provisionOpenclawState(req, scratch, 'qwen-agent');
     expect(result).not.toBeNull();
     expect(result!.envOverride.OPENCLAW_STATE_DIR).toBe(result!.stateDir);
@@ -240,7 +247,7 @@ describe('slice 6b — provisionOpenclawState', () => {
   });
 
   it('symlinks state-dir contents (excluding openclaw.json) so plugins/agents are reachable', () => {
-    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const req = { ...baseReq, allowed_drivers: ['openclaw-glm-flash'] as const };
     const result = provisionOpenclawState(req, scratch, 'qwen-agent');
     expect(result).not.toBeNull();
     expect(existsSync(join(result!.stateDir, 'agents'))).toBe(true);
@@ -250,7 +257,7 @@ describe('slice 6b — provisionOpenclawState', () => {
   });
 
   it("does not mutate the user's source openclaw.json", () => {
-    const req = { ...baseReq, allowed_drivers: ['local-qwen'] as const };
+    const req = { ...baseReq, allowed_drivers: ['openclaw-glm-flash'] as const };
     const before = readFileSync(join(fakeOpenclaw, 'openclaw.json'), 'utf8');
     const result = provisionOpenclawState(req, scratch, 'qwen-agent');
     const after = readFileSync(join(fakeOpenclaw, 'openclaw.json'), 'utf8');

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -104,15 +104,27 @@ The dispatcher's invariants:
 - **T5 entries are never dispatched** — those are human-only
   (governance changes, irreversible decisions, ambiguous strategy).
 
-## Tier → driver routing (slice 7c)
+## Tier → driver routing (2026-05-04 reshuffle)
 
-| Tier | Driver | Wall timeout | Cost |
-|------|--------|--------------|------|
-| T0 | `local-qwen` (qwen3-coder:30b) | 180s | $0 (local) |
-| T1 | `copilot` (GPT-4.1 free) | 240s | $0 |
-| T2 | `claude-code-headless` (haiku) | 360s | low |
-| T3 | `claude-code-headless` (sonnet) | 600s | medium |
-| T4 | `claude-code-headless` (opus) | 600s | high |
+| Tier | Driver | Model | Wall timeout | Account / cost |
+|------|--------|-------|--------------|----------------|
+| T0 | `openclaw-glm-flash` | glm-4.7-flash:latest (~30B on 3090) | 180s | free, unlimited |
+| T1 | `openclaw-glm-flash` | same | 240s | free, unlimited |
+| T2 | `copilot` | claude-haiku-4-5 (0.33× premium-multiplier) | 360s | Copilot Pro flat |
+| T3 | `openclaw-glm-cloud` | glm-5.1:cloud (opus-light) | 600s | Ollama Cloud sub flat |
+| T4 | `claude-code-headless` | claude-opus-4-7 | 600s | Anthropic Max metered (rare escalation) |
+
+| Reviewer | Driver | Model | Account |
+|----------|--------|-------|---------|
+| R1 | `copilot` | gpt-5-mini | Copilot Pro 0× free |
+| R2 | `copilot` | claude-haiku-4-5 | Copilot Pro 0.33× |
+| R3 | `claude-code-headless` | claude-opus-4-7 | Anthropic Max |
+
+Operator overrides:
+- `CHITIN_TIER_DRIVER_T<N>=<driver>` flips a tier at runtime, no code change.
+- `CHITIN_REVIEWER_R<N>_DRIVER=<driver>` and `CHITIN_REVIEWER_R<N>_MODEL=<model>` for reviewer overrides.
+- `CHITIN_MODEL_<DRIVER>_<TIER>=<model>` for per-(driver,tier) model picks.
+- `CHITIN_AGENT_OPENCLAW_GLM_FLASH=<agent-id>` etc. for openclaw agent remapping.
 
 ## Failure modes
 

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -52,36 +52,51 @@ export const RoleSchema = z.enum([
   'debt-curator',       // Maintain debt-ledger; surface debt that blocks other work
 ]);
 
-// Driver tiers for the swarm. The 2026-04-30 framing that excluded
-// `claude-code` was based on a misread of Anthropic's terms — verified
-// 2026-05-02 against code.claude.com/docs/en/headless that headless mode
-// (`claude -p ... --dangerously-skip-permissions`) is officially supported
-// for unattended/CI/cron use. The interactive CLI surface is a separate
-// thing and not represented in this enum (you don't programmatically
-// dispatch interactive sessions; they're always Jared-driven).
+// Driver tiers for the swarm.
 //
-// claude-code-headless joins as the strongest programmatic tier (T4 in
-// swarm-backlog.md), distinct from `copilot` (T1-T3 depending on Copilot
-// model) and the local-* drivers (T0/T2).
+// 2026-05-04 rename: the `local-*` driver IDs were misleading (the
+// "local" prefix grouped both 3090-resident models AND ollama-cloud
+// subscription models under one bucket; `local-glm` actually pointed
+// at `glm-5.1:cloud`, fully cloud-resident). The `openclaw-*` prefix
+// is accurate: every entry in this group dispatches through openclaw,
+// and the model-residency dimension lives in the model name suffix
+// (`-flash` = 3090, `-cloud` = Ollama Cloud sub).
+//
+// Drivers grouped by dispatch path:
+//
+// 1. Direct CLI: `copilot`, `claude-code-headless`, `codex`, `gemini`.
+//    Each spawns the vendor CLI (chitin-kernel drive copilot, claude,
+//    codex, gemini) and gates per-tool-call via PreToolUse hooks. Model
+//    selection is per-call via `--model` flag.
+//
+// 2. Via openclaw plugin: `openclaw-glm-flash` (3090 local, glm-4.7-flash),
+//    `openclaw-glm-cloud` (Ollama Cloud, glm-5.1:cloud), `openclaw-deepseek`
+//    (3090). Each routes to a distinct openclaw agent so the per-agent
+//    model config in ~/.openclaw/openclaw.json is the source of truth.
+//    Governance via the chitin-governance plugin's before_tool_call hook.
+//
+// `local-qwen` was dropped 2026-05-04 — the swarm's qwen-agent path
+// produced low-quality output relative to glm-flash and consumed 3090
+// capacity that's better used by openclaw-glm-flash. The qwen3-coder
+// model files are still on disk; nothing dispatches to them by default.
 export const DriverIdSchema = z.enum([
   'copilot',
   'claude-code-headless',
   // `codex` = OpenAI Codex CLI (codex exec --json). Used as an
   // alternative reviewer in REVIEW_TIER_DRIVER — gives the
-  // review-graph a non-Anthropic reasoning lens. No PreToolUse
-  // hook; governance is post-hoc via codex_mine ingest + the
-  // chitin-budget usage feed (5h/1w rate-limit visibility).
+  // review-graph a non-Anthropic reasoning lens. PreToolUse hook
+  // is wired (codex 0.128.0+, byte-compatible with Claude Code's
+  // hook protocol — verified 2026-05-04).
   'codex',
-  'local-qwen',
-  // `local-glm` historically routed to glm-5.1:cloud for reasoning
-  // delegation; kept for that role. `local-glm-flash` is the local
-  // mechanical-tier variant added 2026-05-03 — glm-4.7-flash:latest
-  // on the 3090, T0 default. Distinct driver because the cost/latency
-  // profile is fundamentally different (flash = local + fast,
-  // glm-5.1 = cloud + slower + smarter).
-  'local-glm',
-  'local-glm-flash',
-  'local-deepseek',
+  // `gemini` = Gemini CLI on Google AI Pro plan. PreToolUse hook
+  // is wired via ~/.gemini/settings.json BeforeTool (same wire shape
+  // as Claude Code, just a renamed event).
+  'gemini',
+  // openclaw-* dispatch through openclaw + chitin-governance plugin.
+  // The plugin gates each tool call before execution.
+  'openclaw-glm-flash',  // 3090: glm-4.7-flash:latest (~30B)
+  'openclaw-glm-cloud',  // Ollama Cloud sub: glm-5.1:cloud (opus-light)
+  'openclaw-deepseek',   // 3090: deepseek (kept for future use, not in defaults)
 ]);
 
 export const NetworkPolicySchema = z.enum(['none', 'allowlist', 'open']);

--- a/tools/lint/tsconfig.json
+++ b/tools/lint/tsconfig.json
@@ -7,5 +7,10 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["*.ts", "tests/**/*.ts"]
+  "include": ["*.ts", "tests/**/*.ts"],
+  "references": [
+    {
+      "path": "../../libs/contracts"
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,15 @@
     },
     {
       "path": "./libs/governance"
+    },
+    {
+      "path": "./apps/mcp-server"
+    },
+    {
+      "path": "./apps/slack-app"
+    },
+    {
+      "path": "./tools/lint"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 1 of the routing-as-learning-system overhaul (per the 2026-05-04 design discussion + project memory). Static-config part only — ELO/learning phases are filed as P2-P5 backlog entries.

**Goal**: every flat-rate account does work; the 3090 stays busy; Anthropic Max is reserved for actual escalation rather than bulk.

## Driver renames

| Was | Is | Why |
|-----|-----|-----|
| `local-glm-flash` | `openclaw-glm-flash` | 3090: glm-4.7-flash (~30B) |
| `local-glm` | `openclaw-glm-cloud` | Ollama Cloud sub: glm-5.1:cloud (was misnamed — never was "local") |
| `local-deepseek` | `openclaw-deepseek` | 3090, kept but not in defaults |
| `local-qwen` | DROPPED | 3090 capacity better used by glm-flash |

Plus new `gemini` case in `planInvocation` for Google AI Pro plan.

## Tier reshuffle

| Tier | Driver | Model | Account |
|------|--------|-------|---------|
| T0 | `openclaw-glm-flash` | glm-4.7-flash | 3090 free |
| T1 | `openclaw-glm-flash` | (same) | 3090 free ← was copilot |
| T2 | `copilot` | claude-haiku-4-5 (0.33×) | Copilot Pro ← was sonnet-4-6 (1×) |
| T3 | `openclaw-glm-cloud` | glm-5.1:cloud | Ollama Cloud sub ← was Anthropic |
| T4 | `claude-code-headless` | opus-4-7 | Anthropic Max ← unchanged |

| Reviewer | Driver | Model |
|---|---|---|
| R1 | `copilot` | gpt-5-mini (0× free) ← was gpt-4.1 |
| R2 | `copilot` | claude-haiku-4-5 (0.33×) ← was sonnet-4.6 (1×) |
| R3 | `claude-code-headless` | opus-4-7 ← unchanged |

## Premium-request math

Operator measured Copilot Pro multipliers: `gpt-5-mini` 0× free, `gpt-5.4-mini`/`haiku-4-5` 0.33×, `sonnet`/`gpt-5.4` 1×, `opus-4-6` 3×, `gpt-5.5` 7.5×. Defaults stick to 0×/0.33× to preserve the ~300/mo Pro budget. Sonnet/opus/gpt-5.5 are operator-opt-in via env override only.

## Net effect on subscriptions

- **3090**: T0 + T1 (was T0 only) — actually busy
- **Copilot Pro**: T2 + R2 on haiku (cheap); T1-cascade + R1 on free
- **Anthropic Max**: T4 + R3 only — escalation, not bulk
- **ChatGPT Plus**: parked (operator-opt-in for codex driver)
- **Gemini Pro**: parked (driver wired; rate-limit research pending)
- **Ollama Cloud sub**: T3 default (was idle) — finally getting load

## Test plan
- [x] 692 vitest cases pass (`nx run temporal-worker:test`)
- [x] All 11 Nx projects test green
- [x] Activity tests cover: openclaw-* renames, gemini dispatch, env overrides
- [ ] Worker restart picks up the new tier mapping; first dispatch tick uses openclaw-glm-flash for T0/T1
- [ ] First T2 dispatch uses copilot/claude-haiku-4-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)