### PR TITLE
auto: flip 2 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -5237,7 +5237,7 @@ soul_lens) + outcome dimensions (cost, efficacy per role).
 ```yaml
 id: routing-fingerprint-helper
 tier: T2
-status: ready
+status: partial
 estimated_loc: 200
 blocks: []
 file: libs/contracts/src/fingerprint.ts (new), libs/contracts/src/execution-request.schema.ts, apps/temporal-worker/src/activity.ts
@@ -5406,7 +5406,7 @@ full vision.
 ```yaml
 id: nx-generator-with-sync-driver-poc
 tier: T2
-status: ready
+status: partial
 estimated_loc: 350
 blocks: []
 file: tools/generators/investigate/generate.ts (new), tools/generators/investigate/schema.json (new)


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- nx-generator-with-sync-driver-poc (#291)
- routing-fingerprint-helper (#287)

If any of these are wrong, revert + investigate why the title matched without the work shipping.