### PR TITLE
fix(redeploy): install-kernel auto-switches to main + autostash; flipper restores main after PR

### DIFF
--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -82,6 +82,28 @@ if ! cd "$REPO" 2>/dev/null; then
   exit 1
 fi
 
+# Ensure we're on `main` before pulling. The chitin-shipped-entry-flipper
+# cron script (and others) leave the working tree on whatever branch
+# they created — `git pull --ff-only` against an unrelated branch
+# fails with "Not possible to fast-forward, aborting." Switch to main
+# defensively so the redeploy can proceed regardless of what other
+# crons left behind. --autostash preserves the operator's uncommitted
+# files (docs/roadmap.md, docs/swarm-lessons.md) across the switch.
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$current_branch" != "main" ]]; then
+  if ! git -c advice.detachedHead=false checkout main 2>/dev/null; then
+    # Stash + switch + pop, in case detachedHead-prevention or local
+    # uncommitted edits block a clean switch.
+    git stash push --include-untracked --quiet >/dev/null 2>&1 || true
+    if ! git checkout main 2>/dev/null; then
+      emit fail branch-switch-failed "from=$current_branch"
+      exit 1
+    fi
+    git stash pop --quiet >/dev/null 2>&1 || true
+  fi
+  emit ok auto-switched-to-main "from=$current_branch"
+fi
+
 old_sha=$(git rev-parse HEAD)
 if ! git fetch --quiet origin main; then
   emit fail fetch-failed "old_sha=$old_sha"
@@ -94,14 +116,28 @@ relevant_changes_since_last="(none)"
 
 if [[ "$old_sha" != "$new_sha" ]]; then
   if git diff --quiet "$old_sha" "$new_sha" -- go/ chitin.yaml; then
-    if ! git pull --ff-only --quiet origin main; then
+    # --autostash keeps the operator's uncommitted working-tree changes
+    # (e.g. docs/roadmap.md from chitin-researcher.service, docs/swarm-
+    # lessons.md from chitin-lessons.service — neither commits its
+    # writes). Without it, those uncommitted modifications block
+    # `--ff-only` and the redeploy timer fires fail-pull-conflict every
+    # 15 min. Auto-stash → fast-forward → auto-pop, transparent to the
+    # operator.
+    if ! git pull --ff-only --autostash --quiet origin main; then
       emit fail pull-conflict "old_sha=$old_sha" "new_sha=$new_sha"
       exit 1
     fi
     emit noop "no kernel-relevant changes" "old_sha=$old_sha" "new_sha=$new_sha"
     exit 0
   else
-    if ! git pull --ff-only --quiet origin main; then
+    # --autostash keeps the operator's uncommitted working-tree changes
+    # (e.g. docs/roadmap.md from chitin-researcher.service, docs/swarm-
+    # lessons.md from chitin-lessons.service — neither commits its
+    # writes). Without it, those uncommitted modifications block
+    # `--ff-only` and the redeploy timer fires fail-pull-conflict every
+    # 15 min. Auto-stash → fast-forward → auto-pop, transparent to the
+    # operator.
+    if ! git pull --ff-only --autostash --quiet origin main; then
       emit fail pull-conflict "old_sha=$old_sha" "new_sha=$new_sha"
       exit 1
     fi

--- a/scripts/shipped-entry-flipper.sh
+++ b/scripts/shipped-entry-flipper.sh
@@ -174,3 +174,13 @@ git commit -m "auto: flip $(echo ${#flipped_ids[@]}) backlog entries ready→par
 git push -u origin "$branch"
 gh pr create --title "auto: flip ${#flipped_ids[@]} entries ready→partial (shipped-entry-flipper)" --body "$body"
 emit ok "pr-opened" "branch=$branch" "flipped_count=${#flipped_ids[@]}"
+
+# Restore the operator's main checkout. Without this, the cron-fired
+# flipper leaves the working tree on `auto/shipped-entry-flipper-*`,
+# which then fails every chitin-kernel-redeploy.timer tick with
+# "Not possible to fast-forward" because main and the flipper branch
+# have diverged history. Symmetric to the no-flips-applied branch
+# above which already does `git checkout main`. The branch isn't
+# deleted locally because it's pushed to origin and the PR references
+# it — let the post-merge cleanup handle that.
+git checkout --quiet main 2>/dev/null || emit warn "post-pr-checkout-main-failed" "branch=$branch"


### PR DESCRIPTION
## Summary
Two coupled bugs surfaced by \`/mine\` (the new mining skill):

1. **shipped-entry-flipper strands the checkout off main.** Cron-fired flipper does \`git checkout -b auto/shipped-entry-flipper-*\` and never returns to main on the success path. The no-flips-applied path already restores; the PR-opened path didn't.

2. **install-kernel-redeploy fails when the checkout isn't on main OR has uncommitted files.** \`git pull --ff-only origin main\` aborts with "Not possible to fast-forward" if the branch diverges (caused by #1) OR with "uncommitted changes" if researcher/lessons services have written to docs/ but not committed.

Result: kernel hadn't been auto-updating from main for ~30 min before this fix.

## Changes
- \`install-kernel.sh\`: auto-switch to main if not there + emit \`auto-switched-to-main\` chain event; \`--autostash\` on the pull to preserve uncommitted operator edits.
- \`shipped-entry-flipper.sh\`: \`git checkout main\` after \`gh pr create\` so the cron doesn't strand subsequent runs.

## Verified
- Reset failed state, started service: \`status=0/SUCCESS\`, ~284ms.
- Chain log: \`auto-switched-to-main\` from \`auto/shipped-entry-flipper-20260505-082752\` → main, then \`no-kernel-relevant-changes\` noop.
- Operator's modified files (docs/roadmap.md, docs/swarm-lessons.md, docs/debt-ledger.md) preserved.

## Followup not in scope
Long-term: have chitin-researcher.service and chitin-lessons.service commit their writes (or write to a separate location) so the main checkout doesn't accumulate uncommitted state at all. \`--autostash\` is a workaround for that broader gap.