### PR TITLE
fix(rollup): exit 0 even when alarms fire; surface via JSON

### DIFF
--- a/python/analysis/swarm_health.py
+++ b/python/analysis/swarm_health.py
@@ -508,8 +508,20 @@ def main(argv: list[str] | None = None) -> int:
         print("[rollup] posted to Slack", file=sys.stderr)
 
     if report.alarms:
-        print(f"[rollup] {len(report.alarms)} alarm(s) fired", file=sys.stderr)
-        return 1
+        # Alarms surface via three paths today:
+        #   (a) the rollup JSON, which chitin-alarm-feeder reads to file
+        #       backlog entries, and chitin-watchdog (PR #305) reads to
+        #       emit operator desktop notifications.
+        #   (b) Slack post above (when CHITIN_SLACK_WEBHOOK_URL is set).
+        #   (c) stderr line below for journalctl readers.
+        # The legacy "exit 1 if alarms fired" made systemd mark the unit
+        # as failed, which was the alarm channel before paths (a)–(c)
+        # existed. It's now noise — chitin-swarm-rollup was a permanent
+        # `systemctl --user list-units --state=failed` entry, both
+        # confusing humans and triggering a false positive in the
+        # watchdog's failed-units signal. Exit 0 so "failed" means
+        # "actually broken".
+        print(f"[rollup] {len(report.alarms)} alarm(s) fired (visible via JSON + watchdog + slack)", file=sys.stderr)
     return 0
 
 

--- a/python/analysis/tests/test_swarm_health.py
+++ b/python/analysis/tests/test_swarm_health.py
@@ -295,8 +295,15 @@ def test_main_writes_journal_and_exits_zero_when_healthy(tmp_path, monkeypatch, 
     assert parsed["alarms"] == []
 
 
-def test_main_returns_one_when_alarms_fire(tmp_path, monkeypatch):
-    """End-to-end: alarm fires → exit 1 (so systemd flags the unit)."""
+def test_main_returns_zero_even_when_alarms_fire(tmp_path, monkeypatch):
+    """End-to-end: alarm fires → exit 0; alarms surface via JSON,
+    watchdog, and slack — not via systemd's failed-unit signal.
+
+    Pre-watchdog (PR #305) the rollup exited 1 to mark the unit failed
+    as the alarm channel. Now it's noise: chitin-swarm-rollup was
+    permanently in `--state=failed`, both confusing humans and tripping
+    the watchdog's failed-units detector. Exit 0 makes "failed" mean
+    "actually broken"."""
     state_dir = tmp_path / "state"
     tmp_dir = tmp_path / "tmp"
     rollup_dir = tmp_path / "rollups"
@@ -329,4 +336,9 @@ def test_main_returns_one_when_alarms_fire(tmp_path, monkeypatch):
         "--window", "24h",
         "--no-slack",
     ])
-    assert rc == 1
+    assert rc == 0
+    # Alarm content must still be present in the rollup JSON — that's
+    # the contract the watchdog + alarm-feeder rely on now.
+    rollup_path = next(rollup_dir.iterdir())
+    rollup = json.loads(rollup_path.read_text())
+    assert len(rollup["alarms"]) >= 1

--- a/scripts/swarm-daily-rollup.sh
+++ b/scripts/swarm-daily-rollup.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # swarm-daily-rollup.sh — Daily swarm health rollup.
-# Called by chitin-swarm-rollup.service. Exits non-zero if alarms fired.
+# Called by chitin-swarm-rollup.service. Exits 0 on success regardless
+# of whether alarms fired — alarms are surfaced via the rollup JSON
+# (read by alarm-feeder + watchdog) and optional Slack post, not via
+# systemd's failed-unit signal. See swarm_health.py:main for rationale.
 set -euo pipefail
 
 REPO_ROOT="${CHITIN_REPO_ROOT:-$HOME/workspace/chitin}"


### PR DESCRIPTION
## Summary
- chitin-swarm-rollup.service exited 1 when alarms fired (legacy alarm channel via systemd's failed-unit signal).
- With watchdog (#305) reading rollup JSON directly, this is now noise: the unit was permanently failed, the watchdog flagged it as a false positive, and \`--state=failed\` lost meaning.
- Exit 0 instead. Alarms still surface via three paths: JSON (alarm-feeder + watchdog), Slack (when CHITIN_SLACK_WEBHOOK_URL set), stderr line.

## Test plan
- [x] Existing test \`test_main_returns_one_when_alarms_fire\` updated → \`test_main_returns_zero_even_when_alarms_fire\`. Asserts rc==0 AND that alarms remain in the rollup JSON.
- [x] All 21 swarm_health tests pass
- [x] Live verification: \`python3 -m analysis.swarm_health --window 24h\` produces JSON with 4 alarms and exits 0
- [ ] After merge: \`chitin-swarm-rollup.service\` should drop out of \`systemctl --user list-units --state=failed\` on its next daily run

## Related
- Closes the false-positive that the watchdog (#305) was reporting as one of "4 failed chitin-* units"
- Future direction: alarm-feeder (the existing rollup → backlog flywheel) reads alarms from the same JSON, so its behavior is unchanged