### PR TITLE
swarm: formalize-no-github-issues-decision

### DIFF
--- a/docs/decisions/2026-05-03-no-github-issues.md
+++ b/docs/decisions/2026-05-03-no-github-issues.md
@@ -1,0 +1,21 @@
+# Decision: No GitHub Issues for Swarm Work-Tracking (2026-05-03)
+
+## Decision
+GitHub issues are reserved for external, human-filed bug reports. The Chitin swarm does not create issues for work-tracking or kanban. Instead, all swarm work is tracked in `docs/swarm-backlog.md`, which serves as the authoritative kanban surface.
+
+## Why
+- **Machine-readable backlog:** The markdown backlog supports dependencies (`blocks`), status, and role fields, enabling structured, automatable workflows that GitHub issues cannot match.
+- **Workflow alignment:** PRs reference backlog entry IDs, and the lessons extractor reads from PRs, not issues. The dispatcher and audit flows already route around issues.
+- **Operator clarity:** There is no operator-side gain to duplicating work-tracking in issues.
+
+## Forward Direction
+The flat-file backlog is an interim solution. The upcoming `libs/scheduler` library will subsume the backlog, with backlog entries becoming scheduler items. These will retain fields like `status`, `tier`, `role`, and `blocks`, and add scheduling metadata (e.g., deadlines, preferred windows). The planned `apps/scheduler-dashboard` Angular UI will provide a unified kanban view for both life-scheduling and swarm work, eliminating the need for a separate swarm-backlog-kanban app.
+
+## Exception
+This policy applies only to swarm work-tracking. Real bug reports filed by humans should continue to use GitHub issues as normal.
+
+## When to Revisit
+Revisit this decision if:
+- Swarm scaling or operator visibility suffers.
+- External contributors require an issues-based entrypoint.
+- Scheduler absorption of the backlog stalls or fails.

--- a/docs/superpowers/plans/2026-05-02-scheduler-design.md
+++ b/docs/superpowers/plans/2026-05-02-scheduler-design.md
@@ -11,6 +11,8 @@ Two compatible goals, both served by the same artifact:
 1. **Personal scheduler.** Operator's daily task list + calendar. Voice/chat ingest, time-of-day-aware slotting, Slack/ntfy notifications, local Angular dashboard.
 2. **Swarm coordination substrate.** The same ranking primitive that decides "what's the operator's next task" also decides "what's the swarm's next backlog entry to dispatch." Today's `apps/temporal-worker/src/dispatcher.ts:pickEntryToDispatch` and a personal scheduler's `next()` are isomorphic — both rank a queue against context to pick a slot.
 
+**Note:** The scheduler is also slated to subsume the swarm backlog. Backlog entries in `docs/swarm-backlog.md` will become scheduler items, retaining fields like `status`, `tier`, `role`, and `blocks`, and gaining scheduling metadata (e.g., deadlines, preferred windows). The dispatcher will eventually read from the scheduler API instead of markdown. The flat-file backlog is interim until this migration completes.
+
 The hard rule: swarm may tune the heuristic, never the kernel. Architecture must enforce that, not by convention.
 
 ## Package layout (Nx)

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -1,5 +1,7 @@
 # Swarm Backlog
 
+**Note:** This file is the interim work-tracking surface for the Chitin swarm. Expect migration to the scheduler system (`libs/scheduler`) when its workflow-item shape ships; at that point, backlog entries will become scheduler items and this file will be retired.
+
 Tier-tagged work the local 24/7 swarm chews through. Distinct from `roadmap.md`:
 the roadmap is *strategy* (where chitin is going), this doc is *execution*
 (what individual issues are ready to grab, sized for which tier).


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `formalize-no-github-issues-decision`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-formalize-no-github-issues-decision-1777946327611`

## Entry context

The chitin workflow drifted away from per-PR GitHub issues months
ago — closed-issue history shows the OLD pattern (`[swarm/T1]
openclaw-tool-coverage-audit` etc.) ending around 2026-04-23. Today
the only open issues (#22, #13, #4) are real bug reports filed by
humans, not work-tracking artifacts. The active work surface is
`docs/swarm-backlog.md`: the dispatcher reads markdown directly,
PRs reference backlog-entry-IDs in titles, lessons-extractor
reads from PRs not issues.

Operator framing 2026-05-03: "I agree [with formalizing no-issues]
because I think our scheduler will eventually be the backlog
instead of a flat file."

So the decision has TWO components:

1. **Today's formalization** (status quo): GitHub issues are
   reserved for outside-the-swarm bug reports filed by humans.
   The swarm doesn't create issues. Backlog entries in
   `docs/swarm-backlog.md` are the kanban + work-tracking
   surface.

2. **Forward direction**: the flat-file backlog is INTERIM.
   `libs/scheduler` (life scheduling lib being built) will
   eventually subsume the swarm backlog — backlog entries become
   scheduler items with the same `status`/`tier`/`role`/`blocks`
   shape as today, plus deadline + window-pref fields native to
   the scheduler. `apps/scheduler-dashboard` (the planned Angular
   UI) becomes the kanban view across both life-scheduling work
   AND swarm-backlog work. No separate "swarm-backlog-kanban-view"
   app needed — the scheduler-dashboard handles both.

This entry's job is the docs + decision record, not the
implementation. Implementation lands in scheduler entries.

Steps:

1. Add a one-page decision doc at `docs/decisions/2026-05-03-no-github-issues.md`
   (or amend CONTRIBUTING.md if that file exists / is the right
   home — operator's call). Sections:
   - Decision (what's true today)
   - Why (the structural reasons: backlog file beats issues for
     machine-readable kanban with deps + blocks; lessons + PR
     workflow already routes around issues; no operator-side
     gain)
   - Forward direction (the scheduler subsumes the backlog;
     the flat file is interim)
   - Exception (real bug reports filed by humans use issues
     normally; the no-issues rule is for SWARM work-tracking,
     not all GitHub usage)
   - When this decision should be revisited (if the swarm
     stops scaling under operator-side visibility; if external
     contributors need an issues-mediated entrypoint; if the
     scheduler absorption stalls)

2. Forward-pointer in `docs/superpowers/plans/2026-05-02-scheduler-design.md`:
   add a note that the scheduler is also slated to subsume the
   swarm backlog, with the data model implications (status/tier/
   role/blocks fields, dispatcher reads scheduler API instead of
   markdown).

3. Optional: add a short note to `docs/swarm-backlog.md`'s file
   header explaining "this file is the interim work-tracking
   surface; expect migration to the scheduler when libs/scheduler
   ships its workflow-item shape."

**Acceptance:**
- [ ] `docs/decisions/2026-05-03-no-github-issues.md` exists with
      the five sections above
- [ ] Scheduler design doc has the forward-pointer
- [ ] swarm-backlog.md header notes the interim status (optional)
- [ ] Existing 3 open issues (#22, #13, #4) are NOT closed by
      this entry — they're real bug reports


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-formalize-no-github-issues-decision-1777946327611`
Branch: `swarm/swarm-formalize-no-github-issues-decision-1777946327611`
Head: `f114c37b`
Diff: `2 files changed, 4 insertions(+)`
Commits: 0 (+ auto-committed uncommitted state)