### PR TITLE
fix(activity): remove unsupported --include-hook-events from openclaw call (T0/T1 unblock)

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -288,6 +288,16 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
       // dispatches passes through before_tool_call → chitin gate. The per-
       // driver agent mapping routes to distinct openclaw agents so each
       // tier runs its own model.
+      //
+      // No `--include-hook-events`: openclaw 2026.4.x doesn't support that
+      // flag (it's claude-code-only). Passing it caused `openclaw agent` to
+      // exit 1 immediately on every T0/T1 dispatch from 2026-05-04 17:00
+      // UTC (shift-left routing reshuffle, when T0/T1 first started routing
+      // to openclaw-glm-flash) until 2026-05-05 02:09 UTC (this fix), with
+      // every run silently producing `commits_added: 0` and "agent made no
+      // changes." Hook-event capture for openclaw runs happens via the
+      // chitin-governance plugin's chain emission instead — the flag is
+      // unnecessary on this path.
       return {
         command: 'openclaw',
         args: [
@@ -295,7 +305,6 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
           '--local',
           '--agent', resolveAgent(driver),
           '--json',
-          '--include-hook-events',
           '--timeout', String(req.bounds.wall_timeout_s),
           '--message', req.prompt,
         ],


### PR DESCRIPTION
## Summary
- openclaw 2026.4.x rejects \`--include-hook-events\` (\"error: unknown option\")
- Passing it caused every T0/T1 dispatch to exit 1 in ~2s since the 2026-05-04 17:00 UTC shift-left
- Removes the flag from the openclaw branch only; claude-code-headless still passes it (claude does support it)

## How this was found
Tonight cleared the stale T0 marker for \`workflow-name-drift-test\` (the only \`tier: T0\` entry that was claimable) so the dispatcher could re-dispatch on glm-flash. It picked the entry, ran 1.99s, exited 1, "agent made no changes". Reproduced manually:

\`\`\`
$ openclaw agent --json --include-hook-events --message "say ok"
error: unknown option '--include-hook-events'
\`\`\`

Same args minus the flag completes successfully against \`glm-flash-agent\`.

## Hidden cost since 2026-05-04 17:00 UTC
The shift-left strategy was non-functional for ~9 hours. Every T0/T1 entry routed to openclaw-glm-flash exited 1, the dispatcher escalated through tiers, eventually hit "tier ladder exhausted" operator-only. The 13-entry operator-only cohort cleared earlier tonight was largely secondary fallout from this single bug.

## Hook-event observability for openclaw
The chitin-governance plugin's chain emission already captures every tool call as a chain event. Removing the CLI flag doesn't lose the audit signal on this path.

## Test plan
- [x] \`bash openclaw agent --local --agent glm-flash-agent --json --timeout 60 --message "..."\` completes successfully
- [x] Typecheck clean on apps/temporal-worker
- [ ] After merge: next dispatcher tick that picks a T0 entry should route to glm-flash and produce real commits (not exit 1 in 2s)
- [ ] Update or close \`activity-include-hook-events-flag\` backlog entry — its description called for adding the flag "where supported", but openclaw doesn't support it

## Related
- 2026-05-04 shift-left commit (#285) introduced the routing change
- 2026-05-04 lockdown incident (separate, on copilot-cli) coincidentally happened the same day; the two failures masked each other