### PR TITLE
auto: flip 5 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/apps/temporal-worker/src/router/types.ts
+++ b/apps/temporal-worker/src/router/types.ts
@@ -91,7 +91,10 @@ export interface RouterPolicy {
       | 'kernel_denied'
     >;
     chain: { max_depth: number; tier_steps: string[] };
-    /** Model id (e.g., 'claude-code-headless', 'gemini-cli', 'openclaw-glm-flash'). */
+    /** Driver id from DriverIdSchema (e.g., 'claude-code-headless', 'copilot',
+     *  'codex', 'gemini', 'openclaw-glm-flash'). Despite the field name,
+     *  this is a driver id, not a model name — the actual model is resolved
+     *  per-driver from CHITIN_MODEL_<DRIVER>_<TIER> env or driver defaults. */
     model: string;
   };
 }

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -5062,7 +5062,7 @@ Note: PR #272 ships REAL-TIME codex governance via the codex-cli PreToolUse hook
 ```yaml
 id: chitin-codex-chain-ingest-timer
 tier: T1
-status: ready
+status: partial
 estimated_loc: 80
 blocks: []
 file: infra/systemd/chitin-codex-chain-ingest.{service,timer}, scripts/chitin-codex-chain-ingest.sh
@@ -5083,7 +5083,7 @@ Why two separate timers: usage feed needs to be fresh (operator dashboard), chai
 ```yaml
 id: nx-target-consistency-and-validate
 tier: T2
-status: ready
+status: partial
 estimated_loc: 300
 blocks: []
 file: nx.json, project.json (across apps/*), apps/cli/tsconfig.json, package.json, .github/workflows/ci.yml
@@ -5115,7 +5115,7 @@ Fixes:
 ```yaml
 id: agent-lockdown-auto-recovery
 tier: T2
-status: ready
+status: partial
 estimated_loc: 200
 blocks: []
 file: scripts/chitin-agent-unlock.sh, infra/systemd/chitin-agent-unlock.service, infra/systemd/chitin-agent-unlock.timer, go/execution-kernel/internal/gov/escalation.go (read-side)
@@ -5162,7 +5162,7 @@ lands.
 ```yaml
 id: alarm-on-systemd-chdir-failures
 tier: T2
-status: ready
+status: partial
 estimated_loc: 150
 blocks: []
 file: apps/temporal-worker/src/alarm-feeder.ts (or co-located new file), infra/systemd/chitin-alarm-feeder.service (env addition only)
@@ -5194,7 +5194,7 @@ or any downstream consumer can route it).
 ```yaml
 id: cleanup-ownership-allowlist
 tier: T1
-status: ready
+status: partial
 estimated_loc: 80
 blocks: []
 file: apps/temporal-worker/src/activity.ts

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -111,11 +111,11 @@ The dispatcher's invariants:
 
 | Tier | Driver | Model | Wall timeout | Account / cost |
 |------|--------|-------|--------------|----------------|
-| T0 | `openclaw-glm-flash` | glm-4.7-flash:latest (~30B on 3090) | 180s | free, unlimited |
-| T1 | `openclaw-glm-flash` | same | 240s | free, unlimited |
-| T2 | `copilot` | claude-haiku-4-5 (0.33× premium-multiplier) | 360s | Copilot Pro flat |
-| T3 | `openclaw-glm-cloud` | glm-5.1:cloud (opus-light) | 600s | Ollama Cloud sub flat |
-| T4 | `claude-code-headless` | claude-opus-4-7 | 600s | Anthropic Max metered (rare escalation) |
+| T0 | `openclaw-glm-flash` | glm-4.7-flash:latest (~30B on 3090) | 1200s (20m) | free, unlimited |
+| T1 | `openclaw-glm-flash` | same | 1200s | free, unlimited |
+| T2 | `copilot` | claude-haiku-4-5 (0.33× premium-multiplier) | 1800s (30m) | Copilot Pro flat |
+| T3 | `openclaw-glm-cloud` | glm-5.1:cloud (opus-light) | 1800s | Ollama Cloud sub flat |
+| T4 | `claude-code-headless` | claude-opus-4-7 | 1800s | Anthropic Max metered (escalation) |
 
 | Reviewer | Driver | Model | Account |
 |----------|--------|-------|---------|
@@ -126,7 +126,12 @@ The dispatcher's invariants:
 Operator overrides:
 - `CHITIN_TIER_DRIVER_T<N>=<driver>` flips a tier at runtime, no code change.
 - `CHITIN_REVIEWER_R<N>_DRIVER=<driver>` and `CHITIN_REVIEWER_R<N>_MODEL=<model>` for reviewer overrides.
-- `CHITIN_MODEL_<DRIVER>_<TIER>=<model>` for per-(driver,tier) model picks.
+- `CHITIN_MODEL_<DRIVER>_<TIER>=<model>` — per-(driver,tier) model picks.
+  Applies to **tier-aware drivers only**: `copilot` and `claude-code-headless`
+  (e.g. `CHITIN_MODEL_COPILOT_T2=claude-haiku-4-5`,
+  `CHITIN_MODEL_CLAUDE_CODE_HEADLESS_T4=claude-opus-4-7`).
+- `CHITIN_MODEL_CODEX=<model>` — codex driver uses a single env var (not tiered).
+- `CHITIN_MODEL_GEMINI=<model>` — gemini driver uses a single env var (not tiered).
 - `CHITIN_AGENT_OPENCLAW_GLM_FLASH=<agent-id>` etc. for openclaw agent remapping.
 
 ## Failure modes

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -67,7 +67,9 @@ export const RoleSchema = z.enum([
 // 1. Direct CLI: `copilot`, `claude-code-headless`, `codex`, `gemini`.
 //    Each spawns the vendor CLI (chitin-kernel drive copilot, claude,
 //    codex, gemini) and gates per-tool-call via PreToolUse hooks. Model
-//    selection is per-call via `--model` flag.
+//    selection is per-call via the driver-specific flag: `--model` for
+//    copilot and claude-code-headless, `-m` for codex and gemini (see
+//    apps/temporal-worker/src/activity.ts planInvocation).
 //
 // 2. Via openclaw plugin: `openclaw-glm-flash` (3090 local, glm-4.7-flash),
 //    `openclaw-glm-cloud` (Ollama Cloud, glm-5.1:cloud), `openclaw-deepseek`


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- cleanup-ownership-allowlist (#284)
- alarm-on-systemd-chdir-failures (#283)
- agent-lockdown-auto-recovery (#282)
- nx-target-consistency-and-validate (#276)
- chitin-codex-chain-ingest-timer (#273)

If any of these are wrong, revert + investigate why the title matched without the work shipping.