### PR TITLE
swarm: install-kernel-restart-worker-on-ts-change

### DIFF
--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -212,4 +212,60 @@ if [[ -x "$ROTATOR" ]]; then
 fi
 
 emit ok redeploy-success "old_sha=$old_sha" "new_sha=$new_sha" "build_dur_ms=$build_dur_ms" "changed=$relevant_changes_since_last"
+
+# --- Chitin worker restart logic for TS changes ---
+# Track last-applied SHA for apps/temporal-worker/src/ in ~/.cache/chitin/install-kernel-state.json
+STATE_FILE="$HOME/.cache/chitin/install-kernel-state.json"
+TS_PATH="apps/temporal-worker/src/"
+
+restart_worker=0
+restart_reason=""
+
+# Get current HEAD
+current_head=$(git rev-parse HEAD)
+
+# Read last-applied SHA for TS worker (if exists)
+last_ts_sha=""
+if [[ -f "$STATE_FILE" ]]; then
+  last_ts_sha=$(jq -r '.ts_worker_sha // empty' "$STATE_FILE" 2>/dev/null || true)
+fi
+
+# If no prior state, record baseline and skip restart
+if [[ -z "$last_ts_sha" ]]; then
+  jq -n --arg sha "$current_head" '{ts_worker_sha: $sha}' > "$STATE_FILE"
+  emit noop "ts-worker baseline set" "ts_worker_sha=$current_head"
+else
+  # Check for changes in apps/temporal-worker/src/ since last applied
+  if ! git diff --quiet "$last_ts_sha" "$current_head" -- "$TS_PATH"; then
+    restart_worker=1
+    restart_reason="ts-changed"
+  fi
+fi
+
+if [[ $restart_worker -eq 1 ]]; then
+  old_sha="$last_ts_sha"
+  new_sha="$current_head"
+  commits_in_diff=$(git rev-list --count "$old_sha".."$new_sha" -- "$TS_PATH")
+  restart_start=$(date +%s%3N)
+  if systemctl --user restart chitin-worker.service; then
+    # Wait for active (running)
+    for i in {1..10}; do
+      if systemctl --user is-active --quiet chitin-worker.service; then
+        break
+      fi
+      sleep 1
+    done
+    restart_end=$(date +%s%3N)
+    restart_dur_ms=$((restart_end - restart_start))
+    emit worker-restarted "worker restarted after TS change" \
+      "old_sha=$old_sha" "new_sha=$new_sha" "restart_dur_ms=$restart_dur_ms" "commits_in_diff=$commits_in_diff"
+    # Update state file
+    jq -n --arg sha "$new_sha" '{ts_worker_sha: $sha}' > "$STATE_FILE"
+  else
+    restart_end=$(date +%s%3N)
+    restart_dur_ms=$((restart_end - restart_start))
+    emit fail worker-restart-failed "old_sha=$old_sha" "new_sha=$new_sha" "restart_dur_ms=$restart_dur_ms"
+  fi
+fi
+
 exit 0


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `install-kernel-restart-worker-on-ts-change`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-install-kernel-restart-worker-on-ts-change-1777952304418`

## Entry context

`install-kernel.sh` (run every 15 min by chitin-kernel-redeploy.timer)
already pulls main, rebuilds the Go kernel when `go/` changed, syncs
systemd units (#313). It does NOT restart `chitin-worker.service` when
TypeScript under `apps/temporal-worker/src/` changes — so a merged TS
fix can sit unapplied for hours while the worker process runs the old
in-memory code.

Concrete instance from 2026-05-04:
- 22:46 EDT: PR #318 merged (removes broken `--include-hook-events`
  flag from openclaw invocation). Fixes T0/T1 dispatch.
- 23:09 EDT: T0 dispatch still failed in 1.95s with the OLD bug —
  worker hadn't been restarted, was running pre-#318 code from its
  13:06 EDT launch.
- 23:09 EDT (manual restart): T0 dispatch succeeded at 4 min, 1
  commit, PR #326.

Same shape we already address for Go: `install-kernel.sh` runs
`go build` when `go/**` changed since last redeploy. Symmetric for TS.

Approach (subject to design tightening — programmer should propose):

1. Track last-applied SHA per-source-tree at
   `~/.cache/chitin/install-kernel-state.json` (or extend the existing
   chain log). Compare current main HEAD against last applied.
2. If `git diff <last>..<HEAD> -- apps/temporal-worker/src/` is
   non-empty: `systemctl --user restart chitin-worker.service` and
   wait for `active (running)` (`systemctl --user is-active`).
3. Emit a structured chain event `worker-restarted` with
   `{old_sha, new_sha, restart_dur_ms, commits_in_diff}`.
4. Idempotent: no-op when nothing in apps/temporal-worker/src/ changed.

Boundary cases:
- New checkout, no prior state → skip restart (worker is on whatever
  main has, no drift to fix); record HEAD as baseline.
- Pull fails / can't fetch → skip restart, leave a warn in the log.
- Restart fails (service stuck) → emit fail-event, leave operator
  to triage; don't loop-restart.

**Acceptance:**
- [ ] After landing a TS-only change to apps/temporal-worker/src/,
      next `chitin-kernel-redeploy.timer` tick restarts the worker
      automatically (verified via journalctl)
- [ ] No-op when no TS changes since last redeploy
- [ ] Chain event surfaced to alarm-feeder for ops visibility

**Followup not in scope:** other long-running services (worker is the
big one; openclaw-gateway is the other). When this proves itself,
extend the same pattern to openclaw-gateway when its embedded JS
changes — though that's a `nvm/.../node_modules/openclaw` install
issue, not a chitin source issue, so the trigger differs.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-install-kernel-restart-worker-on-ts-change-1777952304418`
Branch: `swarm/swarm-install-kernel-restart-worker-on-ts-change-1777952304418`
Head: `baa35fac`
Diff: `1 file changed, 56 insertions(+)`
Commits: 1