### PR TITLE
swarm: routing-fingerprint-helper

### DIFF
--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -146,6 +146,15 @@ export const ExecutionRequestSchema = z
     // loop.maxIterations equivalent — chitin caps at 3 per the
     // design doc to prevent runaway chains). Absent = 0.
     step_index: z.number().int().nonnegative().max(3).optional(),
+    // Phase 2 (routing-as-learning-system, P2): canonical agent
+    // fingerprint computed by computeFingerprint() in fingerprint.ts.
+    // Captures the dimensions that define what an agent IS at run
+    // time (driver, model, role, station-prompt-hash, skills+tools-
+    // hash, soul-lens) so chain dispatches join to outcomes for ELO
+    // analysis. Hash is SHA-256 truncated to 12 hex chars (96 bits —
+    // collision-resistant for the dispatch volumes we'd ever hit).
+    // Absent = older callers / pre-fingerprint dispatches.
+    fingerprint: z.string().regex(/^[a-f0-9]{12}$/).optional(),
   })
   .superRefine((req, ctx) => {
     if (req.network_policy === 'open' && (req.risk_level === 'high' || req.risk_level === 'irreversible')) {

--- a/libs/contracts/src/fingerprint.ts
+++ b/libs/contracts/src/fingerprint.ts
@@ -1,0 +1,39 @@
+import crypto from "crypto";
+
+/**
+ * Dimensions that define an agent's runtime identity for routing fingerprinting.
+ */
+export interface AgentFingerprintDimensions {
+  driver: string | null;
+  model: string | null;
+  role: string | null;
+  stationPromptHash: string | null;
+  skillsToolsHash: string | null;
+  soulLens: string | null;
+}
+
+/**
+ * Computes a canonical agent fingerprint: deterministic hash + unhashed payload.
+ * - Same input always yields same hash (sort lists before hashing externally)
+ * - All 6 dimensions must be present; missing = null (not omitted)
+ * - Hash is SHA-256, hex, truncated to 12 chars
+ * - Soul lens: read from CHITIN_ACTIVE_SOUL env if not provided, else 'none'
+ */
+export function computeFingerprint(dimensions: Partial<AgentFingerprintDimensions>): {
+  hash: string;
+  payload: AgentFingerprintDimensions;
+} {
+  const soulLens = dimensions.soulLens ?? process.env.CHITIN_ACTIVE_SOUL ?? "none";
+  const payload: AgentFingerprintDimensions = {
+    driver: dimensions.driver ?? null,
+    model: dimensions.model ?? null,
+    role: dimensions.role ?? null,
+    stationPromptHash: dimensions.stationPromptHash ?? null,
+    skillsToolsHash: dimensions.skillsToolsHash ?? null,
+    soulLens,
+  };
+  // Canonical JSON: stable key order, explicit nulls
+  const canonical = JSON.stringify(payload);
+  const hash = crypto.createHash("sha256").update(canonical).digest("hex").slice(0, 12);
+  return { hash, payload };
+}

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -3,5 +3,6 @@ export * from './payloads.schema.js';
 export * from './event.schema.js';
 export * from './event.types.js';
 export * from './execution-request.schema.js';
+export * from './fingerprint.js';
 export * from './hash.js';
 export { resolveChitinDir } from './chitindir-resolve.js';

--- a/libs/contracts/tests/fingerprint.test.ts
+++ b/libs/contracts/tests/fingerprint.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { computeFingerprint } from '../src/fingerprint.js';
+
+describe('computeFingerprint', () => {
+  // Deterministic input fixture used across multiple tests.
+  const baseDims = {
+    driver: 'copilot',
+    model: 'claude-haiku-4-5',
+    role: 'reviewer',
+    stationPromptHash: 'abc123',
+    skillsToolsHash: 'def456',
+    soulLens: 'da-vinci',
+  };
+
+  it('produces a 12-char hex hash', () => {
+    const { hash } = computeFingerprint(baseDims);
+    expect(hash).toMatch(/^[a-f0-9]{12}$/);
+  });
+
+  it('is canonical: same input always produces same hash', () => {
+    const a = computeFingerprint(baseDims);
+    const b = computeFingerprint(baseDims);
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it('hash changes when any single dimension changes', () => {
+    const baseline = computeFingerprint(baseDims).hash;
+    expect(computeFingerprint({ ...baseDims, driver: 'codex' }).hash).not.toBe(baseline);
+    expect(computeFingerprint({ ...baseDims, model: 'gpt-5-mini' }).hash).not.toBe(baseline);
+    expect(computeFingerprint({ ...baseDims, role: 'programmer' }).hash).not.toBe(baseline);
+    expect(computeFingerprint({ ...baseDims, stationPromptHash: 'zzz' }).hash).not.toBe(baseline);
+    expect(computeFingerprint({ ...baseDims, skillsToolsHash: 'zzz' }).hash).not.toBe(baseline);
+    expect(computeFingerprint({ ...baseDims, soulLens: 'knuth' }).hash).not.toBe(baseline);
+  });
+
+  it('payload includes ALL 6 dimensions with explicit nulls (not omitted)', () => {
+    const { payload } = computeFingerprint({});
+    expect(payload).toHaveProperty('driver');
+    expect(payload).toHaveProperty('model');
+    expect(payload).toHaveProperty('role');
+    expect(payload).toHaveProperty('stationPromptHash');
+    expect(payload).toHaveProperty('skillsToolsHash');
+    expect(payload).toHaveProperty('soulLens');
+    // 5 of 6 are explicitly null (soulLens reads env or 'none', tested below)
+    expect(payload.driver).toBeNull();
+    expect(payload.model).toBeNull();
+    expect(payload.role).toBeNull();
+    expect(payload.stationPromptHash).toBeNull();
+    expect(payload.skillsToolsHash).toBeNull();
+  });
+
+  it('hash space is stable: missing dims hash same as explicit-null dims', () => {
+    const omitted = computeFingerprint({ driver: 'copilot' });
+    const explicitNull = computeFingerprint({
+      driver: 'copilot',
+      model: null,
+      role: null,
+      stationPromptHash: null,
+      skillsToolsHash: null,
+      // Note: soulLens passed explicit null vs omitted produces same
+      // result because both fall through to the env/'none' fallback.
+      soulLens: null,
+    });
+    expect(omitted.hash).toBe(explicitNull.hash);
+  });
+
+  it('soul lens defaults to CHITIN_ACTIVE_SOUL env when not in dimensions', () => {
+    const orig = process.env.CHITIN_ACTIVE_SOUL;
+    process.env.CHITIN_ACTIVE_SOUL = 'knuth';
+    try {
+      const { payload } = computeFingerprint({});
+      expect(payload.soulLens).toBe('knuth');
+    } finally {
+      if (orig === undefined) delete process.env.CHITIN_ACTIVE_SOUL;
+      else process.env.CHITIN_ACTIVE_SOUL = orig;
+    }
+  });
+
+  it("soul lens falls back to 'none' when env is unset and dim is omitted", () => {
+    const orig = process.env.CHITIN_ACTIVE_SOUL;
+    delete process.env.CHITIN_ACTIVE_SOUL;
+    try {
+      const { payload } = computeFingerprint({});
+      expect(payload.soulLens).toBe('none');
+    } finally {
+      if (orig !== undefined) process.env.CHITIN_ACTIVE_SOUL = orig;
+    }
+  });
+
+  it('explicit soul lens dimension overrides env', () => {
+    const orig = process.env.CHITIN_ACTIVE_SOUL;
+    process.env.CHITIN_ACTIVE_SOUL = 'knuth';
+    try {
+      const { payload } = computeFingerprint({ soulLens: 'sun-tzu' });
+      expect(payload.soulLens).toBe('sun-tzu');
+    } finally {
+      if (orig === undefined) delete process.env.CHITIN_ACTIVE_SOUL;
+      else process.env.CHITIN_ACTIVE_SOUL = orig;
+    }
+  });
+
+  it('hash matches the 12-char prefix shape required by ExecutionRequest schema', () => {
+    // ExecutionRequestSchema accepts fingerprint as /^[a-f0-9]{12}$/.
+    // Pin both ends — function output and schema regex must agree.
+    const { hash } = computeFingerprint(baseDims);
+    expect(hash).toHaveLength(12);
+    expect(hash).toMatch(/^[a-f0-9]+$/);
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `routing-fingerprint-helper`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-routing-fingerprint-helper-1777913532926`

## Entry context

Phase 2 of the routing system. Add a canonical agent-fingerprint
helper that produces a deterministic hash + the unhashed payload
from the dimensions that define what an agent IS at run time:
driver, model, role, station-prompt-hash, skills+tools-hash, soul-lens.

Why canonical: the same configuration must always hash to the same
fingerprint so the future ELO database joins. Sort lists before
hashing. Use SHA-256 truncated to 12 hex chars.

ExecutionRequest gains an optional `fingerprint` field. When the
dispatcher builds an ExecutionRequest, it computes the fingerprint
and embeds it. The activity layer surfaces the fingerprint in
ActivityResult so the kernel can write it into chain dispatches.

Soul lens: read from `CHITIN_ACTIVE_SOUL` env at dispatch time
(souls in `~/.claude/CLAUDE.md` are operator-context; the dispatcher
needs an explicit signal). When unset, fingerprint records `none`.

**Acceptance:**
- [ ] `computeFingerprint(...)` is canonical: same input → same hash
- [ ] Fingerprint payload includes all 6 dimensions; missing dims
      get an explicit `null` (not omitted) so the hash space is stable
- [ ] ExecutionRequest's optional `fingerprint` field round-trips
      through dispatcher → activity → ActivityResult
- [ ] Unit tests pin canonical behavior + the include-null-dims rule
- [ ] No breakage: 692+ existing tests pass


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-routing-fingerprint-helper-1777913532926`
Branch: `swarm/swarm-routing-fingerprint-helper-1777913532926`
Head: `ec4c87df`
Diff: `1 file changed, 39 insertions(+)`
Commits: 1