### PR TITLE
auto: flip 5 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/apps/temporal-worker/src/router/types.ts
+++ b/apps/temporal-worker/src/router/types.ts
@@ -91,10 +91,15 @@ export interface RouterPolicy {
       | 'kernel_denied'
     >;
     chain: { max_depth: number; tier_steps: string[] };
-    /** Driver id from DriverIdSchema (e.g., 'claude-code-headless', 'copilot',
-     *  'codex', 'gemini', 'openclaw-glm-flash'). Despite the field name,
-     *  this is a driver id, not a model name — the actual model is resolved
-     *  per-driver from CHITIN_MODEL_<DRIVER>_<TIER> env or driver defaults. */
+    /** Driver id intended for the router's advisor invocation (e.g.,
+     *  'claude-code-headless', 'copilot', 'codex', 'gemini',
+     *  'openclaw-glm-flash'). Despite the field name it carries a
+     *  driver id, not a model name. NOTE 2026-05-04: this field is
+     *  parsed from chitin.yaml but `hook-wrapper.ts` currently calls
+     *  `callAdvisor()` with the hard-coded Claude binary; operators
+     *  changing this value won't see per-driver dispatch until
+     *  `callAdvisor` is taught to honor it (tracked as a router-
+     *  driver-dispatch follow-up). */
     model: string;
   };
 }

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -5062,7 +5062,7 @@ Note: PR #272 ships REAL-TIME codex governance via the codex-cli PreToolUse hook
 ```yaml
 id: chitin-codex-chain-ingest-timer
 tier: T1
-status: ready
+status: partial
 estimated_loc: 80
 blocks: []
 file: infra/systemd/chitin-codex-chain-ingest.{service,timer}, scripts/chitin-codex-chain-ingest.sh
@@ -5083,7 +5083,7 @@ Why two separate timers: usage feed needs to be fresh (operator dashboard), chai
 ```yaml
 id: nx-target-consistency-and-validate
 tier: T2
-status: ready
+status: partial
 estimated_loc: 300
 blocks: []
 file: nx.json, project.json (across apps/*), apps/cli/tsconfig.json, package.json, .github/workflows/ci.yml
@@ -5115,7 +5115,7 @@ Fixes:
 ```yaml
 id: agent-lockdown-auto-recovery
 tier: T2
-status: ready
+status: partial
 estimated_loc: 200
 blocks: []
 file: scripts/chitin-agent-unlock.sh, infra/systemd/chitin-agent-unlock.service, infra/systemd/chitin-agent-unlock.timer, go/execution-kernel/internal/gov/escalation.go (read-side)
@@ -5162,7 +5162,7 @@ lands.
 ```yaml
 id: alarm-on-systemd-chdir-failures
 tier: T2
-status: ready
+status: partial
 estimated_loc: 150
 blocks: []
 file: apps/temporal-worker/src/alarm-feeder.ts (or co-located new file), infra/systemd/chitin-alarm-feeder.service (env addition only)
@@ -5194,7 +5194,7 @@ or any downstream consumer can route it).
 ```yaml
 id: cleanup-ownership-allowlist
 tier: T1
-status: ready
+status: partial
 estimated_loc: 80
 blocks: []
 file: apps/temporal-worker/src/activity.ts


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- cleanup-ownership-allowlist (#284)
- alarm-on-systemd-chdir-failures (#283)
- agent-lockdown-auto-recovery (#282)
- nx-target-consistency-and-validate (#276)
- chitin-codex-chain-ingest-timer (#273)

If any of these are wrong, revert + investigate why the title matched without the work shipping.