### PR TITLE
swarm: pr-event-ingester-dedup-against-completed-workflows

### DIFF
--- a/apps/temporal-worker/src/pr-event-ingester.ts
+++ b/apps/temporal-worker/src/pr-event-ingester.ts
@@ -27,6 +27,9 @@
 
 import { Connection, Client } from '@temporalio/client';
 import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 import { computeStartingTier, type PrMeta } from './review-graph.ts';
@@ -53,32 +56,131 @@ const EXECUTE_REQUEST_WORKFLOW_NAME = 'executeRequestWorkflow';
 
 const TASK_QUEUE = 'chitin-worker-q';
 
+// ── Per-PR dispatch markers ─────────────────────────────────────────
+//
+// listRunningAgentWorkflows only returns Running workflows. Once a
+// peer-reviewer run for PR #N completes, the next ingester tick (5 min
+// later) sees no running workflow with id `peer-review-pr-N` and
+// re-dispatches against the same unchanged PR — leaving duplicate
+// review comments on every tick.
+//
+// Fix: dedup against PR state, not workflow state. Each peer-reviewer
+// run is identified by (pr_number, head_sha). On dispatch the ingester
+// writes a marker file recording the head_sha it dispatched against.
+// On the next tick, if the marker's head_sha matches the PR's current
+// HEAD, skip — there's nothing new to review. A new commit pushed to
+// the PR rotates head_sha and the marker no longer matches, so the
+// next tick dispatches.
+//
+// Comment-responder uses a composite key (head_sha, comment_count): a
+// new commit OR new comments since last dispatch warrants another run.
+// Strictly this should be the unresolved-comment-set hash (see backlog
+// entry pr-event-ingester-comment-count-is-unresolved); comment_count
+// is a coarser proxy that still solves the every-5-minutes regression.
+//
+// Markers live under ~/.cache/chitin/, mirroring the dispatcher's
+// existing dispatched/<entry-id>.json convention.
+const PEER_REVIEWER_STATE_DIR = path.join(
+  os.homedir(),
+  '.cache/chitin/peer-reviewer-state',
+);
+const COMMENT_RESPONDER_STATE_DIR = path.join(
+  os.homedir(),
+  '.cache/chitin/comment-responder-state',
+);
+
+export interface PeerReviewerMarker {
+  head_sha: string;
+  dispatched_at: string;
+  workflow_id: string;
+}
+
+export interface CommentResponderMarker {
+  head_sha: string;
+  comment_count: number;
+  dispatched_at: string;
+  workflow_id: string;
+}
+
+export function readPeerReviewerMarker(
+  prNumber: number,
+  baseDir: string = PEER_REVIEWER_STATE_DIR,
+): PeerReviewerMarker | undefined {
+  return readMarker<PeerReviewerMarker>(baseDir, prNumber);
+}
+
+export function writePeerReviewerMarker(
+  prNumber: number,
+  marker: PeerReviewerMarker,
+  baseDir: string = PEER_REVIEWER_STATE_DIR,
+): void {
+  writeMarker(baseDir, prNumber, marker);
+}
+
+export function readCommentResponderMarker(
+  prNumber: number,
+  baseDir: string = COMMENT_RESPONDER_STATE_DIR,
+): CommentResponderMarker | undefined {
+  return readMarker<CommentResponderMarker>(baseDir, prNumber);
+}
+
+export function writeCommentResponderMarker(
+  prNumber: number,
+  marker: CommentResponderMarker,
+  baseDir: string = COMMENT_RESPONDER_STATE_DIR,
+): void {
+  writeMarker(baseDir, prNumber, marker);
+}
+
+function readMarker<T>(baseDir: string, prNumber: number): T | undefined {
+  const p = path.join(baseDir, `pr-${prNumber}.json`);
+  try {
+    const raw = fs.readFileSync(p, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    // Missing file or malformed JSON → treat as no marker. Fail-open
+    // means we MIGHT re-dispatch once; the running-workflow check is
+    // the second layer of dedup so the worst case is bounded.
+    return undefined;
+  }
+}
+
+function writeMarker(baseDir: string, prNumber: number, marker: unknown): void {
+  fs.mkdirSync(baseDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(baseDir, `pr-${prNumber}.json`),
+    JSON.stringify(marker),
+  );
+}
+
 // ── Pure logic ──────────────────────────────────────────────────────
 
 /**
- * Pure: decide which agents to dispatch for a PR, given running agents and options.
- * Mirrors the per-PR agent dispatch logic in runIngesterTick.
+ * Pure: decide which agents to dispatch for a PR, given running agents,
+ * persisted dispatch markers, and options. Mirrors the per-PR agent
+ * dispatch logic in runIngesterTick.
  *
  * Two agents may be dispatched per PR:
  *
  *   - peer-reviewer: a higher-tier reviewer that re-evaluates the PR
- *     beyond what GitHub's Copilot bot already produced. Always
- *     dispatched on each tick UNLESS its workflow id is already in
- *     runningAgents (Temporal-side dedup; the workflow id is stable
- *     per PR number, so a re-tick won't double-dispatch).
+ *     beyond what GitHub's Copilot bot already produced. Skipped when:
+ *       1. its workflow id is already in runningAgents (Temporal-side
+ *          dedup against an in-flight run), OR
+ *       2. peerReviewerMarker.head_sha === pr.headRefOid (state-side
+ *          dedup against an already-completed run for this commit).
+ *     A new commit on the PR rotates headRefOid; the marker no longer
+ *     matches and the next tick dispatches.
  *
  *   - comment-responder: redrafts patches in response to inline
  *     review comments. Dispatched only when copilotCommentCount
- *     EXCEEDS the threshold (`>` not `>=`). Important caveat: today's
- *     `copilotCommentCount` is the TOTAL comment count, NOT the
- *     unresolved-only count. That means a PR that's already been
- *     iterated on (with resolved threads) can still trip the
- *     threshold and re-dispatch the responder, which then noops or
- *     applies a redundant patch. Filed as backlog entry
- *     `pr-event-ingester-comment-count-is-unresolved`. Until that
- *     lands, the dedup via runningAgents is the only thing keeping
- *     the responder from spinning on an already-handled PR — which
- *     is why the runningAgents check fires BEFORE the threshold check.
+ *     EXCEEDS the threshold (`>` not `>=`). Skipped when:
+ *       1. its workflow id is already in runningAgents, OR
+ *       2. commentResponderMarker matches both head_sha AND
+ *          comment_count is not strictly greater — i.e. nothing has
+ *          changed since the last dispatch.
+ *     The composite (head_sha, comment_count) key approximates the
+ *     ideal (PR#, unresolved-comment-set hash) until backlog entry
+ *     pr-event-ingester-comment-count-is-unresolved lands.
  *
  * Decisions are returned as bools + a reasons map so callers can
  * distinguish "skipped because of dedup" from "skipped because below
@@ -87,7 +189,11 @@ const TASK_QUEUE = 'chitin-worker-q';
 export function decideAgentDispatches(
   pr: OpenPrSummary,
   runningAgents: ReadonlySet<string>,
-  opts?: { commentResponderThreshold?: number }
+  opts?: {
+    commentResponderThreshold?: number;
+    peerReviewerMarker?: PeerReviewerMarker;
+    commentResponderMarker?: CommentResponderMarker;
+  }
 ): {
   dispatchPeerReviewer: boolean;
   dispatchCommentResponder: boolean;
@@ -106,6 +212,13 @@ export function decideAgentDispatches(
   if (runningAgents.has(peerWorkflowId)) {
     dispatchPeerReviewer = false;
     reasons.skip_peer_reviewer = 'peer-reviewer already running';
+  } else if (
+    opts?.peerReviewerMarker &&
+    pr.headRefOid &&
+    opts.peerReviewerMarker.head_sha === pr.headRefOid
+  ) {
+    dispatchPeerReviewer = false;
+    reasons.skip_peer_reviewer = `peer-reviewer already ran for head_sha ${pr.headRefOid.slice(0, 7)}`;
   }
 
   let dispatchCommentResponder = false;
@@ -113,7 +226,16 @@ export function decideAgentDispatches(
     dispatchCommentResponder = false;
     reasons.skip_comment_responder = 'comment-responder already running';
   } else if (commentCount > threshold) {
-    dispatchCommentResponder = true;
+    const marker = opts?.commentResponderMarker;
+    const headMatches =
+      !!marker && !!pr.headRefOid && marker.head_sha === pr.headRefOid;
+    const noNewComments = !!marker && commentCount <= marker.comment_count;
+    if (headMatches && noNewComments) {
+      dispatchCommentResponder = false;
+      reasons.skip_comment_responder = `comment-responder already ran for (head_sha=${pr.headRefOid!.slice(0, 7)}, comment_count<=${marker!.comment_count})`;
+    } else {
+      dispatchCommentResponder = true;
+    }
   } else {
     dispatchCommentResponder = false;
     reasons.skip_comment_responder = `comment count (${commentCount}) <= threshold (${threshold})`;
@@ -144,6 +266,12 @@ export interface OpenPrSummary {
   number: number;
   title: string;
   headRefName: string;
+  /** Current HEAD commit sha of the PR's head branch. Idempotency key
+   *  for per-PR agent dispatch (peer-reviewer, comment-responder): a
+   *  new commit pushed to the PR rotates this and earns a fresh run.
+   *  Optional because callers in tests synthesize summaries without
+   *  faking a sha; production listOpenPrs always populates it. */
+  headRefOid?: string;
   additions: number;
   deletions: number;
   changedFiles: number;
@@ -298,7 +426,7 @@ export function listOpenPrs(repo: string): OpenPrSummary[] {
       '--limit',
       '1000',
       '--json',
-      'number,title,headRefName,additions,deletions,changedFiles,isDraft,url',
+      'number,title,headRefName,headRefOid,additions,deletions,changedFiles,isDraft,url',
     ],
     { encoding: 'utf8' },
   );
@@ -558,11 +686,34 @@ export async function runIngesterTick(opts: {
   // Iterate the same enriched set so the dispatch decision sees the
   // up-to-date Copilot comment count and PR shape. Non-skip decisions
   // already qualify (non-draft, non-swarm/, non-already-running review-
-  // graph); we add per-agent dedup against runningAgents.
+  // graph); we add per-agent dedup against runningAgents AND against
+  // persisted markers so completed runs don't re-fire on every tick.
   for (const decision of decisions) {
     if (decision.kind === 'skip') continue;
     const pr = decision.pr;
-    const agentDecision = decideAgentDispatches(pr, runningAgents);
+    const peerMarker = readPeerReviewerMarker(pr.number);
+    const responderMarker = readCommentResponderMarker(pr.number);
+    const agentDecision = decideAgentDispatches(pr, runningAgents, {
+      peerReviewerMarker: peerMarker,
+      commentResponderMarker: responderMarker,
+    });
+
+    if (agentDecision.reasons.skip_peer_reviewer) {
+      log(JSON.stringify({
+        component: 'pr-event-ingester',
+        msg: 'skip-peer-reviewer',
+        pr: pr.number,
+        reason: agentDecision.reasons.skip_peer_reviewer,
+      }));
+    }
+    if (agentDecision.reasons.skip_comment_responder) {
+      log(JSON.stringify({
+        component: 'pr-event-ingester',
+        msg: 'skip-comment-responder',
+        pr: pr.number,
+        reason: agentDecision.reasons.skip_comment_responder,
+      }));
+    }
 
     // Peer-reviewer
     if (agentDecision.dispatchPeerReviewer) {
@@ -581,8 +732,23 @@ export async function runIngesterTick(opts: {
           repo: opts.repo,
           log,
         });
-        if (peerRes.enqueued) result.peer_reviewers_enqueued += 1;
-        else result.errors += 1;
+        if (peerRes.enqueued) {
+          result.peer_reviewers_enqueued += 1;
+          // Record the dispatch so subsequent ticks skip until either
+          // a new commit (head_sha rotates) or operator-initiated
+          // marker removal. Skipped if headRefOid isn't available —
+          // we'd rather re-dispatch than write a marker keyed on an
+          // empty sha.
+          if (pr.headRefOid) {
+            writePeerReviewerMarker(pr.number, {
+              head_sha: pr.headRefOid,
+              dispatched_at: new Date().toISOString(),
+              workflow_id: peerReviewerWorkflowIdForPr(pr.number),
+            });
+          }
+        } else {
+          result.errors += 1;
+        }
       }
     }
 
@@ -604,8 +770,19 @@ export async function runIngesterTick(opts: {
           repo: opts.repo,
           log,
         });
-        if (respRes.enqueued) result.comment_responders_enqueued += 1;
-        else result.errors += 1;
+        if (respRes.enqueued) {
+          result.comment_responders_enqueued += 1;
+          if (pr.headRefOid) {
+            writeCommentResponderMarker(pr.number, {
+              head_sha: pr.headRefOid,
+              comment_count: pr.copilotCommentCount ?? 0,
+              dispatched_at: new Date().toISOString(),
+              workflow_id: commentResponderWorkflowIdForPr(pr.number),
+            });
+          }
+        } else {
+          result.errors += 1;
+        }
       }
     }
   }

--- a/apps/temporal-worker/test/pr-event-ingester.test.ts
+++ b/apps/temporal-worker/test/pr-event-ingester.test.ts
@@ -5,7 +5,9 @@ import {
   pickPrsToIngest,
   reviewGraphWorkflowIdForPr,
   synthesizeBacklogEntry,
+  type CommentResponderMarker,
   type OpenPrSummary,
+  type PeerReviewerMarker,
 } from '../src/pr-event-ingester.ts';
 
 // peerReviewer + commentResponder workflow id helpers — same
@@ -261,5 +263,114 @@ describe('decideAgentDispatches — peer-reviewer + comment-responder gating', (
     expect(d.dispatchCommentResponder).toBe(false);
     expect(d.reasons.skip_peer_reviewer).toBeDefined();
     expect(d.reasons.skip_comment_responder).toBeDefined();
+  });
+});
+
+
+describe('decideAgentDispatches — marker-based dedup against completed runs', () => {
+  // Closes the gap left by listRunningAgentWorkflows: once a peer-
+  // reviewer run completes for (PR, head_sha), the marker keeps the
+  // ingester from re-dispatching against that exact commit on the
+  // next tick.
+  const SHA_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const SHA_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const peerMarker = (sha: string): PeerReviewerMarker => ({
+    head_sha: sha,
+    dispatched_at: '2026-05-04T12:00:00Z',
+    workflow_id: peerReviewerWorkflowIdForPr(207),
+  });
+  const responderMarker = (sha: string, count: number): CommentResponderMarker => ({
+    head_sha: sha,
+    comment_count: count,
+    dispatched_at: '2026-05-04T12:00:00Z',
+    workflow_id: commentResponderWorkflowIdForPr(207),
+  });
+  const basePr = (overrides: Partial<OpenPrSummary>): OpenPrSummary =>
+    pr({ number: 207, ...overrides });
+
+  it('skips peer-reviewer when marker.head_sha matches PR head_sha (completed run dedup)', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_A, copilotCommentCount: 0 }),
+      new Set<string>(), // nothing currently running
+      { peerReviewerMarker: peerMarker(SHA_A) },
+    );
+    expect(d.dispatchPeerReviewer).toBe(false);
+    expect(d.reasons.skip_peer_reviewer).toMatch(/already ran for head_sha/);
+  });
+
+  it('dispatches peer-reviewer when PR head_sha advances past marker (new commit)', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_B, copilotCommentCount: 0 }),
+      new Set<string>(),
+      { peerReviewerMarker: peerMarker(SHA_A) },
+    );
+    expect(d.dispatchPeerReviewer).toBe(true);
+    expect(d.reasons.skip_peer_reviewer).toBeUndefined();
+  });
+
+  it('dispatches peer-reviewer when no marker has been written yet', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_A, copilotCommentCount: 0 }),
+      new Set<string>(),
+      { peerReviewerMarker: undefined },
+    );
+    expect(d.dispatchPeerReviewer).toBe(true);
+  });
+
+  it('running-workflow check wins over marker — already-running message takes precedence', () => {
+    const running = new Set<string>([peerReviewerWorkflowIdForPr(207)]);
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_A }),
+      running,
+      { peerReviewerMarker: peerMarker(SHA_A) },
+    );
+    expect(d.dispatchPeerReviewer).toBe(false);
+    expect(d.reasons.skip_peer_reviewer).toMatch(/already running/);
+  });
+
+  it('skips comment-responder when marker matches both head_sha and comment_count is unchanged', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_A, copilotCommentCount: 5 }),
+      new Set<string>(),
+      {
+        commentResponderThreshold: 2,
+        commentResponderMarker: responderMarker(SHA_A, 5),
+      },
+    );
+    expect(d.dispatchCommentResponder).toBe(false);
+    expect(d.reasons.skip_comment_responder).toMatch(/already ran/);
+  });
+
+  it('dispatches comment-responder when PR head_sha advances past marker', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_B, copilotCommentCount: 5 }),
+      new Set<string>(),
+      {
+        commentResponderThreshold: 2,
+        commentResponderMarker: responderMarker(SHA_A, 5),
+      },
+    );
+    expect(d.dispatchCommentResponder).toBe(true);
+  });
+
+  it('dispatches comment-responder when comment_count grows beyond marker (new comments arrived)', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: SHA_A, copilotCommentCount: 10 }),
+      new Set<string>(),
+      {
+        commentResponderThreshold: 2,
+        commentResponderMarker: responderMarker(SHA_A, 5),
+      },
+    );
+    expect(d.dispatchCommentResponder).toBe(true);
+  });
+
+  it('marker dedup is bypassed when PR has no headRefOid (production safety: prefer dispatching over silent skip)', () => {
+    const d = decideAgentDispatches(
+      basePr({ headRefOid: undefined, copilotCommentCount: 0 }),
+      new Set<string>(),
+      { peerReviewerMarker: peerMarker(SHA_A) },
+    );
+    expect(d.dispatchPeerReviewer).toBe(true);
   });
 });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `pr-event-ingester-dedup-against-completed-workflows`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-pr-event-ingester-dedup-against-completed-workflows-1777945377107`

## Entry context

`listRunningAgentWorkflows` only returns workflows in
`ExecutionStatus="Running"`. After a peer-reviewer's run completes
on PR #207, the next ingester tick (5 min later) will see no
running workflows for `peer-review-pr-207` — and will dispatch
another peer review for the same unchanged PR. The dispatch will
keep posting duplicate review comments every 5 minutes.

The robust fix is dedup against PR state rather than workflow
state: each peer-reviewer run is per (PR#, head_sha). A new
commit pushed to the PR → new review needed; same head_sha → no
review needed.

Two implementation paths to consider during grooming:

(a) **Marker-file dedup** (mirrors the dispatcher's existing
    `~/.cache/chitin/swarm-state/dispatched/<entry-id>.json`
    pattern): per-PR marker at
    `~/.cache/chitin/peer-reviewer-state/pr-<n>.json` recording
    `{ head_sha, ran_at, workflow_run_id }`. Ingester reads the
    marker before dispatch and skips if `head_sha` matches the PR's
    current HEAD. Peer-reviewer (the agent) writes the marker when
    its run completes successfully.

(b) **Temporal visibility query against completed workflows**:
    list completed workflows with `WorkflowId="peer-review-pr-<n>"`,
    inspect their result envelope for the recorded head_sha. More
    Temporal-native; doesn't introduce new state. Risk: workflow
    history retention windows may evict old runs.

Same shape applies to comment-responder, with the additional
twist that a comment-responder run can produce new commits +
new pushes; head_sha will change as a result OF the run.
Idempotency key for comment-responder is probably (PR#,
unresolved_comment_set_hash) rather than head_sha — needs a
groomer-pass before code lands.

**Acceptance:**
- [ ] Peer-reviewer is dispatched at most ONCE per (PR#, head_sha)
- [ ] Comment-responder dispatch is gated on a similar idempotency
      key (decision in design phase, then implement)
- [ ] Ingester does not re-fire either agent on the same PR every
      tick after the first run completes
- [ ] Tests: same PR ingested twice across two ticks dispatches
      exactly once unless head_sha changes


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-pr-event-ingester-dedup-against-completed-workflows-1777945377107`
Branch: `swarm/swarm-pr-event-ingester-dedup-against-completed-workflows-1777945377107`
Head: `128bd47a`
Diff: `12 files changed, 330 insertions(+), 471 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)