### PR TITLE
swarm: lessons-distill-fast-path

### DIFF
--- a/apps/temporal-worker/src/lessons.ts
+++ b/apps/temporal-worker/src/lessons.ts
@@ -376,6 +376,73 @@ export async function fetchMergedSwarmPrs(limit: number): Promise<MergedPr[]> {
  * merged swarm PRs, dedups by pr_number, distills new ones, appends.
  * Idempotent: re-runs on the same input produce zero new entries.
  */
+// --- Fast-path cache and parallel distillation additions ---
+import { createHash } from 'node:crypto';
+import { cpus } from 'node:os';
+
+const LESSONS_CACHE_PATH = resolve(process.env.HOME || '', '.cache/chitin/lessons-cache.jsonl');
+const N_PARALLEL = 4;
+
+type LessonCacheEntry = {
+  pr_number: number;
+  head_sha: string;
+  lesson: string;
+};
+
+function loadLessonCache(): Record<string, string> {
+  try {
+    const text = readFileSync(LESSONS_CACHE_PATH, 'utf8');
+    const lines = text.split('\n').filter(Boolean);
+    const cache: Record<string, string> = {};
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as LessonCacheEntry;
+        cache[`${entry.pr_number}:${entry.head_sha}`] = entry.lesson;
+      } catch {}
+    }
+    return cache;
+  } catch {
+    return {};
+  }
+}
+
+function appendLessonCache(entries: LessonCacheEntry[]) {
+  if (!entries.length) return;
+  const fd = require('fs').openSync(LESSONS_CACHE_PATH, 'a');
+  for (const entry of entries) {
+    require('fs').writeSync(fd, JSON.stringify(entry) + '\n');
+  }
+  require('fs').closeSync(fd);
+}
+
+function is_distill_worthwhile(pr: MergedPr & { filesChanged?: number }): boolean {
+  const title = pr.title.toLowerCase();
+  if (/^(auto:|docs:|chore:|fix\(typo\)|bump:)/.test(title)) return false;
+  if ((pr.body || '').length < 20) return false;
+  if (pr.filesChanged !== undefined && pr.filesChanged <= 1) return false;
+  return true;
+}
+
+async function fetchPrHeadSha(prNumber: number): Promise<string> {
+  try {
+    const out = execFileSync('gh', ['pr', 'view', String(prNumber), '--json', 'headRefOid'], { encoding: 'utf8' });
+    const obj = JSON.parse(out);
+    return obj.headRefOid || '';
+  } catch {
+    return '';
+  }
+}
+
+async function fetchPrFilesChanged(prNumber: number): Promise<number> {
+  try {
+    const out = execFileSync('gh', ['pr', 'view', String(prNumber), '--json', 'files'], { encoding: 'utf8' });
+    const obj = JSON.parse(out);
+    return Array.isArray(obj.files) ? obj.files.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export async function runLessonsExtractor(
   opts: LessonsExtractorOptions,
 ): Promise<LessonsExtractorResult> {
@@ -387,21 +454,59 @@ export async function runLessonsExtractor(
 
   const merged = await opts.fetchMergedPrs(opts.scanLimit);
 
+  // --- Load cache ---
+  const cache = loadLessonCache();
   const newEntries: LessonEntry[] = [];
   let duplicates_skipped = 0;
-  for (const pr of merged) {
+  const cacheAppends: LessonCacheEntry[] = [];
+
+  // --- Prepare PRs with head_sha and filesChanged ---
+  const mergedWithMeta = await Promise.all(
+    merged.map(async (pr) => {
+      const head_sha = await fetchPrHeadSha(pr.number);
+      const filesChanged = await fetchPrFilesChanged(pr.number);
+      return { ...pr, head_sha, filesChanged };
+    })
+  );
+
+  // --- Parallel distillation ---
+  const distillTargets = mergedWithMeta.filter(pr => !knownPrs.has(pr.number));
+  const results: (LessonEntry | null)[] = [];
+  for (let i = 0; i < distillTargets.length; i += N_PARALLEL) {
+    const chunk = distillTargets.slice(i, i + N_PARALLEL);
+    const chunkResults = await Promise.all(chunk.map(async (pr) => {
+      const cacheKey = `${pr.number}:${pr.head_sha}`;
+      if (cache[cacheKey]) {
+        return {
+          pr_number: pr.number,
+          date: pr.mergedAt.slice(0, 10),
+          lesson: cache[cacheKey],
+        };
+      }
+      if (!is_distill_worthwhile(pr)) {
+        return null;
+      }
+      const distilled = await opts.distill(pr);
+      const lesson = distilled.trim();
+      if (!lesson) return null;
+      cacheAppends.push({ pr_number: pr.number, head_sha: pr.head_sha, lesson });
+      return {
+        pr_number: pr.number,
+        date: pr.mergedAt.slice(0, 10),
+        lesson,
+      };
+    }));
+    results.push(...chunkResults);
+  }
+
+  for (const pr of mergedWithMeta) {
     if (knownPrs.has(pr.number)) {
       duplicates_skipped++;
-      continue;
     }
-    const distilled = await opts.distill(pr);
-    const lesson = distilled.trim();
-    if (!lesson) continue;
-    newEntries.push({
-      pr_number: pr.number,
-      date: pr.mergedAt.slice(0, 10),
-      lesson,
-    });
+  }
+
+  for (const entry of results) {
+    if (entry) newEntries.push(entry);
   }
 
   if (newEntries.length > 0) {
@@ -409,6 +514,7 @@ export async function runLessonsExtractor(
     newEntries.sort((a, b) => b.pr_number - a.pr_number);
     const updated = appendLessons(text, newEntries);
     await writeFile(opts.lessonsPath, updated, 'utf8');
+    appendLessonCache(cacheAppends);
   }
 
   const result: LessonsExtractorResult = {


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `lessons-distill-fast-path`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-lessons-distill-fast-path-1777951486057`

## Entry context

`chitin-lessons.service` calls `claude -p --model claude-haiku-4-5`
sequentially, once per NEW merged swarm PR. The internal per-call
timeout is 60s with heuristic fallback, so the wallclock ceiling is
~60s × N_new_prs. PR #310 bumped TimeoutStartSec from 60s → 1800s as
a defense-in-depth fix — but at high merge volume the daily run still
takes 5+ minutes. The heuristic-only path is 1.2s for the same input,
so there's a ~150x speedup available without losing the lesson quality
that motivates the LLM call.

Three layers of optimization, pick a combination:

1. **Filter LLM to "interesting" PRs only.** Heuristic produces a
   plausible one-sentence lesson from title + body for most PRs;
   only escalate to claude when the heuristic is low-confidence
   (very short body, generic title, no diff_shortstat, etc.). Most
   swarm PRs are heuristic-friendly.
2. **Parallelize.** `Promise.all` over `claude -p` spawns. Cap at N=4
   concurrent so we don't hammer claude or the gh API. Cuts a 30-PR
   day from ~30 min to ~7.5 min.
3. **Cache by (pr_number, head_sha).** Store distilled lessons in
   `~/.cache/chitin/lessons-cache.jsonl`; skip re-distillation when
   the same head_sha is seen. Dispatcher already checks
   `entryIdInRecentSubjects` — same dedup pattern.

Approach (subject to design tightening — programmer should propose):

- Add `is_distill_worthwhile(pr)` heuristic predicate; only call
  claude when it returns true. Cheap signals: body_length, title
  patterns ("auto:" / "fix(typo)" / "docs:" → skip), files_changed
  count.
- Replace the sequential for-loop in `runLessonsExtractor` with
  `Promise.all` chunked at `N_PARALLEL = 4`.
- Add a tiny JSONL cache + dedup at the load step. Cache invalidates
  when entry sha changes.
- Keep the per-call 60s claude timeout + heuristic fallback as the
  inner safety net.

**Acceptance:**
- [ ] 30-PR live day completes in <5 min (currently ~5 min with the
      1800s timeout headroom)
- [ ] The same PRs produce the same lesson text on re-runs (cache
      hit) without spawning claude
- [ ] Lesson quality preserved on a hand-picked sample of 10 PRs
      vs the LLM-only baseline (manual operator audit on the
      docs/swarm-lessons.md diff)
- [ ] TimeoutStartSec can drop back to 300s after the change ships

**Caveat:** the chain of "PR title → backlog entry id → recent
merged subjects" expects literal one-line lessons. The cache key
must be stable; pr_number+head_sha is fine, but if a PR is force-
pushed mid-review the cached lesson goes stale. Heuristic-only
path is the fallback when cache invalidates and the LLM is busy.


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-lessons-distill-fast-path-1777951486057`
Branch: `swarm/swarm-lessons-distill-fast-path-1777951486057`
Head: `3d758e4c`
Diff: `1 file changed, 116 insertions(+), 10 deletions(-)`
Commits: 1