### PR TITLE
swarm: router-heuristics-go-sdk

### DIFF
--- a/go/execution-kernel/internal/router/evaluate.go
+++ b/go/execution-kernel/internal/router/evaluate.go
@@ -1,0 +1,123 @@
+package router
+
+import (
+	"time"
+)
+
+// EvaluateResult is the structured output of EvaluateHeuristics —
+// the in-process Go pipeline that runs blast-radius + floundering
+// in pure Go and decides whether the (slow) advisor needs to be
+// consulted. The advisor call itself is left to an external caller
+// (TS shim or `chitin-kernel router evaluate`) so the hot path
+// stays pure-Go.
+//
+// Wire shape (JSON):
+//
+//	{
+//	  "decision": "allow" | "deny",
+//	  "advisor_needed": bool,
+//	  "advisor_request": { ...AdvisorRequest } | null,
+//	  "heuristic_outcome": { ...HeuristicOutcome }
+//	}
+type EvaluateResult struct {
+	Decision         string            `json:"decision"`
+	AdvisorNeeded    bool              `json:"advisor_needed"`
+	AdvisorRequest   *AdvisorRequest   `json:"advisor_request,omitempty"`
+	HeuristicOutcome HeuristicOutcome  `json:"heuristic_outcome"`
+}
+
+// EvaluateHeuristics is the in-process router pipeline. Inputs:
+//
+//   - input:         the PreToolUse payload (already parsed)
+//   - policy:        the loaded router policy (LoadPolicy)
+//   - kernelDeny:    true iff the deterministic kernel verdict was deny
+//   - kernelMessage: the kernel's deny reason (empty when allowed)
+//   - now:           injected time.Now for testability
+//
+// The function:
+//
+//  1. Runs blast-radius on the input (when enabled in policy)
+//  2. Runs floundering against the chain (when enabled in policy)
+//  3. Decides advisor_needed by walking policy.Advisor.When
+//  4. Builds AdvisorRequest when advisor_needed is true (so the
+//     external advisor caller has all context in one envelope)
+//
+// Returns EvaluateResult — pure data, no side effects, no
+// subprocess spawning. Calling code is responsible for:
+//
+//   - reading chain events for floundering (passed in as `events`)
+//   - invoking the advisor when advisor_needed
+//   - composing the final hook output
+//
+// Invariant: when advisor_needed is true, AdvisorRequest is
+// non-nil. When false, AdvisorRequest is nil.
+func EvaluateHeuristics(input HookInput, policy Policy, events []ChainEvent, kernelDeny bool, kernelMessage string, now time.Time) EvaluateResult {
+	outcome := HeuristicOutcome{}
+
+	if cfg, ok := policy.Heuristics["blast_radius"]; ok && cfg.Enabled {
+		score := ScoreBlastRadius(input, cfg.Threshold)
+		outcome.BlastRadius = &score
+		if score.Fired {
+			outcome.AnyFired = true
+		}
+	}
+	if cfg, ok := policy.Heuristics["floundering"]; ok && cfg.Enabled {
+		score := DetectFloundering(events, FlounderingThresholds{
+			MaxLoopCount:    cfg.MaxLoopCount,
+			MaxStallSeconds: cfg.MaxStallSeconds,
+		}, now)
+		outcome.Floundering = &score
+		if score.Fired {
+			outcome.AnyFired = true
+		}
+	}
+
+	decision := "allow"
+	if kernelDeny {
+		decision = "deny"
+	}
+
+	advisorNeeded := false
+	if policy.Advisor.Enabled {
+		for _, trigger := range policy.Advisor.When {
+			switch trigger {
+			case "blast_radius_above_threshold":
+				if outcome.BlastRadius != nil && outcome.BlastRadius.Fired {
+					advisorNeeded = true
+				}
+			case "floundering_detected":
+				if outcome.Floundering != nil && outcome.Floundering.Fired {
+					advisorNeeded = true
+				}
+			case "kernel_denied":
+				if kernelDeny {
+					advisorNeeded = true
+				}
+			}
+			if advisorNeeded {
+				break
+			}
+		}
+	}
+
+	res := EvaluateResult{
+		Decision:         decision,
+		AdvisorNeeded:    advisorNeeded,
+		HeuristicOutcome: outcome,
+	}
+	if advisorNeeded {
+		question := "Heuristic flagged this action. Is the agent on track, or should it pause/escalate?"
+		if kernelDeny {
+			question = "The kernel denied this action: " + kernelMessage + ". Should the agent be re-routed or is this denial correct?"
+		}
+		req := AdvisorRequest{
+			Question:         question,
+			Context:          "Session: " + input.SessionID + ". Heuristic outcome attached.",
+			ProposedAction:   input,
+			HeuristicOutcome: outcome,
+			ChainDepth:       0,
+		}
+		res.AdvisorRequest = &req
+	}
+	return res
+}

--- a/go/execution-kernel/internal/router/evaluate_test.go
+++ b/go/execution-kernel/internal/router/evaluate_test.go
@@ -1,0 +1,121 @@
+package router
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvaluateHeuristics_AllowReadOnly(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Enabled = true
+	res := EvaluateHeuristics(
+		HookInput{ToolName: "Read", ToolInput: map[string]interface{}{"file_path": "/etc/hosts"}},
+		policy, nil, false, "", time.Now(),
+	)
+	if res.Decision != "allow" {
+		t.Errorf("decision=%q want allow", res.Decision)
+	}
+	if res.AdvisorNeeded {
+		t.Error("advisor_needed=true on read-only tool; want false")
+	}
+	if res.AdvisorRequest != nil {
+		t.Error("advisor_request non-nil when advisor not needed")
+	}
+	if res.HeuristicOutcome.BlastRadius == nil {
+		t.Error("blast_radius outcome missing")
+	}
+}
+
+func TestEvaluateHeuristics_BlastRadiusFiresAdvisor(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Enabled = true
+	res := EvaluateHeuristics(
+		HookInput{
+			ToolName:  "Bash",
+			ToolInput: map[string]interface{}{"command": "rm -rf /tmp/foo"},
+			SessionID: "sess-1",
+		},
+		policy, nil, false, "", time.Now(),
+	)
+	if !res.AdvisorNeeded {
+		t.Error("advisor_needed=false on rm-rf; want true (blast above threshold)")
+	}
+	if res.AdvisorRequest == nil {
+		t.Fatal("advisor_request nil despite advisor_needed=true")
+	}
+	if res.AdvisorRequest.ProposedAction.ToolName != "Bash" {
+		t.Errorf("proposed_action.tool_name=%q want Bash", res.AdvisorRequest.ProposedAction.ToolName)
+	}
+	if res.AdvisorRequest.HeuristicOutcome.BlastRadius == nil ||
+		!res.AdvisorRequest.HeuristicOutcome.BlastRadius.Fired {
+		t.Error("advisor_request.heuristic_outcome.blast_radius didn't fire")
+	}
+}
+
+func TestEvaluateHeuristics_KernelDenyTriggersAdvisorWhenConfigured(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Enabled = true
+	policy.Advisor.When = []string{"kernel_denied"}
+	res := EvaluateHeuristics(
+		HookInput{ToolName: "Read", ToolInput: map[string]interface{}{"file_path": "/etc/hosts"}},
+		policy, nil, true, "policy_invalid: missing rule", time.Now(),
+	)
+	if res.Decision != "deny" {
+		t.Errorf("decision=%q want deny", res.Decision)
+	}
+	if !res.AdvisorNeeded {
+		t.Error("advisor_needed=false on kernel_denied trigger; want true")
+	}
+	if res.AdvisorRequest == nil || res.AdvisorRequest.Question == "" {
+		t.Fatal("advisor_request missing question on kernel-deny path")
+	}
+}
+
+func TestEvaluateHeuristics_PolicyDisabledStillBuildsOutcome(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Enabled = true
+	policy.Advisor.Enabled = false
+	res := EvaluateHeuristics(
+		HookInput{
+			ToolName:  "Bash",
+			ToolInput: map[string]interface{}{"command": "rm -rf /tmp/foo"},
+		},
+		policy, nil, false, "", time.Now(),
+	)
+	if res.AdvisorNeeded {
+		t.Error("advisor_needed=true with advisor disabled; want false")
+	}
+	if res.HeuristicOutcome.BlastRadius == nil || !res.HeuristicOutcome.BlastRadius.Fired {
+		t.Error("blast-radius should still fire even when advisor is off")
+	}
+}
+
+func TestEvaluateHeuristics_FlounderingFires(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Enabled = true
+	ev := func(target string) ChainEvent {
+		return ChainEvent{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":     "Bash",
+				"action_target": target,
+				"decision":      "allow",
+			},
+		}
+	}
+	now, _ := time.Parse(time.RFC3339, "2026-05-03T20:00:30Z")
+	res := EvaluateHeuristics(
+		HookInput{ToolName: "Read", ToolInput: map[string]interface{}{"file_path": "/etc/hosts"}},
+		policy,
+		[]ChainEvent{ev("rm /tmp/x"), ev("rm /tmp/x"), ev("rm /tmp/x")},
+		false, "",
+		now,
+	)
+	if res.HeuristicOutcome.Floundering == nil || !res.HeuristicOutcome.Floundering.Fired {
+		t.Error("floundering didn't fire on three identical calls")
+	}
+	if !res.AdvisorNeeded {
+		t.Error("advisor_needed=false despite floundering; want true (default trigger)")
+	}
+}


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `router-heuristics-go-sdk`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-router-heuristics-go-sdk-1777947886289`

## Entry context

The router's heuristic+policy layer ships as TypeScript MVP in
`apps/temporal-worker/src/router/`. Operator hot-path concern:
every tool call that hits the slow path eats `pnpm tsx` startup
(~500ms-1s). With many tool calls per session, that adds up.

Move the deterministic-fast pieces into the Go kernel:

1. **policy reader** — Go YAML parser for chitin.yaml `router:`
   section; matches the TS `policy-loader.ts` shape
2. **blast-radius scorer** — pure Go function; same axes as
   TS version (reversibility / scope / visibility / counterparties)
3. **floundering detector** — Go reads chain JSONL, applies same
   signals (looping / stalled / denial-cascade)
4. **session-state reads** — chain index lookups (already in Go)

Only the ADVISOR call stays external (it's slow anyway —
`claude -p` is a multi-second LLM call). The Go kernel exposes
`--with-router` flag on `gate evaluate` that runs heuristics in-
process and prints `{decision, advisor_needed, advisor_request}`.
The TS layer (or a thin shim) handles the advisor call when
flagged.

End-state: hot path is pure-Go. Slow path (advisor) is TS or
external. No `pnpm tsx` overhead per tool call.

**Acceptance:**
- [ ] Go modules at `go/execution-kernel/internal/router/{policy,blast_radius,floundering}.go`
- [ ] `gate evaluate --with-router` flag wires them in-process
- [ ] Same test fixtures pass against Go + TS implementations (port the TS tests)
- [ ] Bin script `chitin-router-hook` updated to skip the TS pipeline when kernel handles it
- [ ] Benchmark: average hot-path latency before / after (target: < 50ms)
- [ ] CI green


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-router-heuristics-go-sdk-1777947886289`
Branch: `swarm/swarm-router-heuristics-go-sdk-1777947886289`
Head: `a8135536`
Diff: `3 files changed, 256 insertions(+), 10 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)