### PR TITLE
feat(install): auto-enable new timers + wire installer into kernel-redeploy

### DIFF
--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -31,6 +31,39 @@ User-mode systemd units that run the autonomous swarm: worker daemon
 
 ## Install
 
+First-time setup is one command:
+
+```bash
+bash scripts/install-systemd-units.sh --enable-all
+```
+
+After that, **just pull main**. `chitin-kernel-redeploy.timer` fires
+every 15 min and re-runs `install-systemd-units.sh` automatically,
+auto-enabling any newly-shipped timers. Existing timers' enable state
+is preserved (manual `systemctl --user disable <unit>` actions stick).
+
+Closes the recurring "shipped a unit, forgot to install" gap that
+caused 2026-05-04's 20.5h auto-recovery outage (PR #282 shipped the
+unlock units, operator never enabled them, missed the lockdown).
+
+For ad-hoc operator use:
+
+```bash
+# Default: link all + auto-enable NEW timers only (existing untouched)
+bash scripts/install-systemd-units.sh
+
+# Force-enable every timer (e.g. fresh checkout, prior state lost)
+bash scripts/install-systemd-units.sh --enable-all
+
+# Preview without changes
+bash scripts/install-systemd-units.sh --dry-run
+```
+
+The legacy manual snippet below still works but is no longer the
+recommended path:
+
+<details><summary>Legacy: cp + per-unit enable</summary>
+
 ```bash
 mkdir -p ~/.config/systemd/user
 cp infra/systemd/*.{service,timer} ~/.config/systemd/user/
@@ -47,6 +80,8 @@ systemctl --user enable --now chitin-groomer.timer
 systemctl --user enable --now chitin-agent-unlock.timer
 systemctl --user enable --now chitin-watchdog.timer
 ```
+
+</details>
 
 To survive logout (start at boot):
 

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -172,6 +172,25 @@ for installer in \
   rm -f "$hook_log"
 done
 
+# Sync systemd user units with infra/systemd/. New units (e.g. a
+# freshly-merged chitin-foo.timer) get auto-enabled here so the
+# install step matches the merge step — closes the 2026-05-04
+# pattern where PR #282 shipped chitin-agent-unlock.{service,timer}
+# but the operator never `cp`'d + `enable`'d them, missing a 20.5h
+# auto-recovery window. Idempotent; existing timers' enable state
+# is preserved (operator-disabled units stay disabled).
+INSTALL_UNITS="$REPO/scripts/install-systemd-units.sh"
+if [[ -x "$INSTALL_UNITS" ]]; then
+  units_log=$(mktemp)
+  if "$INSTALL_UNITS" >"$units_log" 2>&1; then
+    emit ok systemd-units-synced
+  else
+    tail=$(tail -c 500 "$units_log" | tr '\n' ' ' | tr -d '"' || true)
+    emit warn systemd-units-sync-failed "tail=$tail"
+  fi
+  rm -f "$units_log"
+fi
+
 # Rotate the budget envelope if the active one closed. Without
 # this, a sticky-closed envelope deny-cascades every tool call
 # until manual rotation. Idempotent; no-op when the active

--- a/scripts/install-systemd-units.sh
+++ b/scripts/install-systemd-units.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
 # Symlink all chitin-* systemd units from infra/systemd/ into the user unit
-# directory, then reload and enable timers.
+# directory, daemon-reload, and auto-enable any *newly-linked* timers.
 #
 # Usage:
-#   bash scripts/install-systemd-units.sh [--enable] [--dry-run]
+#   bash scripts/install-systemd-units.sh [--enable-all] [--dry-run]
 #
 # Options:
-#   --enable   Enable (and start) all timer units after symlinking (default: off)
-#   --dry-run  Print what would be done without changing anything
+#   --enable-all  Force-enable every timer (override new-only logic).
+#                 Use after a fresh checkout where prior enable state is gone.
+#   --dry-run     Print what would be done without changing anything.
+#
+# Default behavior: link all units, auto-enable timers that didn't exist
+# before this run, leave already-symlinked timers alone (preserves the
+# operator's intentional `systemctl --user disable <unit>` actions).
+#
+# Closes the recurring "shipped a unit, forgot to enable" gap. 2026-05-04
+# incident: PR #282 shipped chitin-agent-unlock.{service,timer}, the
+# operator never copied + enabled them, so when copilot-cli locked down
+# at 03:27 UTC the auto-recovery never ran (manual unlock at ~21:30 UTC,
+# after a 20.5h outage). Auto-enabling new timers makes the install step
+# match the merge step.
+#
+# Designed to be invoked:
+#   - Manually post-pull / post-merge
+#   - From install-kernel.sh after a successful rebuild (every 15 min)
 
 set -euo pipefail
 
@@ -15,13 +31,14 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 UNIT_SRC_DIR="$REPO_ROOT/infra/systemd"
 UNIT_DST_DIR="${SYSTEMD_USER_DIR:-$HOME/.config/systemd/user}"
 
-ENABLE=false
+ENABLE_ALL=false
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --enable)  ENABLE=true;  shift ;;
-    --dry-run) DRY_RUN=true; shift ;;
+    --enable-all) ENABLE_ALL=true; shift ;;
+    --enable)     ENABLE_ALL=true; shift ;;  # legacy alias
+    --dry-run)    DRY_RUN=true;    shift ;;
     *) echo "error: unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -49,20 +66,28 @@ if [[ "$DRY_RUN" == "false" ]]; then
 fi
 
 linked=()
+newly_linked=()  # subset that didn't exist before this run
 for src in "${units[@]}"; do
   [[ -f "$src" ]] || continue
   name="$(basename "$src")"
   dst="$UNIT_DST_DIR/$name"
   if [[ "$DRY_RUN" == "true" ]]; then
-    echo "would symlink $dst -> $src"
+    if [[ -e "$dst" ]]; then
+      echo "would re-link $dst -> $src"
+    else
+      echo "would symlink (new) $dst -> $src"
+    fi
   else
     if [[ -e "$dst" && ! -L "$dst" ]]; then
       echo "warning: $dst exists and is not a symlink — skipping" >&2
       continue
     fi
+    pre_existed=false
+    [[ -L "$dst" ]] && pre_existed=true
     ln -sf "$src" "$dst"
     echo "symlinked $dst -> $src"
     linked+=("$name")
+    [[ "$pre_existed" == "false" ]] && newly_linked+=("$name")
   fi
 done
 
@@ -73,14 +98,25 @@ fi
 systemctl --user daemon-reload
 echo "daemon-reload done"
 
-if [[ "$ENABLE" == "true" ]]; then
-  for name in "${linked[@]}"; do
-    if [[ "$name" == *.timer ]]; then
-      systemctl --user enable --now "$name"
-      echo "enabled $name"
-    fi
-  done
+# Decide which timers to enable. Default: only NEW links (preserves
+# operator's manual `disable` actions on existing timers). --enable-all
+# overrides for explicit operator intent (e.g. fresh checkout).
+to_enable=()
+if [[ "$ENABLE_ALL" == "true" ]]; then
+  to_enable=("${linked[@]}")
+else
+  to_enable=("${newly_linked[@]}")
 fi
+
+for name in "${to_enable[@]}"; do
+  if [[ "$name" == *.timer ]]; then
+    if systemctl --user enable --now "$name" 2>/dev/null; then
+      echo "enabled $name"
+    else
+      echo "warning: failed to enable $name (manual enable may be needed)" >&2
+    fi
+  fi
+done
 
 echo ""
 echo "Done. Verify with: systemctl --user list-timers"


### PR DESCRIPTION
## Summary
- Closes the "shipped a systemd unit, forgot to enable it" gap that caused 2026-05-04's 20.5h auto-recovery outage.
- \`install-systemd-units.sh\` now auto-enables timers that didn't exist before the run; existing timers' enable state is preserved (manual disables stick).
- \`install-kernel.sh\` invokes the installer after every successful rebuild, so a freshly-merged unit lands enabled within ~15 min of the merge — no operator action.

## Behavior
| Scenario | Old | New |
|---|---|---|
| Fresh unit shipped in main | cp + enable manually | auto-enabled by next redeploy |
| Operator disabled a timer | might get re-enabled | preserved |
| Forced full re-enable | \`--enable\` | \`--enable-all\` (legacy \`--enable\` aliased) |
| Operator-customized non-symlink unit | overwritten | skipped with warning |

## Test plan
- [x] Live run on current state — picked up 2 new units (\`chitin-codex-chain-ingest.timer\`, \`chitin-codex-usage-feed.timer\`), symlinked them, auto-enabled both
- [x] Existing copy-installed units skipped with clear warnings (operator-customized state preserved)
- [x] Existing symlinks re-pointed (no-op when target unchanged)
- [x] \`bash -n\` clean on both scripts
- [ ] After merge: chitin-kernel-redeploy.service emits \`systemd-units-synced\` log line on next 15-min tick

## Related
- 2026-05-04 incident root cause: PR #282 shipped chitin-agent-unlock.{service,timer}, operator never enabled, copilot-cli locked 20.5h
- Watchdog (#305) surfaces unit-failure visibility; this PR closes the unit-install side