### PR TITLE
feat(analysis): fingerprint × outcomes recipe (P3)

### DIFF
--- a/python/analysis/__main__.py
+++ b/python/analysis/__main__.py
@@ -8,7 +8,8 @@ print(
     "  python -m analysis.debt        # debt-ledger draft\n"
     "  python -m analysis.souls       # soul-routing decisions\n"
     "  python -m analysis.skill_mine  # workflow n-gram surface from chain telemetry\n"
-    "  python -m analysis.codex_mine  # codex session ingest + quota usage",
+    "  python -m analysis.codex_mine  # codex session ingest + quota usage\n"
+    "  python -m analysis.fingerprint_outcomes  # fingerprint × PR/review outcomes (P3)",
     file=sys.stderr,
 )
 sys.exit(2)

--- a/python/analysis/fingerprint_outcomes.py
+++ b/python/analysis/fingerprint_outcomes.py
@@ -1,0 +1,441 @@
+"""P3 — fingerprint × outcome join: chain dispatches × swarm-runs results.
+
+Materializes a sqlite table keyed by ``(fingerprint, role, task_class)``
+with the outcome metrics that downstream ELO computation (P4) consumes.
+Also emits a markdown report grouped per-role so the operator can read
+"haiku-4-5 + reviewer + small-PR = 92% consensus" without translating
+opaque hashes.
+
+Why per-role aggregation: different roles have different definitions of
+"success." Programmer = first-pass merge rate. Reviewer = consensus-with-
+final-merge rate. Researcher = entry-acceptance rate. A flat global
+table averages out the very signal we want.
+
+Idempotent: re-running picks up new dispatches by re-deriving the table
+each time. The sqlite output is materialized-view-shaped (DROP TABLE +
+recreate), not append-only, so duplicate runs never inflate counts.
+
+Usage::
+
+    python -m analysis.fingerprint_outcomes \\
+        --decisions-dir ~/.chitin \\
+        --state-dir ~/.cache/chitin/swarm-state \\
+        --tmp-dir ~/workspace/chitin/tmp \\
+        --since 7d \\
+        --out python/analysis/out/fingerprint-outcomes-2026-05-04.md \\
+        --sqlite python/analysis/out/fingerprint-outcomes.sqlite
+
+When ``--out`` and ``--sqlite`` are omitted, defaults to today's dated
+filename in ``python/analysis/out/``.
+
+Schema (sqlite):
+
+    fingerprint_outcomes(
+      fingerprint   TEXT,    -- 12-char hex hash from libs/contracts/src/fingerprint.ts
+      model         TEXT,    -- driver-resolved model id
+      role          TEXT,    -- programmer | reviewer | researcher | ...
+      task_class    TEXT,    -- refactor | doc_update | bug_fix | ... (NULL when unknown)
+      dispatch_count INT,
+      allow_count   INT,
+      deny_count    INT,
+      lockdown_count INT,
+      total_cost_usd REAL,
+      pr_opened_count INT,
+      pr_merged_count INT,
+      bucket_b_count INT,
+      mean_duration_ms REAL,
+      first_seen_ts TEXT,    -- ISO-8601
+      last_seen_ts  TEXT,
+      PRIMARY KEY(fingerprint, role, task_class)
+    )
+
+P2 (chain-fingerprint-tagging) is the upstream prereq. Until that
+merges + dogfoods 24h, this recipe runs over a chain whose fingerprint
+columns are mostly empty — output is sparse but the recipe doesn't
+crash. Empty fingerprint groups everything under fingerprint=''
+which surfaces as one big "untagged" bucket for now.
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from analysis.loaders import load_gov_decisions, parse_window_str
+from analysis.swarm_runs import load_swarm_runs
+
+
+# ─── Aggregation key + accumulator ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FingerprintKey:
+    """Composite group-by key. All four dims, with empty string for
+    pre-fingerprint dispatches (so the row still aggregates rather than
+    being silently dropped)."""
+
+    fingerprint: str
+    model: str
+    role: str
+    task_class: str
+
+
+@dataclass
+class Accumulator:
+    """Mutable per-key accumulator. Filled by both chain-side iteration
+    (Decisions) and swarm-runs-side iteration (workflow outcomes)."""
+
+    dispatch_count: int = 0
+    allow_count: int = 0
+    deny_count: int = 0
+    lockdown_count: int = 0
+    total_cost_usd: float = 0.0
+    pr_opened_count: int = 0
+    pr_merged_count: int = 0
+    bucket_b_count: int = 0
+    duration_samples_ms: list[int] = field(default_factory=list)
+    first_seen_ts: Optional[datetime] = None
+    last_seen_ts: Optional[datetime] = None
+
+    def observe_ts(self, ts: datetime) -> None:
+        if self.first_seen_ts is None or ts < self.first_seen_ts:
+            self.first_seen_ts = ts
+        if self.last_seen_ts is None or ts > self.last_seen_ts:
+            self.last_seen_ts = ts
+
+    @property
+    def mean_duration_ms(self) -> float:
+        return (
+            sum(self.duration_samples_ms) / len(self.duration_samples_ms)
+            if self.duration_samples_ms
+            else 0.0
+        )
+
+
+# ─── Build the aggregation table ──────────────────────────────────────────
+
+
+def build_table(
+    decisions_dir: Path,
+    state_dir: Path,
+    tmp_dir: Path,
+    window_str: str = "7d",
+    now: Optional[datetime] = None,
+) -> dict[FingerprintKey, Accumulator]:
+    """Run the full join + aggregate. Returns the in-memory table that
+    write_sqlite + render_markdown consume. Pure function modulo
+    filesystem reads; safe to unit-test against a tmpdir.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    window = parse_window_str(window_str, now)
+
+    table: dict[FingerprintKey, Accumulator] = defaultdict(Accumulator)
+
+    # Side 1: chain decisions. Dispatch counts, cost, allow/deny/lockdown
+    # tallies. workflow_id ties these to swarm-runs.
+    chain_load = load_gov_decisions(decisions_dir, window)
+    # workflow_id → set of (fingerprint, model, role) tuples seen on the chain.
+    # Used in side-2 to back-fill swarm-runs that don't carry fingerprint.
+    wf_index: dict[str, set[tuple[str, str, str]]] = defaultdict(set)
+
+    for d in chain_load.decisions:
+        # task_class isn't on the gov-decision row (it's in the
+        # ExecutionRequest, not the chain). Mark unknown for now;
+        # P3.5 follow-up could plumb task_class via env the same way
+        # P2 plumbs the fingerprint.
+        key = FingerprintKey(
+            fingerprint=d.fingerprint or "",
+            model=d.model or "",
+            role=d.role or "",
+            task_class="",
+        )
+        acc = table[key]
+        acc.dispatch_count += 1
+        if d.allowed:
+            acc.allow_count += 1
+        else:
+            acc.deny_count += 1
+        if d.escalation == "lockdown":
+            acc.lockdown_count += 1
+        acc.total_cost_usd += d.cost_usd
+        acc.observe_ts(d.ts)
+        if d.workflow_id:
+            wf_index[d.workflow_id].add((key.fingerprint, key.model, key.role))
+
+    # Side 2: swarm runs. PR-opened, PR-merged, bucket-B, duration.
+    # Joins to chain-side via workflow_id. swarm-runs has its own driver
+    # field but no fingerprint — use the chain's fingerprint when we can
+    # find a matching workflow_id, else fall through to an untagged bucket.
+    runs = load_swarm_runs(state_dir, tmp_dir, window)
+
+    for run in runs:
+        # Build a sentinel "swarm-<entry_id>-<ts>" → workflow_id from
+        # the run's marker. The marker stores it directly in the
+        # SwarmRun, but we also have wf_index from the chain side.
+        # SwarmRun doesn't expose workflow_id directly in its public
+        # shape, so fall back to wf_index by entry-id substring.
+        match_keys: set[tuple[str, str, str]] = set()
+        for wf_id, dims_set in wf_index.items():
+            if run.entry_id in wf_id:
+                match_keys |= dims_set
+
+        # If chain-side never tagged this workflow, surface under an
+        # empty-fingerprint bucket so the row isn't silently dropped.
+        if not match_keys:
+            match_keys = {("", "", "")}
+
+        for fp, model, role in match_keys:
+            key = FingerprintKey(
+                fingerprint=fp,
+                model=model or run.model or "",
+                role=role,
+                task_class="",
+            )
+            acc = table[key]
+            if run.pr_url:
+                acc.pr_opened_count += 1
+            if run.bucket_b:
+                acc.bucket_b_count += 1
+            if run.duration_ms:
+                acc.duration_samples_ms.append(run.duration_ms)
+            # PR-merged signal: SwarmRun doesn't currently distinguish
+            # opened-vs-merged. P3.5 follow-up wires `gh pr view --json
+            # mergedAt` into the swarm-runs loader. For now, pr_merged_count
+            # stays 0 — the field is reserved but un-populated.
+            acc.observe_ts(run.dispatched_at)
+
+    return table
+
+
+# ─── Sqlite write ─────────────────────────────────────────────────────────
+
+
+def write_sqlite(table: dict[FingerprintKey, Accumulator], db_path: Path) -> None:
+    """Materialized view: drop + recreate. Idempotent over re-runs."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS fingerprint_outcomes")
+        cur.execute(
+            """
+            CREATE TABLE fingerprint_outcomes (
+              fingerprint TEXT NOT NULL,
+              model TEXT NOT NULL,
+              role TEXT NOT NULL,
+              task_class TEXT NOT NULL,
+              dispatch_count INTEGER NOT NULL,
+              allow_count INTEGER NOT NULL,
+              deny_count INTEGER NOT NULL,
+              lockdown_count INTEGER NOT NULL,
+              total_cost_usd REAL NOT NULL,
+              pr_opened_count INTEGER NOT NULL,
+              pr_merged_count INTEGER NOT NULL,
+              bucket_b_count INTEGER NOT NULL,
+              mean_duration_ms REAL NOT NULL,
+              first_seen_ts TEXT,
+              last_seen_ts TEXT,
+              PRIMARY KEY (fingerprint, model, role, task_class)
+            )
+            """
+        )
+        for key, acc in table.items():
+            cur.execute(
+                """
+                INSERT INTO fingerprint_outcomes VALUES
+                (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    key.fingerprint,
+                    key.model,
+                    key.role,
+                    key.task_class,
+                    acc.dispatch_count,
+                    acc.allow_count,
+                    acc.deny_count,
+                    acc.lockdown_count,
+                    acc.total_cost_usd,
+                    acc.pr_opened_count,
+                    acc.pr_merged_count,
+                    acc.bucket_b_count,
+                    acc.mean_duration_ms,
+                    acc.first_seen_ts.isoformat() if acc.first_seen_ts else None,
+                    acc.last_seen_ts.isoformat() if acc.last_seen_ts else None,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ─── Markdown report ──────────────────────────────────────────────────────
+
+
+def render_markdown(
+    table: dict[FingerprintKey, Accumulator], window_str: str, generated_at: datetime
+) -> str:
+    """Group rows by role; show fingerprint dimensions + outcome metrics
+    in human-readable form. Per-role only — no global average row, since
+    averaging across roles dilutes the signal we exist to surface."""
+    lines: list[str] = []
+    lines.append("# Fingerprint × outcomes report")
+    lines.append("")
+    lines.append(f"Window: last {window_str} (generated at {generated_at.isoformat()})")
+    lines.append("")
+    lines.append(
+        "Each row aggregates chain dispatches × swarm-runs outcomes by "
+        "the dispatch's fingerprint dimensions. Empty fingerprint = "
+        "pre-P2-fingerprint dispatches; will shrink as P2 dogfooding "
+        "tags new rows."
+    )
+    lines.append("")
+
+    by_role: dict[str, list[tuple[FingerprintKey, Accumulator]]] = defaultdict(list)
+    for key, acc in table.items():
+        by_role[key.role or "(untagged)"].append((key, acc))
+
+    # Stable role order: known roles first (programmer, reviewer, etc.),
+    # untagged last.
+    known_role_order = [
+        "programmer",
+        "reviewer",
+        "peer-reviewer",
+        "comment-responder",
+        "researcher",
+        "groomer",
+        "analyst",
+        "tech-writer",
+        "debt-curator",
+        "(untagged)",
+    ]
+    role_keys = sorted(
+        by_role.keys(),
+        key=lambda r: (
+            known_role_order.index(r) if r in known_role_order else len(known_role_order),
+            r,
+        ),
+    )
+
+    for role in role_keys:
+        rows = by_role[role]
+        # Sort within role by dispatch_count desc — most-active fingerprint
+        # surfaces first.
+        rows.sort(key=lambda kv: -kv[1].dispatch_count)
+
+        lines.append(f"## Role: `{role}`")
+        lines.append("")
+        lines.append(
+            "| fingerprint | model | dispatches | allow% | deny | lockdown | "
+            "PRs opened | bucket-B | $ cost | mean dur (s) |"
+        )
+        lines.append(
+            "|---|---|---|---|---|---|---|---|---|---|"
+        )
+        for key, acc in rows:
+            allow_pct = (
+                100.0 * acc.allow_count / acc.dispatch_count
+                if acc.dispatch_count > 0
+                else 0.0
+            )
+            fp_short = key.fingerprint or "(none)"
+            model_short = key.model or "(none)"
+            lines.append(
+                f"| `{fp_short}` | `{model_short}` | "
+                f"{acc.dispatch_count} | {allow_pct:.1f}% | "
+                f"{acc.deny_count} | {acc.lockdown_count} | "
+                f"{acc.pr_opened_count} | {acc.bucket_b_count} | "
+                f"${acc.total_cost_usd:.4f} | "
+                f"{acc.mean_duration_ms / 1000:.1f} |"
+            )
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "Source: `python -m analysis.fingerprint_outcomes`. "
+        "Schema in module docstring. Materialized to "
+        "`fingerprint-outcomes.sqlite`. ELO board (P4) consumes the same table."
+    )
+    return "\n".join(lines)
+
+
+# ─── CLI entry ────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the fingerprint × outcomes table from chain + swarm-runs.",
+    )
+    parser.add_argument(
+        "--decisions-dir",
+        type=Path,
+        default=Path.home() / ".chitin",
+        help="Directory containing gov-decisions-*.jsonl files.",
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path.home() / ".cache" / "chitin" / "swarm-state" / "dispatched",
+        help="Dispatcher marker directory (contains <entry-id>.json files).",
+    )
+    parser.add_argument(
+        "--tmp-dir",
+        type=Path,
+        default=Path.cwd() / "tmp",
+        help="Repo-relative tmp/ where workflow result envelopes live.",
+    )
+    parser.add_argument(
+        "--since",
+        default="7d",
+        help="Window: Nd / Nh / Nm. Default 7d.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Markdown report path. Defaults to python/analysis/out/fingerprint-outcomes-<YYYY-MM-DD>.md.",
+    )
+    parser.add_argument(
+        "--sqlite",
+        type=Path,
+        default=None,
+        help="Sqlite materialized-view path. Defaults to python/analysis/out/fingerprint-outcomes.sqlite.",
+    )
+    args = parser.parse_args(argv)
+
+    now = datetime.now(timezone.utc)
+    table = build_table(
+        decisions_dir=args.decisions_dir,
+        state_dir=args.state_dir,
+        tmp_dir=args.tmp_dir,
+        window_str=args.since,
+        now=now,
+    )
+
+    out_dir = Path(__file__).parent / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    md_path = args.out or (
+        out_dir / f"fingerprint-outcomes-{now.strftime('%Y-%m-%d')}.md"
+    )
+    sqlite_path = args.sqlite or (out_dir / "fingerprint-outcomes.sqlite")
+
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(render_markdown(table, args.since, now))
+    write_sqlite(table, sqlite_path)
+
+    print(
+        f"fingerprint_outcomes: {len(table)} rows "
+        f"→ md={md_path} sqlite={sqlite_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/models.py
+++ b/python/analysis/models.py
@@ -27,6 +27,13 @@ class Decision:
     cost_usd: float = 0.0
     input_bytes: int = 0
     tool_calls: int = 0
+    # Routing-as-learning-system fingerprint dims (P2). Optional —
+    # pre-fingerprint dispatches omit these, so all four default to None.
+    # See go/execution-kernel/internal/gov/policy.go Decision struct.
+    model: Optional[str] = None
+    role: Optional[str] = None
+    workflow_id: Optional[str] = None
+    fingerprint: Optional[str] = None
 
 
 def _coerce_float(v, default: float = 0.0) -> float:
@@ -97,6 +104,11 @@ def parse_decision_line(line: str) -> Optional[Decision]:
         cost_usd=_coerce_float(raw.get("cost_usd")),
         input_bytes=_coerce_int(raw.get("input_bytes")),
         tool_calls=_coerce_int(raw.get("tool_calls")),
+        # P2 fingerprint dims; pre-fingerprint dispatches omit these.
+        model=raw.get("model") or None,
+        role=raw.get("role") or None,
+        workflow_id=raw.get("workflow_id") or None,
+        fingerprint=raw.get("fingerprint") or None,
     )
 
 

--- a/python/analysis/tests/test_fingerprint_outcomes.py
+++ b/python/analysis/tests/test_fingerprint_outcomes.py
@@ -1,0 +1,434 @@
+"""Tests for analysis.fingerprint_outcomes — chain × swarm-runs join.
+
+The recipe is the substrate for the P4 ELO board, so the contract this
+test suite pins is the join semantics + the table-shape: which dispatches
+roll up into which (fingerprint, model, role) cells.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from analysis.fingerprint_outcomes import (
+    Accumulator,
+    FingerprintKey,
+    build_table,
+    render_markdown,
+    write_sqlite,
+)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────
+
+
+def _write_decisions_log(decisions_dir: Path, date: str, rows: list[dict]) -> None:
+    """Write a gov-decisions-<date>.jsonl with the given rows."""
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    log_path = decisions_dir / f"gov-decisions-{date}.jsonl"
+    with log_path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _write_marker(state_dir: Path, entry_id: str, marker: dict) -> None:
+    """Write a dispatcher marker file. state_dir is the `dispatched/`
+    directory itself (not its parent — load_swarm_runs iterates directly)."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{entry_id}.json").write_text(json.dumps(marker))
+
+
+def _write_envelope(tmp_dir: Path, workflow_id: str, envelope: dict) -> None:
+    """Write a workflow result envelope. The loader looks for files
+    matching `result-swarm-*.json`."""
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_dir / f"result-{workflow_id}.json").write_text(json.dumps(envelope))
+
+
+# ─── build_table — chain side ────────────────────────────────────────────
+
+
+def test_build_table_aggregates_decisions_by_fingerprint(tmp_path: Path) -> None:
+    """Decisions sharing a fingerprint roll up into one row; counts increment.
+    The pre-P2-fingerprint case (fingerprint='') is its own bucket."""
+    now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    decisions = tmp_path / "chain"
+    state = tmp_path / "state"
+    tmpd = tmp_path / "tmp"
+
+    _write_decisions_log(
+        decisions,
+        "2026-05-04",
+        [
+            {
+                "ts": "2026-05-04T11:00:00Z",
+                "allowed": True,
+                "rule_id": "default-allow",
+                "agent": "claude-code",
+                "model": "claude-haiku-4-5",
+                "role": "reviewer",
+                "fingerprint": "abc123",
+                "workflow_id": "swarm-foo-1",
+            },
+            {
+                "ts": "2026-05-04T11:01:00Z",
+                "allowed": False,
+                "rule_id": "no-rm",
+                "agent": "claude-code",
+                "model": "claude-haiku-4-5",
+                "role": "reviewer",
+                "fingerprint": "abc123",
+                "workflow_id": "swarm-foo-1",
+                "escalation": "elevated",
+            },
+            {
+                "ts": "2026-05-04T11:02:00Z",
+                "allowed": True,
+                "rule_id": "default-allow",
+                "agent": "copilot",
+                # No fingerprint dims → groups under empty-string bucket
+            },
+        ],
+    )
+
+    table = build_table(
+        decisions_dir=decisions,
+        state_dir=state,
+        tmp_dir=tmpd,
+        window_str="7d",
+        now=now,
+    )
+
+    # Two rows: one for (abc123, haiku, reviewer), one untagged.
+    assert len(table) == 2
+
+    tagged_key = FingerprintKey(
+        fingerprint="abc123",
+        model="claude-haiku-4-5",
+        role="reviewer",
+        task_class="",
+    )
+    tagged = table[tagged_key]
+    assert tagged.dispatch_count == 2
+    assert tagged.allow_count == 1
+    assert tagged.deny_count == 1
+
+    untagged_key = FingerprintKey(fingerprint="", model="", role="", task_class="")
+    assert table[untagged_key].dispatch_count == 1
+
+
+def test_build_table_counts_lockdown_decisions(tmp_path: Path) -> None:
+    """escalation=lockdown rows roll up into the lockdown_count column."""
+    now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    decisions = tmp_path / "chain"
+    _write_decisions_log(
+        decisions,
+        "2026-05-04",
+        [
+            {
+                "ts": "2026-05-04T11:00:00Z",
+                "allowed": False,
+                "rule_id": "lockdown",
+                "escalation": "lockdown",
+                "model": "x",
+                "role": "y",
+                "fingerprint": "fp1",
+            },
+        ],
+    )
+
+    table = build_table(
+        decisions_dir=decisions,
+        state_dir=tmp_path / "state",
+        tmp_dir=tmp_path / "tmp",
+        window_str="7d",
+        now=now,
+    )
+    only = next(iter(table.values()))
+    assert only.lockdown_count == 1
+    assert only.deny_count == 1
+
+
+def test_build_table_window_filters_old_decisions(tmp_path: Path) -> None:
+    """Decisions older than the window don't aggregate."""
+    now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    decisions = tmp_path / "chain"
+    _write_decisions_log(
+        decisions,
+        "2026-04-01",
+        [
+            {
+                "ts": "2026-04-01T11:00:00Z",
+                "allowed": True,
+                "model": "x",
+                "fingerprint": "old",
+            },
+        ],
+    )
+    _write_decisions_log(
+        decisions,
+        "2026-05-04",
+        [
+            {
+                "ts": "2026-05-04T11:00:00Z",
+                "allowed": True,
+                "model": "x",
+                "fingerprint": "fresh",
+            },
+        ],
+    )
+
+    table = build_table(
+        decisions_dir=decisions,
+        state_dir=tmp_path / "state",
+        tmp_dir=tmp_path / "tmp",
+        window_str="7d",
+        now=now,
+    )
+
+    fingerprints = {key.fingerprint for key in table.keys()}
+    assert "fresh" in fingerprints
+    assert "old" not in fingerprints
+
+
+# ─── build_table — swarm-runs side ───────────────────────────────────────
+
+
+def test_build_table_joins_swarm_runs_via_workflow_id(tmp_path: Path) -> None:
+    """Swarm-run with matching workflow_id (chain side has the fingerprint)
+    enriches the chain-side row with PR/duration metrics."""
+    now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    decisions = tmp_path / "chain"
+    state = tmp_path / "state"
+    tmpd = tmp_path / "tmp"
+
+    workflow_id = "swarm-test-entry-1234567890"
+
+    _write_decisions_log(
+        decisions,
+        "2026-05-04",
+        [
+            {
+                "ts": "2026-05-04T11:00:00Z",
+                "allowed": True,
+                "model": "haiku",
+                "role": "programmer",
+                "fingerprint": "fp-X",
+                "workflow_id": workflow_id,
+            },
+        ],
+    )
+
+    _write_marker(
+        state,
+        "test-entry",
+        {
+            "entry_id": "test-entry",
+            "workflow_id": workflow_id,
+            "tier": "T2",
+            "driver": "copilot",
+            "dispatched_at": "2026-05-04T11:00:00Z",
+        },
+    )
+    _write_envelope(
+        tmpd,
+        workflow_id,
+        {
+            "workflow_id": workflow_id,
+            "result": {
+                "exit_code": 0,
+                "stdout_tail": "PR → https://github.com/chitinhq/chitin/pull/999",
+                "stderr_tail": "",
+                "duration_ms": 12000,
+                "worktree": {
+                    "path": "/tmp/x",
+                    "branch": "swarm/test-entry",
+                    "head_sha": "abc",
+                    "commits_added": 1,
+                    "has_uncommitted_changes": False,
+                    "diff_shortstat": "2 files changed, 5 insertions(+), 1 deletion(-)",
+                },
+            },
+        },
+    )
+
+    table = build_table(
+        decisions_dir=decisions,
+        state_dir=state,
+        tmp_dir=tmpd,
+        window_str="7d",
+        now=now,
+    )
+
+    # Find the (fp-X, haiku, programmer) row — the PR-opened + duration
+    # metrics from the swarm-run side should have joined onto it via
+    # workflow_id substring match.
+    target = next(
+        (acc for key, acc in table.items() if key.fingerprint == "fp-X"),
+        None,
+    )
+    assert target is not None
+    assert target.dispatch_count == 1
+    assert target.pr_opened_count == 1
+    assert 11000 <= target.mean_duration_ms <= 13000
+
+
+def test_build_table_swarm_runs_without_chain_match_use_untagged_bucket(
+    tmp_path: Path,
+) -> None:
+    """A swarm-run whose workflow_id never appeared on the chain (older
+    runs from before P2 dogfooding) lands in the empty-fingerprint
+    bucket rather than getting silently dropped."""
+    now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    decisions = tmp_path / "chain"
+    state = tmp_path / "state"
+    tmpd = tmp_path / "tmp"
+
+    decisions.mkdir(parents=True, exist_ok=True)  # empty chain
+    _write_marker(
+        state,
+        "ancient-entry",
+        {
+            "entry_id": "ancient-entry",
+            "workflow_id": "swarm-ancient-entry-0",
+            "tier": "T2",
+            "driver": "copilot",
+            "dispatched_at": "2026-05-04T11:00:00Z",
+        },
+    )
+    _write_envelope(
+        tmpd,
+        "swarm-ancient-entry-0",
+        {
+            "workflow_id": "swarm-ancient-entry-0",
+            "result": {
+                "exit_code": 0,
+                "stdout_tail": "PR → https://github.com/chitinhq/chitin/pull/1",
+                "stderr_tail": "",
+                "duration_ms": 5000,
+                "worktree": {
+                    "path": "/tmp",
+                    "branch": "swarm/ancient",
+                    "head_sha": "x",
+                    "commits_added": 1,
+                    "has_uncommitted_changes": False,
+                    "diff_shortstat": "1 file changed",
+                },
+            },
+        },
+    )
+
+    table = build_table(
+        decisions_dir=decisions,
+        state_dir=state,
+        tmp_dir=tmpd,
+        window_str="7d",
+        now=now,
+    )
+
+    # Untagged bucket exists with the PR-opened count from the swarm-run.
+    untagged_key = FingerprintKey(fingerprint="", model="", role="", task_class="")
+    assert untagged_key in table
+    assert table[untagged_key].pr_opened_count == 1
+
+
+# ─── Sqlite write ─────────────────────────────────────────────────────────
+
+
+def test_write_sqlite_creates_table_with_expected_schema(tmp_path: Path) -> None:
+    """The sqlite output has the exact column set ELO board (P4) consumes."""
+    table: dict[FingerprintKey, Accumulator] = {
+        FingerprintKey("fp-1", "haiku", "reviewer", ""): Accumulator(
+            dispatch_count=5,
+            allow_count=4,
+            deny_count=1,
+            total_cost_usd=0.12,
+            pr_opened_count=2,
+        ),
+    }
+    db_path = tmp_path / "out.sqlite"
+    write_sqlite(table, db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(fingerprint_outcomes)")
+        cols = {row[1] for row in cur.fetchall()}
+        for required in {
+            "fingerprint",
+            "model",
+            "role",
+            "task_class",
+            "dispatch_count",
+            "allow_count",
+            "deny_count",
+            "lockdown_count",
+            "total_cost_usd",
+            "pr_opened_count",
+            "pr_merged_count",
+            "bucket_b_count",
+            "mean_duration_ms",
+        }:
+            assert required in cols, f"missing column {required}"
+
+        cur.execute("SELECT COUNT(*) FROM fingerprint_outcomes")
+        assert cur.fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_write_sqlite_is_idempotent(tmp_path: Path) -> None:
+    """Re-running drop+recreate doesn't accumulate stale rows."""
+    db_path = tmp_path / "out.sqlite"
+
+    table_a: dict[FingerprintKey, Accumulator] = {
+        FingerprintKey("fp-A", "x", "y", ""): Accumulator(dispatch_count=1),
+    }
+    table_b: dict[FingerprintKey, Accumulator] = {
+        FingerprintKey("fp-B", "x", "y", ""): Accumulator(dispatch_count=1),
+    }
+    write_sqlite(table_a, db_path)
+    write_sqlite(table_b, db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT fingerprint FROM fingerprint_outcomes")
+        rows = [r[0] for r in cur.fetchall()]
+        # First write's row must be gone; only second's remains.
+        assert rows == ["fp-B"]
+    finally:
+        conn.close()
+
+
+# ─── Markdown render ─────────────────────────────────────────────────────
+
+
+def test_render_markdown_groups_by_role(tmp_path: Path) -> None:
+    """Report has one ## section per role, no global average."""
+    table: dict[FingerprintKey, Accumulator] = {
+        FingerprintKey("fp-1", "haiku", "reviewer", ""): Accumulator(
+            dispatch_count=10, allow_count=9, deny_count=1
+        ),
+        FingerprintKey("fp-2", "opus", "programmer", ""): Accumulator(
+            dispatch_count=3, allow_count=3
+        ),
+    }
+    out = render_markdown(table, "7d", datetime(2026, 5, 4, tzinfo=timezone.utc))
+
+    assert "## Role: `reviewer`" in out
+    assert "## Role: `programmer`" in out
+    # No global "all-roles" section
+    assert "## Role: all" not in out
+    assert "## Role: global" not in out
+
+
+def test_render_markdown_handles_empty_table() -> None:
+    """No data → no role sections, but the report header still renders
+    cleanly so the operator can tell the recipe ran."""
+    out = render_markdown({}, "1d", datetime(2026, 5, 4, tzinfo=timezone.utc))
+    assert "Fingerprint × outcomes report" in out
+    assert "## Role:" not in out


### PR DESCRIPTION
## Summary

P3 of the routing-as-learning-system phase ladder. Stacks on #294 (P2 — chain fingerprint tagging) — review/merge that one first.

Materializes the join table that ELO computation (P4) consumes: chain dispatches × swarm-runs outcomes, grouped by `(fingerprint, model, role, task_class)`.

## Output

- `python/analysis/out/fingerprint-outcomes-<YYYY-MM-DD>.md` — markdown report grouped per-role. No global-average row — averaging across roles buries the signal we exist to surface.
- `python/analysis/out/fingerprint-outcomes.sqlite` — materialized view; drop-and-recreate on each run, idempotent.

## Per-row metrics

| Source | Metric |
|---|---|
| chain | dispatch_count, allow_count, deny_count, lockdown_count, total_cost_usd |
| swarm-runs | pr_opened_count, bucket_b_count, mean_duration_ms |
| both | first_seen_ts, last_seen_ts |

## Join semantics

Chain decision's `workflow_id` substring-matches swarm-run's `entry_id` to enrich the chain row with outcome metrics. Swarm-runs with no chain match (older runs, pre-P2 dispatches) land in an empty-fingerprint bucket — surfaced rather than silently dropped.

## Test plan

- [x] 9 unit tests pass (`uv run pytest tests/test_fingerprint_outcomes.py`)
- [x] Smoke run on real chain (last 7 days, 6588 dispatches): produces valid md + sqlite. Everything currently in `(untagged)` bucket since P2 hasn't dogfooded yet — will populate as #294 merges + tags new rows.

## Unblocks

P4 `routing-elo-board` — pairwise ELO per role/task_class. P5 dynamic-routing-from-ELO is filed but unimplemented until P4 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)