### PR TITLE
fix(peer-reviewer): explicit DO-NOT-CLONE warnings to stop tempdir fixups

### DIFF
--- a/apps/temporal-worker/skills/peer-reviewer/SKILL.md
+++ b/apps/temporal-worker/skills/peer-reviewer/SKILL.md
@@ -31,6 +31,8 @@ YOUR WORKFLOW:
    gh pr <subcmd> --repo <owner>/<repo> <pr_number> [args...]
    ```
 
+   **CRITICAL — DO NOT TRY TO "FIX" YOUR WORKING DIRECTORY.** The empty tempdir is intentional. Peer-review is a *read-only, gh-API-only* role. NEVER run `gh repo clone`, `gh pr checkout`, `git clone`, or any command that mutates your cwd or the repo. NEVER `rm` files trying to clear the way for a clone. If a `gh` command says "not in a git repo," that means you forgot the `--repo` flag — fix the flag, do NOT try to populate the tempdir. Cloning here destroys the dispatch and produces no review (this exact pattern caused the 2026-05-04 cascade where peer-reviewers tried `rm chitin.yaml && gh repo clone .` and never posted comments).
+
 2. Read the PR diff:
    ```
    gh pr diff --repo <owner>/<repo> <pr_number>
@@ -70,4 +72,5 @@ R0 (Copilot) overlap handling:
 DON'T:
 - Don't dispatch a comment-responder yourself; the dispatcher chains that based on your <<<PEER_REVIEW>>> output (red > 0 → responder).
 - Don't checkout the branch or run tests yourself — peer review is read-only by design (write_policy=none in your bounds).
+- Don't `gh repo clone`, `git clone`, or any cwd-mutating command. If `gh` complains about "not in a git repo," you forgot the `--repo` flag — fix the flag, don't fix the tempdir. (Trying to clone into the tempdir is the 2026-05-04 cascade pattern: 4 swarm PRs got no review because the agent kept trying `rm chitin.yaml && gh repo clone .` instead of just adding `--repo`.)
 - Don't escalate to R2/R3 directly; that's the review-graph workflow's job. You set verdict=OBSERVE if you want a heavier tier; the graph picks it up.


### PR DESCRIPTION
## Summary
- Production bug: peer-reviewer agent keeps trying \`gh repo clone .\` and \`gh pr checkout <n>\` to "fix" its empty tempdir, eating time without posting any review.
- Observed on swarm PRs #304, #307, #309, #312, #315 — review-graph enqueued, agent ran, no comment posted.
- Adds two explicit DO-NOT-CLONE warnings to \`apps/temporal-worker/skills/peer-reviewer/SKILL.md\` (inline at step 1 + DON'T list at bottom).

## What the agent kept doing
\`\`\`
gh pr diff 315                                              ✓ ok
gh repo clone chitinhq/chitin . && gh pr checkout 315       ✗ fails (. non-empty)
rm chitin.yaml && gh repo clone . && gh pr checkout 315     ✗ destructive fallback
\`\`\`

Same shape as 2026-05-04T03:27 lockdown trigger (\`rm -rf .git && gh repo clone .\`). The current variant uses a single-file rm so it doesn't trip \`no-rm-recursive\` — the agent burns its budget, the review never posts.

## What the skill already said
The skill **does** say to use \`--repo\` on every call and **does** have \`Don't checkout the branch\` in the DON'T list. The agent ignored both. New text names the antipattern explicitly so a fresh agent reads it as a known failure mode, not a generic prohibition.

## Followup (not in scope)
A kernel-layer governance rule (\`role=peer-reviewer ⇒ deny shell.exec=~/^gh repo clone/\`) would catch this regardless of skill prompt drift. Depends on chain-fingerprint role tagging shipping first (entry: \`chain-fingerprint-tagging\`).

## Test plan
- [x] Skill reads correctly, frontmatter unchanged
- [ ] After merge: next peer-review dispatch on a swarm PR posts a review comment via \`gh pr review --comment\` and emits \`<<<PEER_REVIEW>>>\` signal (vs current behavior of clone attempts and silence)
- [ ] Operator: re-check #304 / #307 / #309 / #312 / #315 24h post-merge for chitin reviews