### PR TITLE
fix(flipper): single-flight check to prevent duplicate PRs

### DIFF
--- a/scripts/shipped-entry-flipper.sh
+++ b/scripts/shipped-entry-flipper.sh
@@ -42,6 +42,25 @@ emit() {
 
 cd "$REPO"
 
+# Single-flight: in apply mode, exit early if a previous flipper PR is
+# still open. The script reads `status: ready` from main, so until the
+# previous flip merges, the same entries still look ready and we'd open
+# a byte-identical duplicate (cf. #299 + #301 on 2026-05-04).
+# Fail-closed on gh errors: a missed cycle costs less than a duplicate.
+if (( APPLY == 1 )); then
+  open_flippers=$(gh pr list --state open --json headRefName \
+    --jq '[.[] | select(.headRefName | startswith("auto/shipped-entry-flipper-"))] | length' \
+    2>/dev/null || echo "")
+  if [[ -z "$open_flippers" ]]; then
+    emit warn "open-pr-check-failed" "msg=could not query open flipper PRs; skipping cycle"
+    exit 0
+  fi
+  if (( open_flippers > 0 )); then
+    emit ok "skip-open-flip-pr-exists" "open_count=$open_flippers" "msg=previous flipper PR not yet merged; retry next cycle"
+    exit 0
+  fi
+fi
+
 # Pull main fresh (fail open if it doesn't fast-forward — operator
 # would have manual changes worth preserving)
 if ! git pull --ff-only --quiet origin main 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Add a single-flight check to `scripts/shipped-entry-flipper.sh`: in apply mode, exit early if any open PR has a head branch matching `auto/shipped-entry-flipper-*`.
- Fail-closed on `gh` errors so a transient API failure doesn't produce a duplicate.
- Dry-run mode is unchanged.

## Why
The flipper reads `status: ready` from `main`. Until the previous flip PR merges, the same entries still look ready, so the hourly cron opens a byte-identical duplicate. #299 and #301 on 2026-05-04 are an instance — same body, same two flipped entries (`nx-generator-with-sync-driver-poc`, `routing-fingerprint-helper`), opened exactly 1h apart. #301 has been closed manually.

## Invariant enforced
At most one open `auto/shipped-entry-flipper-*` PR exists at any time.

**Tradeoff:** if the operator is slow to merge an open flip PR and a new entry ships in the meantime, the next entry waits a cycle. That's acceptable for hourly bookkeeping.

## Test plan
- [x] `bash -n` passes
- [x] Dry-run against current state returns the same 2 candidates as before the patch
- [x] The detection query (`gh pr list … startswith("auto/shipped-entry-flipper-")`) returns `1` against current state, matching the open #299 — so apply mode would short-circuit cleanly
- [ ] Operator: verify next hourly cron run logs `skip-open-flip-pr-exists` instead of opening a third duplicate