### PR TITLE
fix(pages): populate recent-merges feed (GH_TOKEN + pull-requests:read)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,11 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  # Read-only access to PRs so web/build.mjs's `gh pr list` can fetch
+  # the recent-merges feed at build time. Without this the call returns
+  # 404/empty and the page renders the "GitHub data unavailable"
+  # placeholder.
+  pull-requests: read
 
 concurrency:
   group: pages
@@ -33,6 +38,11 @@ jobs:
 
       - name: build site
         run: node web/build.mjs
+        env:
+          # gh CLI on the runner uses GH_TOKEN. Without this the
+          # `gh pr list` call in web/build.mjs fails auth and the
+          # build emits the placeholder "GitHub data unavailable" row.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: configure pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

The teaser at `https://chitinhq.github.io/chitin/` renders "GitHub data unavailable at build time" instead of the live merge feed. Two missing pieces in `.github/workflows/pages.yml`:

1. **No `pull-requests: read` permission** — even with a token, `gh pr list --state merged` would 404 on the merged-PRs query.
2. **No `GH_TOKEN` env on the build step** — `gh` CLI has no auth in the runner, so the call fails before it reaches GitHub at all. `web/build.mjs`'s catch-block then emits the placeholder.

Both fixed.

## Test plan
- [x] No code changes outside `.github/workflows/pages.yml`
- [ ] After merge: pages workflow re-runs, the page renders the actual recent-merges list (currently 18+ merged PRs from today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)