### PR TITLE
swarm: code-pattern-lessons

### DIFF
--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -56,7 +56,10 @@ emit() {
   printf '%s\n' "$line" | tee -a "$LOG" >&2
 }
 
-cd "$REPO"
+if ! cd "$REPO" 2>/dev/null; then
+  emit fail chdir-failed "repo=$REPO"
+  exit 1
+fi
 
 old_sha=$(git rev-parse HEAD)
 if ! git fetch --quiet origin main; then


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `code-pattern-lessons`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-code-pattern-lessons-1777944775940`

## Entry context

Close the deploy-lag gap that produced the 2026-05-03 low-success
alarm. PRs touching `go/` or `chitin.yaml` only take effect when
an operator manually runs `go build`. The swarm runs unattended;
nobody redeploys; policy fixes sit dark for hours-to-days.

The simplest mechanic that closes the gap (avoid GitHub Actions
because the binary needs to land on the operator's rig, not in CI):

1. **`scripts/install-kernel.sh`** — idempotent shell script that
   - `cd /home/red/workspace/chitin && git fetch origin && git
     pull --ff-only origin main`
   - if `git diff --quiet HEAD@{1} HEAD -- go/ chitin.yaml` returns
     non-zero (i.e. changes), rebuild via `( cd
     go/execution-kernel && go build -o
     ~/.local/bin/chitin-kernel ./cmd/chitin-kernel )` — the
     subshell is required because chitin's go module is rooted at
     `go/execution-kernel/go.mod` (no top-level `go.mod`)
   - log start + end + sha + duration to the chain (use
     `chitin-kernel emit` if the previous binary was healthy enough
     to call, otherwise stderr); the log line is the operator's
     "what changed when" trail
   - exit 0 on no-op; exit 0 on rebuild-success; exit non-zero on
     git-pull-conflict OR build-failure (neither should auto-recover —
     surface to the operator)

2. **`infra/systemd/chitin-kernel-redeploy.service`** — oneshot unit
   that runs the script under the operator's user (NOT root — the
   binary lives under `~/.local/bin`).

3. **`infra/systemd/chitin-kernel-redeploy.timer`** — `OnUnitActiveSec=15min`,
   `OnBootSec=2min`, `Persistent=true`. 15-minute redeploy cadence
   keeps the lag bounded; persistent + boot-delay handles
   reboots cleanly. Operator can suspend by `systemctl --user stop
   chitin-kernel-redeploy.timer` without breaking anything.

4. **Rollback rule:** if the new build fails to start (smoke-test:
   `chitin-kernel gate evaluate --hook-stdin --agent=smoke` with a
   canned input must exit 0 within 2s), restore the previous binary
   from `~/.local/bin/chitin-kernel.prev` (kept by the script) and
   chain-log the rollback. We don't want a bad merge to brick the
   gate for the swarm.

5. **README + telemetry:** `docs/runbooks/chitin-kernel-redeploy.md`
   covering install, suspend, manual override, where the chain
   logs land. Operator should be able to read "when did the kernel
   last update" off the chain in one query.

**Acceptance:**
- [ ] `scripts/install-kernel.sh` no-ops cleanly when no go/ or
      chitin.yaml changes since last run
- [ ] Script rebuilds + reinstalls when go/ or chitin.yaml changes
- [ ] Smoke-test (canned `Task` PreToolUse evaluate) exits 0
      against the new binary OR the script auto-rolls-back
- [ ] systemd timer + service install cleanly via
      `systemctl --user enable --now chitin-kernel-redeploy.timer`
- [ ] Chain emits a `kernel_redeploy` event per rebuild with
      `{old_sha, new_sha, duration_ms, smoke_test_passed}`
- [ ] Runbook in docs/runbooks/


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-code-pattern-lessons-1777944775940`
Branch: `swarm/swarm-code-pattern-lessons-1777944775940`
Head: `0bfb50e0`
Diff: `2 files changed, 16 insertions(+), 11 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)