### PR TITLE
fix(routing): post-merge Copilot followups on #285

### DIFF
--- a/apps/temporal-worker/src/router/types.ts
+++ b/apps/temporal-worker/src/router/types.ts
@@ -91,7 +91,10 @@ export interface RouterPolicy {
       | 'kernel_denied'
     >;
     chain: { max_depth: number; tier_steps: string[] };
-    /** Model id (e.g., 'claude-code-headless', 'gemini-cli', 'openclaw-glm-flash'). */
+    /** Driver id from DriverIdSchema (e.g., 'claude-code-headless', 'copilot',
+     *  'codex', 'gemini', 'openclaw-glm-flash'). Despite the field name,
+     *  this is a driver id, not a model name — the actual model is resolved
+     *  per-driver from CHITIN_MODEL_<DRIVER>_<TIER> env or driver defaults. */
     model: string;
   };
 }

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -111,11 +111,11 @@ The dispatcher's invariants:
 
 | Tier | Driver | Model | Wall timeout | Account / cost |
 |------|--------|-------|--------------|----------------|
-| T0 | `openclaw-glm-flash` | glm-4.7-flash:latest (~30B on 3090) | 180s | free, unlimited |
-| T1 | `openclaw-glm-flash` | same | 240s | free, unlimited |
-| T2 | `copilot` | claude-haiku-4-5 (0.33× premium-multiplier) | 360s | Copilot Pro flat |
-| T3 | `openclaw-glm-cloud` | glm-5.1:cloud (opus-light) | 600s | Ollama Cloud sub flat |
-| T4 | `claude-code-headless` | claude-opus-4-7 | 600s | Anthropic Max metered (rare escalation) |
+| T0 | `openclaw-glm-flash` | glm-4.7-flash:latest (~30B on 3090) | 1200s (20m) | free, unlimited |
+| T1 | `openclaw-glm-flash` | same | 1200s | free, unlimited |
+| T2 | `copilot` | claude-haiku-4-5 (0.33× premium-multiplier) | 1800s (30m) | Copilot Pro flat |
+| T3 | `openclaw-glm-cloud` | glm-5.1:cloud (opus-light) | 1800s | Ollama Cloud sub flat |
+| T4 | `claude-code-headless` | claude-opus-4-7 | 1800s | Anthropic Max metered (escalation) |
 
 | Reviewer | Driver | Model | Account |
 |----------|--------|-------|---------|
@@ -126,7 +126,12 @@ The dispatcher's invariants:
 Operator overrides:
 - `CHITIN_TIER_DRIVER_T<N>=<driver>` flips a tier at runtime, no code change.
 - `CHITIN_REVIEWER_R<N>_DRIVER=<driver>` and `CHITIN_REVIEWER_R<N>_MODEL=<model>` for reviewer overrides.
-- `CHITIN_MODEL_<DRIVER>_<TIER>=<model>` for per-(driver,tier) model picks.
+- `CHITIN_MODEL_<DRIVER>_<TIER>=<model>` — per-(driver,tier) picks for
+  tier-aware drivers (`copilot`, `claude-code-headless`). Examples:
+  `CHITIN_MODEL_COPILOT_T2=claude-haiku-4-5`,
+  `CHITIN_MODEL_CLAUDE_CODE_HEADLESS_T4=claude-opus-4-7`.
+- `CHITIN_MODEL_CODEX=<model>` — codex driver uses a single env var (not tiered).
+- `CHITIN_MODEL_GEMINI=<model>` — gemini driver uses a single env var (not tiered).
 - `CHITIN_AGENT_OPENCLAW_GLM_FLASH=<agent-id>` etc. for openclaw agent remapping.
 
 ## Failure modes

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -67,7 +67,9 @@ export const RoleSchema = z.enum([
 // 1. Direct CLI: `copilot`, `claude-code-headless`, `codex`, `gemini`.
 //    Each spawns the vendor CLI (chitin-kernel drive copilot, claude,
 //    codex, gemini) and gates per-tool-call via PreToolUse hooks. Model
-//    selection is per-call via `--model` flag.
+//    selection is per-call via the driver-specific flag: `--model` for
+//    copilot and claude-code-headless, `-m` for codex and gemini (see
+//    apps/temporal-worker/src/activity.ts planInvocation).
 //
 // 2. Via openclaw plugin: `openclaw-glm-flash` (3090 local, glm-4.7-flash),
 //    `openclaw-glm-cloud` (Ollama Cloud, glm-5.1:cloud), `openclaw-deepseek`


### PR DESCRIPTION
## Summary

Four docs/comment-level findings Copilot left on #285 after the swarm auto-merged. All real, all fix-able with no functional change.

| Finding | File | Fix |
|---|---|---|
| `--model` flag wrong for codex/gemini | execution-request.schema.ts | clarify per-driver flag |
| `gemini-cli` example wrong; driver-id vs model-name ambiguous | router/types.ts | rename to driver ids, clarify |
| Missing CHITIN_MODEL_CODEX/_GEMINI docs | infra/systemd/README.md | add to override list |
| Stale wall-timeout values | infra/systemd/README.md | update to 1200s/1800s (match dispatcher.ts) |

## Test plan
- [x] No functional change; comments + docs only
- [x] Existing tests pass (no test impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)