### PR TITLE
fix(apply-step): commit real untracked work, not just tracked diffs

### DIFF
--- a/apps/temporal-worker/src/grooming/apply-workflow-result.ts
+++ b/apps/temporal-worker/src/grooming/apply-workflow-result.ts
@@ -93,12 +93,25 @@ async function main() {
   if (wt.has_uncommitted_changes) {
     revertWorktreeSettingsArtifact(wt.path);
     const trackedDiff = git(wt.path, ['--no-pager', 'diff', '--shortstat']).length > 0;
-    if (trackedDiff) {
-      console.log('[apply-result] auto-committing tracked uncommitted changes…');
+    const realUntracked = listRealUntrackedFiles(wt.path);
+    // Auto-commit when there are TRACKED edits OR untracked files at
+    // non-bootstrap paths. The original Slice 7 heuristic rejected
+    // untracked-only outcomes wholesale, but that loses real work for
+    // entries that legitimately produce only new files (e.g.,
+    // `tools/lint/role-coverage.ts` for a new lint rule) — those land
+    // as untracked-only because the agent didn't `git add`+commit.
+    // Bootstrap blocklist is small + explicit (.claude/), and other
+    // chitin-written files (WORKTREE_INDEX.md) are already in
+    // .git/info/exclude so they don't show in porcelain output.
+    if (trackedDiff || realUntracked.length > 0) {
+      const reason = trackedDiff
+        ? 'tracked uncommitted changes'
+        : `${realUntracked.length} untracked file(s) at non-bootstrap paths`;
+      console.log(`[apply-result] auto-committing: ${reason}…`);
       git(wt.path, ['add', '-A']);
       git(wt.path, ['commit', '-m', defaultCommitMessage(env)]);
     } else {
-      console.log('[apply-result] worktree has untracked-only changes (likely agent bootstrap files); skipping auto-commit.');
+      console.log('[apply-result] worktree has only bootstrap-path untracked changes; skipping auto-commit.');
       // If there are no committed changes either, treat as no-work-done
       // and skip push entirely (don't pollute origin with empty branches).
       if (wt.commits_added === 0) {
@@ -161,6 +174,40 @@ export function revertWorktreeSettingsArtifact(worktreePath: string): void {
     console.log('[apply-result] reverted writeWorktreeClaudeSettings artifact: .claude/settings.json');
   } catch (err) {
     console.warn(`[apply-result] revert of .claude/settings.json failed (ignored): ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// Path prefixes that chitin's worker writes into every worktree at
+// provisioning time. Untracked files under these are treated as
+// bootstrap noise, not agent work product. Note: `WORKTREE_INDEX.md`
+// is also worker-written but lives in `.git/info/exclude`, so it
+// never appears in `git status --porcelain` output and doesn't need
+// a prefix here.
+const BOOTSTRAP_UNTRACKED_PREFIXES = ['.claude/'];
+
+// Return untracked files that look like real agent work — i.e. NOT
+// under a known bootstrap path. Uses `-uall` so a new directory
+// shows its files individually rather than as a single dir entry,
+// which is needed for the prefix filter to work.
+//
+// Errors are swallowed and treated as "no real untracked" — same
+// fail-safe as `revertWorktreeSettingsArtifact`. The caller still
+// has the trackedDiff check + commits_added counter as backstops.
+export function listRealUntrackedFiles(worktreePath: string): string[] {
+  try {
+    const out = git(worktreePath, ['status', '--porcelain', '-uall']);
+    if (!out) return [];
+    const real: string[] = [];
+    for (const line of out.split('\n')) {
+      if (!line.startsWith('?? ')) continue;
+      const path = line.slice(3);
+      if (BOOTSTRAP_UNTRACKED_PREFIXES.some((p) => path.startsWith(p))) continue;
+      real.push(path);
+    }
+    return real;
+  } catch (err) {
+    console.warn(`[apply-result] listRealUntrackedFiles failed (ignored): ${err instanceof Error ? err.message : String(err)}`);
+    return [];
   }
 }
 

--- a/apps/temporal-worker/test/grooming-list-real-untracked.test.ts
+++ b/apps/temporal-worker/test/grooming-list-real-untracked.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { listRealUntrackedFiles } from '../src/grooming/apply-workflow-result.ts';
+
+// Build a tiny git repo, drop various untracked files, verify the
+// helper distinguishes real-work paths from bootstrap-noise paths.
+describe('listRealUntrackedFiles', () => {
+  let scratch: string;
+
+  function git(args: string[]): string {
+    return execFileSync('git', args, { cwd: scratch, encoding: 'utf8' }).trim();
+  }
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'chitin-untracked-test-'));
+    git(['init', '--quiet']);
+    git(['config', 'user.email', 'test@example.invalid']);
+    git(['config', 'user.name', 'test']);
+    git(['config', 'commit.gpgsign', 'false']);
+    writeFileSync(join(scratch, 'README.md'), 'baseline\n');
+    git(['add', 'README.md']);
+    git(['commit', '-m', 'baseline', '--quiet']);
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('returns empty when there are no untracked files', () => {
+    expect(listRealUntrackedFiles(scratch)).toEqual([]);
+  });
+
+  it('filters out .claude/ bootstrap files', () => {
+    mkdirSync(join(scratch, '.claude'));
+    writeFileSync(join(scratch, '.claude/settings.json'), '{}');
+    writeFileSync(join(scratch, '.claude/notes.md'), 'agent notes');
+    expect(listRealUntrackedFiles(scratch)).toEqual([]);
+  });
+
+  it('returns real-work paths even when bootstrap is also present', () => {
+    mkdirSync(join(scratch, '.claude'));
+    writeFileSync(join(scratch, '.claude/settings.json'), '{}');
+    mkdirSync(join(scratch, 'tools/lint'), { recursive: true });
+    writeFileSync(join(scratch, 'tools/lint/role-coverage.ts'), '// new lint rule\n');
+
+    const real = listRealUntrackedFiles(scratch);
+    expect(real).toContain('tools/lint/role-coverage.ts');
+    expect(real.every((p) => !p.startsWith('.claude/'))).toBe(true);
+  });
+
+  it('reports nested new files individually (uses -uall)', () => {
+    // The default `git status --porcelain` collapses an untracked
+    // directory to a single trailing-slash entry; -uall expands it.
+    // The prefix filter relies on path-level granularity, so this
+    // test guards the -uall flag from being dropped.
+    mkdirSync(join(scratch, 'libs/scheduler/src'), { recursive: true });
+    writeFileSync(join(scratch, 'libs/scheduler/src/index.ts'), '');
+    writeFileSync(join(scratch, 'libs/scheduler/src/schema.ts'), '');
+
+    const real = listRealUntrackedFiles(scratch);
+    expect(real.sort()).toEqual([
+      'libs/scheduler/src/index.ts',
+      'libs/scheduler/src/schema.ts',
+    ]);
+  });
+
+  it('respects .git/info/exclude (mirrors WORKTREE_INDEX.md handling)', () => {
+    // WORKTREE_INDEX.md is added to info/exclude by the worker; this
+    // test confirms that pattern flows through — anything excluded
+    // there never reaches the helper, so no prefix entry is needed.
+    mkdirSync(join(scratch, '.git/info'), { recursive: true });
+    writeFileSync(join(scratch, '.git/info/exclude'), 'WORKTREE_INDEX.md\n');
+    writeFileSync(join(scratch, 'WORKTREE_INDEX.md'), 'auto-generated');
+    mkdirSync(join(scratch, 'apps'), { recursive: true });
+    writeFileSync(join(scratch, 'apps/foo.ts'), 'real');
+
+    expect(listRealUntrackedFiles(scratch)).toEqual(['apps/foo.ts']);
+  });
+
+  it('returns empty array when worktree is invalid (no git failure escape)', () => {
+    // Helper must fail-safe rather than throw — apply-step should fall
+    // back to the trackedDiff + commits_added backstops on errors.
+    expect(listRealUntrackedFiles('/nonexistent/path/abc123')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Apply-step heuristic was rejecting entries that legitimately produce new files (untracked-only) as bootstrap junk, silently dropping real agent work.
- New invariant: auto-commit iff TRACKED diffs OR untracked files at non-bootstrap paths.
- Bootstrap blocklist: only \`.claude/\` (\`WORKTREE_INDEX.md\` already in \`.git/info/exclude\`).
- Adds \`listRealUntrackedFiles()\` helper + 6 boundary tests. Existing revert-test suite unchanged + still passes.

## Why now
Tonight (2026-05-04 23:32 UTC) post-lockdown-clear: \`lint-role-coverage\` ran at T4 for 34s, agent wrote \`tools/lint/role-coverage.ts\`, apply-step rejected with \"untracked-only changes (likely agent bootstrap files)\". The chain audit log confirms the agent did exactly the work the entry asked for; the heuristic just couldn't tell real new files from bootstrap.

This is a recurring failure mode — same symptom blocked \`scheduler-gov-rule\` runs on 2026-05-03 (same shape: \"1 file changed, 12+/10−\" = bare \`.claude/settings.json\` artifact, agent's actual work in untracked files).

## Test plan
- [x] 6 new tests cover empty, only-bootstrap, only-real, mixed, nested (\`-uall\` flag), invalid-path
- [x] 5 existing tests for \`revertWorktreeSettingsArtifact\` still green
- [x] Typecheck clean on \`apps/temporal-worker\`
- [ ] First post-merge dispatcher tick should commit + open PR for any entry whose agent produced new files

## Tradeoff
A future entry that legitimately wants to commit changes under \`.claude/\` will see those silently dropped. Same caveat as the existing settings-revert. Two mitigations available if it ever bites:
1. Entry pre-commits its \`.claude/*\` edit before declining (auto-commit fallback then sees only that)
2. Plumb the entry's \`file:\` scope into apply-step and gate the filter on whether the entry claims that path