### PR TITLE
swarm: workflow-name-drift-test

### DIFF
--- a/apps/temporal-worker/test/activity.test.ts
+++ b/apps/temporal-worker/test/activity.test.ts
@@ -415,6 +415,17 @@ describe('parseToolSummary', () => {
   });
 });
 
+// ─── executeRequestWorkflow.name === WORKFLOW_NAME ─────────────────────────
+
+import { WORKFLOW_NAME } from '../src/submit';
+import type { executeRequestWorkflow } from '../src/submit';
+
+describe('WORKFLOW_NAME matches executeRequestWorkflow.name', () => {
+  it('should match the actual workflow function name', () => {
+    expect((executeRequestWorkflow as any).name).toBe(WORKFLOW_NAME);
+  });
+});
+
 // ─── isWorkerOwnedPath ─────────────────────────────────────────────────────
 //
 // Cleanup-cleanup-rmSync gate. The 2026-05-04 cwd-rm incident (#280)


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `workflow-name-drift-test`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-workflow-name-drift-test-1777947585836`

## Entry context

`apps/temporal-worker/src/submit.ts:8` uses `WORKFLOW_NAME = 'executeRequestWorkflow'`
as a string, with `import type { executeRequestWorkflow }` for type safety.
If the export is renamed, the string goes stale silently. Add a unit test
asserting `executeRequestWorkflow.name === WORKFLOW_NAME`.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-workflow-name-drift-test-1777947585836`
Branch: `swarm/swarm-workflow-name-drift-test-1777947585836`
Head: `8dd18879`
Diff: `1 file changed, 11 insertions(+)`
Commits: 1