### PR TITLE
fix(openclaw-plugin): wire to router evaluate so T0/T1/T3 hit the advisor

### DIFF
--- a/apps/openclaw-plugin-governance/src/chitin-bridge.mjs
+++ b/apps/openclaw-plugin-governance/src/chitin-bridge.mjs
@@ -114,3 +114,121 @@ function failClosed(opts, reason) {
   }
   return { allow: true };
 }
+
+/**
+ * Invoke `chitin-kernel router evaluate --hook-stdin` (the router-pipeline
+ * path: kernel verdict → heuristics → advisor → composed response).
+ *
+ * Why a second function alongside `evaluateGate`:
+ *
+ * - `evaluateGate` calls `chitin-kernel gate evaluate` with FLAGS, gets a
+ *   {allowed, reason, rule_id} JSON back. Deterministic-only — no
+ *   heuristics, no advisor.
+ * - `evaluateRouter` calls `chitin-kernel router evaluate` with a Claude
+ *   Code-style HookInput on STDIN, gets the Claude Code hook protocol
+ *   back: exit 0 + empty stdout = allow; exit non-0 + first JSON line
+ *   {"decision":"block","reason":"..."} = deny.
+ *
+ * Rationale (2026-05-05): the openclaw plugin originally called
+ * `evaluateGate`, which meant T0/T1/T3 agents (every openclaw-driven
+ * tier) bypassed heuristics + advisor. T4 (claude-code-headless) was the
+ * only tier that hit the router pipeline — exactly inverted from where
+ * the advisor is most valuable: Claude itself is the agent at T4, so a
+ * smaller advisor checking a smarter agent has marginal worth; cheap
+ * local glm-flash at T0 benefits MUCH more from a Claude-class second
+ * opinion. This function flips the wiring: openclaw → router → advisor.
+ *
+ * @param {GateInput & { sessionId?: string }} input
+ * @param {BridgeOptions} opts
+ * @returns {Promise<GateDecision>}
+ */
+export async function evaluateRouter(input, opts) {
+  const hookInput = {
+    hook_event_name: 'PreToolUse',
+    tool_name: input.tool,
+    tool_input: input.params ?? {},
+    cwd: input.cwd ?? process.cwd(),
+    session_id: input.sessionId ?? `openclaw-${input.agent}`,
+  };
+
+  const args = ['router', 'evaluate', '--hook-stdin', '--agent', input.agent];
+
+  let stdout = '';
+  let stderr = '';
+  let timedOut = false;
+  let exitCode = -1;
+
+  try {
+    await new Promise((resolve, reject) => {
+      const child = spawn(opts.kernelPath, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const killTimer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, opts.timeoutMs);
+      child.stdout.on('data', (b) => (stdout += b.toString()));
+      child.stderr.on('data', (b) => (stderr += b.toString()));
+      child.on('close', (code) => {
+        clearTimeout(killTimer);
+        exitCode = code ?? -1;
+        resolve(undefined);
+      });
+      child.on('error', reject);
+      child.stdin.write(JSON.stringify(hookInput));
+      child.stdin.end();
+    });
+
+    if (timedOut) {
+      return failClosed(opts, `chitin-kernel router timed out after ${opts.timeoutMs}ms`);
+    }
+
+    return parseRouterDecision(exitCode, stdout, opts);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('ENOENT')) {
+      return failClosed(opts, `chitin-kernel binary not found at "${opts.kernelPath}"`);
+    }
+    return failClosed(
+      opts,
+      `chitin-kernel router invocation failed: ${msg}${stderr ? ` | stderr: ${stderr.slice(0, 200)}` : ''}`,
+    );
+  }
+}
+
+/**
+ * Parse the Claude Code hook protocol output from `router evaluate
+ * --hook-stdin`. Contract:
+ *   exit 0, empty/non-block stdout            → allow
+ *   exit non-0, first JSON line {decision,..} → deny
+ *
+ * @param {number} exitCode
+ * @param {string} stdout
+ * @param {BridgeOptions} opts
+ * @returns {GateDecision}
+ */
+function parseRouterDecision(exitCode, stdout, opts) {
+  if (exitCode === 0) {
+    return { allow: true };
+  }
+  const firstLine = stdout.split('\n').find((l) => l.trim().startsWith('{')) ?? '';
+  if (!firstLine) {
+    return failClosed(opts, `chitin-kernel router exited ${exitCode} with no parseable verdict`);
+  }
+  try {
+    const j = JSON.parse(firstLine);
+    if (j.decision === 'block') {
+      return {
+        allow: false,
+        reason: typeof j.reason === 'string' ? j.reason : 'denied by chitin router',
+        ruleId: 'router_block',
+      };
+    }
+    return failClosed(
+      opts,
+      `chitin-kernel router returned non-block deny verdict: ${JSON.stringify(j).slice(0, 200)}`,
+    );
+  } catch {
+    return failClosed(opts, `chitin-kernel router returned unparseable verdict: ${firstLine.slice(0, 200)}`);
+  }
+}

--- a/apps/openclaw-plugin-governance/src/index.mjs
+++ b/apps/openclaw-plugin-governance/src/index.mjs
@@ -1,4 +1,4 @@
-import { evaluateGate } from './chitin-bridge.mjs';
+import { evaluateRouter } from './chitin-bridge.mjs';
 
 const PLUGIN_ID = 'chitin-governance';
 
@@ -37,12 +37,15 @@ const plugin = {
 
     // ── pre-tool gate (pi runtime) ───────────────────────────────────────
     api.on('before_tool_call', async (event, ctx) => {
-      const decision = await evaluateGate(
+      const decision = await evaluateRouter(
         {
           agent: ctx.agentId ?? 'openclaw-plugin',
           tool: event.toolName,
           params: event.params ?? {},
           cwd: process.cwd(),
+          // Stable session id per (agent, cwd) so the floundering
+          // heuristic can read prior chain events for this session.
+          sessionId: `openclaw-${ctx.agentId ?? 'plugin'}-${process.pid}`,
         },
         cfg,
       );
@@ -140,7 +143,11 @@ export function resolveConfig(raw) {
     mode: r.mode === 'observe' ? 'observe' : 'enforce',
     workerMode: r.workerMode === true,
     denyOnError: r.denyOnError !== false,
-    timeoutMs: typeof r.timeoutMs === 'number' && r.timeoutMs >= 100 ? r.timeoutMs : 5000,
+    // Default 30s: covers the router pipeline including a possible advisor
+    // (claude -p) round-trip which can take 5-15s. The pre-router gate path
+    // was 5s — bumped because evaluateRouter replaced evaluateGate as the
+    // default invocation surface.
+    timeoutMs: typeof r.timeoutMs === 'number' && r.timeoutMs >= 100 ? r.timeoutMs : 30000,
   };
 }
 

--- a/apps/openclaw-plugin-governance/test/bridge.test.ts
+++ b/apps/openclaw-plugin-governance/test/bridge.test.ts
@@ -117,11 +117,14 @@ describe('evaluateGate (bridge → chitin-kernel subprocess)', () => {
   });
 });
 
-describe('plugin.before_tool_call params handling', () => {
+describe('plugin.before_tool_call (calls evaluateRouter)', () => {
   type Handler = (event: { toolName: string; params?: unknown }, ctx: { agentId?: string }) => Promise<unknown>;
 
-  function captureBeforeToolCall(kernelStdoutJson: string): { handler: Handler; cleanup: () => void } {
-    const fake = makeFakeKernel(`echo '${kernelStdoutJson}'; exit 0`);
+  // The plugin now calls `evaluateRouter`, which uses the Claude Code
+  // hook protocol: exit 0 + empty stdout = allow; exit non-0 + first
+  // JSON line `{"decision":"block","reason":"..."}` = deny.
+  function captureBeforeToolCall(scriptBody: string): { handler: Handler; cleanup: () => void } {
+    const fake = makeFakeKernel(scriptBody);
     let handler: Handler | undefined;
     const api = {
       pluginConfig: { kernelPath: fake.path, timeoutMs: 2000, mode: 'enforce' },
@@ -135,32 +138,42 @@ describe('plugin.before_tool_call params handling', () => {
     return { handler, cleanup: fake.cleanup };
   }
 
-  it('returns undefined when kernel allows with empty params object', async () => {
-    // Empty `{}` is truthy in JS — the pre-fix `decision.params ? ...` branch
-    // would return `{ params: {} }` and clobber the agent's actual args. The
-    // fix uses `Object.keys(...).length > 0` so {} now resolves to undefined.
-    const { handler, cleanup } = captureBeforeToolCall('{"allowed":true,"params":{}}');
+  it('returns undefined when router allows (exit 0, no stdout)', async () => {
+    const { handler, cleanup } = captureBeforeToolCall(`exit 0`);
     try {
       const result = await handler(
         { toolName: 'shell.exec', params: { cmd: 'ls' } },
         { agentId: 'test-agent' },
       );
+      // Allow → return undefined → openclaw proceeds with the agent's
+      // original params unchanged.
       expect(result).toBeUndefined();
     } finally {
       cleanup();
     }
   });
 
-  it('returns the rewrite when kernel allows with non-empty params', async () => {
-    const { handler, cleanup } = captureBeforeToolCall('{"allowed":true,"params":{"cmd":"ls -la"}}');
+  it('blocks when router denies (exit non-0 + decision:block JSON)', async () => {
+    const { handler, cleanup } = captureBeforeToolCall(
+      `echo '{"decision":"block","reason":"router denied"}'; exit 2`,
+    );
     try {
-      const result = await handler(
-        { toolName: 'shell.exec', params: { cmd: 'ls' } },
+      const result = (await handler(
+        { toolName: 'shell.exec', params: { cmd: 'rm -rf /' } },
         { agentId: 'test-agent' },
-      );
-      expect(result).toEqual({ params: { cmd: 'ls -la' } });
+      )) as { block?: boolean; blockReason?: string } | undefined;
+      expect(result?.block).toBe(true);
+      expect(result?.blockReason).toBe('router denied');
     } finally {
       cleanup();
     }
   });
+
+  // Param rewrites are NOT supported by `router evaluate` — it uses
+  // the Claude Code hook protocol which has no param-modification
+  // surface. The pre-router code path (evaluateGate) DID propagate
+  // param rewrites; that capability is exercised in the
+  // `describe('evaluateGate ...')` block at the top of this file
+  // for direct callers, but no longer reachable through the plugin's
+  // before_tool_call handler.
 });

--- a/apps/openclaw-plugin-governance/test/resolve-config.test.ts
+++ b/apps/openclaw-plugin-governance/test/resolve-config.test.ts
@@ -60,10 +60,13 @@ describe('resolveConfig (plugin defaults — slice 3 default-enforce)', () => {
     expect(resolveConfig({ denyOnError: false }).denyOnError).toBe(false);
   });
 
-  it('timeoutMs defaults to 5000; rejects <100 and non-numbers', () => {
-    expect(resolveConfig({}).timeoutMs).toBe(5000);
-    expect(resolveConfig({ timeoutMs: '5000' }).timeoutMs).toBe(5000);
-    expect(resolveConfig({ timeoutMs: 50 }).timeoutMs).toBe(5000);
+  it('timeoutMs defaults to 30000; rejects <100 and non-numbers', () => {
+    // Default bumped 5000 → 30000 when the plugin switched from
+    // `evaluateGate` to `evaluateRouter` (router pipeline can include
+    // a 5-15s claude-advisor LLM round-trip; 5s ceiling was too tight).
+    expect(resolveConfig({}).timeoutMs).toBe(30000);
+    expect(resolveConfig({ timeoutMs: '5000' }).timeoutMs).toBe(30000); // string falls to default
+    expect(resolveConfig({ timeoutMs: 50 }).timeoutMs).toBe(30000); // <100 falls to default
     expect(resolveConfig({ timeoutMs: 100 }).timeoutMs).toBe(100);
     expect(resolveConfig({ timeoutMs: 1500 }).timeoutMs).toBe(1500);
   });


### PR DESCRIPTION
## Summary
The advisor (heuristics + claude-advisor LLM second opinion) was wired ONLY to T4 (claude-code-headless) because the openclaw governance plugin called \`chitin-kernel gate evaluate\` (deterministic-only) instead of \`chitin-kernel router evaluate\` (full pipeline). That's exactly inverted from where the advisor is most valuable: T0 = glm-flash 30B local model.

This PR flips the wiring: T0/T1/T3 (every openclaw-driven tier) now hit the router pipeline.

## Changes
- \`chitin-bridge.mjs\`: \`evaluateRouter(input, opts)\` alongside existing \`evaluateGate\`. Claude Code hook protocol on stdin/stdout (exit 0 = allow; exit non-0 + \`{decision:"block", reason}\` = deny).
- \`index.mjs\`: \`before_tool_call\` switched to \`evaluateRouter\`. Synthesizes stable \`sessionId\` for the floundering heuristic.
- Default \`timeoutMs\` 5000 → 30000 (router can include 5-15s advisor LLM call).

## Verification
- 41/41 tests pass on \`apps/openclaw-plugin-governance\`
- Typecheck clean
- Manual: \`echo '{...high-blast rm -rf...}' | chitin-kernel router evaluate --hook-stdin\` returns \`{decision:"block"}\` exit 2 with advisor reasoning

## What changes operationally
After merge:
- T0/T1/T3 tool calls → router → kernel verdict → heuristics → optional advisor → composed decision
- Most calls still hit the fast path (~26ms) — heuristics fire only on high blast_radius or floundering
- Rare high-blast calls add 5-15s latency (advisor round-trip) — exactly when you want the second opinion

## Followups
- Per-tier advisor model (T0 advisor could use Haiku at 0.33× cost)
- Router param-rewrite extension if needed (not used today)