### PR TITLE
fix(install-kernel): self-locate go so systemd --user runs succeed

### DIFF
--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -39,6 +39,27 @@ LOG="${CHITIN_INSTALL_KERNEL_LOG:-$HOME/.cache/chitin/install-kernel.jsonl}"
 
 mkdir -p "$(dirname "$LOG")" "$(dirname "$BIN")"
 
+# Ensure `go` is on PATH. Under systemd --user (the production caller),
+# the inherited PATH often misses /usr/local/go/bin and ~/go/bin even
+# though the operator's interactive shell has them. The result was
+# 13h of failed redeploys logged as "build-failed" on 2026-05-04 with
+# the build actually fine — `go` simply wasn't reachable. Probe in
+# order: existing PATH → /usr/local/go/bin → $HOME/go/bin. Fail with
+# a structured chain log if none works so the caller sees the cause
+# instead of a generic exit-2.
+ensure_go_on_path() {
+  if command -v go >/dev/null 2>&1; then return 0; fi
+  for candidate in /usr/local/go/bin "$HOME/go/bin"; do
+    if [[ -x "$candidate/go" ]]; then
+      export PATH="$candidate:$PATH"
+      return 0
+    fi
+  done
+  emit fail go-not-found "searched=PATH,/usr/local/go/bin,$HOME/go/bin"
+  return 1
+}
+ensure_go_on_path || exit 2
+
 emit() {
   local kind="$1" msg="$2"
   shift 2


### PR DESCRIPTION
## Summary
- \`install-kernel.sh\` runs \`go build\` directly, relying on PATH.
- systemd --user inherits a PATH that doesn't include /usr/local/go/bin or ~/go/bin → \`go: not found\` → exit 127 → script's build-failed path → rollback-to-prev → systemd reports status=2.
- This had been firing every 15 min since ~12:00 EDT 2026-05-04 (>13h, ~52 failed runs).
- Fix: probe PATH → /usr/local/go/bin → \$HOME/go/bin. Prepend discovered dir to PATH. Emit a structured \`go-not-found\` chain log if all three fail.

## Why script-level vs unit-level
The unit could've added \`Environment=PATH=...\`. Script-level chosen because the script also runs from cron and ad-hoc operator invocations — fixing once covers all callers.

## Test plan
- [x] \`bash -n\` clean
- [x] After fix, \`systemctl --user start chitin-kernel-redeploy.service\` succeeds (build_dur_ms=749, exit 0)
- [x] Prior to fix: 52+ consecutive exit-2 failures in journal since 12:00 EDT
- [ ] Operator: confirm chitin-kernel-redeploy.service stays green across the next few timer fires after merge

## Related
- \`chitin-watchdog\` (#305) was reporting this as one of the 4 failed units. After merge, it drops off that list.
- Same pattern (script-level PATH probe) is worth porting to other shell-based chitin units if they hit similar issues. Watchdog will surface them.