### PR TITLE
fix(lessons): bump TimeoutStartSec 60s → 300s

### DIFF
--- a/infra/systemd/chitin-lessons.service
+++ b/infra/systemd/chitin-lessons.service
@@ -23,5 +23,11 @@ EnvironmentFile=-%h/.config/systemd/user/chitin.env
 ExecStart=/home/red/.vite-plus/bin/pnpm exec tsx apps/temporal-worker/src/lessons.ts
 StandardOutput=journal
 StandardError=journal
-# 60s is generous for a `gh pr list` of 30 + a markdown rewrite.
-TimeoutStartSec=60
+# 30 min covers high-merge-volume days. The script does one `gh pr list`
+# + one `gh pr diff` + one `claude -p --model haiku` distillation per
+# NEW PR. claude has its own 60s per-call internal timeout with heuristic
+# fallback, so the worst case is bounded at ~60s × N_new_prs. With ~30
+# merged swarm PRs/day at peak (2026-05-03 cohort), the bound is 30 min.
+# Header docstring in lessons.ts says "heuristic-only v1" — that's
+# outdated; LLM distillation has shipped since.
+TimeoutStartSec=1800


### PR DESCRIPTION
## Summary
- chitin-lessons.service was SIGTERM'd at 60s on 2026-05-03 22:46.
- Live diagnosis revealed lessons.ts calls \`claude -p --model claude-haiku-4-5\` per NEW PR (header docstring claiming "heuristic-only v1" is outdated).
- 60s per-call internal timeout × ~30 daily merged swarm PRs at peak ≈ 30 min worst case.
- Bumps TimeoutStartSec to 1800s.

## Why 1800 not 300
First commit landed at 300s expecting heuristic-only sequential gh diffs (~1.2s for 30 PRs in the cached benchmark). Live systemd run during diagnosis hit 5+ minutes — gh diff plus a claude subprocess per new PR. The script self-bounds (claude internal timeout → heuristic fallback) at ~60s × N_new_prs, so the wallclock ceiling is ~30 min.

## Why bump vs redesign
The heuristic-only path takes 1.2s — there's a ~1500x speedup available if O(seconds) matters. Worth a separate redesign entry (parallelize claude calls, cache by PR-number+sha, drop LLM for non-interesting PRs). For now: bump, see if it recurs, file the redesign if it does.

## Test plan
- [x] Live systemd run during diagnosis ran 5+ min, still running at PR submit — would have been killed at 60s and at 300s
- [x] Manual heuristic-only run took 1.2s (the LLM path is what's slow)
- [ ] Operator: verify next daily timer fire stays green; watchdog (#305) will surface any future timeouts

## Related
- \`chitin-watchdog\` (#305) currently surfaces this as one of the 4 failed units. After merge + a clean run, it drops off.
- Worth filing follow-up: \`lessons-distill-fast-path\` to avoid the O(N×60s) ceiling.