### PR TITLE
auto: flip 1 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -4310,7 +4310,7 @@ Steps:
 ```yaml
 id: pr-event-ingester-dedup-against-completed-workflows
 tier: T3
-status: ready
+status: partial
 estimated_loc: 200
 blocks: []
 file: apps/temporal-worker/src/pr-event-ingester.ts, apps/temporal-worker/src/peer-reviewer/dispatch.ts, apps/temporal-worker/src/comment-responder/dispatch.ts


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- pr-event-ingester-dedup-against-completed-workflows (#312)

If any of these are wrong, revert + investigate why the title matched without the work shipping.