### PR TITLE
swarm: ollama-cloud-usage-capture

### DIFF
--- a/apps/temporal-worker/src/activity.ts
+++ b/apps/temporal-worker/src/activity.ts
@@ -843,8 +843,43 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
     }
   }
 
+  // Ollama Cloud usage capture: if this was an ollama-cloud fallback, capture quota headers and emit usage feed
+  try {
+    await captureOllamaCloudUsage(req, result);
+  } catch (err) {
+    // Non-fatal: log to stderr_tail for operator visibility
+    const msg = err instanceof Error ? err.message : String(err);
+    result.stderr_tail = `${result.stderr_tail}\n[ollama-cloud-usage-capture] ${msg}`.slice(-TAIL_BYTES);
+  }
   return result;
 }
+
+// Capture Ollama Cloud quota headers and emit usage feed if applicable
+async function captureOllamaCloudUsage(req: ExecutionRequest, result: ActivityResult): Promise<void> {
+  // Only run for openclaw-glm-cloud driver (Ollama Cloud)
+  if (!req.allowed_drivers.includes('openclaw-glm-cloud')) return;
+  // Look for quota headers in tool_summary or stdout_tail
+  const summary = result.tool_summary || parseToolSummary(result.stdout_tail || '');
+  if (!summary || typeof summary !== 'object') return;
+  // Expect quota headers in summary.headers or summary.quota or similar
+  const headers = summary.headers || summary.quota || {};
+  const rpm = Number(headers['X-RateLimit-Remaining'] ?? headers['x-ratelimit-remaining']);
+  const tpm = Number(headers['X-RateLimit-Reset'] ?? headers['x-ratelimit-reset']);
+  if (!Number.isFinite(rpm) && !Number.isFinite(tpm)) return;
+  // Write usage feed
+  const usageFeedPath = join(homedir(), '.cache/chitin/usage/ollama-cloud.json');
+  const usage = {
+    axis: 'rpm_tpm',
+    observed_at: new Date().toISOString(),
+    rpm: Number.isFinite(rpm) ? rpm : null,
+    tpm: Number.isFinite(tpm) ? tpm : null,
+    workflow_id: req.workflow_id,
+    run_id: req.run_id,
+  };
+  mkdirSync(join(homedir(), '.cache/chitin/usage'), { recursive: true });
+  writeFileSync(usageFeedPath, JSON.stringify(usage, null, 2));
+}
+
 
 /**
  * Project the agent's stream-json stdout tail into a typed


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `ollama-cloud-usage-capture`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-ollama-cloud-usage-capture-1777950262969`

## Entry context

Ollama Cloud surfaces quota via response headers (`X-RateLimit-Remaining`, `X-RateLimit-Reset`, etc) on every API call. Capture those at the activity layer (or in the openclaw plugin if openclaw's the dispatch path) and emit a `~/.cache/chitin/usage/ollama-cloud.json` feed with `axis: rpm_tpm`.

Why this matters: ollama-cloud is the local-tier fallback when 3090 is busy or off; without quota visibility, dispatching to ollama-cloud right after hitting the 5h codex window is a pattern that'll silently degrade. Universal usage feed surfaces both.

**Acceptance:**
- [ ] Feed file populated after a 3090-fallback dispatch
- [ ] `chitin-budget` renders an ollama-cloud row with `rpm` + `tpm` percentages
- [ ] Stale-feed detection in chitin-status (warn if `last_observed > 30min`)


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-ollama-cloud-usage-capture-1777950262969`
Branch: `swarm/swarm-ollama-cloud-usage-capture-1777950262969`
Head: `02aa3338`
Diff: `1 file changed, 35 insertions(+)`
Commits: 1