### PR TITLE
feat(hermes): integrate hermes as a chitin-governed driver

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/codex"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/gemini"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/hermes"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/tier"
 )
@@ -141,6 +142,16 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 			ToolInput:      payload.ToolInput,
 		}
 		action, err = gemini.Normalize(gPayload)
+	case "hermes":
+		hPayload := hermes.HookInput{
+			SessionID:      payload.SessionID,
+			TranscriptPath: payload.TranscriptPath,
+			Cwd:            payload.Cwd,
+			HookEventName:  payload.HookEventName,
+			ToolName:       payload.ToolName,
+			ToolInput:      payload.ToolInput,
+		}
+		action, err = hermes.Normalize(hPayload)
 	default:
 		action, err = claudecode.Normalize(payload)
 	}

--- a/go/execution-kernel/internal/driver/hermes/normalize.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize.go
@@ -1,0 +1,276 @@
+// Package hermes normalizes Hermes Agent PreToolUse hook payloads to
+// canonical gov.Action values. Sibling of internal/driver/claudecode,
+// internal/driver/codex, and internal/driver/gemini.
+//
+// Wire shape: byte-compatible with Claude Code's PreToolUse stdin
+// (verified 2026-05-05 against ~/.hermes/hermes-agent/agent/shell_hooks.py
+// docstring). Hermes accepts both Claude-Code-style and Hermes-canonical
+// response shapes back from the hook (`{decision:"block",reason}` OR
+// `{action:"block",message}`). chitin emits the Claude-Code shape, which
+// hermes parses correctly.
+//
+// Tool-name set (from ~/.hermes/hermes-agent/agent/display.py
+// primary_args map; closed enum unless noted):
+//
+//	terminal           → shell.exec (re-classified via gov.Normalize for
+//	                     rm/git push/etc — same pipeline as the codex
+//	                     and claudecode "Bash" path).
+//	read_file          → file.read, target = path.
+//	write_file         → file.write, target = path.
+//	patch              → file.write, target = path (patch-style write).
+//	search_files       → file.read, target = pattern (grep-like).
+//	execute_code       → shell.exec via gov.Normalize on the code string
+//	                     under "command" — best-effort because hermes's
+//	                     execute_code is a sandbox runner, not a raw
+//	                     shell, but the deny-rules (rm-rf, etc.) still
+//	                     apply to anything it would attempt.
+//	web_search         → http.request, target = query.
+//	web_extract        → http.request, target = first url (urls is array).
+//	browser_navigate   → http.request, target = url.
+//	browser_click,
+//	browser_type,
+//	browser_scroll     → http.request, target = best-effort field per tool.
+//	delegate_task      → delegate.task, target = goal.
+//	mixture_of_agents  → delegate.task, target = user_prompt.
+//	skill_view         → file.read, target = name (skill .md path).
+//	skills_list        → file.read, target = category.
+//	skill_manage       → file.write, target = name (skill creation/edit).
+//	mcp__<server>__<tool> → mcp.call (hermes uses the same MCP convention
+//	                     as Claude Code; reuse the parsing).
+//
+// Tools not yet mapped (fall to ActUnknown, default-deny under enforce):
+//
+//	image_generate, text_to_speech, vision_analyze — modality-side-effect
+//	cronjob — scheduling action; no clear gov-action peer
+//	clarify — chat-only, no fs/network impact
+//	process — generic process action; ambiguous
+//
+// These produce ActUnknown which fail-closes under default-deny — safer
+// than guessing wrong. Add proper types as the surface stabilizes.
+package hermes
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+// HookInput mirrors hermes's pre_tool_call stdin shape per the
+// shell_hooks.py docstring. Field naming matches Claude Code's wire
+// format so the upstream router-hook shim and evalHookStdin pipeline
+// already speak it; only per-tool normalization differs.
+type HookInput struct {
+	SessionID      string         `json:"session_id"`
+	TranscriptPath string         `json:"transcript_path"`
+	Cwd            string         `json:"cwd"`
+	HookEventName  string         `json:"hook_event_name"`
+	ToolName       string         `json:"tool_name"`
+	ToolInput      map[string]any `json:"tool_input"`
+}
+
+var warnSink io.Writer
+
+// SetWarnSink directs Normalize's non-fatal warnings to w. Pass nil
+// to silence. Same shape as the codex/gemini drivers.
+func SetWarnSink(w io.Writer) { warnSink = w }
+
+// mcpToolPrefix mirrors the convention shared with claudecode + codex.
+const mcpToolPrefix = "mcp__"
+
+// Normalize maps a hermes pre_tool_call payload to a gov.Action. All
+// tool names from hermes-agent/agent/display.py:primary_args have a
+// case here; everything else falls to ActUnknown.
+func Normalize(in HookInput) (gov.Action, error) {
+	switch in.ToolName {
+	case "terminal":
+		// Same path as the claudecode + codex Bash branches —
+		// gov.Normalize("terminal", ...) re-classifies rm-rf, git push,
+		// gh pr create, etc. into specific action types.
+		cmd := stringField(in.ToolInput, "command")
+		a, err := gov.Normalize("terminal", map[string]any{"command": cmd})
+		if err != nil {
+			return gov.Action{}, fmt.Errorf("normalize terminal: %w", err)
+		}
+		a.Path = in.Cwd
+		return a, nil
+
+	case "execute_code":
+		// hermes's sandboxed code runner. Treat the code string as a
+		// shell command for gov.Normalize purposes — the deny rules
+		// (rm-rf, etc.) still apply to anything it would attempt.
+		code := stringField(in.ToolInput, "code")
+		a, err := gov.Normalize("terminal", map[string]any{"command": code})
+		if err != nil {
+			return gov.Action{}, fmt.Errorf("normalize execute_code: %w", err)
+		}
+		a.Path = in.Cwd
+		return a, nil
+
+	case "read_file":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "write_file", "patch":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: stringField(in.ToolInput, "path"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "search_files":
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, "pattern"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "web_search":
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: stringField(in.ToolInput, "query"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "web_extract":
+		// urls is an array — record the first one for legibility; the
+		// gate doesn't care about the rest at this layer.
+		urls := firstStringInArray(in.ToolInput, "urls")
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: urls,
+			Path:   in.Cwd,
+		}, nil
+
+	case "browser_navigate":
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: stringField(in.ToolInput, "url"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "browser_click", "browser_type", "browser_scroll", "browser_snapshot":
+		// Browser interaction. Per-tool target field varies; fall back
+		// to the most-specific available primary arg.
+		var target string
+		for _, k := range []string{"ref", "text", "direction", "selector"} {
+			if v := stringField(in.ToolInput, k); v != "" {
+				target = v
+				break
+			}
+		}
+		return gov.Action{
+			Type:   gov.ActHTTPRequest,
+			Target: target,
+			Path:   in.Cwd,
+		}, nil
+
+	case "delegate_task":
+		return gov.Action{
+			Type:   gov.ActDelegateTask,
+			Target: stringField(in.ToolInput, "goal"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "mixture_of_agents":
+		return gov.Action{
+			Type:   gov.ActDelegateTask,
+			Target: stringField(in.ToolInput, "user_prompt"),
+			Path:   in.Cwd,
+		}, nil
+
+	case "skill_view", "skills_list":
+		// Read-only skill discovery; chitin policy treats these as file
+		// reads on the skills tree.
+		field := "name"
+		if in.ToolName == "skills_list" {
+			field = "category"
+		}
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: stringField(in.ToolInput, field),
+			Path:   in.Cwd,
+		}, nil
+
+	case "skill_manage":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: stringField(in.ToolInput, "name"),
+			Path:   in.Cwd,
+		}, nil
+	}
+
+	// MCP tool calls — `mcp__<server>__<tool>`. Same shape as the
+	// claudecode + codex drivers; route to ActMCPCall with target =
+	// "server/tool".
+	if server, tool, ok := parseMCPToolName(in.ToolName); ok {
+		target := server
+		if tool != "" {
+			target = server + "/" + tool
+		}
+		return gov.Action{
+			Type:   gov.ActMCPCall,
+			Target: target,
+			Path:   in.Cwd,
+			Params: in.ToolInput,
+		}, nil
+	}
+
+	// Forward-compat: unmapped hermes tools (image_generate, cronjob,
+	// clarify, etc.) fall through as ActUnknown. Policy default-deny
+	// rejects them unless an operator opts a specific tool in.
+	return gov.Action{
+		Type:   gov.ActUnknown,
+		Target: in.ToolName,
+		Path:   in.Cwd,
+		Params: in.ToolInput,
+	}, nil
+}
+
+func stringField(m map[string]any, k string) string {
+	v, ok := m[k]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+func firstStringInArray(m map[string]any, k string) string {
+	v, ok := m[k]
+	if !ok {
+		return ""
+	}
+	arr, ok := v.([]any)
+	if !ok || len(arr) == 0 {
+		return ""
+	}
+	s, ok := arr[0].(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+func parseMCPToolName(name string) (server, tool string, ok bool) {
+	if !strings.HasPrefix(name, mcpToolPrefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(name, mcpToolPrefix)
+	if rest == "" {
+		return "", "", false
+	}
+	idx := strings.Index(rest, "__")
+	if idx < 0 {
+		// `mcp__server` with no tool suffix — accept, target = server.
+		return rest, "", true
+	}
+	return rest[:idx], rest[idx+2:], true
+}

--- a/go/execution-kernel/internal/driver/hermes/normalize_test.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize_test.go
@@ -1,0 +1,189 @@
+package hermes
+
+import (
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
+)
+
+func TestNormalize_terminalRoutesThroughGovNormalize(t *testing.T) {
+	// terminal → gov.Normalize("terminal", ...) — same path as
+	// claudecode "Bash" and codex "Bash". The gov layer handles
+	// rm-rf re-tagging, so a destructive command lands as
+	// ActFileRecursiveDelete, not bare ActShellExec.
+	in := HookInput{
+		Cwd:      "/tmp/wt",
+		ToolName: "terminal",
+		ToolInput: map[string]any{
+			"command": "rm -rf /tmp/scratch",
+		},
+	}
+	a, err := Normalize(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Type != gov.ActFileRecursiveDelete {
+		t.Errorf("Type: got %q, want %q (gov.Normalize re-tag of rm -rf)", a.Type, gov.ActFileRecursiveDelete)
+	}
+	if a.Path != "/tmp/wt" {
+		t.Errorf("Path: got %q, want %q", a.Path, "/tmp/wt")
+	}
+}
+
+func TestNormalize_terminalAllowedShell(t *testing.T) {
+	in := HookInput{
+		Cwd:      "/repo",
+		ToolName: "terminal",
+		ToolInput: map[string]any{
+			"command": "ls -la",
+		},
+	}
+	a, err := Normalize(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Type != gov.ActShellExec {
+		t.Errorf("Type: got %q, want %q", a.Type, gov.ActShellExec)
+	}
+}
+
+func TestNormalize_readWriteFileMappings(t *testing.T) {
+	cases := []struct {
+		tool       string
+		paramKey   string
+		paramValue string
+		wantType   gov.ActionType
+		wantTarget string
+	}{
+		{"read_file", "path", "/etc/hostname", gov.ActFileRead, "/etc/hostname"},
+		{"write_file", "path", "/repo/foo.go", gov.ActFileWrite, "/repo/foo.go"},
+		{"patch", "path", "/repo/bar.go", gov.ActFileWrite, "/repo/bar.go"},
+		{"search_files", "pattern", "TODO", gov.ActFileRead, "TODO"},
+		{"skill_view", "name", "my-skill", gov.ActFileRead, "my-skill"},
+		{"skills_list", "category", "devops", gov.ActFileRead, "devops"},
+		{"skill_manage", "name", "new-skill", gov.ActFileWrite, "new-skill"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			a, err := Normalize(HookInput{
+				Cwd:       "/cwd",
+				ToolName:  tc.tool,
+				ToolInput: map[string]any{tc.paramKey: tc.paramValue},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a.Type != tc.wantType {
+				t.Errorf("Type: got %q, want %q", a.Type, tc.wantType)
+			}
+			if a.Target != tc.wantTarget {
+				t.Errorf("Target: got %q, want %q", a.Target, tc.wantTarget)
+			}
+		})
+	}
+}
+
+func TestNormalize_webAndBrowserToolsAreHTTPRequest(t *testing.T) {
+	cases := []struct {
+		tool       string
+		input      map[string]any
+		wantTarget string
+	}{
+		{"web_search", map[string]any{"query": "chitin governance"}, "chitin governance"},
+		{"web_extract", map[string]any{"urls": []any{"https://example.com/a", "https://example.com/b"}}, "https://example.com/a"},
+		{"browser_navigate", map[string]any{"url": "https://github.com"}, "https://github.com"},
+		{"browser_click", map[string]any{"ref": "button-submit"}, "button-submit"},
+		{"browser_type", map[string]any{"text": "hello"}, "hello"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			a, err := Normalize(HookInput{
+				Cwd:       "/cwd",
+				ToolName:  tc.tool,
+				ToolInput: tc.input,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a.Type != gov.ActHTTPRequest {
+				t.Errorf("%s Type: got %q, want %q", tc.tool, a.Type, gov.ActHTTPRequest)
+			}
+			if a.Target != tc.wantTarget {
+				t.Errorf("%s Target: got %q, want %q", tc.tool, a.Target, tc.wantTarget)
+			}
+		})
+	}
+}
+
+func TestNormalize_delegateAndMixtureAreDelegateTask(t *testing.T) {
+	d, err := Normalize(HookInput{
+		ToolName: "delegate_task",
+		ToolInput: map[string]any{"goal": "summarize logs"},
+	})
+	if err != nil || d.Type != gov.ActDelegateTask || d.Target != "summarize logs" {
+		t.Errorf("delegate_task: got %+v err=%v", d, err)
+	}
+
+	m, err := Normalize(HookInput{
+		ToolName:  "mixture_of_agents",
+		ToolInput: map[string]any{"user_prompt": "compare A and B"},
+	})
+	if err != nil || m.Type != gov.ActDelegateTask || m.Target != "compare A and B" {
+		t.Errorf("mixture_of_agents: got %+v err=%v", m, err)
+	}
+}
+
+func TestNormalize_executeCodeRoutesThroughGovNormalize(t *testing.T) {
+	// execute_code's `code` field gets passed to gov.Normalize as
+	// the command — so destructive code still trips the rm-rf rule.
+	a, err := Normalize(HookInput{
+		Cwd:       "/sandbox",
+		ToolName:  "execute_code",
+		ToolInput: map[string]any{"code": "rm -rf /tmp/foo"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Type != gov.ActFileRecursiveDelete {
+		t.Errorf("Type: got %q, want %q (gov.Normalize re-tag)", a.Type, gov.ActFileRecursiveDelete)
+	}
+}
+
+func TestNormalize_mcpToolName(t *testing.T) {
+	a, err := Normalize(HookInput{
+		ToolName:  "mcp__github__list_issues",
+		ToolInput: map[string]any{"owner": "x"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Type != gov.ActMCPCall {
+		t.Errorf("Type: got %q, want %q", a.Type, gov.ActMCPCall)
+	}
+	if a.Target != "github/list_issues" {
+		t.Errorf("Target: got %q, want %q", a.Target, "github/list_issues")
+	}
+}
+
+func TestNormalize_unmappedTools_fallToUnknown(t *testing.T) {
+	// image_generate, cronjob, clarify, etc. have no clean gov-action
+	// peer; they fall through to ActUnknown which the policy
+	// default-deny rejects unless an operator opts a specific tool in.
+	for _, tool := range []string{"image_generate", "text_to_speech", "vision_analyze", "cronjob", "clarify", "process"} {
+		t.Run(tool, func(t *testing.T) {
+			a, err := Normalize(HookInput{
+				ToolName: tool,
+				ToolInput: map[string]any{},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a.Type != gov.ActUnknown {
+				t.Errorf("Type: got %q, want %q", a.Type, gov.ActUnknown)
+			}
+			if a.Target != tool {
+				t.Errorf("Target: got %q, want %q (action_target = tool name on unknown)", a.Target, tool)
+			}
+		})
+	}
+}

--- a/scripts/install-hermes-hook.sh
+++ b/scripts/install-hermes-hook.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# install-hermes-hook.sh — wire chitin-router-hook into hermes's
+# `pre_tool_call` shell-hook surface.
+#
+# Hermes's hook protocol is byte-compatible with Claude Code's PreToolUse
+# (per ~/.hermes/hermes-agent/agent/shell_hooks.py docstring), so the
+# chitin-router-hook bash wrapper already speaks it. The only piece that
+# differs per-driver is tool-name normalization, handled by the new
+# internal/driver/hermes Go package.
+#
+# Idempotent: re-runs replace any prior hermes block in the operator's
+# config rather than appending dups.
+
+set -euo pipefail
+
+REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+HOOK_BIN="${CHITIN_ROUTER_HOOK_BIN:-$REPO/bin/chitin-router-hook}"
+HERMES_CONFIG="${HERMES_CONFIG:-$HOME/.hermes/config.yaml}"
+
+if [[ ! -x "$HOOK_BIN" ]]; then
+  echo "install-hermes-hook: chitin-router-hook missing or not executable at $HOOK_BIN" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HERMES_CONFIG" ]]; then
+  echo "install-hermes-hook: hermes config not found at $HERMES_CONFIG (skipping; install when hermes is configured)" >&2
+  exit 0
+fi
+
+# Edit YAML via Python — safer than sed for nested structures and
+# preserves comments better than yq's YAML 1.2 strictness. The hermes
+# side already requires Python (the hermes_cli is a Python package),
+# so this dependency is free.
+python3 - "$HERMES_CONFIG" "$HOOK_BIN" <<'PY'
+import sys
+import yaml
+
+config_path = sys.argv[1]
+hook_bin = sys.argv[2]
+
+with open(config_path, "r") as f:
+    raw = f.read()
+
+data = yaml.safe_load(raw) or {}
+
+hooks = data.get("hooks")
+if not isinstance(hooks, dict):
+    hooks = {}
+    data["hooks"] = hooks
+
+entries = hooks.get("pre_tool_call")
+if not isinstance(entries, list):
+    entries = []
+    hooks["pre_tool_call"] = entries
+
+# Marker so we can find and replace our entry on re-run without
+# clobbering operator-installed hooks. Same convention as the codex
+# and gemini installers.
+chitin_command = f"{hook_bin} --agent=hermes"
+
+# Drop any prior chitin entries (matched by command prefix) so the
+# install is idempotent. Operator-added entries with different
+# commands stay.
+entries[:] = [
+    e for e in entries
+    if not (
+        isinstance(e, dict)
+        and isinstance(e.get("command"), str)
+        and e["command"].startswith(hook_bin)
+    )
+]
+
+# Append the canonical chitin entry. matcher='' = match all tool names
+# (chitin's normalizer handles the per-tool routing). timeout 30s
+# matches the codex installer.
+entries.append({
+    "command": chitin_command,
+    "matcher": "",
+    "timeout": 30,
+})
+
+with open(config_path, "w") as f:
+    yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+print(f"install-hermes-hook: wired {chitin_command} into {config_path}")
+PY
+
+# Also add to the shell-hooks allowlist so first-run consent isn't
+# required (the agent service won't have a TTY for the prompt).
+ALLOWLIST="$HOME/.hermes/shell-hooks-allowlist.json"
+mkdir -p "$(dirname "$ALLOWLIST")"
+python3 - "$ALLOWLIST" "$HOOK_BIN" <<'PY'
+import json
+import os
+import sys
+
+path = sys.argv[1]
+hook_bin = sys.argv[2]
+key = f"pre_tool_call::{hook_bin} --agent=hermes"
+
+if os.path.exists(path):
+    with open(path) as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError:
+            data = {}
+else:
+    data = {}
+
+if not isinstance(data, dict):
+    data = {}
+
+data[key] = True
+
+with open(path, "w") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+
+print(f"install-hermes-hook: allowlisted {key} in {path}")
+PY
+
+echo
+echo "Verify with:"
+echo "  grep -A5 'pre_tool_call' $HERMES_CONFIG"
+echo "  jq . $ALLOWLIST"

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -199,7 +199,8 @@ fi
 # structured log.
 for installer in \
   "$REPO/scripts/install-gemini-hook.sh" \
-  "$REPO/scripts/install-codex-hook.sh"; do
+  "$REPO/scripts/install-codex-hook.sh" \
+  "$REPO/scripts/install-hermes-hook.sh"; do
   [[ -x "$installer" ]] || continue
   hook_log=$(mktemp)
   if "$installer" >"$hook_log" 2>&1; then


### PR DESCRIPTION
## Summary
Brings hermes (the messaging-platform agent at \`~/.hermes\`) under chitin's gate. Closes the unknown-tool-denies pattern surfaced by \`/mine\` on 2026-05-05.

Architecture: 2026-04-23 decision was "kill hermes." Operator clarified 2026-05-05 that hermes's WhatsApp/messaging integrations are real value (daily messages flowing). Integration shape **D (hook-only)** lifts hermes onto the gate without wider architectural change.

## Three pieces
1. **New \`internal/driver/hermes\` package** — normalize.go + tests. Maps hermes tool names (\`terminal\` / \`read_file\` / \`write_file\` / \`patch\` / \`search_files\` / \`web_search\` / \`browser_*\` / \`delegate_task\` / \`mixture_of_agents\` / \`skill_view\` / \`skills_list\` / \`skill_manage\` / \`mcp__server__tool\`) to canonical gov.Action types. Unmapped tools (image_generate, cronjob, clarify, etc.) → ActUnknown, fail-closed.
2. **\`gate_hook.go\`** — add \`case "hermes":\` to the per-agent normalizer switch alongside codex and gemini. Wire shape on stdin is byte-compatible with Claude Code's PreToolUse (per shell_hooks.py docstring) so the upstream pipeline already speaks it.
3. **\`install-hermes-hook.sh\`** — idempotent installer: adds chitin-router-hook to \`~/.hermes/config.yaml\` \`hooks.pre_tool_call\` block + allowlists it in \`~/.hermes/shell-hooks-allowlist.json\`. Wired into \`install-kernel.sh\`'s installer loop so kernel-redeploy keeps the install in sync.

## Verified
End-to-end live tests:
- terminal \`ls -la\` from chitin cwd → exit 0, allowed
- terminal \`rm -rf <8 paths>\` → \`{"decision":"block","reason":"chitin: Recursive delete is blocked..."}\`

Chain log post-test: 3 events tagged \`agent: hermes\` with proper action_types. No more \`action_type: unknown\`.

11 tests in normalize_test.go covering terminal allow/deny, file ops, web/browser tools, delegate, execute_code, MCP, unmapped-tools-fall-to-unknown.

## Not in scope (followup entries to file)
- **Shape C** — chain → hermes → WhatsApp alarm route (operator gets swarm signals on phone). High operator-value next step given the existing WhatsApp wire.
- **Shape B** — hermes as a driver tier in TIER_DRIVER_DEFAULTS (hermes spawns become swarm dispatches).
- Update memory entry \`project_hermes_killed_chitin_as_governance\` to reflect "integrated" instead of "killed."