### PR TITLE
fix(comment-responder): clone to subdir to avoid rm-rf trap

### DIFF
--- a/apps/temporal-worker/skills/comment-responder/SKILL.md
+++ b/apps/temporal-worker/skills/comment-responder/SKILL.md
@@ -28,12 +28,14 @@ YOUR WORKFLOW (one tool call per step where possible):
 
    Make NO edits, commits, or comments. The dispatcher's apply step would otherwise pick up an empty worktree and produce a bogus no-op PR. Bail before that happens.
 
-1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** You're running in an empty tempdir (no git repo, no working clone), so `gh pr checkout <pr_number>` would fail with "not in a git repo." Clone the repo first into the cwd, then check out the PR's branch:
+1. **Extract <owner>/<repo> + <pr_number> from the PR URL above.** You're running in a tempdir (no git repo, no working clone), so `gh pr checkout <pr_number>` would fail with "not in a git repo." Clone the repo into a SUBDIRECTORY (NOT the cwd), then `cd` into it, then check out the PR's branch:
    ```
-   gh repo clone <owner>/<repo> .
+   gh repo clone <owner>/<repo>
+   cd <repo>
    gh pr checkout <pr_number>
    ```
-   The first command clones into `.` (cwd); the second switches the worktree to the PR's branch so subsequent edits + commits land on it.
+
+   **CRITICAL — DO NOT use `gh repo clone .` (clone-into-cwd) or `rm -rf` to clear cwd.** The tempdir may already contain chitin bootstrap files (`WORKTREE_INDEX.md`, `.claude/settings.json`, etc.) — `gh repo clone .` would fail because cwd isn't empty, and `rm -rf ./*` would trigger the kernel's `no-rm-recursive` guard, locking down the agent. Cloning to a subdirectory sidesteps both. (This exact `rm -rf ./* && gh repo clone .` pattern caused the 2026-05-04T03:27 lockdown of copilot-cli and recurred 2026-05-05T03:23 — explicit guidance now to prevent the next round.)
 
 2. Pull all unresolved inline comments:
    ```


### PR DESCRIPTION
## Summary
- Comment-responder skill instructed \`gh repo clone . && gh pr checkout\`, but the tempdir may have chitin bootstrap files (WORKTREE_INDEX.md, .claude/settings.json, openclaw set). \`gh repo clone .\` fails on non-empty cwd; agent reaches for \`rm -rf ./*\`; kernel's \`no-rm-recursive\` guard blocks.
- Fix: clone to a SUBDIRECTORY then \`cd\` into it. Plus explicit warning naming the antipattern.

## How this surfaced (chain mining)
\`jq\` over today's gov-decisions for \`rule_id == "no-rm-recursive"\`:
- 2 historical (pre-fix copilot-cli, before this session)
- 2 my own \`advisor-smoke\` test invocations
- **1 real:** \`role: comment-responder\`, target: \`rm -rf ./* .[^.]* 2>/dev/null || true && gh repo clone chitinhq/chitin . && gh pr checkout 328\` at 03:23:08 UTC

Same antipattern as the 2026-05-04 lockdown that took 20h to clear. Now warned-against in the skill itself.

## Test plan
- [x] Skill file renders, frontmatter unchanged
- [ ] Operator: next comment-responder dispatch produces a clean repo checkout in subdir (no rm-rf attempt)