### PR TITLE
feat(analysis): routing ELO leaderboard (P4 routing-as-learning-system)

### DIFF
--- a/python/analysis/__main__.py
+++ b/python/analysis/__main__.py
@@ -8,7 +8,8 @@ print(
     "  python -m analysis.debt        # debt-ledger draft\n"
     "  python -m analysis.souls       # soul-routing decisions\n"
     "  python -m analysis.skill_mine  # workflow n-gram surface from chain telemetry\n"
-    "  python -m analysis.codex_mine  # codex session ingest + quota usage",
+    "  python -m analysis.codex_mine  # codex session ingest + quota usage\n"
+    "  python -m analysis.routing_elo  # ELO leaderboard per (role, task_class) — P4",
     file=sys.stderr,
 )
 sys.exit(2)

--- a/python/analysis/routing_elo.py
+++ b/python/analysis/routing_elo.py
@@ -1,0 +1,386 @@
+"""P4 — Pairwise ELO leaderboard per (role, task_class).
+
+Reads the materialized sqlite from ``analysis.fingerprint_outcomes`` (P3)
+and computes an ELO score per fingerprint within each role × task_class
+bucket. Each dispatch is a "match" against a virtual baseline opponent
+at rating 1500; success → win, failure → loss. Standard chess ELO update
+(K=32) with deterministic match ordering so re-runs over the same input
+produce identical scores.
+
+Why ELO and not flat success-rate ranking: different fingerprints work
+different task-shapes. A flat ``success_rate`` table averages out
+strengths. ELO via per-match updates surfaces "fingerprint A converged
+to 1620 over 50 matches" vs "fingerprint B is at 1500 (unproven)" —
+sample size is part of the signal, not just the rate.
+
+Drift behavior: when the static-default baseline changes (e.g., a routing
+reshuffle promotes haiku-4-5 to a tier where sonnet was), absolute ELO
+numbers reset for fingerprints that fall out of the leaderboard, but
+relative ranking among the remaining fingerprints carries forward
+because their match histories don't change.
+
+Usage::
+
+    python -m analysis.routing_elo \\
+        --sqlite python/analysis/out/fingerprint-outcomes.sqlite \\
+        --role reviewer \\
+        --out python/analysis/out/routing-elo-2026-05-04.md
+
+When ``--role`` is omitted, the report covers all roles. Output is
+markdown grouped by (role, task_class).
+
+Match-outcome rules (per-row in the fingerprint_outcomes table):
+- "Success" = ``allow_count > 0`` (chain side) OR ``pr_opened_count > 0`` (swarm-runs side)
+- "Failure" = ``deny_count`` + ``lockdown_count`` + ``bucket_b_count``
+- "Draw" / unmapped = neither (rare; doesn't update ELO)
+
+The matches are derived by treating each dispatch as a match. A
+fingerprint with 10 successes and 3 failures plays 13 matches. Win/loss
+order within a fingerprint is deterministic (wins first, then losses).
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import sqlite3
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ─── Constants ────────────────────────────────────────────────────────────
+
+# Standard chess ELO baseline. Means a brand-new fingerprint with zero
+# matches is rated as "average" against the baseline opponent at 1500.
+BASELINE_RATING = 1500.0
+
+# K factor — how much each match moves the rating. 32 is the chess-USCF
+# default for new players; 16 for established. We use 32 to stay
+# responsive to recent shifts (fingerprints that start failing quickly
+# fall in the leaderboard) at the cost of some noise.
+K_FACTOR = 32.0
+
+# The virtual opponent every fingerprint plays against. Static at the
+# baseline rating so all fingerprints are evaluated against the same
+# anchor. Per the design's drift-behavior note, when this anchor's
+# semantics change (e.g., the static-default routing shifts), absolute
+# numbers reset but relative ranking among non-resetting fingerprints
+# carries forward.
+OPPONENT_RATING = BASELINE_RATING
+
+
+# ─── Match derivation ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FingerprintRow:
+    """One row from the fingerprint_outcomes sqlite materialized view."""
+
+    fingerprint: str
+    model: str
+    role: str
+    task_class: str
+    dispatch_count: int
+    allow_count: int
+    deny_count: int
+    lockdown_count: int
+    pr_opened_count: int
+    bucket_b_count: int
+    total_cost_usd: float
+    mean_duration_ms: float
+    first_seen_ts: Optional[str]
+    last_seen_ts: Optional[str]
+
+
+def derive_match_record(row: FingerprintRow) -> tuple[int, int]:
+    """Return (wins, losses) for the fingerprint's pseudo-tournament.
+
+    Wins: any successful dispatch — allow_count + pr_opened_count.
+    Losses: deny + lockdown + bucket_b.
+
+    The chain side and swarm-runs side don't always overlap on the same
+    dispatches; when both fire for the same fingerprint we count each
+    success/failure once. ``min(allow, dispatch)`` clamps in case of
+    pre-P2 rows where allow_count was filled in but dispatch_count
+    underflowed (rare; defensive).
+    """
+    successes = min(row.allow_count + row.pr_opened_count, max(row.dispatch_count, 1) * 2)
+    failures = row.deny_count + row.lockdown_count + row.bucket_b_count
+    return (successes, failures)
+
+
+# ─── ELO computation ──────────────────────────────────────────────────────
+
+
+def expected_score(my_rating: float, opp_rating: float) -> float:
+    """Standard ELO expected score: probability of winning against an
+    opponent with the given rating. Range [0, 1]."""
+    return 1.0 / (1.0 + math.pow(10.0, (opp_rating - my_rating) / 400.0))
+
+
+def apply_match(rating: float, outcome: float, opponent: float) -> float:
+    """Standard ELO update. ``outcome`` is 1.0 for a win, 0.0 for a loss,
+    0.5 for a draw."""
+    return rating + K_FACTOR * (outcome - expected_score(rating, opponent))
+
+
+def compute_elo(wins: int, losses: int) -> float:
+    """Iterate ELO updates with interleaved wins/losses for path-fairness.
+
+    Why deterministic ordering: the table input doesn't carry per-match
+    timestamps (only first/last_seen on the bucket), so any ordering
+    we pick is somewhat arbitrary. Interleaving wins and losses
+    proportional to their counts gives the path-fairest progression —
+    a 50/50 record converges very close to baseline rather than
+    swinging wildly through wins-first-then-losses. Re-running on the
+    same (W, L) counts produces identical output, which is the
+    testability invariant.
+
+    Algorithm: walk N total matches; at each step, emit a "win" if
+    we've drawn fewer wins than expected proportionally, else a
+    "loss." This is the same pattern as Bresenham's line algorithm
+    for proportional event placement. Equivalent to sorted-by-fraction
+    interleave but cheaper and integer-only.
+    """
+    rating = BASELINE_RATING
+    total = wins + losses
+    if total == 0:
+        return rating
+    wins_emitted = 0
+    losses_emitted = 0
+    for _ in range(total):
+        # Emit a win if we're "behind" on wins, else a loss.
+        if wins_emitted * losses < losses_emitted * wins:
+            rating = apply_match(rating, 1.0, OPPONENT_RATING)
+            wins_emitted += 1
+        else:
+            rating = apply_match(rating, 0.0, OPPONENT_RATING)
+            losses_emitted += 1
+    return rating
+
+
+# ─── Sqlite read ──────────────────────────────────────────────────────────
+
+
+def load_rows(db_path: Path, role_filter: Optional[str] = None) -> list[FingerprintRow]:
+    """Load all rows from the fingerprint_outcomes table.
+
+    Missing DB or empty table → empty list (analysis tolerates absent
+    inputs, mirroring the loaders convention).
+    """
+    if not db_path.exists():
+        return []
+    rows: list[FingerprintRow] = []
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        # Confirm the table exists before querying.
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='fingerprint_outcomes'"
+        )
+        if cur.fetchone() is None:
+            return []
+        sql = (
+            "SELECT fingerprint, model, role, task_class, "
+            "dispatch_count, allow_count, deny_count, lockdown_count, "
+            "pr_opened_count, bucket_b_count, total_cost_usd, mean_duration_ms, "
+            "first_seen_ts, last_seen_ts FROM fingerprint_outcomes"
+        )
+        if role_filter is not None:
+            sql += " WHERE role = ?"
+            cur.execute(sql, (role_filter,))
+        else:
+            cur.execute(sql)
+        for r in cur.fetchall():
+            rows.append(FingerprintRow(*r))
+    finally:
+        conn.close()
+    return rows
+
+
+# ─── Leaderboard build ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LeaderboardEntry:
+    fingerprint: str
+    model: str
+    role: str
+    task_class: str
+    dispatch_count: int
+    wins: int
+    losses: int
+    elo: float
+    success_rate: float
+    cost_per_success: Optional[float]
+
+
+def build_leaderboard(rows: list[FingerprintRow]) -> list[LeaderboardEntry]:
+    """Convert rows into ELO-scored entries. Sortable by elo desc."""
+    entries: list[LeaderboardEntry] = []
+    for row in rows:
+        wins, losses = derive_match_record(row)
+        total_matches = wins + losses
+        elo = compute_elo(wins, losses)
+        success_rate = (wins / total_matches) if total_matches > 0 else 0.0
+        cost_per_success = (row.total_cost_usd / wins) if wins > 0 else None
+        entries.append(
+            LeaderboardEntry(
+                fingerprint=row.fingerprint,
+                model=row.model,
+                role=row.role,
+                task_class=row.task_class,
+                dispatch_count=row.dispatch_count,
+                wins=wins,
+                losses=losses,
+                elo=elo,
+                success_rate=success_rate,
+                cost_per_success=cost_per_success,
+            )
+        )
+    return entries
+
+
+# ─── Markdown render ──────────────────────────────────────────────────────
+
+
+def render_leaderboard(
+    entries: list[LeaderboardEntry], generated_at: datetime, role_filter: Optional[str]
+) -> str:
+    """One ## section per (role, task_class). Within each section,
+    fingerprints are sorted by ELO descending."""
+    lines: list[str] = []
+    lines.append("# Routing ELO leaderboard")
+    lines.append("")
+    if role_filter:
+        lines.append(f"Role filter: `{role_filter}`")
+    else:
+        lines.append("All roles included.")
+    lines.append("")
+    lines.append(f"Generated at {generated_at.isoformat()}.")
+    lines.append("")
+    lines.append(
+        "Each row is a fingerprint's ELO score after playing wins+losses "
+        f"matches against a virtual baseline opponent at rating "
+        f"{int(BASELINE_RATING)}. K-factor is {int(K_FACTOR)} (chess-USCF "
+        "default for new players). Higher ELO = the fingerprint outperforms "
+        "the baseline; lower = underperforms. Sample size matters — a "
+        "fingerprint with 5 wins and 0 losses can still be lower than one "
+        "with 50 wins and 5 losses because ELO rewards consistency across "
+        "many matches, not the rate alone."
+    )
+    lines.append("")
+
+    by_bucket: dict[tuple[str, str], list[LeaderboardEntry]] = defaultdict(list)
+    for e in entries:
+        by_bucket[(e.role or "(untagged)", e.task_class or "(any)")].append(e)
+
+    # Stable bucket order: known roles first, then alphabetical.
+    known_role_order = [
+        "programmer",
+        "reviewer",
+        "peer-reviewer",
+        "comment-responder",
+        "researcher",
+        "groomer",
+        "analyst",
+        "tech-writer",
+        "debt-curator",
+        "(untagged)",
+    ]
+    bucket_keys = sorted(
+        by_bucket.keys(),
+        key=lambda rt: (
+            known_role_order.index(rt[0]) if rt[0] in known_role_order else len(known_role_order),
+            rt[0],
+            rt[1],
+        ),
+    )
+
+    for (role, task_class) in bucket_keys:
+        bucket = by_bucket[(role, task_class)]
+        bucket.sort(key=lambda e: -e.elo)
+
+        lines.append(f"## `{role}` × `{task_class}`")
+        lines.append("")
+        lines.append(
+            "| ELO | fingerprint | model | dispatches | W-L | success% | "
+            "$/success |"
+        )
+        lines.append("|---|---|---|---|---|---|---|")
+        for e in bucket:
+            fp = e.fingerprint or "(none)"
+            model = e.model or "(none)"
+            cost_per = f"${e.cost_per_success:.4f}" if e.cost_per_success else "—"
+            lines.append(
+                f"| **{e.elo:.0f}** | `{fp}` | `{model}` | "
+                f"{e.dispatch_count} | {e.wins}-{e.losses} | "
+                f"{e.success_rate * 100:.1f}% | {cost_per} |"
+            )
+        lines.append("")
+
+    if not by_bucket:
+        lines.append("_No data — populate by running `python -m analysis.fingerprint_outcomes` first._")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        f"Source: `python -m analysis.routing_elo`. "
+        f"Reads the sqlite materialized view from "
+        "`analysis.fingerprint_outcomes`. Re-runs are deterministic "
+        "given fixed match-derivation rules + opponent rating."
+    )
+    return "\n".join(lines)
+
+
+# ─── CLI entry ────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="ELO leaderboard for fingerprint × role/task_class.",
+    )
+    parser.add_argument(
+        "--sqlite",
+        type=Path,
+        default=None,
+        help="fingerprint-outcomes.sqlite path (defaults to python/analysis/out/).",
+    )
+    parser.add_argument(
+        "--role",
+        default=None,
+        help="Filter to one role (programmer, reviewer, ...). Default: all roles.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Markdown report path. Defaults to python/analysis/out/routing-elo-<YYYY-MM-DD>.md.",
+    )
+    args = parser.parse_args(argv)
+
+    out_dir = Path(__file__).parent / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sqlite_path = args.sqlite or (out_dir / "fingerprint-outcomes.sqlite")
+    rows = load_rows(sqlite_path, role_filter=args.role)
+    entries = build_leaderboard(rows)
+
+    now = datetime.now(timezone.utc)
+    md_path = args.out or (out_dir / f"routing-elo-{now.strftime('%Y-%m-%d')}.md")
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(render_leaderboard(entries, now, args.role))
+
+    print(
+        f"routing_elo: {len(entries)} entries → {md_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/analysis/routing_elo.py
+++ b/python/analysis/routing_elo.py
@@ -30,13 +30,16 @@ When ``--role`` is omitted, the report covers all roles. Output is
 markdown grouped by (role, task_class).
 
 Match-outcome rules (per-row in the fingerprint_outcomes table):
-- "Success" = ``allow_count > 0`` (chain side) OR ``pr_opened_count > 0`` (swarm-runs side)
-- "Failure" = ``deny_count`` + ``lockdown_count`` + ``bucket_b_count``
-- "Draw" / unmapped = neither (rare; doesn't update ELO)
+- ``wins = allow_count + pr_opened_count`` (chain successes + swarm-runs successes)
+- ``losses = deny_count + lockdown_count + bucket_b_count``
 
-The matches are derived by treating each dispatch as a match. A
-fingerprint with 10 successes and 3 failures plays 13 matches. Win/loss
-order within a fingerprint is deterministic (wins first, then losses).
+Each integer in those counts contributes one match to the
+fingerprint's tournament. A row with allow_count=10 + pr_opened_count=3
++ deny_count=2 yields 13 wins and 2 losses → 15 total matches.
+
+Win/loss order within a fingerprint is deterministic — Bresenham-style
+interleaving so a 50/50 record stays near baseline rather than
+swinging through wins-first-then-losses. See ``compute_elo`` docstring.
 """
 from __future__ import annotations
 
@@ -98,16 +101,21 @@ class FingerprintRow:
 def derive_match_record(row: FingerprintRow) -> tuple[int, int]:
     """Return (wins, losses) for the fingerprint's pseudo-tournament.
 
-    Wins: any successful dispatch — allow_count + pr_opened_count.
-    Losses: deny + lockdown + bucket_b.
+    Wins: ``allow_count + pr_opened_count`` — chain successes plus
+    swarm-runs successes. Each side is its own count of distinct
+    matches; we deliberately do not de-duplicate, because a chain
+    decision and a swarm-runs PR-open are different events even when
+    they belong to the same workflow_id.
 
-    The chain side and swarm-runs side don't always overlap on the same
-    dispatches; when both fire for the same fingerprint we count each
-    success/failure once. ``min(allow, dispatch)`` clamps in case of
-    pre-P2 rows where allow_count was filled in but dispatch_count
-    underflowed (rare; defensive).
+    Losses: ``deny_count + lockdown_count + bucket_b_count``.
+
+    Pre-P2 rows where dispatch_count is zero but pr_opened_count is
+    non-zero (swarm-only bucket) are honored: the swarm-runs successes
+    still count as wins. The previous cap that mistakenly used
+    dispatch_count would have under-counted these — fixed per Copilot
+    review on #296.
     """
-    successes = min(row.allow_count + row.pr_opened_count, max(row.dispatch_count, 1) * 2)
+    successes = row.allow_count + row.pr_opened_count
     failures = row.deny_count + row.lockdown_count + row.bucket_b_count
     return (successes, failures)
 
@@ -144,10 +152,24 @@ def compute_elo(wins: int, losses: int) -> float:
     "loss." This is the same pattern as Bresenham's line algorithm
     for proportional event placement. Equivalent to sorted-by-fraction
     interleave but cheaper and integer-only.
+
+    Edge cases (per Copilot review on #296): when one side is zero,
+    the proportional-emit condition can mis-classify because both sides
+    of the inequality go to zero. Explicit handling: if losses==0,
+    emit only wins; if wins==0, emit only losses. Verified by test
+    cases at (N, 0), (0, N), (1, 0), (0, 1).
     """
     rating = BASELINE_RATING
     total = wins + losses
     if total == 0:
+        return rating
+    if losses == 0:
+        for _ in range(wins):
+            rating = apply_match(rating, 1.0, OPPONENT_RATING)
+        return rating
+    if wins == 0:
+        for _ in range(losses):
+            rating = apply_match(rating, 0.0, OPPONENT_RATING)
         return rating
     wins_emitted = 0
     losses_emitted = 0
@@ -183,6 +205,12 @@ def load_rows(db_path: Path, role_filter: Optional[str] = None) -> list[Fingerpr
         )
         if cur.fetchone() is None:
             return []
+        # Explicit ORDER BY so re-runs over the same DB yield identical
+        # markdown output. Without this, sqlite returns rows in
+        # insertion-order which is fine but not contractual; tests + the
+        # determinism guarantee in the module docstring rely on a stable
+        # order. Sort by (role, task_class, fingerprint, model) — a
+        # composite key guaranteed unique by the table's PRIMARY KEY.
         sql = (
             "SELECT fingerprint, model, role, task_class, "
             "dispatch_count, allow_count, deny_count, lockdown_count, "
@@ -191,8 +219,10 @@ def load_rows(db_path: Path, role_filter: Optional[str] = None) -> list[Fingerpr
         )
         if role_filter is not None:
             sql += " WHERE role = ?"
+            sql += " ORDER BY role, task_class, fingerprint, model"
             cur.execute(sql, (role_filter,))
         else:
+            sql += " ORDER BY role, task_class, fingerprint, model"
             cur.execute(sql)
         for r in cur.fetchall():
             rows.append(FingerprintRow(*r))
@@ -302,7 +332,12 @@ def render_leaderboard(
 
     for (role, task_class) in bucket_keys:
         bucket = by_bucket[(role, task_class)]
-        bucket.sort(key=lambda e: -e.elo)
+        # Stable sort: primary by ELO desc, then fingerprint + model + dispatch
+        # count to break ties at baseline (where many entries cluster). Without
+        # the tiebreaker, ties produced report churn between runs.
+        bucket.sort(
+            key=lambda e: (-e.elo, e.fingerprint, e.model, -e.dispatch_count)
+        )
 
         lines.append(f"## `{role}` × `{task_class}`")
         lines.append("")
@@ -314,7 +349,12 @@ def render_leaderboard(
         for e in bucket:
             fp = e.fingerprint or "(none)"
             model = e.model or "(none)"
-            cost_per = f"${e.cost_per_success:.4f}" if e.cost_per_success else "—"
+            # `is not None` (not truthiness) so a real $0.00 cost renders as
+            # "$0.0000" rather than the missing-data dash — matters for free-
+            # tier copilot runs where cost is genuinely zero.
+            cost_per = (
+                f"${e.cost_per_success:.4f}" if e.cost_per_success is not None else "—"
+            )
             lines.append(
                 f"| **{e.elo:.0f}** | `{fp}` | `{model}` | "
                 f"{e.dispatch_count} | {e.wins}-{e.losses} | "

--- a/python/analysis/tests/test_routing_elo.py
+++ b/python/analysis/tests/test_routing_elo.py
@@ -1,0 +1,289 @@
+"""Tests for analysis.routing_elo — pairwise ELO leaderboard.
+
+Pins the determinism and convergence properties:
+- same input → same scores (re-run safe)
+- known-better fingerprint converges higher than baseline
+- ties / no-data cases stay at baseline
+- markdown shows fingerprint dimensions, not just hash
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from analysis.routing_elo import (
+    BASELINE_RATING,
+    FingerprintRow,
+    LeaderboardEntry,
+    apply_match,
+    build_leaderboard,
+    compute_elo,
+    derive_match_record,
+    expected_score,
+    load_rows,
+    render_leaderboard,
+)
+
+
+# ─── ELO math primitives ──────────────────────────────────────────────────
+
+
+def test_expected_score_equal_ratings_is_50_percent() -> None:
+    assert expected_score(1500.0, 1500.0) == pytest.approx(0.5)
+
+
+def test_expected_score_higher_rating_favors_self() -> None:
+    """Rating gap of 400 → ~91% expected score for the higher-rated player."""
+    assert expected_score(1900.0, 1500.0) == pytest.approx(0.909, abs=0.01)
+
+
+def test_apply_match_win_against_equal_opponent_increases_rating() -> None:
+    new_rating = apply_match(1500.0, outcome=1.0, opponent=1500.0)
+    assert new_rating > 1500.0
+    # K=32, expected=0.5, actual=1 → +16
+    assert new_rating == pytest.approx(1516.0)
+
+
+def test_apply_match_loss_against_equal_opponent_decreases_rating() -> None:
+    new_rating = apply_match(1500.0, outcome=0.0, opponent=1500.0)
+    assert new_rating < 1500.0
+    assert new_rating == pytest.approx(1484.0)
+
+
+def test_apply_match_draw_against_equal_opponent_no_change() -> None:
+    """Outcome=0.5, expected=0.5 → delta=0."""
+    new_rating = apply_match(1500.0, outcome=0.5, opponent=1500.0)
+    assert new_rating == pytest.approx(1500.0)
+
+
+# ─── compute_elo determinism + convergence ────────────────────────────────
+
+
+def test_compute_elo_zero_matches_returns_baseline() -> None:
+    """A brand-new fingerprint with no matches sits at the baseline."""
+    assert compute_elo(0, 0) == BASELINE_RATING
+
+
+def test_compute_elo_is_deterministic() -> None:
+    """Re-running on the same (W, L) input produces identical ELO."""
+    a = compute_elo(20, 5)
+    b = compute_elo(20, 5)
+    assert a == b
+
+
+def test_compute_elo_higher_win_count_yields_higher_rating() -> None:
+    """Known-better fingerprint converges higher."""
+    strong = compute_elo(50, 5)
+    weak = compute_elo(5, 50)
+    assert strong > weak
+    assert strong > BASELINE_RATING
+    assert weak < BASELINE_RATING
+
+
+def test_compute_elo_equal_wins_losses_returns_close_to_baseline() -> None:
+    """Tied W=L should converge near baseline (path-dependent ordering
+    pulls slightly off, but within tens of points)."""
+    rating = compute_elo(20, 20)
+    assert abs(rating - BASELINE_RATING) < 100  # within ~6% of baseline
+
+
+# ─── Match derivation ─────────────────────────────────────────────────────
+
+
+def test_derive_match_record_counts_chain_and_swarm_successes() -> None:
+    row = FingerprintRow(
+        fingerprint="fp",
+        model="m",
+        role="r",
+        task_class="",
+        dispatch_count=10,
+        allow_count=8,
+        deny_count=2,
+        lockdown_count=0,
+        pr_opened_count=3,  # additional swarm-runs side success
+        bucket_b_count=0,
+        total_cost_usd=0.0,
+        mean_duration_ms=0.0,
+        first_seen_ts=None,
+        last_seen_ts=None,
+    )
+    wins, losses = derive_match_record(row)
+    assert wins == 11  # 8 allow + 3 pr_opened
+    assert losses == 2
+
+
+def test_derive_match_record_counts_lockdown_and_bucket_b_as_losses() -> None:
+    row = FingerprintRow(
+        fingerprint="fp",
+        model="m",
+        role="r",
+        task_class="",
+        dispatch_count=5,
+        allow_count=3,
+        deny_count=1,
+        lockdown_count=1,
+        pr_opened_count=0,
+        bucket_b_count=2,
+        total_cost_usd=0.0,
+        mean_duration_ms=0.0,
+        first_seen_ts=None,
+        last_seen_ts=None,
+    )
+    wins, losses = derive_match_record(row)
+    assert wins == 3
+    assert losses == 4  # 1 deny + 1 lockdown + 2 bucket_b
+
+
+# ─── Sqlite read ──────────────────────────────────────────────────────────
+
+
+def _make_sqlite(path: Path, rows: list[tuple]) -> None:
+    """Write a fingerprint-outcomes-shaped sqlite for testing.
+
+    Schema mirrors fingerprint_outcomes.write_sqlite but defined here
+    locally so the test doesn't depend on the writer (avoids circular
+    test coupling)."""
+    conn = sqlite3.connect(path)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE fingerprint_outcomes (
+              fingerprint TEXT NOT NULL,
+              model TEXT NOT NULL,
+              role TEXT NOT NULL,
+              task_class TEXT NOT NULL,
+              dispatch_count INTEGER NOT NULL,
+              allow_count INTEGER NOT NULL,
+              deny_count INTEGER NOT NULL,
+              lockdown_count INTEGER NOT NULL,
+              total_cost_usd REAL NOT NULL,
+              pr_opened_count INTEGER NOT NULL,
+              pr_merged_count INTEGER NOT NULL,
+              bucket_b_count INTEGER NOT NULL,
+              mean_duration_ms REAL NOT NULL,
+              first_seen_ts TEXT,
+              last_seen_ts TEXT,
+              PRIMARY KEY (fingerprint, model, role, task_class)
+            )
+            """
+        )
+        cur.executemany(
+            "INSERT INTO fingerprint_outcomes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_load_rows_returns_empty_for_missing_db(tmp_path: Path) -> None:
+    rows = load_rows(tmp_path / "nope.sqlite")
+    assert rows == []
+
+
+def test_load_rows_returns_empty_for_db_without_table(tmp_path: Path) -> None:
+    """A sqlite file that exists but has no fingerprint_outcomes table —
+    e.g., a stale db from a different recipe — returns empty rather than
+    crashing on the SELECT."""
+    db = tmp_path / "empty.sqlite"
+    conn = sqlite3.connect(db)
+    conn.close()
+    assert load_rows(db) == []
+
+
+def test_load_rows_returns_all_rows_when_role_filter_is_none(tmp_path: Path) -> None:
+    db = tmp_path / "out.sqlite"
+    _make_sqlite(
+        db,
+        [
+            ("fp1", "haiku", "reviewer", "", 5, 4, 1, 0, 0.0, 0, 0, 0, 0.0, None, None),
+            ("fp2", "opus", "programmer", "", 3, 3, 0, 0, 0.0, 0, 0, 0, 0.0, None, None),
+        ],
+    )
+    rows = load_rows(db)
+    assert len(rows) == 2
+
+
+def test_load_rows_filters_by_role(tmp_path: Path) -> None:
+    db = tmp_path / "out.sqlite"
+    _make_sqlite(
+        db,
+        [
+            ("fp1", "haiku", "reviewer", "", 5, 4, 1, 0, 0.0, 0, 0, 0, 0.0, None, None),
+            ("fp2", "opus", "programmer", "", 3, 3, 0, 0, 0.0, 0, 0, 0, 0.0, None, None),
+        ],
+    )
+    rows = load_rows(db, role_filter="reviewer")
+    assert len(rows) == 1
+    assert rows[0].role == "reviewer"
+
+
+# ─── Leaderboard build ────────────────────────────────────────────────────
+
+
+def test_build_leaderboard_orders_by_elo_descending_within_role() -> None:
+    rows = [
+        FingerprintRow("fp1", "m1", "reviewer", "", 50, 45, 5, 0, 0, 0, 0.0, 0.0, None, None),
+        FingerprintRow("fp2", "m2", "reviewer", "", 50, 5, 45, 0, 0, 0, 0.0, 0.0, None, None),
+    ]
+    entries = build_leaderboard(rows)
+    # build_leaderboard returns in input order; the markdown render sorts
+    # within bucket. The leaderboard data structure itself is order-
+    # agnostic.
+    by_fp = {e.fingerprint: e for e in entries}
+    assert by_fp["fp1"].elo > by_fp["fp2"].elo
+
+
+def test_build_leaderboard_computes_cost_per_success() -> None:
+    rows = [
+        FingerprintRow("fp1", "m", "r", "", 10, 8, 2, 0, 0, 0, 0.40, 0.0, None, None),
+    ]
+    entries = build_leaderboard(rows)
+    assert len(entries) == 1
+    # 8 wins, $0.40 total → $0.05 per success
+    assert entries[0].cost_per_success == pytest.approx(0.05)
+
+
+def test_build_leaderboard_handles_zero_dispatches() -> None:
+    rows = [
+        FingerprintRow("fp1", "m", "r", "", 0, 0, 0, 0, 0, 0, 0.0, 0.0, None, None),
+    ]
+    entries = build_leaderboard(rows)
+    assert entries[0].elo == BASELINE_RATING
+    assert entries[0].cost_per_success is None
+
+
+# ─── Markdown render ──────────────────────────────────────────────────────
+
+
+def test_render_leaderboard_groups_by_role_and_task_class() -> None:
+    entries = [
+        LeaderboardEntry("fp1", "haiku", "reviewer", "", 10, 8, 2, 1550, 0.8, 0.05),
+        LeaderboardEntry("fp2", "opus", "programmer", "", 3, 3, 0, 1540, 1.0, 0.10),
+    ]
+    out = render_leaderboard(entries, datetime(2026, 5, 4, tzinfo=timezone.utc), None)
+    assert "## `reviewer`" in out
+    assert "## `programmer`" in out
+    # Fingerprint dimensions visible (not just opaque hash)
+    assert "haiku" in out
+    assert "opus" in out
+    # ELO numbers visible
+    assert "1550" in out
+    assert "1540" in out
+
+
+def test_render_leaderboard_handles_empty_input() -> None:
+    out = render_leaderboard([], datetime(2026, 5, 4, tzinfo=timezone.utc), None)
+    assert "Routing ELO leaderboard" in out
+    assert "No data" in out
+
+
+def test_render_leaderboard_shows_role_filter_when_set() -> None:
+    out = render_leaderboard(
+        [], datetime(2026, 5, 4, tzinfo=timezone.utc), role_filter="reviewer"
+    )
+    assert "Role filter: `reviewer`" in out

--- a/python/analysis/tests/test_routing_elo.py
+++ b/python/analysis/tests/test_routing_elo.py
@@ -90,6 +90,34 @@ def test_compute_elo_equal_wins_losses_returns_close_to_baseline() -> None:
     assert abs(rating - BASELINE_RATING) < 100  # within ~6% of baseline
 
 
+def test_compute_elo_only_wins_strictly_above_baseline() -> None:
+    """No-loss edge case (Copilot review #296): the Bresenham
+    interleaving condition can mis-classify when one side is zero.
+    Explicit handling: N wins + 0 losses applies N win-updates,
+    rating is strictly higher than baseline."""
+    rating = compute_elo(10, 0)
+    assert rating > BASELINE_RATING
+
+
+def test_compute_elo_only_losses_strictly_below_baseline() -> None:
+    """Symmetric no-win edge case."""
+    rating = compute_elo(0, 10)
+    assert rating < BASELINE_RATING
+
+
+def test_compute_elo_one_win_zero_loss_increases_rating() -> None:
+    """Smallest win-only case (1, 0): one apply_match win update."""
+    rating = compute_elo(1, 0)
+    # K=32, expected=0.5 against equal opponent → +16
+    assert rating == pytest.approx(BASELINE_RATING + 16)
+
+
+def test_compute_elo_zero_win_one_loss_decreases_rating() -> None:
+    """Smallest loss-only case (0, 1)."""
+    rating = compute_elo(0, 1)
+    assert rating == pytest.approx(BASELINE_RATING - 16)
+
+
 # ─── Match derivation ─────────────────────────────────────────────────────
 
 
@@ -135,6 +163,31 @@ def test_derive_match_record_counts_lockdown_and_bucket_b_as_losses() -> None:
     wins, losses = derive_match_record(row)
     assert wins == 3
     assert losses == 4  # 1 deny + 1 lockdown + 2 bucket_b
+
+
+def test_derive_match_record_swarm_only_bucket_with_zero_dispatch_count() -> None:
+    """Pre-P2 / swarm-only rows have dispatch_count=0 but pr_opened_count
+    or bucket_b_count from the swarm-runs side. The previous capped
+    derivation under-counted these — fixed per Copilot #296."""
+    row = FingerprintRow(
+        fingerprint="",
+        model="haiku",
+        role="programmer",
+        task_class="",
+        dispatch_count=0,  # zero chain decisions
+        allow_count=0,
+        deny_count=0,
+        lockdown_count=0,
+        pr_opened_count=8,  # but 8 successful PRs from swarm-runs
+        bucket_b_count=2,
+        total_cost_usd=0.0,
+        mean_duration_ms=0.0,
+        first_seen_ts=None,
+        last_seen_ts=None,
+    )
+    wins, losses = derive_match_record(row)
+    assert wins == 8  # not capped to 0 * 2 = 0
+    assert losses == 2
 
 
 # ─── Sqlite read ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

P4 of the routing-as-learning-system phase ladder. Pairwise ELO leaderboard per `(role, task_class)`, fed by the sqlite materialized view from #295 (P3 fingerprint_outcomes).

Stacks on #294 (P2 chain tagging) and #295 (P3 outcomes recipe) for empirical data — but the recipe runs against any fingerprint-outcomes.sqlite, including the empty-fingerprint bucket that surfaces while P2 dogfoods.

## How matches are derived

Each row in the P3 sqlite represents N dispatches with M successes:

| Source | Win | Loss |
|---|---|---|
| Chain | `allow_count` | `deny_count` + `lockdown_count` |
| Swarm-runs | `pr_opened_count` | `bucket_b_count` |

Total matches per fingerprint = wins + losses. Each match runs against a virtual opponent at rating 1500 (BASELINE_RATING). Standard chess-USCF K=32.

## Determinism

Re-runs over the same input produce identical scores. Match ordering interleaves wins and losses in Bresenham fashion so a 50/50 fingerprint converges close to baseline rather than swinging via wins-first-then-losses ordering. Pin: `test_compute_elo_equal_wins_losses_returns_close_to_baseline`.

## Output

`python/analysis/out/routing-elo-<YYYY-MM-DD>.md`:
- Grouped per `(role, task_class)` — no global average; averaging across roles buries the signal we exist to surface
- Sorted by ELO desc within each section
- Shows fingerprint dimensions (model, role, task_class) — not just opaque hash
- Includes `$/success` when per-call cost data is available

## Test plan

- [x] 21 unit tests pass (`uv run pytest tests/test_routing_elo.py`)
  - ELO primitives (expected_score, apply_match)
  - Determinism: same input → same output
  - Convergence: known-better fingerprint > baseline > known-worse
  - Edge cases: zero matches, missing db, no table, role filter
- [x] Smoke run on real data: 2 entries (one with 6588 matches, one with 0), produces valid markdown

## Why ELO instead of flat success-rate

A flat table averages out strengths. ELO via per-match updates makes sample size part of the signal: a fingerprint with 50 wins and 5 losses ranks higher than one with 5 wins and 0 losses because consistency across many matches matters, not just the rate.

## Follow-up

The TS CLI `chitin elo` lands in a separate PR. Python recipe alone delivers the ranking; the CLI is sugar.

P5 (dynamic-routing-from-ELO) is filed but deliberately unimplemented until P4 ships and we see what the data shape looks like in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)