### PR TITLE
swarm: apply-step-exclude-openclaw-bootstrap-files

### DIFF
--- a/apps/temporal-worker/src/grooming/apply-workflow-result.ts
+++ b/apps/temporal-worker/src/grooming/apply-workflow-result.ts
@@ -183,7 +183,16 @@ export function revertWorktreeSettingsArtifact(worktreePath: string): void {
 // is also worker-written but lives in `.git/info/exclude`, so it
 // never appears in `git status --porcelain` output and doesn't need
 // a prefix here.
-const BOOTSTRAP_UNTRACKED_PREFIXES = ['.claude/'];
+const BOOTSTRAP_UNTRACKED_PREFIXES = [
+  '.claude/',
+  'AGENTS.md',
+  'HEARTBEAT.md',
+  'IDENTITY.md',
+  'SOUL.md',
+  'TOOLS.md',
+  'USER.md',
+  '.openclaw/'
+];
 
 // Return untracked files that look like real agent work — i.e. NOT
 // under a known bootstrap path. Uses `-uall` so a new directory


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `apply-step-exclude-openclaw-bootstrap-files`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-apply-step-exclude-openclaw-bootstrap-files-1777982165070`

## Entry context

Tonight's T0 smoke (PR #326, closed) shipped the requested
`docs/observations/2026-05-05-t0-glm-flash-smoke.md` AND seven
openclaw-bootstrap files at repo root that the agent shouldn't have
committed: `AGENTS.md`, `HEARTBEAT.md`, `IDENTITY.md`, `SOUL.md`,
`TOOLS.md`, `USER.md`, `.openclaw/workspace-state.json`.

Same shape as the existing handlers for chitin's own bootstrap:
- `.claude/settings.json` reverted in `revertWorktreeSettingsArtifact`
- `WORKTREE_INDEX.md` added to `.git/info/exclude` in
  `writeWorktreeIndex` so it never appears in `git status --porcelain`

openclaw-spawned agents (T0/T1/T3 — glm-flash, glm-cloud, deepseek)
write these identity/state files into the cwd at session start.
They're agent bootstrap, not task work product. Currently:
- The apply-step's `BOOTSTRAP_UNTRACKED_PREFIXES` only includes
  `'.claude/'` (PR #303). Doesn't catch the openclaw set.
- These files aren't in `.git/info/exclude` either, so they show
  up in `git status` and get auto-committed when the apply-step
  detects "tracked uncommitted changes."

Approach (subject to design tightening — programmer should propose):

Two tactics, pick one OR combine:

A. **Add openclaw bootstrap to `BOOTSTRAP_UNTRACKED_PREFIXES`** in
   `apply-workflow-result.ts:listRealUntrackedFiles`. Easier to test.
   Misses the case where the agent `git add`s them (turning untracked
   into tracked).

B. **Extend the worker's worktree-setup to write the openclaw bootstrap
   names into `.git/info/exclude`** at the same point we already do for
   `WORKTREE_INDEX.md` (apps/temporal-worker/src/activity.ts:548-554).
   Cleaner: git ignores them at every layer, no special-case needed in
   apply-step. The list of names lives in one place — the openclaw
   driver activity branch — close to where openclaw spawns.

Recommended: **(B)**, because the existing `WORKTREE_INDEX.md` pattern
already proves the model works and keeps the special-casing local to
the openclaw driver.

The 7 names to add (from PR #326's `gh pr view 326 --json files`):
```
AGENTS.md
HEARTBEAT.md
IDENTITY.md
SOUL.md
TOOLS.md
USER.md
.openclaw/
```

Last is a directory prefix — every file under `.openclaw/` is
bootstrap state per openclaw's docs.

**Acceptance:**
- [ ] After landing, a fresh T0 dispatch on a tiny "create one file"
      entry produces a PR with ONLY the requested file (no AGENTS.md,
      no IDENTITY.md, etc.)
- [ ] Existing `WORKTREE_INDEX.md` exclude continues to work
- [ ] No regression in the 11-test
      `grooming-list-real-untracked.test.ts` suite (which pinned the
      `.claude/`-only filter behavior in PR #303)
- [ ] Test added: vitest case verifying openclaw files are excluded
      via `.git/info/exclude` in a scratch worktree

**Caveat:** if a backlog entry's `file:` field legitimately names one
of these paths (unlikely — `IDENTITY.md` at repo root is reserved for
openclaw), the agent's edit would be silently dropped. Same caveat
already documented for `.claude/settings.json` — same mitigation
(operator pre-commits, or future plumbing of entry's file scope into
the apply-step).

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-apply-step-exclude-openclaw-bootstrap-files-1777982165070`
Branch: `swarm/swarm-apply-step-exclude-openclaw-bootstrap-files-1777982165070`
Head: `427cb229`
Diff: `1 file changed, 10 insertions(+), 1 deletion(-)`
Commits: 1