### PR TITLE
swarm: hermes-whatsapp-alarm-relay

### DIFF
--- a/scripts/chitin-alarm-relay.sh
+++ b/scripts/chitin-alarm-relay.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# chitin-alarm-relay.sh: Relays high-severity chitin alarms to operator's phone via hermes
+# Reads ~/.cache/chitin/watchdog-state.json, dedups via ~/.cache/chitin/alarm-relay-state.json
+# Requires CHITIN_ALARM_PEER env var (operator's hermes peer/channel)
+
+set -euo pipefail
+
+WATCHDOG_STATE="$HOME/.cache/chitin/watchdog-state.json"
+RELAY_STATE="$HOME/.cache/chitin/alarm-relay-state.json"
+
+if [[ -z "${CHITIN_ALARM_PEER:-}" ]]; then
+  echo "CHITIN_ALARM_PEER env var must be set to the operator's hermes peer/channel" >&2
+  exit 1
+fi
+
+# Read current signals (empty array if missing)
+if [[ -f "$WATCHDOG_STATE" ]]; then
+  SIGNALS=$(jq -c '.signals // []' "$WATCHDOG_STATE")
+else
+  SIGNALS="[]"
+fi
+
+# Read last relayed signals (empty array if missing)
+if [[ -f "$RELAY_STATE" ]]; then
+  LAST=$(jq -c '.' "$RELAY_STATE")
+else
+  LAST="[]"
+fi
+
+# If signals are empty and last was non-empty, emit recovery message
+if [[ "$SIGNALS" == "[]" && "$LAST" != "[]" ]]; then
+  hermes send --to "$CHITIN_ALARM_PEER" --message "All clear: no active chitin alarms."
+  echo "[]" > "$RELAY_STATE"
+  exit 0
+fi
+
+# If signals are non-empty and changed since last relay, send digest
+if [[ "$SIGNALS" != "[]" && "$SIGNALS" != "$LAST" ]]; then
+  # Compose digest message
+  DIGEST=$(jq -r 'map("- " + (.summary // .type // .id // "(unknown alarm)")) | join("\n")' <<< "$SIGNALS")
+  MSG="Chitin alarm(s):\n$DIGEST"
+  hermes send --to "$CHITIN_ALARM_PEER" --message "$MSG"
+  echo "$SIGNALS" > "$RELAY_STATE"
+  exit 0
+fi
+
+# No change: do nothing
+exit 0


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `hermes-whatsapp-alarm-relay`
Tier: `T2`  •  Driver: `copilot`
Workflow: `swarm-hermes-whatsapp-alarm-relay-1777987285894`

## Entry context

Closes the loop opened by PR #340: hermes is now chitin-governed AND
already wired to WhatsApp on this rig (operator gets daily messages
from hermes today). Add a Shape-C alarm relay so chitin's chain
signals (locked agents, failed `chitin-*` units, rollup alarms) reach
the operator's phone without a desktop session.

**Why this beats the existing watchdog:** the watchdog (PR #305) emits
`notify-send` desktop notifications. Useful when operator is at the
3090, useless off-box. The 2026-05-04 lockdown took 20.5h to surface
because no off-box channel existed. This entry adds one.

Approach (subject to design tightening — programmer should propose):

1. New script `scripts/chitin-alarm-relay.sh`. Reads watchdog's signal
   set (`~/.cache/chitin/watchdog-state.json`, computed by PR #305's
   watchdog logic). When signals are non-empty AND distinct from
   prior relay-tick state, send a hermes message via the hermes CLI:
   ```
   hermes send --to <CHITIN_ALARM_PEER> --message "<digest>"
   ```
   Stable peer is the operator's phone-as-self-chat (the channel
   already in use for daily hermes messages).

2. Suppression: separate state file
   `~/.cache/chitin/alarm-relay-state.json` so the relay's dedup is
   independent of the watchdog's own. (Operator may want desktop and
   phone notifications on different cadences — desktop on every
   change, phone only on persistent or new-class signals.)

3. New systemd unit `chitin-alarm-relay.{service,timer}` firing
   every 15 min, mirroring the watchdog. Auto-installed via #313's
   idempotent installer.

4. Extend `alarm-feeder.ts` so high-severity alarms (e.g., locked
   agent for >1h, failed unit older than 1 redeploy cycle) flag
   themselves for relay. Most alarms stay desktop-only; phone is
   reserved for "you should look at this even if you're not at
   the box."

**Acceptance:**
- [ ] Operator receives a hermes message within 15 min of:
      (a) any locked agent persisting >1h,
      (b) a chitin-* systemd unit failing for >2 consecutive ticks
- [ ] Relay state suppresses repeats — same signal-set across
      consecutive ticks doesn't re-message
- [ ] Recovery transition emits one "all clear" message
- [ ] Vitest covers: empty signals, novel signals, suppressed
      repeats, recovery message

**Caveat — operator notification fatigue:** desktop watchdog +
phone relay is two channels. If both fire on the same signal,
operator sees noise. Default split: desktop for all changes, phone
only for sustained / high-severity. Operator-tunable thresholds
in `chitin.yaml` (new section `alarm_relay:`).

**Caveat — hermes peer config:** the entry assumes a stable
`CHITIN_ALARM_PEER` env var with the operator's preferred hermes
channel/peer. Document this in `infra/systemd/README.md` so a
fresh checkout can wire it once.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-hermes-whatsapp-alarm-relay-1777987285894`
Branch: `swarm/swarm-hermes-whatsapp-alarm-relay-1777987285894`
Head: `1859e87e`
Diff: `1 file changed, 48 insertions(+)`
Commits: 1