### PR TITLE
fix(dispatcher): skip entry-filing PR titles in shipped-entry dedup

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -323,12 +323,29 @@ function recordDispatchOutcome(
  * top of an already-pushed branch.
  */
 /**
+ * PR subject prefixes that FILE an entry rather than implement it.
+ * Mirrors `scripts/shipped-entry-flipper.sh`'s prefix filter so the
+ * two dedup paths agree. Without this, the dispatcher dedup matched
+ * the operator's own `backlog: <entry-id>` PR title and treated the
+ * fresh entry as already-shipped (2026-05-05 incident: PR #322 filed
+ * `t0-glm-flash-smoke-confirm-end-to-end`; dispatcher refused to
+ * dispatch the entry on the next tick because its id appeared in
+ * #322's merged title).
+ */
+const ENTRY_FILING_PREFIXES = /^(backlog|auto|docs?|test):/;
+
+/**
  * Check whether a backlog entry's id appears literally in the
  * recent-merged-PR-subjects scan. Pure string match — backlog ids
  * can contain regex metacharacters (e.g., `pr-event-ingester-1.0`
  * has `.`), so we deliberately skip --grep and do an in-memory
  * `includes` to avoid false matches AND `fatal: invalid regexp`
  * errors that would silently disable the suppression.
+ *
+ * Skips entry-FILING PR subjects (backlog:/auto:/docs:/test:) so
+ * the dedup only fires on IMPLEMENTATION PRs (feat:/fix:/swarm:/
+ * refactor:/perf:/chore:). Same convention as
+ * scripts/shipped-entry-flipper.sh.
  *
  * Exported for unit tests; not part of the public dispatcher API.
  */
@@ -343,6 +360,7 @@ export function entryIdInRecentSubjects(entryId: string, recentSubjects: string)
   const lines = recentSubjects.split('\n');
   for (const line of lines) {
     if (!line) continue;
+    if (ENTRY_FILING_PREFIXES.test(line)) continue;
     let idx = 0;
     while ((idx = line.indexOf(entryId, idx)) !== -1) {
       const before = idx === 0 ? '' : line[idx - 1];

--- a/apps/temporal-worker/test/dispatcher-shipped-skip.test.ts
+++ b/apps/temporal-worker/test/dispatcher-shipped-skip.test.ts
@@ -68,4 +68,44 @@ describe('entryIdInRecentSubjects', () => {
     const subjects = 'fix: x\n\n\nswarm: target — closes\n';
     expect(entryIdInRecentSubjects('target', subjects)).toBe(true);
   });
+
+  // Entry-filing prefix filter — the dispatcher's dedup must NOT
+  // skip an entry just because the operator's `backlog: <id>` PR
+  // landed. Otherwise filing an entry instantly disqualifies it
+  // from being dispatched (2026-05-05 incident with PR #322 +
+  // entry t0-glm-flash-smoke-confirm-end-to-end).
+
+  it('does NOT match a `backlog:`-prefixed PR title', () => {
+    expect(entryIdInRecentSubjects('my-entry', 'backlog: my-entry (filed 2026-05-05)')).toBe(false);
+  });
+
+  it('does NOT match an `auto:`-prefixed PR title (auto-flipper / sweepers)', () => {
+    expect(entryIdInRecentSubjects('my-entry', 'auto: flip my-entry ready→partial')).toBe(false);
+  });
+
+  it('does NOT match a `docs:`-prefixed PR title', () => {
+    expect(entryIdInRecentSubjects('my-entry', 'docs: clarify my-entry rationale')).toBe(false);
+  });
+
+  it('does NOT match a `doc:`-prefixed PR title (singular alias)', () => {
+    expect(entryIdInRecentSubjects('my-entry', 'doc: my-entry footnote')).toBe(false);
+  });
+
+  it('does NOT match a `test:`-prefixed PR title', () => {
+    expect(entryIdInRecentSubjects('my-entry', 'test: my-entry boundary cases')).toBe(false);
+  });
+
+  it('STILL matches when an entry-filing PR sits next to a real implementation PR', () => {
+    const subjects = [
+      'backlog: my-entry (filed 2026-05-05)',  // would dedup-trip without the filter
+      'swarm: my-entry — closes #999',          // real implementation
+    ].join('\n');
+    expect(entryIdInRecentSubjects('my-entry', subjects)).toBe(true);
+  });
+
+  it('STILL matches feat:/fix:/swarm:/refactor:/perf:/chore: prefixes', () => {
+    for (const prefix of ['feat', 'fix', 'swarm', 'refactor', 'perf', 'chore']) {
+      expect(entryIdInRecentSubjects('my-entry', `${prefix}: my-entry — done`)).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Dispatcher's \`entryIdInRecentSubjects\` substring-matched the operator's own \`backlog: <entry-id>\` PR title, treating a freshly-filed entry as already-shipped.
- Flipper script already had this filter; dispatcher didn't. Now they agree.
- Filters out \`backlog:|auto:|docs?:|test:\` prefixed subjects from the dedup.

## How this surfaced
Tonight: filed entry \`t0-glm-flash-smoke-confirm-end-to-end\` via PR #322. The PR title naturally contains the entry id. After PR merge, the dispatcher's *next* tick saw the id in the merged subject and skipped the entry as already-shipped — making the entry undispatchable from the moment it was filed.

The flipper script (\`scripts/shipped-entry-flipper.sh\`) handles this exact case with the same prefix filter:

\`\`\`bash
if [[ "$title" =~ ^(backlog|auto|docs?|test): ]]; then
  continue
fi
\`\`\`

## Test plan
- [x] 7 new boundary tests added (backlog/auto/docs/doc/test prefixes do NOT match; feat/fix/swarm/refactor/perf/chore DO match)
- [x] All 17 \`entryIdInRecentSubjects\` tests pass
- [x] Full worker suite: 736/736 passing
- [ ] After merge: next dispatcher tick should pick \`t0-glm-flash-smoke-confirm-end-to-end\` (no longer deduped against #322's title)

## Related
- Closes the gap that almost made tonight's T0 verification untestable
- The /land skill landed earlier today; this PR was developed under it (review-fix-merge), tests added before commit