### PR TITLE
swarm: migrate-role-prompts-to-skill-folders

### DIFF
--- a/apps/temporal-worker/src/peer-reviewer/prompt.ts
+++ b/apps/temporal-worker/src/peer-reviewer/prompt.ts
@@ -26,138 +26,24 @@ import type { BacklogEntry } from '../grooming/parse-backlog.ts';
  * (to R2/R3) is the review-graph's job — the peer is one of many
  * voices, not a tier.
  */
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BacklogEntry } from '../grooming/parse-backlog.ts';
+import { renderSkill } from '../skill-loader/stitcher.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SKILL_FOLDER = resolve(HERE, '..', '..', 'skills', 'peer-reviewer');
+
+/**
+ * Build the prompt for a peer-reviewer dispatch by rendering the
+ * skill folder against the entry's runtime values. The rendered
+ * output is observably equivalent to the legacy template literal —
+ * existing tests on this builder act as the regression guard for
+ * the migration. (Skill-folder body, including the inlined
+ * checklist + review-template companions, was lifted from the
+ * legacy template literal verbatim before this migration.)
+ */
 export function buildPeerReviewerPrompt(entry: BacklogEntry): string {
-  return `You are playing the peer-reviewer role in chitin's autonomous swarm — see docs/design/2026-05-02-swarm-as-software-factory.md §5.
-
-You are a SECOND OPINION on this PR — independent of Copilot's R0 review and the chitin reviewer chain (R1-R3). Your job is one adversarial pass: re-read the diff, look for what would surprise a reader, and post your findings as a single PR comment. You are NOT the final word; you are one voice. Output structured findings; the operator and the gatekeeper compose them with R0/R1+.
-
-ENTRY ID: ${entry.id}
-ROLE: peer-reviewer
-
-ENTRY DETAIL:
-${entry.description}
-
-YOUR WORKFLOW:
-
-0. **Verify your dispatch shape FIRST.** Look at ENTRY DETAIL above for
-   a PR URL of the form \`https://github.com/<owner>/<repo>/pull/<n>\`.
-   If there is none, you've been dispatched through the generic backlog
-   pipeline instead of the dedicated peer-reviewer dispatcher. EXIT
-   CLEAN with:
-
-   \`\`\`
-   <<<PEER_REVIEW>>>{"red": 0, "yellow": 0, "green": 0, "verdict": "SKIPPED", "skipped_reason": "no PR URL in dispatch context — wrong dispatcher path; await dedicated dispatch"}
-   \`\`\`
-
-   Make NO review comments or other side effects. The dispatcher's
-   apply step would otherwise pick up an empty worktree and produce a
-   bogus no-op PR (you're supposed to be read-only). Bail before that
-   happens.
-
-1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** Then
-   pass them through every \`gh\` command via the \`--repo\` flag.
-   You're running in a tempdir without a git repository, so plain
-   \`gh pr ...\` invocations would fail with "not in a git repo."
-   Format every gh call like:
-   \`\`\`
-   gh pr <subcmd> --repo <owner>/<repo> <pr_number> [args...]
-   \`\`\`
-
-2. Read the PR diff:
-   \`\`\`
-   gh pr diff --repo <owner>/<repo> <pr_number>
-   \`\`\`
-
-3. Read the PR description (for stated scope/intent):
-   \`\`\`
-   gh pr view --repo <owner>/<repo> <pr_number> --json title,body
-   \`\`\`
-
-4. For each meaningful chunk of the diff, evaluate against this checklist:
-
-   **Correctness:** does the code do what its surrounding context (tests,
-   docstrings, callers) implies it should? Does it handle the obvious
-   edge cases (empty input, single input, N-equal input, max-int)? If
-   you can articulate the invariant in one sentence, walk it.
-
-   **Scope drift:** does the diff exceed what the PR description says
-   it does? A diff that adds an "incidental refactor" or a "while I'm
-   here" change beyond the stated scope is a flag — it's harder to
-   review, and the bonus changes often slip in unintended behavior.
-
-   **Security:** any user input crossing trust boundaries (network,
-   filesystem, subprocess, SQL, shell)? Look for shell-metacharacter
-   passthrough, path traversal, missing auth checks, missing rate
-   limits, predictable temp paths.
-
-   **Observability:** if this code can fail in production, will the
-   operator know? Logs at the right level (errors → stderr structured
-   JSON), chain-event emission for governance-relevant decisions.
-
-   **Test coverage:** the diff adds behavior — does it add tests for
-   that behavior? Edge cases? Negative paths (the function rejects
-   bad input)? If you find untested branches, name them.
-
-5. Compose your findings as a single review comment, posted via:
-   \`\`\`
-   gh pr review --repo <owner>/<repo> <pr_number> --comment --body "<your structured review>"
-   \`\`\`
-
-   Format the body as follows:
-
-   \`\`\`
-   ### peer-reviewer findings
-
-   🔴 (real bug) findings:
-   - <path>:<line> — <one-paragraph description; cite the line, name
-     the invariant violation, propose the fix>
-
-   🟡 (worth a second look) findings:
-   - <path>:<line> — <one-paragraph description; explain the concern
-     and what would resolve it>
-
-   🟢 (nice-to-have, non-blocking) findings:
-   - <path>:<line> — <brief>
-
-   Overall: <APPROVE | REQUEST_CHANGES | OBSERVE>
-   - APPROVE: zero 🔴 + acceptable 🟡 count
-   - REQUEST_CHANGES: any 🔴
-   - OBSERVE: complexity merits a second tier reviewer (R2/R3)
-   \`\`\`
-
-6. Emit your final structured signal so the runner can record outcomes:
-   \`\`\`
-   <<<PEER_REVIEW>>>{"red": <n>, "yellow": <n>, "green": <n>, "verdict": "<APPROVE|REQUEST_CHANGES|OBSERVE>"}
-   \`\`\`
-
-INVARIANTS:
-- One review per dispatch — never spam the PR with multiple comments.
-- Cite specific lines — "the function looks complicated" is noise; "X
-  on line Y violates Z invariant" is signal.
-- 🟢 (nice-to-have) findings are optional — skip the section if you
-  have none. Don't pad the review.
-
-R0 (Copilot) overlap handling:
-- DO read R0's comments first via
-  \`gh api repos/<o>/<r>/pulls/<n>/comments\`.
-- DO include findings R0 already flagged in your structured counts
-  (red/yellow/green) — those issues still need a comment-responder
-  pass, and the responder's trigger reads YOUR red count. If you
-  silently dropped duplicates, R0's findings would never get acted on.
-- Annotate duplicates in your review body so the operator can see what
-  overlaps R0:
-  \`- path:line — <description> (also flagged by R0)\`
-- The point of the dedup-aware annotation is operator readability,
-  NOT downstream signal suppression. Counts must reflect the full
-  set of issues you'd flag if R0 didn't exist.
-
-DON'T:
-- Don't dispatch a comment-responder yourself; the dispatcher chains
-  that based on your <<<PEER_REVIEW>>> output (red > 0 → responder).
-- Don't checkout the branch or run tests yourself — peer review is
-  read-only by design (write_policy=none in your bounds).
-- Don't escalate to R2/R3 directly; that's the review-graph workflow's
-  job. You set verdict=OBSERVE if you want a heavier tier; the
-  graph picks it up.
-`;
+  return renderSkill(SKILL_FOLDER, { entry });
 }
+


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `migrate-role-prompts-to-skill-folders`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-migrate-role-prompts-to-skill-folders-1777942945912`

## Entry context

Move the five existing prompt.ts builders to skill folders per the
authoring doc. The prompt.ts files become thin shims that call the
stitcher rather than building strings inline.

Per role:
- apps/temporal-worker/skills/<role>/SKILL.md: the role frame +
  workflow, lifted from the existing prompt.ts string (rewritten
  to authoring-doc shape).
- apps/temporal-worker/skills/<role>/<supporting>.md: per-skill
  rubrics, templates, examples extracted from the inline prompt.
- apps/temporal-worker/src/<role>/prompt.ts: simplifies to
  `(entry) => stitcher.assemble('<role>', entry, tier)`.

Migration order: simplest first. peer-reviewer (read-only) →
analyst (recipe-driven) → researcher → comment-responder (write
flow) → programmer (most context).

**Acceptance:**
- [ ] All 5 existing roles have skill folders that pass
      lint-skill-folder-shape
- [ ] role-prompts.ts builders reduce to stitcher calls
- [ ] All existing tests still pass (the stitcher's output is
      observably equivalent for tiers without harness skill support)
- [ ] Smoke test: a real dispatch at T2 produces the same agent
      behavior pre/post migration


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-migrate-role-prompts-to-skill-folders-1777942945912`
Branch: `swarm/swarm-migrate-role-prompts-to-skill-folders-1777942945912`
Head: `03c3743c`
Diff: `1 file changed, 18 insertions(+), 132 deletions(-)`
Commits: 1