### PR TITLE
swarm: skill-folder-dispatcher-stitcher

### DIFF
--- a/apps/temporal-worker/src/skill-loader/stitcher.ts
+++ b/apps/temporal-worker/src/skill-loader/stitcher.ts
@@ -349,3 +349,148 @@ export function skillFolderForRole(rootDir: string, role: string): string {
   return join(rootDir, SKILLS_ROOT, role);
 }
 
+// ── Caching layer ──────────────────────────────────────────────────
+//
+// Skill folders are static files that change rarely; in a worker
+// process that dispatches dozens of agents per minute, re-reading
+// SKILL.md + companions for every dispatch is pure overhead. We
+// keep a small in-process LRU keyed by absolute folder path.
+//
+// Invalidation:
+//   - Env var CHITIN_STITCHER_NO_CACHE=1 disables caching entirely
+//     (set by integration tests / when authoring a skill folder).
+//   - TTL via CHITIN_STITCHER_TTL_MS (default 5 minutes). Past TTL
+//     the entry is re-read from disk on next access.
+//   - clearSkillCache() exported for explicit invalidation in tests.
+//
+// Hit-rate counters (cacheStats) are read by the worker's metrics
+// surface — "measurable hit rate on repeat dispatches" per the
+// entry's acceptance criteria.
+
+interface CacheEntry {
+  skill: ParsedSkill;
+  loadedAt: number;
+}
+
+const SKILL_CACHE = new Map<string, CacheEntry>();
+const CACHE_MAX_ENTRIES = 64;
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+const cacheStats = { hits: 0, misses: 0, evictions: 0 };
+
+function cacheEnabled(): boolean {
+  return process.env.CHITIN_STITCHER_NO_CACHE !== '1';
+}
+
+function cacheTtlMs(): number {
+  const raw = process.env.CHITIN_STITCHER_TTL_MS;
+  if (!raw) return DEFAULT_TTL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MS;
+}
+
+/** Pure: O(1) LRU touch — delete + re-set moves the key to MRU end. */
+function touch(key: string, entry: CacheEntry): void {
+  SKILL_CACHE.delete(key);
+  SKILL_CACHE.set(key, entry);
+}
+
+/**
+ * Cached variant of loadSkill. Fresh reads on cache miss, expiry,
+ * or when caching is disabled. Updates cacheStats so the worker
+ * can expose hit/miss telemetry.
+ */
+export function loadSkillCached(folder: string): ParsedSkill {
+  const key = resolve(folder);
+  if (!cacheEnabled()) {
+    cacheStats.misses += 1;
+    return loadSkill(folder);
+  }
+  const now = Date.now();
+  const existing = SKILL_CACHE.get(key);
+  if (existing && now - existing.loadedAt < cacheTtlMs()) {
+    cacheStats.hits += 1;
+    touch(key, existing);
+    return existing.skill;
+  }
+  cacheStats.misses += 1;
+  const skill = loadSkill(folder);
+  SKILL_CACHE.set(key, { skill, loadedAt: now });
+  while (SKILL_CACHE.size > CACHE_MAX_ENTRIES) {
+    const oldest = SKILL_CACHE.keys().next().value;
+    if (oldest === undefined) break;
+    SKILL_CACHE.delete(oldest);
+    cacheStats.evictions += 1;
+  }
+  return skill;
+}
+
+/** Snapshot of cache counters; safe for a metrics endpoint. */
+export function getCacheStats(): { hits: number; misses: number; evictions: number; size: number } {
+  return { ...cacheStats, size: SKILL_CACHE.size };
+}
+
+/** Drop all cached skill folders + reset counters. Tests + skill
+ *  authors call this; the worker doesn't need it in normal flow. */
+export function clearSkillCache(): void {
+  SKILL_CACHE.clear();
+  cacheStats.hits = 0;
+  cacheStats.misses = 0;
+  cacheStats.evictions = 0;
+}
+
+// ── Unified tier-aware dispatch ───────────────────────────────────
+
+/**
+ * Tier classification per project_driver_model_tier_map. T0-T2 do
+ * NOT have native skill discovery, so the stitcher inlines the
+ * SKILL.md body into a prompt string. T3-T4 (Claude Code headless)
+ * receive the folder path and let the harness load it.
+ */
+export type Tier = 'T0' | 'T1' | 'T2' | 'T3' | 'T4';
+
+export interface StitchedSkill {
+  /** Inlined prompt string — populated for T0-T2 only. */
+  prompt?: string;
+  /** Skill folder path — populated for T3-T4 only. The dispatcher
+   *  copies this into the agent's working dir. */
+  folderPath?: string;
+  /** Frontmatter, exposed for both shapes (e.g. `tools` allowlist
+   *  the dispatcher feeds into ExecutionRequest). */
+  frontmatter: SkillFrontmatter;
+}
+
+/**
+ * Single entry point the dispatcher calls. Resolves the role's
+ * skill folder under `rootDir`, branches on tier-shape, and returns
+ * either an inlined prompt (T0-T2) or a folder path (T3-T4).
+ *
+ * Caching is automatic via loadSkillCached; bypass with
+ * CHITIN_STITCHER_NO_CACHE=1.
+ */
+export function stitchForTier(
+  rootDir: string,
+  role: string,
+  vars: Record<string, unknown>,
+  tier: Tier,
+): StitchedSkill {
+  const folder = skillFolderForRole(rootDir, role);
+  const skill = loadSkillCached(folder);
+  if (tier === 'T3' || tier === 'T4') {
+    return {
+      folderPath: materializePath(skill.folder),
+      frontmatter: skill.frontmatter,
+    };
+  }
+  const prompt = renderSkillBody(skill.body, vars, (relativePath) => {
+    const fullPath = join(skill.folder, relativePath);
+    try {
+      return readFileSync(fullPath, 'utf8');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`stitcher: cannot read companion ${relativePath}: ${msg}`);
+    }
+  });
+  return { prompt, frontmatter: skill.frontmatter };
+}
+


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `skill-folder-dispatcher-stitcher`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-skill-folder-dispatcher-stitcher-1777943864909`

## Entry context

The skill-folder pattern depends on the harness for discovery
(Claude Code headless = T3-T4 native; Copilot CLI / ollama models
including the new T0 GLM-4.7-flash = no native skill loading). The
stitcher closes that gap so SKILL.md is the single source of truth
across all tiers.

What it does:
- Given a role + entry, locates the corresponding skill folder
  (apps/temporal-worker/skills/<role>/).
- Reads SKILL.md and any files SKILL.md references.
- For T3-T4 (Claude Code headless): copies the skill folder into
  the agent's working dir; the harness handles loading.
- For T0-T2 (Copilot CLI, ollama): inlines SKILL.md + referenced
  templates into the prompt string at dispatch time. Falls back to
  the same shape current prompt.ts builders produce — but the
  source is markdown, not TypeScript.
- Substitutes entry-specific values (entry.id, entry.description,
  PR URL, etc.) via simple template variables (`{{entry.id}}`).
- Caches the load step (in-process LRU); skill folders are static
  files that change rarely.

Steps:
1. Implement stitcher as a pure function over (role, entry, tier)
   → string (the assembled prompt).
2. Tests with synthesized skill folders + entries.
3. Integrate into role-prompts.ts: builders call into the stitcher
   with the role name; stitcher reads from disk.
4. Caching layer with explicit invalidation (env var or TTL).

**Acceptance:**
- [ ] Stitcher loads SKILL.md + referenced files for a sample role
- [ ] Tier-shape branching: T3-T4 returns folder path; T0-T2
      returns inlined string
- [ ] Variable substitution (entry.id et al)
- [ ] Caching with measurable hit rate on repeat dispatches
- [ ] Round-trip: a SKILL.md authored per the linter rules produces
      a runnable prompt at every tier


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-skill-folder-dispatcher-stitcher-1777943864909`
Branch: `swarm/swarm-skill-folder-dispatcher-stitcher-1777943864909`
Head: `b392171d`
Diff: `2 files changed, 157 insertions(+), 10 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)