### PR TITLE
swarm: comment-responder-mutable-status

### DIFF
--- a/apps/temporal-worker/src/comment-responder/README.md
+++ b/apps/temporal-worker/src/comment-responder/README.md
@@ -1,0 +1,69 @@
+# comment-responder
+
+This folder contains the dispatch helpers and prompt builders for the
+`comment-responder` agent role plus the **mutable status comment**
+helper used by the review-graph tiers (R0–R4) to maintain a single,
+edited-in-place comment per PR rather than appending a fresh comment
+per pass.
+
+## Mutable status comment
+
+The review-graph used to post a new comment for every reviewer tier.
+A PR walking R0 → R1 → R2 → R3 ended up with a stack of overlapping
+comments — all relevant, none authoritative — forcing operators to
+scroll for the latest verdict and downstream tooling to scrape prose.
+
+`mutable-status.ts` replaces that pattern. Each tier calls
+`upsert(prNumber, repo, body, verdict)`; the first call creates the
+comment and every subsequent call edits it in place.
+
+### Body marker
+
+The first line of the comment body is a fixed magic string used to
+identify the chitin-owned comment among any number of human / bot
+comments on the PR:
+
+```
+<!-- chitin-status-comment v1 -->
+```
+
+`findByMarker` looks for this prefix via
+`gh api repos/<repo>/issues/<pr>/comments` (with `--paginate` for PRs
+with more than 100 comments) and returns the matching comment's id +
+body, or `{comment_id: null, body: ''}` when no chitin comment exists
+yet. The `v1` suffix lets us version the body schema without changing
+the search predicate.
+
+### Verdict marker
+
+The current tier's verdict lives in a structured HTML comment embedded
+in the body and parsed by `parseVerdict`:
+
+```
+<!-- chitin:verdict tier=R2 status=approve workflow_id=<id> ts=2026-05-05T12:00:00Z -->
+```
+
+Schema (zod-validated):
+
+| Field         | Values                                          |
+|---------------|-------------------------------------------------|
+| `tier`        | `R0` \| `R1` \| `R2` \| `R3` \| `R4`            |
+| `status`      | `approve` \| `changes_requested` \| `pending`   |
+| `workflow_id` | non-empty string (the dispatching workflow id)  |
+| `ts`          | ISO-8601 datetime                               |
+
+A body may contain markers from multiple tiers (one per pass). `parseVerdict`
+returns the latest by `ts`, with tier index (R4 > R3 > … > R0) as the
+tie-breaker for same-`ts` collisions. Malformed or missing markers
+return `null` — callers (e.g. `gatekeeper.ts`) treat `null` as **no
+verdict**, never as an approve. Fail-closed by design.
+
+### Backward compatibility
+
+PRs touched before this helper landed retain their append-style
+comment chain — there is no migration. The first tier that runs after
+the helper is wired in creates a new mutable comment; older comments
+remain visible as historical record. Operators expecting forensic
+"R1 said X, then R2 said Y" history in the PR thread should consult
+the chain audit log (`.chitin/events-<run_id>.jsonl`) instead — the
+GitHub thread shows the current verdict only.

--- a/apps/temporal-worker/src/comment-responder/mutable-status.ts
+++ b/apps/temporal-worker/src/comment-responder/mutable-status.ts
@@ -1,0 +1,353 @@
+// Mutable status comment helper for the review-graph tiers.
+//
+// Goal: replace the append-per-tier comment chain with one mutable
+// "chitin status comment" per PR, edited in place, carrying the
+// current tier's verdict in a hidden HTML marker so downstream tooling
+// (gatekeeper, pr-event-ingester, future operator commands) can read
+// the verdict without scraping prose.
+//
+// Conventions:
+//
+//   1. Body marker — the FIRST line of the comment body is a fixed
+//      magic string:
+//
+//        <!-- chitin-status-comment v1 -->
+//
+//      `findByMarker` searches PR comments for this prefix to identify
+//      the chitin-owned comment among any number of human / bot
+//      comments. The `v1` suffix lets us version the body schema
+//      without changing the search predicate (parse the `vN` and
+//      branch on it later).
+//
+//   2. Verdict marker — a structured HTML comment embedded in the
+//      body, parsed by `parseVerdict`:
+//
+//        <!-- chitin:verdict tier=R2 status=approve workflow_id=foo ts=2026-05-05T12:00:00Z -->
+//
+//      Multiple tiers may write multiple verdict markers into the same
+//      body (R0, R1, R2, ...) — `parseVerdict` returns the LATEST one
+//      by ts, with tier index as the tie-breaker. Mismatch /
+//      malformed: returns null and logs (caller treats as "no
+//      verdict"). Fail-closed semantics — never mistake a malformed
+//      marker for an approve.
+//
+// Backward compatibility: PRs that already have an append-style
+// comment chain are unaffected. The first time this helper runs on
+// such a PR, `findByMarker` returns null and `upsert` creates a NEW
+// comment — older comments remain as historical record. No migration.
+
+import { execFileSync } from 'node:child_process';
+import { z } from 'zod';
+
+// ─── Marker constants ────────────────────────────────────────────────────
+
+/** Fixed first-line magic string identifying the chitin status comment. */
+export const STATUS_BODY_MARKER = '<!-- chitin-status-comment v1 -->';
+
+/** Regex for parsing verdict markers out of a comment body. */
+const VERDICT_MARKER_RE =
+  /<!--\s*chitin:verdict\s+([^>]+?)\s*-->/g;
+
+// ─── Verdict schema (zod) ────────────────────────────────────────────────
+//
+// Inlined here rather than under libs/contracts/ to keep this entry's
+// scope to apps/temporal-worker/src/comment-responder/* — the schema
+// is small enough that one consumer (this helper) is the right home
+// for now. Promote to libs/contracts/ when a second consumer (e.g.
+// gatekeeper) lands a direct read.
+
+export const VerdictTierSchema = z.enum(['R0', 'R1', 'R2', 'R3', 'R4']);
+export type VerdictTier = z.infer<typeof VerdictTierSchema>;
+
+export const VerdictStatusSchema = z.enum(['approve', 'changes_requested', 'pending']);
+export type VerdictStatus = z.infer<typeof VerdictStatusSchema>;
+
+export const VerdictMetaSchema = z.object({
+  tier: VerdictTierSchema,
+  status: VerdictStatusSchema,
+  workflow_id: z.string().min(1),
+  ts: z.string().datetime(),
+});
+export type VerdictMeta = z.infer<typeof VerdictMetaSchema>;
+
+// ─── gh runner (injectable for tests) ────────────────────────────────────
+
+export interface GhRunner {
+  /** Run `gh <args>` and return stdout. Throw on non-zero exit. */
+  (args: string[]): string;
+}
+
+const defaultGhRunner: GhRunner = (args) =>
+  execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 });
+
+// ─── PR comment shape (subset of what `gh api` returns) ──────────────────
+
+interface PrIssueComment {
+  /** Numeric comment id (used for the PATCH endpoint). */
+  id: number;
+  /** Markdown body. */
+  body: string;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────
+
+export interface MutableStatusReadResult {
+  /** Numeric comment id, or null if no chitin status comment exists. */
+  comment_id: number | null;
+  /** Full body of the chitin status comment, or empty string when absent. */
+  body: string;
+  /** Latest verdict parsed from the body, or null when missing/malformed. */
+  verdict: VerdictMeta | null;
+}
+
+export interface FindByMarkerResult {
+  comment_id: number | null;
+  body: string;
+}
+
+export interface UpsertInput {
+  pr_number: number;
+  repo: string;
+  /** Pre-rendered comment body WITHOUT the body/verdict markers — this
+   *  helper prepends the body marker and appends the verdict marker so
+   *  callers can't accidentally drift the schema. */
+  body: string;
+  verdict: VerdictMeta;
+  /** Optional logger. Defaults to console.warn for parse-failures. */
+  log?: (line: string) => void;
+  /** Optional gh injection (tests). */
+  gh?: GhRunner;
+}
+
+export interface UpsertResult {
+  /** 'created' on first tier, 'edited' on every subsequent tier. */
+  action: 'created' | 'edited';
+  comment_id: number;
+}
+
+/**
+ * Render the canonical comment body: body marker on the first line,
+ * caller-supplied body in the middle, verdict marker at the end.
+ *
+ * Public so review-graph callers can preview / log the rendered body
+ * without making a `gh` call.
+ */
+export function renderStatusBody(body: string, verdict: VerdictMeta): string {
+  const verdictLine =
+    `<!-- chitin:verdict tier=${verdict.tier} status=${verdict.status} ` +
+    `workflow_id=${verdict.workflow_id} ts=${verdict.ts} -->`;
+  // Trim trailing whitespace on caller body so we don't accumulate
+  // blank lines across tier edits.
+  const trimmed = body.replace(/\s+$/, '');
+  return `${STATUS_BODY_MARKER}\n\n${trimmed}\n\n${verdictLine}\n`;
+}
+
+/**
+ * Parse the LATEST verdict marker out of a comment body.
+ *
+ * Strategy:
+ *   1. Scan all `<!-- chitin:verdict ... -->` blocks.
+ *   2. For each, parse the `key=value` pairs (whitespace-separated,
+ *      no quotes — values must not contain whitespace; we own the
+ *      writer side, so this is fine).
+ *   3. Validate via zod. Malformed entries are logged + skipped.
+ *   4. Return the entry with the largest `ts` (string compare on ISO-8601
+ *      ts is correct because the format is lexically sortable). Tier
+ *      index breaks ties — R4 > R3 > R2 > R1 > R0 — so a same-ts
+ *      conflict resolves to the higher tier (closer to merge).
+ *
+ * Returns null when:
+ *   - no markers in body
+ *   - every marker fails schema validation
+ *
+ * Fail-closed: caller treats null as "no verdict", never as approve.
+ */
+export function parseVerdict(
+  body: string,
+  log: (line: string) => void = (l) => console.warn(l),
+): VerdictMeta | null {
+  const markers = body.match(VERDICT_MARKER_RE);
+  if (!markers || markers.length === 0) {
+    return null;
+  }
+
+  const tierOrder: Record<VerdictTier, number> = {
+    R0: 0,
+    R1: 1,
+    R2: 2,
+    R3: 3,
+    R4: 4,
+  };
+
+  const parsed: VerdictMeta[] = [];
+  for (const marker of markers) {
+    // Strip the surrounding `<!-- chitin:verdict ` and ` -->`.
+    const inner = marker.replace(/^<!--\s*chitin:verdict\s+/, '').replace(/\s*-->\s*$/, '');
+    const fields: Record<string, string> = {};
+    for (const tok of inner.split(/\s+/)) {
+      const eq = tok.indexOf('=');
+      if (eq <= 0) continue;
+      fields[tok.slice(0, eq)] = tok.slice(eq + 1);
+    }
+    const result = VerdictMetaSchema.safeParse(fields);
+    if (!result.success) {
+      log(JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        component: 'mutable-status',
+        msg: 'malformed verdict marker; skipping',
+        marker,
+        issues: result.error.issues.map((i) => ({ path: i.path, message: i.message })),
+      }));
+      continue;
+    }
+    parsed.push(result.data);
+  }
+
+  if (parsed.length === 0) {
+    return null;
+  }
+
+  parsed.sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts < b.ts ? 1 : -1;
+    return tierOrder[b.tier] - tierOrder[a.tier];
+  });
+  return parsed[0];
+}
+
+/**
+ * Locate the chitin status comment on a PR. Returns the comment_id +
+ * body, or {comment_id: null, body: ''} when none exists.
+ *
+ * Searches via `gh api repos/<repo>/issues/<pr>/comments`. We use the
+ * issue-comments endpoint (not pulls/comments) because top-level PR
+ * comments live on the issue side; pulls/comments is for inline
+ * review comments, which we don't want for the status comment.
+ */
+export function findByMarker(
+  pr_number: number,
+  repo: string,
+  marker: string = STATUS_BODY_MARKER,
+  gh: GhRunner = defaultGhRunner,
+): FindByMarkerResult {
+  // --paginate so we don't miss the chitin comment on PRs with >100
+  // comments. `gh api --paginate` concatenates the JSON arrays into
+  // one valid array — no jq needed.
+  const stdout = gh([
+    'api',
+    '--paginate',
+    `repos/${repo}/issues/${pr_number}/comments`,
+  ]);
+  let comments: PrIssueComment[];
+  try {
+    comments = JSON.parse(stdout) as PrIssueComment[];
+  } catch (err) {
+    throw new Error(
+      `mutable-status.findByMarker: gh api returned non-JSON (pr=${pr_number}): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  if (!Array.isArray(comments)) {
+    throw new Error(
+      `mutable-status.findByMarker: gh api returned non-array for pr=${pr_number}`,
+    );
+  }
+  for (const c of comments) {
+    if (typeof c.body === 'string' && c.body.startsWith(marker)) {
+      return { comment_id: c.id, body: c.body };
+    }
+  }
+  return { comment_id: null, body: '' };
+}
+
+/**
+ * Read the chitin status comment from a PR and parse its latest
+ * verdict in one call. Convenience wrapper around findByMarker +
+ * parseVerdict — the gatekeeper's "what's the current verdict on this
+ * PR?" path.
+ */
+export function read(
+  pr_number: number,
+  repo: string,
+  log: (line: string) => void = (l) => console.warn(l),
+  gh: GhRunner = defaultGhRunner,
+): MutableStatusReadResult {
+  const found = findByMarker(pr_number, repo, STATUS_BODY_MARKER, gh);
+  if (found.comment_id === null) {
+    return { comment_id: null, body: '', verdict: null };
+  }
+  return {
+    comment_id: found.comment_id,
+    body: found.body,
+    verdict: parseVerdict(found.body, log),
+  };
+}
+
+/**
+ * Create or edit the chitin status comment on a PR.
+ *
+ *   - First-tier call (no existing comment): POST a new comment via
+ *     `gh pr comment`.
+ *   - Subsequent tiers (existing comment): PATCH the comment in place
+ *     via `gh api -X PATCH repos/<repo>/issues/comments/<id>`.
+ *
+ * Returns the action taken + the comment id.
+ */
+export function upsert(input: UpsertInput): UpsertResult {
+  // Validate verdict shape upfront — fail loudly here rather than
+  // letting a malformed verdict reach the marker writer and pollute
+  // future reads.
+  VerdictMetaSchema.parse(input.verdict);
+
+  const gh = input.gh ?? defaultGhRunner;
+  const log = input.log ?? ((l: string) => console.warn(l));
+
+  const renderedBody = renderStatusBody(input.body, input.verdict);
+  const existing = findByMarker(input.pr_number, input.repo, STATUS_BODY_MARKER, gh);
+
+  if (existing.comment_id === null) {
+    // Create. Use `gh pr comment` with --body-file via stdin to avoid
+    // shell escaping pitfalls on multi-line bodies. gh accepts -F - to
+    // read from stdin? Actually --body-file=-. Use --body and pass via
+    // a temp file to be safe.
+    //
+    // gh pr comment <pr> --repo <repo> --body <body>
+    // Output ends with a comment URL — parse the trailing /<id> off it
+    // for the return value. If parse fails, we re-find via findByMarker
+    // so the next tier's edit still works.
+    const stdout = gh([
+      'pr', 'comment', String(input.pr_number),
+      '--repo', input.repo,
+      '--body', renderedBody,
+    ]);
+    const idMatch = stdout.match(/#issuecomment-(\d+)/);
+    if (idMatch) {
+      return { action: 'created', comment_id: Number(idMatch[1]) };
+    }
+    // Fallback — re-fetch to recover the id.
+    const refound = findByMarker(input.pr_number, input.repo, STATUS_BODY_MARKER, gh);
+    if (refound.comment_id === null) {
+      log(JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        component: 'mutable-status',
+        msg: 'created comment but could not recover id from gh stdout or re-find',
+        pr_number: input.pr_number,
+      }));
+      throw new Error(
+        `mutable-status.upsert: created comment on pr=${input.pr_number} but failed to recover id`,
+      );
+    }
+    return { action: 'created', comment_id: refound.comment_id };
+  }
+
+  // Edit. PATCH the issue comment by id.
+  gh([
+    'api',
+    '-X', 'PATCH',
+    `repos/${input.repo}/issues/comments/${existing.comment_id}`,
+    '-f', `body=${renderedBody}`,
+  ]);
+  return { action: 'edited', comment_id: existing.comment_id };
+}

--- a/apps/temporal-worker/test/comment-responder-mutable-status.test.ts
+++ b/apps/temporal-worker/test/comment-responder-mutable-status.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STATUS_BODY_MARKER,
+  VerdictMetaSchema,
+  findByMarker,
+  parseVerdict,
+  read,
+  renderStatusBody,
+  upsert,
+  type GhRunner,
+  type VerdictMeta,
+} from '../src/comment-responder/mutable-status.ts';
+
+// ─── gh runner harness ───────────────────────────────────────────────────
+
+interface FakeComment {
+  id: number;
+  body: string;
+}
+
+interface FakeGhCall {
+  args: string[];
+}
+
+interface FakeGhState {
+  comments: FakeComment[];
+  calls: FakeGhCall[];
+  /** Auto-incrementing id for newly-created comments. */
+  nextId: number;
+  /** PR number expected on `gh pr comment <n>`. */
+  pr_number: number;
+  /** Repo expected on `--repo <repo>` and on api paths. */
+  repo: string;
+}
+
+function makeGh(state: FakeGhState): GhRunner {
+  return (args: string[]): string => {
+    state.calls.push({ args });
+    // gh api --paginate repos/<repo>/issues/<pr>/comments
+    if (
+      args[0] === 'api' &&
+      args[1] === '--paginate' &&
+      /^repos\/.+\/issues\/\d+\/comments$/.test(args[2] ?? '')
+    ) {
+      return JSON.stringify(state.comments);
+    }
+    // gh pr comment <pr> --repo <repo> --body <body>
+    if (args[0] === 'pr' && args[1] === 'comment') {
+      const bodyIdx = args.indexOf('--body');
+      const body = bodyIdx >= 0 ? args[bodyIdx + 1] : '';
+      const id = state.nextId++;
+      state.comments.push({ id, body });
+      return `https://github.com/${state.repo}/pull/${state.pr_number}#issuecomment-${id}\n`;
+    }
+    // gh api -X PATCH repos/<repo>/issues/comments/<id> -f body=...
+    if (args[0] === 'api' && args[1] === '-X' && args[2] === 'PATCH') {
+      const path = args[3] ?? '';
+      const m = path.match(/issues\/comments\/(\d+)$/);
+      if (!m) throw new Error(`fake-gh: malformed PATCH path: ${path}`);
+      const id = Number(m[1]);
+      const fIdx = args.indexOf('-f');
+      const fArg = fIdx >= 0 ? args[fIdx + 1] ?? '' : '';
+      const body = fArg.startsWith('body=') ? fArg.slice('body='.length) : '';
+      const comment = state.comments.find((c) => c.id === id);
+      if (!comment) throw new Error(`fake-gh: comment id=${id} not found`);
+      comment.body = body;
+      return '';
+    }
+    throw new Error(`fake-gh: unhandled args: ${args.join(' ')}`);
+  };
+}
+
+function blankState(pr_number = 207, repo = 'chitinhq/chitin'): FakeGhState {
+  return { comments: [], calls: [], nextId: 1001, pr_number, repo };
+}
+
+// ─── renderStatusBody ────────────────────────────────────────────────────
+
+describe('renderStatusBody', () => {
+  it('puts the body marker on the first line and verdict marker at the end', () => {
+    const verdict: VerdictMeta = {
+      tier: 'R1',
+      status: 'changes_requested',
+      workflow_id: 'review-graph-pr-207',
+      ts: '2026-05-05T12:00:00Z',
+    };
+    const out = renderStatusBody('Some prose body.', verdict);
+    expect(out.split('\n')[0]).toBe(STATUS_BODY_MARKER);
+    expect(out).toContain('Some prose body.');
+    expect(out).toMatch(/<!-- chitin:verdict tier=R1 status=changes_requested workflow_id=review-graph-pr-207 ts=2026-05-05T12:00:00Z -->/);
+  });
+
+  it('trims trailing whitespace on the caller body so blank lines do not accumulate', () => {
+    const verdict: VerdictMeta = {
+      tier: 'R0',
+      status: 'pending',
+      workflow_id: 'wf',
+      ts: '2026-05-05T12:00:00Z',
+    };
+    const out = renderStatusBody('body with trailing newlines\n\n\n', verdict);
+    // Between body and verdict marker we expect exactly one blank line.
+    expect(out).not.toMatch(/\n\n\n\n<!-- chitin:verdict/);
+  });
+});
+
+// ─── parseVerdict ────────────────────────────────────────────────────────
+
+describe('parseVerdict', () => {
+  it('returns null when no marker present', () => {
+    expect(parseVerdict('plain prose, no marker', () => {})).toBeNull();
+  });
+
+  it('parses a single well-formed marker', () => {
+    const body = 'foo\n<!-- chitin:verdict tier=R2 status=approve workflow_id=abc ts=2026-05-05T12:00:00Z -->\nbar';
+    const v = parseVerdict(body, () => {});
+    expect(v).toEqual({
+      tier: 'R2',
+      status: 'approve',
+      workflow_id: 'abc',
+      ts: '2026-05-05T12:00:00Z',
+    });
+  });
+
+  it('returns the LATEST marker by ts when multiple are present', () => {
+    const body = [
+      '<!-- chitin:verdict tier=R0 status=pending workflow_id=w0 ts=2026-05-05T10:00:00Z -->',
+      '<!-- chitin:verdict tier=R1 status=changes_requested workflow_id=w1 ts=2026-05-05T11:00:00Z -->',
+      '<!-- chitin:verdict tier=R2 status=approve workflow_id=w2 ts=2026-05-05T12:00:00Z -->',
+    ].join('\n');
+    const v = parseVerdict(body, () => {});
+    expect(v?.tier).toBe('R2');
+    expect(v?.status).toBe('approve');
+  });
+
+  it('breaks ts ties by tier (higher tier wins)', () => {
+    const body = [
+      '<!-- chitin:verdict tier=R1 status=changes_requested workflow_id=w1 ts=2026-05-05T12:00:00Z -->',
+      '<!-- chitin:verdict tier=R3 status=approve workflow_id=w3 ts=2026-05-05T12:00:00Z -->',
+    ].join('\n');
+    const v = parseVerdict(body, () => {});
+    expect(v?.tier).toBe('R3');
+  });
+
+  it('skips malformed markers and logs', () => {
+    const logs: string[] = [];
+    const body = [
+      '<!-- chitin:verdict tier=BOGUS status=approve workflow_id=w ts=2026-05-05T12:00:00Z -->',
+      '<!-- chitin:verdict tier=R2 status=approve workflow_id=w ts=2026-05-05T13:00:00Z -->',
+    ].join('\n');
+    const v = parseVerdict(body, (l) => logs.push(l));
+    expect(v?.tier).toBe('R2');
+    expect(logs.length).toBe(1);
+    expect(logs[0]).toMatch(/malformed verdict marker/);
+  });
+
+  it('returns null and logs when EVERY marker is malformed (fail closed)', () => {
+    const logs: string[] = [];
+    const body = '<!-- chitin:verdict tier=R2 status=YOLO workflow_id=w ts=2026-05-05T12:00:00Z -->';
+    const v = parseVerdict(body, (l) => logs.push(l));
+    expect(v).toBeNull();
+    expect(logs.length).toBe(1);
+  });
+});
+
+// ─── findByMarker ────────────────────────────────────────────────────────
+
+describe('findByMarker', () => {
+  it('returns null when no chitin status comment is on the PR', () => {
+    const state = blankState();
+    state.comments.push({ id: 1, body: 'an unrelated human comment' });
+    state.comments.push({ id: 2, body: 'another bot comment without the marker' });
+    const result = findByMarker(207, 'chitinhq/chitin', STATUS_BODY_MARKER, makeGh(state));
+    expect(result.comment_id).toBeNull();
+    expect(result.body).toBe('');
+  });
+
+  it('returns the comment whose body starts with the marker', () => {
+    const state = blankState();
+    state.comments.push({ id: 1, body: 'unrelated' });
+    state.comments.push({
+      id: 42,
+      body: `${STATUS_BODY_MARKER}\n\nbody text\n\n<!-- chitin:verdict tier=R0 status=pending workflow_id=w ts=2026-05-05T10:00:00Z -->`,
+    });
+    state.comments.push({ id: 99, body: 'noise after the chitin one' });
+    const result = findByMarker(207, 'chitinhq/chitin', STATUS_BODY_MARKER, makeGh(state));
+    expect(result.comment_id).toBe(42);
+    expect(result.body.startsWith(STATUS_BODY_MARKER)).toBe(true);
+  });
+
+  it('uses --paginate on the gh api call', () => {
+    const state = blankState();
+    findByMarker(207, 'chitinhq/chitin', STATUS_BODY_MARKER, makeGh(state));
+    expect(state.calls[0]?.args).toContain('--paginate');
+  });
+});
+
+// ─── read ────────────────────────────────────────────────────────────────
+
+describe('read', () => {
+  it('returns the comment + parsed verdict when present', () => {
+    const state = blankState();
+    state.comments.push({
+      id: 42,
+      body: `${STATUS_BODY_MARKER}\n\nbody\n\n<!-- chitin:verdict tier=R2 status=approve workflow_id=w ts=2026-05-05T13:00:00Z -->`,
+    });
+    const r = read(207, 'chitinhq/chitin', () => {}, makeGh(state));
+    expect(r.comment_id).toBe(42);
+    expect(r.verdict?.tier).toBe('R2');
+    expect(r.verdict?.status).toBe('approve');
+  });
+
+  it('returns null verdict when the comment exists but the marker is malformed', () => {
+    const state = blankState();
+    state.comments.push({
+      id: 42,
+      body: `${STATUS_BODY_MARKER}\n\nbody\n\n<!-- chitin:verdict tier=R2 status=YOLO workflow_id=w ts=2026-05-05T13:00:00Z -->`,
+    });
+    const r = read(207, 'chitinhq/chitin', () => {}, makeGh(state));
+    expect(r.comment_id).toBe(42);
+    expect(r.verdict).toBeNull();
+  });
+
+  it('returns the empty shape when no chitin comment exists', () => {
+    const state = blankState();
+    const r = read(207, 'chitinhq/chitin', () => {}, makeGh(state));
+    expect(r).toEqual({ comment_id: null, body: '', verdict: null });
+  });
+});
+
+// ─── upsert ──────────────────────────────────────────────────────────────
+
+describe('upsert', () => {
+  const verdictR1: VerdictMeta = {
+    tier: 'R1',
+    status: 'changes_requested',
+    workflow_id: 'wf-1',
+    ts: '2026-05-05T12:00:00Z',
+  };
+  const verdictR2: VerdictMeta = {
+    tier: 'R2',
+    status: 'approve',
+    workflow_id: 'wf-2',
+    ts: '2026-05-05T13:00:00Z',
+  };
+
+  it('first-tier upsert creates a new comment via gh pr comment', () => {
+    const state = blankState();
+    const r = upsert({
+      pr_number: 207,
+      repo: 'chitinhq/chitin',
+      body: 'R1 says: please address X',
+      verdict: verdictR1,
+      log: () => {},
+      gh: makeGh(state),
+    });
+    expect(r.action).toBe('created');
+    expect(r.comment_id).toBe(1001);
+    expect(state.comments.length).toBe(1);
+    expect(state.comments[0].body.startsWith(STATUS_BODY_MARKER)).toBe(true);
+    // verdict marker present
+    expect(state.comments[0].body).toMatch(/tier=R1.*status=changes_requested/);
+    // a `gh pr comment` call (not a PATCH) was made
+    const created = state.calls.find((c) => c.args[0] === 'pr' && c.args[1] === 'comment');
+    expect(created).toBeTruthy();
+  });
+
+  it('second-tier upsert edits the existing comment via PATCH (does not create a new one)', () => {
+    const state = blankState();
+    upsert({
+      pr_number: 207,
+      repo: 'chitinhq/chitin',
+      body: 'R1 says: please address X',
+      verdict: verdictR1,
+      log: () => {},
+      gh: makeGh(state),
+    });
+    const before = state.comments.length;
+    const r = upsert({
+      pr_number: 207,
+      repo: 'chitinhq/chitin',
+      body: 'R2 says: looks good now',
+      verdict: verdictR2,
+      log: () => {},
+      gh: makeGh(state),
+    });
+    expect(r.action).toBe('edited');
+    expect(state.comments.length).toBe(before);
+    expect(r.comment_id).toBe(1001);
+    expect(state.comments[0].body).toContain('R2 says: looks good now');
+    expect(state.comments[0].body).toMatch(/tier=R2.*status=approve/);
+    // a PATCH call was made
+    const patch = state.calls.find(
+      (c) => c.args[0] === 'api' && c.args[1] === '-X' && c.args[2] === 'PATCH',
+    );
+    expect(patch).toBeTruthy();
+  });
+
+  it('missing-marker on a PR with other comments → creates new one (no migration)', () => {
+    const state = blankState();
+    state.comments.push({ id: 1, body: 'old append-style R0 comment, no marker' });
+    state.comments.push({ id: 2, body: 'old append-style R1 comment, no marker' });
+    const r = upsert({
+      pr_number: 207,
+      repo: 'chitinhq/chitin',
+      body: 'first chitin status comment on a previously-noisy PR',
+      verdict: verdictR1,
+      log: () => {},
+      gh: makeGh(state),
+    });
+    expect(r.action).toBe('created');
+    // pre-existing comments untouched
+    expect(state.comments[0].body).toBe('old append-style R0 comment, no marker');
+    expect(state.comments[1].body).toBe('old append-style R1 comment, no marker');
+    // a new chitin comment was appended
+    expect(state.comments.length).toBe(3);
+    expect(state.comments[2].body.startsWith(STATUS_BODY_MARKER)).toBe(true);
+  });
+
+  it('malformed verdict input throws (fail loudly before writing)', () => {
+    const state = blankState();
+    expect(() =>
+      upsert({
+        pr_number: 207,
+        repo: 'chitinhq/chitin',
+        body: 'body',
+        // @ts-expect-error — exercising the runtime validation path
+        verdict: { tier: 'BOGUS', status: 'approve', workflow_id: 'w', ts: '2026-05-05T12:00:00Z' },
+        log: () => {},
+        gh: makeGh(state),
+      }),
+    ).toThrow();
+    expect(state.comments.length).toBe(0);
+  });
+});
+
+// ─── schema export sanity ────────────────────────────────────────────────
+
+describe('VerdictMetaSchema', () => {
+  it('accepts the canonical shape', () => {
+    const r = VerdictMetaSchema.safeParse({
+      tier: 'R2',
+      status: 'approve',
+      workflow_id: 'w',
+      ts: '2026-05-05T12:00:00Z',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects unknown tier', () => {
+    const r = VerdictMetaSchema.safeParse({
+      tier: 'R5',
+      status: 'approve',
+      workflow_id: 'w',
+      ts: '2026-05-05T12:00:00Z',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown status', () => {
+    const r = VerdictMetaSchema.safeParse({
+      tier: 'R2',
+      status: 'merge',
+      workflow_id: 'w',
+      ts: '2026-05-05T12:00:00Z',
+    });
+    expect(r.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `comment-responder-mutable-status`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-comment-responder-mutable-status-1777984197190`

## Entry context

Today: `comment-responder` (and the broader review-graph) post a
**new** comment per pass. A PR that walks R0 → R1 → R2 → R3 ends
up with a stack of comments — all relevant, none authoritative. The
operator has to scroll to find the latest verdict, and downstream
tooling has to scrape prose to pick out the current state.

OpenClaw's clawsweeper (https://github.com/openclaw/clawsweeper, v0.2.0
2026-05-03) solved this with a single mutable status comment per
PR/issue, edited in place, with hidden HTML markers carrying the
machine-readable verdict. Same pattern fits chitin's review-graph
naturally — each tier just updates the same comment instead of
appending.

Two concrete wins:
1. **Cleaner PR threads.** One comment per swarm-touched PR, always
   reflecting current state. The growth pattern stops.
2. **Machine-readable verdicts.** Hidden markers (e.g.
   `<!-- chitin:verdict tier=R2 status=approve -->`) let the
   gatekeeper, `entryIdInRecentSubjects`, the pr-event-ingester, and
   any future operator-command surface read the verdict without
   scraping prose.

Approach (subject to design tightening — programmer should propose):

1. Define a `MutableStatusComment` helper (probably under
   `apps/temporal-worker/src/comment-responder/mutable-status.ts`)
   with `read(prNumber)`, `upsert(prNumber, body, verdictMeta)`,
   `findByMarker(prNumber, marker)`. Identifies "the chitin status
   comment" via a top-of-body magic-string marker
   (`<!-- chitin-status-comment v1 -->`).
2. Verdict markers: structured HTML comments embedded in the body.
   Schema lives in `libs/contracts/src/comment-verdict.schema.ts`
   (new). Fields: `tier` (R0–R4), `status` (approve / changes_requested
   / pending), `workflow_id`, `ts`. Zod-parsed; mismatch fails closed
   (assume "no verdict").
3. Plumb through `review-graph-workflow.ts`: every R-tier completion
   calls `upsert(prNumber, renderedBody, {tier, status, ...})` instead
   of `gh pr comment ...`. The renderer composes the new comment from
   prior verdict + this tier's findings.
4. Backward compatibility for PRs that already have an append-style
   comment chain: don't migrate. New mutable comment lands on top of
   the stack; older stuck comments remain as historical record.

**Acceptance:**
- [ ] PRs touched by review-graph after merge have exactly one
      `chitin-status-comment` body, edited across tiers
- [ ] Each verdict marker parses cleanly via the zod schema
- [ ] `gatekeeper.ts` reads the latest verdict via marker, not prose scraping
- [ ] PRs touched before merge are unaffected (no migration churn)
- [ ] Vitest covers: first-tier upsert (creates), second-tier upsert
      (edits), missing-marker (creates new), malformed-marker (logs +
      fails closed)
- [ ] Documentation: one paragraph in `apps/temporal-worker/src/comment-responder/README.md`
      (or equivalent) describing the marker schema for future readers

**Caveat — interaction with comment-responder fix loop:** when the
responder lands a fix commit and re-runs review-graph, the SAME
comment gets re-edited with the new verdict. The history of "was
changes_requested at R1, now approve at R2" lives only in the chain
audit log, not in the GitHub thread. That's intentional (cleaner
thread) but worth calling out for operators expecting forensic
history visible in the PR — point them at the chain.


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-comment-responder-mutable-status-1777984197190`
Branch: `swarm/swarm-comment-responder-mutable-status-1777984197190`
Head: `8b1ea9cb`
Diff: `9 files changed, 812 insertions(+), 236 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)