### PR TITLE
site: public teaser + Apache 2.0 relicense

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - "docs/roadmap.md"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: build site
+        run: node web/build.mjs
+
+      - name: configure pages
+        uses: actions/configure-pages@v5
+
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: deploy
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Chitin
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Chitin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Chitin
+Copyright 2026 Chitin
+
+This product includes software developed by the Chitin project
+(https://github.com/chitinhq/chitin).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chitin
 
-**Execution kernel for AI coding agents.** Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript + Python). MIT licensed.
+**Execution kernel for AI coding agents.** Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript + Python). Apache 2.0 licensed.
 
 > Principle: real execution before policy. Policy before automation. Automation gated by the same kernel.
 
@@ -111,4 +111,4 @@ Archive: [`docs/archive-map.md`](./docs/archive-map.md)
 
 ## License
 
-[MIT](./LICENSE)
+[Apache 2.0](./LICENSE)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -103,7 +103,7 @@ A1 (agent framework builders) → A2 (platform/infra) → A4 (security/complianc
 
 ## Phase 0 — archive predecessors (complete)
 
-Renamed `chitinhq/chitin → chitinhq/chitin-archive` at `v1.0.0`; archived every other v1 repo in the org; created the new public MIT `chitinhq/chitin` monorepo. Hermes (the predecessor driver) was killed as a chitin component on 2026-04-23 — chitin is governance around openclaw + Claude Code, not a tick loop. See [`archive-map.md`](./archive-map.md) for what was extracted vs left behind.
+Renamed `chitinhq/chitin → chitinhq/chitin-archive` at `v1.0.0`; archived every other v1 repo in the org; created the new public Apache 2.0 `chitinhq/chitin` monorepo. Hermes (the predecessor driver) was killed as a chitin component on 2026-04-23 — chitin is governance around openclaw + Claude Code, not a tick loop. See [`archive-map.md`](./archive-map.md) for what was extracted vs left behind.
 
 ## Candidates from external signal
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chitin",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "install-kernel": "pnpm nx build execution-kernel && bash scripts/install-kernel-symlink.sh"
   },

--- a/web/build.mjs
+++ b/web/build.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Builds dist/index.html by injecting recent-merges data from `gh pr list`
+// into web/index.html between <!-- MERGES:* --> markers.
+// Requires `gh` CLI in PATH; in CI it's preinstalled and uses GITHUB_TOKEN.
+// No npm deps. Run: node web/build.mjs
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+const TEMPLATE = resolve(repoRoot, 'web/index.html');
+const OUT = resolve(repoRoot, 'dist/index.html');
+const REPO = 'chitinhq/chitin';
+const LIST_LIMIT = 6;
+const FETCH_LIMIT = 50;
+const STAT_WINDOW_DAYS = 7;
+
+function fetchMerges() {
+  try {
+    const raw = execSync(
+      `gh pr list --repo ${REPO} --state merged --limit ${FETCH_LIMIT} --json number,title,mergedAt,author`,
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) throw new Error('gh returned non-array');
+    return data
+      .filter((pr) => pr.mergedAt)
+      .sort((a, b) => new Date(b.mergedAt) - new Date(a.mergedAt));
+  } catch (e) {
+    console.warn(`warn: gh pr list failed (${e.message}). emitting placeholder.`);
+    return null;
+  }
+}
+
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function splitConventional(title) {
+  const m = title.match(/^([a-z0-9]+(?:\([^)]+\))?):\s*(.+)$/i);
+  if (m) return { prefix: m[1], rest: m[2] };
+  return { prefix: null, rest: title };
+}
+
+function relativeDay(date) {
+  const ms = Date.now() - new Date(date).getTime();
+  const day = Math.floor(ms / 86_400_000);
+  if (day < 1) return 'today';
+  if (day < 2) return 'yesterday';
+  if (day < 14) return `${day}d ago`;
+  return new Date(date).toISOString().slice(0, 10);
+}
+
+function countSince(merges, days) {
+  const cutoff = Date.now() - days * 86_400_000;
+  return merges.filter((pr) => new Date(pr.mergedAt).getTime() >= cutoff).length;
+}
+
+function renderItem(pr) {
+  const { prefix, rest } = splitConventional(pr.title);
+  const url = `https://github.com/${REPO}/pull/${pr.number}`;
+  const prefixHtml = prefix
+    ? `<span class="mono text-xs text-chitin/70 mr-1.5">${escapeHtml(prefix)}:</span>`
+    : '';
+  return (
+    `<li class="py-3 flex items-baseline gap-3">` +
+    `<a href="${url}" class="mono text-xs text-chitin/80 hover:text-chitin shrink-0 w-12">#${pr.number}</a>` +
+    `<span class="flex-1 min-w-0 truncate-fallback">${prefixHtml}<span class="text-bone/90">${escapeHtml(rest)}</span></span>` +
+    `<span class="mono text-xs text-muted/70 shrink-0">${escapeHtml(relativeDay(pr.mergedAt))}</span>` +
+    `</li>`
+  );
+}
+
+function renderPlaceholder() {
+  return (
+    `<li class="py-3 text-muted">` +
+    `GitHub data unavailable at build time. ` +
+    `<a href="https://github.com/${REPO}/pulls?q=is%3Apr+is%3Amerged" class="text-chitin hover:underline">View merged PRs →</a>` +
+    `</li>`
+  );
+}
+
+let sha = 'local';
+try {
+  sha = execSync('git rev-parse --short HEAD', { cwd: repoRoot, encoding: 'utf8' }).trim();
+} catch {}
+if (process.env.GITHUB_SHA) sha = process.env.GITHUB_SHA.slice(0, 7);
+const dateStamp = new Date().toISOString().slice(0, 10);
+
+const merges = fetchMerges();
+const template = readFileSync(TEMPLATE, 'utf8');
+
+let listHtml;
+let statHtml;
+if (merges && merges.length > 0) {
+  const top = merges.slice(0, LIST_LIMIT);
+  listHtml = top.map(renderItem).join('\n      ');
+  const recent = countSince(merges, STAT_WINDOW_DAYS);
+  statHtml = `<span class="text-chitin font-bold">${recent}</span> merged in last ${STAT_WINDOW_DAYS} days`;
+} else {
+  listHtml = renderPlaceholder();
+  statHtml = `<span class="text-muted">—</span> data unavailable`;
+}
+
+const replacements = [
+  {
+    name: 'list',
+    re: /<!-- MERGES:LIST -->[\s\S]*?<!-- \/MERGES:LIST -->/,
+    body: `<!-- MERGES:LIST -->\n      ${listHtml}\n      <!-- /MERGES:LIST -->`,
+  },
+  {
+    name: 'stat',
+    re: /<!-- MERGES:STAT -->[\s\S]*?<!-- \/MERGES:STAT -->/,
+    body: `<!-- MERGES:STAT -->${statHtml}<!-- /MERGES:STAT -->`,
+  },
+  {
+    name: 'sync',
+    re: /<!-- MERGES:SYNC -->[\s\S]*?<!-- \/MERGES:SYNC -->/,
+    body: `<!-- MERGES:SYNC -->source: <a href="https://github.com/${REPO}/pulls?q=is%3Apr+is%3Amerged" class="hover:text-chitin underline-offset-2 hover:underline">gh pr list --state merged</a> · synced ${dateStamp} · <code class="mono">${sha}</code><!-- /MERGES:SYNC -->`,
+  },
+];
+
+let out = template;
+for (const r of replacements) {
+  if (!r.re.test(out)) throw new Error(`marker not found in template: ${r.name}`);
+  out = out.replace(r.re, r.body);
+}
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, out);
+console.log(
+  `built ${OUT.replace(repoRoot + '/', '')}: ` +
+  `${merges ? merges.slice(0, LIST_LIMIT).length : 0} merges shown, ` +
+  `${merges ? countSince(merges, STAT_WINDOW_DAYS) : '—'} in last ${STAT_WINDOW_DAYS}d, sha=${sha}`,
+);

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,877 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>chitin — execution kernel for AI coding agents</title>
+<meta name="description" content="A deterministic governance kernel for AI coding agents. Aggregates events, gates execution, audits chains. Open source." />
+<meta property="og:title" content="chitin — execution kernel for AI coding agents" />
+<meta property="og:description" content="A deterministic governance kernel for AI coding agents." />
+<meta property="og:type" content="website" />
+<meta name="theme-color" content="#0A0E15" />
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet" />
+
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        colors: {
+          bg:      '#0A0E15',
+          panel:   '#11161F',
+          plate:   '#161D29',
+          chitin:  '#D4A574',
+          glow:    '#F5C088',
+          run:     '#22C55E',
+          bone:    '#F5F5F0',
+          muted:   '#94A3B8',
+          line:    'rgba(212,165,116,0.18)',
+        },
+        fontFamily: {
+          mono: ['"Space Mono"', 'ui-monospace', 'monospace'],
+          display: ['"Space Grotesk"', 'system-ui', 'sans-serif'],
+        },
+      },
+    },
+  };
+</script>
+
+<style>
+  html { scroll-behavior: smooth; }
+  body {
+    background: #0A0E15;
+    color: #F5F5F0;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    overflow-x: hidden;
+  }
+  .mono { font-family: 'Space Mono', ui-monospace, monospace; }
+
+  /* Hero hex backdrop */
+  #hex-bg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+  }
+  #hex-bg polygon {
+    fill: transparent;
+    stroke: rgba(212,165,116,0.22);
+    stroke-width: 1;
+    transition: stroke 200ms ease, fill 200ms ease;
+    will-change: transform, opacity;
+  }
+  #hex-bg .bond {
+    stroke: rgba(212,165,116,0.10);
+    stroke-width: 0.5;
+    fill: none;
+  }
+
+  /* Agent particle */
+  .agent-dot {
+    fill: #F5C088;
+    filter: drop-shadow(0 0 6px rgba(245,192,136,0.9)) drop-shadow(0 0 14px rgba(212,165,116,0.5));
+  }
+  .agent-trail {
+    fill: none;
+    stroke: rgba(245,192,136,0.4);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+
+  /* Plates as exoskeleton segments */
+  .plate-card {
+    position: relative;
+    background: linear-gradient(135deg, rgba(22,29,41,0.85) 0%, rgba(17,22,31,0.6) 100%);
+    border: 1px solid rgba(212,165,116,0.15);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    overflow: hidden;
+    transition: border-color 240ms ease, transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .plate-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(212,165,116,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(212,165,116,0.04) 1px, transparent 1px);
+    background-size: 24px 24px;
+    pointer-events: none;
+    opacity: 0.6;
+  }
+  .plate-card:hover {
+    border-color: rgba(212,165,116,0.45);
+    transform: translateY(-2px);
+  }
+  .plate-card .plate-corner {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-color: rgba(212,165,116,0.5);
+  }
+  .plate-card .pc-tl { top:0; left:0; border-top: 1px solid; border-left: 1px solid; }
+  .plate-card .pc-tr { top:0; right:0; border-top: 1px solid; border-right: 1px solid; }
+  .plate-card .pc-bl { bottom:0; left:0; border-bottom: 1px solid; border-left: 1px solid; }
+  .plate-card .pc-br { bottom:0; right:0; border-bottom: 1px solid; border-right: 1px solid; }
+
+  /* Buttons */
+  .btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.85rem 1.5rem;
+    border: 1px solid;
+    cursor: pointer;
+    transition: all 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    font-family: 'Space Mono', ui-monospace, monospace;
+    font-size: 0.92rem;
+    letter-spacing: 0.02em;
+  }
+  .btn-primary {
+    background: rgba(212,165,116,0.06);
+    border-color: rgba(212,165,116,0.55);
+    color: #F5C088;
+  }
+  .btn-primary:hover {
+    background: rgba(212,165,116,0.14);
+    border-color: #F5C088;
+    box-shadow: 0 0 0 1px rgba(245,192,136,0.4), 0 8px 24px -8px rgba(212,165,116,0.4);
+  }
+  .btn-ghost {
+    border-color: rgba(245,245,240,0.18);
+    color: #F5F5F0;
+    background: transparent;
+  }
+  .btn-ghost:hover {
+    border-color: rgba(245,245,240,0.45);
+    color: #F5F5F0;
+  }
+
+  /* Headline lattice underline */
+  .headline-mark {
+    position: relative;
+    display: inline-block;
+  }
+  .headline-mark::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -6px;
+    height: 2px;
+    width: 0;
+    background: linear-gradient(90deg, #D4A574, transparent);
+  }
+
+  /* Scroll cue */
+  .scroll-cue {
+    position: absolute;
+    bottom: 28px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: rgba(245,245,240,0.45);
+    font-size: 0.72rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+  .scroll-cue::before {
+    content: '';
+    display: block;
+    width: 1px;
+    height: 26px;
+    background: linear-gradient(to bottom, transparent, rgba(212,165,116,0.6));
+    margin: 0 auto 10px;
+  }
+
+  /* Reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.001ms !important;
+    }
+  }
+
+  /* Section divider chevrons */
+  .divider {
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(212,165,116,0.3), transparent);
+  }
+
+  /* Metaphor diagram */
+  #shell-diagram {
+    width: 100%;
+    height: 420px;
+    max-width: 720px;
+    margin: 0 auto;
+    display: block;
+  }
+  #shell-diagram .core {
+    fill: url(#coreGradient);
+    filter: drop-shadow(0 0 18px rgba(245,192,136,0.5));
+  }
+  #shell-diagram .shell-hex {
+    fill: rgba(22,29,41,0.85);
+    stroke: rgba(212,165,116,0.55);
+    stroke-width: 1.2;
+  }
+
+  /* Status list bullets */
+  .ship-list li, .next-list li {
+    padding: 0.6rem 0;
+    border-bottom: 1px solid rgba(245,245,240,0.06);
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+  }
+  .ship-list li:last-child, .next-list li:last-child { border-bottom: 0; }
+  .ship-list li::before {
+    content: '';
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    margin-top: 8px;
+    background: #22C55E;
+    border-radius: 1px;
+    box-shadow: 0 0 6px rgba(34,197,94,0.6);
+  }
+  .next-list li::before {
+    content: '';
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    margin-top: 8px;
+    border: 1px solid #D4A574;
+    border-radius: 1px;
+  }
+
+  /* Caret blink */
+  .caret {
+    display: inline-block;
+    width: 0.55ch;
+    height: 1em;
+    background: #D4A574;
+    margin-left: 0.15ch;
+    vertical-align: -0.12em;
+    animation: caret-blink 1.1s steps(1) infinite;
+  }
+  @keyframes caret-blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0; }
+  }
+
+  /* Selection */
+  ::selection { background: rgba(212,165,116,0.4); color: #F5F5F0; }
+</style>
+</head>
+
+<body class="font-display antialiased">
+
+<!-- ============== HERO ============== -->
+<header class="relative min-h-screen flex flex-col">
+  <svg id="hex-bg" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+    <defs>
+      <radialGradient id="heroFade" cx="50%" cy="50%" r="60%">
+        <stop offset="0%" stop-color="#0A0E15" stop-opacity="0" />
+        <stop offset="100%" stop-color="#0A0E15" stop-opacity="0.85" />
+      </radialGradient>
+    </defs>
+    <g id="hex-layer"></g>
+    <g id="agent-layer"></g>
+    <rect x="0" y="0" width="100%" height="100%" fill="url(#heroFade)" pointer-events="none" />
+  </svg>
+
+  <!-- Top bar -->
+  <nav class="relative z-10 px-6 md:px-10 py-6 flex items-center justify-between">
+    <a href="#" class="mono text-sm flex items-center gap-3">
+      <svg width="22" height="22" viewBox="0 0 22 22" aria-hidden="true">
+        <polygon points="11,1 20,6 20,16 11,21 2,16 2,6"
+                 fill="none" stroke="#D4A574" stroke-width="1.4" />
+        <polygon points="11,5 16,8 16,14 11,17 6,14 6,8"
+                 fill="rgba(212,165,116,0.15)" stroke="#F5C088" stroke-width="1" />
+      </svg>
+      <span class="text-bone">chitin</span>
+      <span class="text-muted">/</span>
+    </a>
+    <div class="flex items-center gap-6 mono text-xs">
+      <a href="#planes" class="text-muted hover:text-bone transition-colors">planes</a>
+      <a href="#metaphor" class="text-muted hover:text-bone transition-colors hidden sm:inline">why chitin</a>
+      <a href="#status" class="text-muted hover:text-bone transition-colors">status</a>
+      <a href="https://github.com/chitinhq/chitin"
+         class="text-bone hover:text-chitin transition-colors flex items-center gap-1.5">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        github
+      </a>
+    </div>
+  </nav>
+
+  <!-- Hero content -->
+  <div class="relative z-10 flex-1 flex flex-col justify-center px-6 md:px-10 max-w-5xl mx-auto w-full pb-24">
+    <p data-anim="eyebrow" class="mono text-xs uppercase tracking-[0.32em] text-chitin/80 mb-6">
+      <span class="text-muted">~/</span>chitin <span class="caret"></span>
+    </p>
+
+    <h1 data-anim="headline" class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold leading-[1.02] tracking-tight">
+      <span class="block">the <span class="headline-mark text-chitin">execution kernel</span></span>
+      <span class="block">for AI coding agents.</span>
+    </h1>
+
+    <p data-anim="subhead" class="mt-8 text-lg md:text-xl text-muted max-w-2xl leading-relaxed">
+      A deterministic governance layer that aggregates events, gates execution, and
+      records an auditable chain across the agent swarm. Open source.
+    </p>
+
+    <div data-anim="ctas" class="mt-10 flex flex-wrap gap-4">
+      <a href="https://github.com/chitinhq/chitin" class="btn btn-primary">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        view on github
+      </a>
+      <a href="#metaphor" class="btn btn-ghost">
+        why chitin
+        <span class="text-chitin">→</span>
+      </a>
+    </div>
+
+    <div data-anim="stats" class="mt-14 grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-4 max-w-2xl mono text-xs">
+      <div>
+        <div class="text-chitin text-xl font-bold">3</div>
+        <div class="text-muted mt-0.5">planes</div>
+      </div>
+      <div>
+        <div class="text-chitin text-xl font-bold">go + ts</div>
+        <div class="text-muted mt-0.5">kernel + view</div>
+      </div>
+      <div>
+        <div class="text-chitin text-xl font-bold">otel</div>
+        <div class="text-muted mt-0.5">native emit</div>
+      </div>
+      <div>
+        <div class="text-chitin text-xl font-bold">oss</div>
+        <div class="text-muted mt-0.5">apache 2.0</div>
+      </div>
+    </div>
+  </div>
+
+  <a href="#planes" class="scroll-cue mono">scroll</a>
+</header>
+
+<div class="divider"></div>
+
+<!-- ============== THREE PLANES ============== -->
+<section id="planes" class="px-6 md:px-10 py-28 md:py-36 max-w-6xl mx-auto">
+  <div class="mb-16 max-w-2xl">
+    <p class="mono text-xs uppercase tracking-[0.28em] text-chitin/80 mb-4">// architecture</p>
+    <h2 class="text-3xl md:text-5xl font-bold leading-tight">
+      three planes,<br />
+      <span class="text-chitin">one kernel.</span>
+    </h2>
+    <p class="mt-6 text-muted text-lg leading-relaxed">
+      Control orchestrates. Execution drives the agent. Enforcement gates and audits.
+      Each plane has a job; the kernel makes sure they cooperate.
+    </p>
+  </div>
+
+  <div class="grid md:grid-cols-3 gap-5">
+    <article class="plate-card p-7 reveal">
+      <span class="plate-corner pc-tl"></span><span class="plate-corner pc-tr"></span>
+      <span class="plate-corner pc-bl"></span><span class="plate-corner pc-br"></span>
+      <p class="mono text-xs text-chitin/80 mb-4">/plane/01</p>
+      <h3 class="text-xl font-bold mb-3">control</h3>
+      <p class="mono text-xs text-muted mb-5">temporal</p>
+      <p class="text-muted leading-relaxed text-[0.95rem]">
+        Durable workflows, retries, schedules. The plane that survives a worker crash and
+        knows what was supposed to happen next.
+      </p>
+    </article>
+
+    <article class="plate-card p-7 reveal">
+      <span class="plate-corner pc-tl"></span><span class="plate-corner pc-tr"></span>
+      <span class="plate-corner pc-bl"></span><span class="plate-corner pc-br"></span>
+      <p class="mono text-xs text-chitin/80 mb-4">/plane/02</p>
+      <h3 class="text-xl font-bold mb-3">execution</h3>
+      <p class="mono text-xs text-muted mb-5">openclaw + drivers</p>
+      <p class="text-muted leading-relaxed text-[0.95rem]">
+        The plane that actually drives the agent — Claude Code, Codex, Copilot. Same
+        gate API across open and closed vendors.
+      </p>
+    </article>
+
+    <article class="plate-card p-7 reveal">
+      <span class="plate-corner pc-tl"></span><span class="plate-corner pc-tr"></span>
+      <span class="plate-corner pc-bl"></span><span class="plate-corner pc-br"></span>
+      <p class="mono text-xs text-chitin/80 mb-4">/plane/03</p>
+      <h3 class="text-xl font-bold mb-3">enforcement</h3>
+      <p class="mono text-xs text-muted mb-5">chitin</p>
+      <p class="text-muted leading-relaxed text-[0.95rem]">
+        Policy gate, hash-linked event chain, OTEL projection. The plane that says yes,
+        no, or ask — and remembers every answer.
+      </p>
+    </article>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- ============== METAPHOR ============== -->
+<section id="metaphor" class="px-6 md:px-10 py-28 md:py-36 max-w-5xl mx-auto">
+  <div class="grid md:grid-cols-2 gap-14 items-center">
+    <div>
+      <p class="mono text-xs uppercase tracking-[0.28em] text-chitin/80 mb-4">// etymology</p>
+      <h2 class="text-3xl md:text-5xl font-bold leading-tight mb-7">
+        soft model.<br />
+        <span class="text-chitin">hard kernel.</span>
+      </h2>
+      <p class="text-muted text-lg leading-relaxed mb-5">
+        <span class="mono text-bone">chitin</span>
+        <span class="text-muted">(n.)</span> — the polysaccharide
+        β-1,4 N-acetyl­glucosamine, hex-linked into a structural sheet. The substance that
+        gives crab shells, beetle wings, and fungal cell walls their form.
+      </p>
+      <p class="text-muted text-lg leading-relaxed">
+        Same job, different domain: a structural lattice around something soft —
+        in our case, a stochastic agent. Determinism on the outside;
+        creativity stays free on the inside.
+      </p>
+    </div>
+
+    <figure aria-label="A soft amber core encased in a hexagonal lattice as you scroll">
+      <svg id="shell-diagram" viewBox="0 0 600 420" aria-hidden="true">
+        <defs>
+          <radialGradient id="coreGradient" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#F5C088" stop-opacity="0.95" />
+            <stop offset="60%" stop-color="#D4A574" stop-opacity="0.55" />
+            <stop offset="100%" stop-color="#7C5A3D" stop-opacity="0" />
+          </radialGradient>
+          <filter id="softWobble">
+            <feTurbulence type="fractalNoise" baseFrequency="0.012" numOctaves="2" seed="3" />
+            <feDisplacementMap in="SourceGraphic" scale="6" />
+          </filter>
+        </defs>
+
+        <!-- soft core (the agent) -->
+        <g id="core-group">
+          <circle class="core" cx="300" cy="210" r="58" filter="url(#softWobble)" />
+          <circle cx="300" cy="210" r="34" fill="rgba(245,192,136,0.7)" />
+        </g>
+
+        <!-- hexagonal shell — populated by JS -->
+        <g id="shell-group"></g>
+      </svg>
+      <figcaption class="mt-5 mono text-xs text-muted text-center">scroll — watch the kernel assemble</figcaption>
+    </figure>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- ============== RECENT MERGES (live from gh) ============== -->
+<section id="status" class="px-6 md:px-10 py-28 md:py-36 max-w-5xl mx-auto">
+  <div class="mb-12 max-w-2xl">
+    <p class="mono text-xs uppercase tracking-[0.28em] text-chitin/80 mb-4">// recent activity</p>
+    <h2 class="text-3xl md:text-5xl font-bold leading-tight">
+      the swarm<br />
+      <span class="text-chitin">at work.</span>
+    </h2>
+    <p class="mt-5 text-muted text-lg leading-relaxed">
+      Live merge stream from <a href="https://github.com/chitinhq/chitin/pulls?q=is%3Apr+is%3Amerged" class="text-bone hover:text-chitin underline-offset-2 hover:underline">chitinhq/chitin</a>.
+      The kernel runs a 24/7 local agent swarm that drafts, reviews, and merges its own work — gated by chitin itself.
+    </p>
+  </div>
+
+  <div class="plate-card p-7 md:p-9 reveal">
+    <span class="plate-corner pc-tl"></span><span class="plate-corner pc-tr"></span>
+    <span class="plate-corner pc-bl"></span><span class="plate-corner pc-br"></span>
+
+    <div class="flex flex-wrap items-center gap-x-8 gap-y-3 mb-7">
+      <div class="flex items-center gap-3">
+        <span class="block w-2 h-2 bg-run rounded-sm shadow-[0_0_8px_rgba(34,197,94,0.7)]"></span>
+        <h3 class="font-bold mono text-sm uppercase tracking-wider text-run">recent merges</h3>
+      </div>
+      <div class="mono text-xs text-muted">
+        <!-- MERGES:STAT --><span class="text-chitin font-bold">—</span> merged in last 7 days<!-- /MERGES:STAT -->
+      </div>
+    </div>
+
+    <ul class="merges-list text-[0.95rem] text-bone/90 divide-y divide-bone/5">
+      <!-- MERGES:LIST -->
+      <li class="py-3 text-muted">Loading from GitHub at build time…</li>
+      <!-- /MERGES:LIST -->
+    </ul>
+
+    <p class="mt-7 pt-5 border-t border-bone/5 mono text-xs text-muted/70">
+      <!-- MERGES:SYNC -->source: <a href="https://github.com/chitinhq/chitin/pulls?q=is%3Apr+is%3Amerged" class="hover:text-chitin underline-offset-2 hover:underline">gh pr list --state merged</a> · local preview<!-- /MERGES:SYNC -->
+    </p>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- ============== FOOTER ============== -->
+<footer class="px-6 md:px-10 py-16 max-w-6xl mx-auto">
+  <div class="flex flex-col md:flex-row gap-8 md:items-end justify-between">
+    <div>
+      <div class="mono text-sm flex items-center gap-3 mb-4">
+        <svg width="20" height="20" viewBox="0 0 22 22" aria-hidden="true">
+          <polygon points="11,1 20,6 20,16 11,21 2,16 2,6"
+                   fill="none" stroke="#D4A574" stroke-width="1.4" />
+          <polygon points="11,5 16,8 16,14 11,17 6,14 6,8"
+                   fill="rgba(212,165,116,0.15)" stroke="#F5C088" stroke-width="1" />
+        </svg>
+        <span>chitin</span>
+      </div>
+      <p class="text-muted max-w-md text-[0.95rem] leading-relaxed">
+        the execution kernel for AI coding agents.
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-x-8 gap-y-3 mono text-xs text-muted">
+      <a href="https://github.com/chitinhq/chitin" class="hover:text-bone transition-colors">github</a>
+      <a href="https://github.com/chitinhq/chitin/blob/main/docs/architecture.md" class="hover:text-bone transition-colors">architecture</a>
+      <a href="https://github.com/chitinhq/chitin/blob/main/docs/thesis.md" class="hover:text-bone transition-colors">thesis</a>
+      <a href="https://github.com/chitinhq/chitin/blob/main/LICENSE" class="hover:text-bone transition-colors">apache 2.0</a>
+    </div>
+  </div>
+  <div class="mt-10 pt-8 border-t border-bone/5 mono text-xs text-muted/70">
+    © chitinhq · soft model. hard kernel.
+  </div>
+</footer>
+
+<!-- ============== GSAP + animations ============== -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
+
+<script>
+(() => {
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  gsap.registerPlugin(ScrollTrigger);
+
+  // ─────────── Hex mesh generator ───────────
+  const svg = document.getElementById('hex-bg');
+  const hexLayer = document.getElementById('hex-layer');
+  const agentLayer = document.getElementById('agent-layer');
+
+  const HEX_R = 38;
+  const SQRT3 = Math.sqrt(3);
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+
+  function hexPath(cx, cy, r) {
+    let pts = '';
+    for (let i = 0; i < 6; i++) {
+      const angle = (Math.PI / 3) * i - Math.PI / 6;
+      pts += `${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)} `;
+    }
+    return pts.trim();
+  }
+
+  let hexes = [];
+
+  function buildMesh() {
+    hexLayer.innerHTML = '';
+    hexes = [];
+    const w = svg.clientWidth;
+    const h = svg.clientHeight;
+    const dx = HEX_R * 1.5;
+    const dy = HEX_R * SQRT3;
+    const cols = Math.ceil(w / dx) + 2;
+    const rows = Math.ceil(h / dy) + 2;
+    const cx0 = w / 2;
+    const cy0 = h / 2;
+
+    for (let c = -Math.ceil(cols / 2); c <= Math.ceil(cols / 2); c++) {
+      for (let r = -Math.ceil(rows / 2); r <= Math.ceil(rows / 2); r++) {
+        const x = cx0 + c * dx;
+        const y = cy0 + r * dy + (c % 2 ? dy / 2 : 0);
+        if (x < -HEX_R || x > w + HEX_R || y < -HEX_R || y > h + HEX_R) continue;
+        const poly = document.createElementNS(SVG_NS, 'polygon');
+        poly.setAttribute('points', hexPath(x, y, HEX_R - 2));
+        poly.dataset.cx = x;
+        poly.dataset.cy = y;
+        poly.style.transformOrigin = `${x}px ${y}px`;
+        // distance from center, used for stagger
+        const dist = Math.hypot(x - cx0, y - cy0);
+        poly.dataset.dist = dist;
+        hexLayer.appendChild(poly);
+        hexes.push({ el: poly, x, y, dist });
+      }
+    }
+    // sort by distance for radial stagger
+    hexes.sort((a, b) => a.dist - b.dist);
+  }
+
+  buildMesh();
+  window.addEventListener('resize', () => {
+    buildMesh();
+    if (!reduce) restartIdle();
+  });
+
+  // ─────────── Hero entrance ───────────
+  if (!reduce) {
+    gsap.set(hexes.map(h => h.el), { scale: 0, opacity: 0, transformOrigin: 'center' });
+    const heroTl = gsap.timeline({ defaults: { ease: 'power3.out' } });
+    heroTl.to(hexes.map(h => h.el), {
+      scale: 1, opacity: 1,
+      duration: 0.9,
+      stagger: { each: 0.012, from: 'start' },
+    }, 0);
+
+    // Headline line-by-line (preserves .headline-mark inside lines)
+    const headline = document.querySelector('[data-anim="headline"]');
+    const lines = headline.querySelectorAll('span.block');
+    lines.forEach((line) => {
+      const wrap = document.createElement('span');
+      wrap.style.display = 'block';
+      wrap.style.overflow = 'hidden';
+      line.parentNode.insertBefore(wrap, line);
+      wrap.appendChild(line);
+    });
+    gsap.set(lines, { yPercent: 110, opacity: 0 });
+    heroTl.to(lines, {
+      yPercent: 0, opacity: 1,
+      duration: 0.95,
+      stagger: 0.14,
+      ease: 'expo.out',
+    }, 0.25);
+
+    gsap.set('[data-anim="eyebrow"]', { opacity: 0, y: 8 });
+    gsap.set('[data-anim="subhead"]', { opacity: 0, y: 12 });
+    gsap.set('[data-anim="ctas"]', { opacity: 0, y: 14 });
+    gsap.set('[data-anim="stats"]', { opacity: 0, y: 14 });
+
+    heroTl
+      .to('[data-anim="eyebrow"]', { opacity: 1, y: 0, duration: 0.6 }, 0.1)
+      .to('[data-anim="subhead"]', { opacity: 1, y: 0, duration: 0.7 }, 0.85)
+      .to('[data-anim="ctas"]',    { opacity: 1, y: 0, duration: 0.6 }, 1.05)
+      .to('[data-anim="stats"]',   { opacity: 1, y: 0, duration: 0.6 }, 1.15);
+
+    // Underline draw (CSS pseudo can't be tweened directly, animate a CSS var)
+    document.documentElement.style.setProperty('--mark-w', '0%');
+    gsap.to({ v: 0 }, {
+      v: 100,
+      duration: 0.9,
+      delay: 1.2,
+      ease: 'expo.out',
+      onUpdate() {
+        document.documentElement.style.setProperty('--mark-w', this.targets()[0].v + '%');
+      },
+    });
+  }
+
+  // Inject the underline width binding
+  const underlineStyle = document.createElement('style');
+  underlineStyle.textContent = `.headline-mark::after { width: var(--mark-w, 100%); }`;
+  document.head.appendChild(underlineStyle);
+
+  // ─────────── Idle ambient breathing ───────────
+  let idleTweens = [];
+  function restartIdle() {
+    idleTweens.forEach(t => t.kill());
+    idleTweens = [];
+    if (reduce) return;
+    hexes.forEach(({ el }) => {
+      const t = gsap.to(el, {
+        opacity: gsap.utils.random(0.35, 1),
+        duration: gsap.utils.random(3.5, 6.5),
+        ease: 'sine.inOut',
+        repeat: -1,
+        yoyo: true,
+        delay: gsap.utils.random(0, 4),
+      });
+      idleTweens.push(t);
+    });
+  }
+  if (!reduce) setTimeout(restartIdle, 1300);
+
+  // Random amber pulse on a random hex every 2-4s
+  function schedulePulse() {
+    if (reduce) return;
+    const hex = hexes[Math.floor(Math.random() * hexes.length)];
+    if (hex) {
+      gsap.timeline()
+        .to(hex.el, { stroke: '#F5C088', strokeWidth: 1.8, duration: 0.4, ease: 'power2.out' })
+        .to(hex.el, { stroke: 'rgba(212,165,116,0.22)', strokeWidth: 1, duration: 1.4, ease: 'power2.in' });
+    }
+    setTimeout(schedulePulse, 1800 + Math.random() * 2400);
+  }
+  if (!reduce) setTimeout(schedulePulse, 2200);
+
+  // ─────────── Cursor proximity ───────────
+  if (!reduce && !('ontouchstart' in window)) {
+    let mx = -9999, my = -9999;
+    let rect;
+    let needsUpdate = false;
+    function refreshRect() { rect = svg.getBoundingClientRect(); }
+    refreshRect();
+    window.addEventListener('resize', refreshRect);
+    window.addEventListener('scroll', refreshRect, { passive: true });
+
+    window.addEventListener('mousemove', (e) => {
+      mx = e.clientX - rect.left;
+      my = e.clientY - rect.top;
+      needsUpdate = true;
+    }, { passive: true });
+
+    function tick() {
+      if (needsUpdate) {
+        needsUpdate = false;
+        const R = 200;
+        for (const h of hexes) {
+          const d = Math.hypot(h.x - mx, h.y - my);
+          if (d < R) {
+            const t = 1 - d / R;
+            h.el.style.stroke = `rgba(245,192,136,${0.22 + t * 0.7})`;
+          } else {
+            h.el.style.stroke = '';
+          }
+        }
+      }
+      requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  }
+
+  // ─────────── Agent particle (the showpiece narrative) ───────────
+  function createAgent() {
+    if (reduce || hexes.length < 8) return;
+    const trail = document.createElementNS(SVG_NS, 'path');
+    trail.setAttribute('class', 'agent-trail');
+    agentLayer.appendChild(trail);
+
+    const dot = document.createElementNS(SVG_NS, 'circle');
+    dot.setAttribute('class', 'agent-dot');
+    dot.setAttribute('r', '4');
+    agentLayer.appendChild(dot);
+
+    let trailPts = [];
+    function step() {
+      // pick a random hex weighted toward middle band of viewport
+      const candidates = hexes.filter(h => h.y > 80 && h.y < svg.clientHeight - 80);
+      const target = candidates[Math.floor(Math.random() * candidates.length)] || hexes[0];
+
+      gsap.to(dot, {
+        attr: { cx: target.x, cy: target.y },
+        duration: gsap.utils.random(1.4, 2.4),
+        ease: 'power2.inOut',
+        onUpdate() {
+          const cx = +dot.getAttribute('cx');
+          const cy = +dot.getAttribute('cy');
+          trailPts.push([cx, cy]);
+          if (trailPts.length > 18) trailPts.shift();
+          trail.setAttribute(
+            'd',
+            trailPts.map((p, i) => (i === 0 ? 'M' : 'L') + p[0] + ',' + p[1]).join(' ')
+          );
+        },
+        onComplete() {
+          // brief pause = "policy gate"
+          gsap.to(target.el, {
+            stroke: '#22C55E',
+            strokeWidth: 2,
+            duration: 0.3,
+            yoyo: true,
+            repeat: 1,
+            onComplete: () => { target.el.style.stroke = ''; },
+          });
+          gsap.delayedCall(gsap.utils.random(0.4, 1.0), step);
+        },
+      });
+    }
+
+    // start at random hex
+    const start = hexes[Math.floor(hexes.length / 2)];
+    dot.setAttribute('cx', start.x);
+    dot.setAttribute('cy', start.y);
+    step();
+  }
+  setTimeout(createAgent, 1800);
+
+  // ─────────── Plate reveal on scroll ───────────
+  if (!reduce) {
+    gsap.utils.toArray('.reveal').forEach((el) => {
+      gsap.from(el, {
+        opacity: 0,
+        y: 30,
+        duration: 0.8,
+        ease: 'power3.out',
+        scrollTrigger: { trigger: el, start: 'top 85%', once: true },
+      });
+    });
+  }
+
+  // ─────────── Shell-diagram assembly (Drasner moment) ───────────
+  function buildShellDiagram() {
+    const shellGroup = document.getElementById('shell-group');
+    const cx = 300, cy = 210;
+    const ringR = 130;
+    const hexCount = 12;
+    const shellHexes = [];
+    for (let i = 0; i < hexCount; i++) {
+      const angle = (i / hexCount) * Math.PI * 2;
+      const hx = cx + ringR * Math.cos(angle);
+      const hy = cy + ringR * Math.sin(angle);
+      const poly = document.createElementNS(SVG_NS, 'polygon');
+      poly.setAttribute('class', 'shell-hex');
+      poly.setAttribute('points', hexPath(hx, hy, 22));
+      poly.style.transformOrigin = `${hx}px ${hy}px`;
+      // start: scattered + invisible
+      const offX = (Math.random() - 0.5) * 240;
+      const offY = (Math.random() - 0.5) * 240;
+      poly.dataset.fromX = offX;
+      poly.dataset.fromY = offY;
+      shellGroup.appendChild(poly);
+      shellHexes.push({ el: poly, hx, hy, offX, offY, angle });
+    }
+
+    if (reduce) {
+      shellHexes.forEach(s => gsap.set(s.el, { x: 0, y: 0, opacity: 1, scale: 1 }));
+      return;
+    }
+
+    shellHexes.forEach(s => gsap.set(s.el, {
+      x: s.offX,
+      y: s.offY,
+      opacity: 0,
+      scale: 0.6,
+      rotation: gsap.utils.random(-40, 40),
+    }));
+
+    // core wobble
+    gsap.to('#core-group', {
+      scale: 1.06,
+      transformOrigin: '300px 210px',
+      duration: 2.4,
+      ease: 'sine.inOut',
+      repeat: -1,
+      yoyo: true,
+    });
+
+    const shellTl = gsap.timeline({
+      scrollTrigger: {
+        trigger: '#shell-diagram',
+        start: 'top 75%',
+        end: 'bottom 30%',
+        scrub: 0.6,
+      },
+    });
+    shellHexes.forEach((s, i) => {
+      shellTl.to(s.el, {
+        x: 0, y: 0, opacity: 1, scale: 1, rotation: 0,
+        duration: 1,
+        ease: 'power3.out',
+      }, i * 0.05);
+    });
+  }
+  buildShellDiagram();
+
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Two related changes bundled to ship a public-facing teaser correctly:

1. **`web/` teaser site** — single-file `index.html` with GSAP animations (radial hex-mesh entrance, agent-particle showpiece, ScrollTrigger shell-assembly diagram for the chitin/polymer metaphor). Deploys to GitHub Pages via Actions on pushes to `main` that touch `web/**` or the build inputs.
2. **MIT → Apache 2.0 relicense** — sole-author repo (verified via `git log` author scan). Apache's patent grant aligns chitin with Temporal / OpenTelemetry / CNCF ecosystem neighbors, which matters once chitin is embedded in commercial swarm infra.

## "Recent merges" is live, not curated

Earlier draft pulled "shipped/next" lists from `docs/roadmap.md`. Roadmap drifted three days behind reality (50 PRs merged in the last 7 days while the doc only listed strategic milestones through 2026-05-01). The card now pulls from `gh pr list --state merged` at build time:

- 6 most recent merges, conventional-commit prefix styled separately
- "N merged in last 7 days" momentum stat
- Falls back to a "view on GitHub →" placeholder if `gh` is unavailable

## What's in the diff

| Area | Files |
|---|---|
| License | `LICENSE`, `NOTICE`, `package.json`, `README.md` |
| Roadmap MIT mention | `docs/roadmap.md` |
| Site | `web/index.html`, `web/build.mjs` |
| Deploy | `.github/workflows/pages.yml` |

## Apache 2.0 follow-up: source headers

Apache convention is to add a copyright header to every source file. **Intentionally not in this PR** — file-header drift is a maintenance tax for marginal value; LICENSE alone is binding. Add later if downstream projects pinning specific versions ask.

## Test plan

- [ ] Local preview: ``node web/build.mjs && python3 -m http.server -d dist``
- [ ] Visually verify hero hex mesh, agent-particle, shell-assembly scroll-trigger
- [ ] Confirm "recent merges" card shows fresh PR data + accurate 7-day count
- [ ] Confirm all GitHub links use ``chitinhq/chitin``
- [ ] Confirm footer + stat tile both say "Apache 2.0"
- [ ] After merge: Settings → Pages → Source: **GitHub Actions** (one-time toggle)
- [ ] Trigger workflow (push or ``gh workflow run pages.yml``) and confirm the deploy succeeds + the URL renders

## Notes

- Worktree at ``../chitin-teaser`` is the work environment; main repo state is unaffected until merge.
- Build script handles both CI (uses ``GITHUB_TOKEN`` automatically) and local (uses ``gh`` CLI auth) — same script, no env-var branching.