### PR TITLE
swarm: comment-responder-executor-hard-stop-rm-rf-clone

### DIFF
--- a/apps/temporal-worker/src/skills/comment-responder.ts
+++ b/apps/temporal-worker/src/skills/comment-responder.ts
@@ -34,10 +34,12 @@ export interface PrecheckResult {
   event_kind?: 'bootstrap-rejected';
 }
 
-// `rm -rf`, `rm -fr`, `rm -Rf`, `rm -rfv`, etc. — any clustered
-// recursive+force flag combination. Word boundary on both sides so
-// `confirm-rf` or `armrf` doesn't match.
-const RM_RECURSIVE_RE = /\brm\s+-[rRfF]+\b/;
+// `rm -rf`, `rm -fr`, `rm -Rf`, `rm -rfv`, `rm -r`, etc. — any
+// short-flag cluster that contains the recursive flag (`r` or `R`).
+// Combined with `gh repo clone` on the same chain, that's the
+// bootstrap pattern regardless of which other flags are clustered.
+// Word boundary on `rm` so `confirm` or `armrf` doesn't match.
+const RM_RECURSIVE_RE = /\brm\s+-[a-zA-Z]*[rR][a-zA-Z]*\b/;
 
 // `gh repo clone` — the exact pattern that combined with `rm -rf`
 // produces the bootstrap. `gh repo view` / `gh repo create` etc.
@@ -80,8 +82,8 @@ const REJECT_MESSAGE =
  *   - `rm -rf ./* && gh repo clone .`         → REJECT (the lockdown shape)
  *   - `rm -rf ./* || true && gh repo clone .` → REJECT (the exact 2026-05
  *                                                       trigger shape)
- *   - `rm -fr` / `rm -Rf` / `rm -rfv`         → REJECT path covered (any
- *                                                clustered -[rRfF] flag)
+ *   - `rm -fr` / `rm -Rf` / `rm -rfv` / `rm -r` → REJECT (any short-flag
+ *                                                cluster containing r/R)
  */
 export function precheckShellCommand(command: string): PrecheckResult {
   for (const line of command.split('\n')) {

--- a/apps/temporal-worker/src/skills/comment-responder.ts
+++ b/apps/temporal-worker/src/skills/comment-responder.ts
@@ -1,0 +1,101 @@
+// Skill executor pre-check for the comment-responder role.
+//
+// Layer 2 of three-layer defense against the bootstrap pattern that
+// triggered the 2026-05-04T03:27 + 2026-05-05T03:23 lockdowns of
+// copilot-cli (see chain telemetry: 12 trigger events / 48h, 2091
+// cascade-deny events post-lockdown, two PRs closed unmerged):
+//
+//     rm -rf ./* .[^.]* 2>/dev/null || true \
+//       && gh repo clone chitinhq/chitin . \
+//       && gh pr checkout <N>
+//
+// Layer 1 — prompt warning in `apps/temporal-worker/skills/comment-responder/SKILL.md`
+//   (PR #336, 2026-05-05).
+// Layer 2 — this file: regex pre-check that any executor wiring up
+//   composed shell commands for the agent can call before forwarding.
+//   It catches the case where the agent emits the pattern despite the
+//   prompt warning (model swap, prompt drift, context truncation).
+// Layer 3 — kernel's `no-rm-recursive` policy rule (generic guardrail
+//   independent of skill).
+//
+// All three layers must fail for the pattern to escape — sufficient
+// depth.
+
+/**
+ * Outcome of `precheckShellCommand`. On rejection, caller is expected
+ * to (a) refuse to forward the command to the agent and (b) record a
+ * chain event with `kind: event_kind` so the rejection shows up in
+ * the standard chain telemetry alongside kernel denials.
+ */
+export interface PrecheckResult {
+  ok: boolean;
+  reason?: string;
+  /** Chain event kind when ok=false. Stable identifier for telemetry. */
+  event_kind?: 'bootstrap-rejected';
+}
+
+// `rm -rf`, `rm -fr`, `rm -Rf`, `rm -rfv`, etc. — any clustered
+// recursive+force flag combination. Word boundary on both sides so
+// `confirm-rf` or `armrf` doesn't match.
+const RM_RECURSIVE_RE = /\brm\s+-[rRfF]+\b/;
+
+// `gh repo clone` — the exact pattern that combined with `rm -rf`
+// produces the bootstrap. `gh repo view` / `gh repo create` etc.
+// are unaffected.
+const GH_REPO_CLONE_RE = /\bgh\s+repo\s+clone\b/;
+
+const REJECT_MESSAGE =
+  'comment-responder pre-check: refused to forward shell command. ' +
+  'Detected `rm -rf` followed by `gh repo clone` on the same shell ' +
+  'chain — this is the bootstrap pattern that locked down copilot-cli ' +
+  'on 2026-05-04 and 2026-05-05. Use the subdir-clone recipe from ' +
+  'apps/temporal-worker/skills/comment-responder/SKILL.md step 1 ' +
+  'instead: `gh repo clone <owner>/<repo>` (clones INTO a subdirectory, ' +
+  'not cwd) → `cd <repo>` → `gh pr checkout <pr_number>`.';
+
+/**
+ * Pre-check a shell command before forwarding it to the comment-responder
+ * agent. Rejects iff a single line of the command contains both
+ * `rm -rf` and `gh repo clone`, with `rm -rf` appearing first in
+ * shell-chain order.
+ *
+ * Pure function: no I/O. Caller writes the chain event using the
+ * returned `event_kind`. Pure-function shape is the same lens used
+ * by `parseJournalForUnitFailures` in alarm-feeder.ts — keeps the
+ * unit test fixture-only.
+ *
+ * Invariant — what this rejects:
+ *   For every line L in `command`, if L contains `rm -rf …` at index
+ *   `i_rm` AND `gh repo clone …` at index `i_gh` AND `i_rm < i_gh`,
+ *   reject. Otherwise allow.
+ *
+ * Edge cases (boundary lens):
+ *   - empty string                            → allow (nothing to forward)
+ *   - `rm -rf node_modules`                   → allow (no gh repo clone)
+ *   - `gh repo clone foo bar`                 → allow (no rm -rf)
+ *   - `gh repo clone foo && rm -rf foo`       → allow (rm comes after,
+ *                                                not the bootstrap shape)
+ *   - multi-line script with rm on line 1 and
+ *     gh on line 5                            → allow (independent chains)
+ *   - `rm -rf ./* && gh repo clone .`         → REJECT (the lockdown shape)
+ *   - `rm -rf ./* || true && gh repo clone .` → REJECT (the exact 2026-05
+ *                                                       trigger shape)
+ *   - `rm -fr` / `rm -Rf` / `rm -rfv`         → REJECT path covered (any
+ *                                                clustered -[rRfF] flag)
+ */
+export function precheckShellCommand(command: string): PrecheckResult {
+  for (const line of command.split('\n')) {
+    const rmMatch = RM_RECURSIVE_RE.exec(line);
+    if (!rmMatch) continue;
+    const ghMatch = GH_REPO_CLONE_RE.exec(line);
+    if (!ghMatch) continue;
+    if (rmMatch.index < ghMatch.index) {
+      return {
+        ok: false,
+        reason: REJECT_MESSAGE,
+        event_kind: 'bootstrap-rejected',
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/apps/temporal-worker/test/comment-responder.test.ts
+++ b/apps/temporal-worker/test/comment-responder.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { precheckShellCommand } from '../src/skills/comment-responder.ts';
+
+describe('precheckShellCommand — bootstrap pattern detection', () => {
+  it('rejects the exact 2026-05-04 / 2026-05-05 lockdown shape', () => {
+    const cmd =
+      'rm -rf ./* .[^.]* 2>/dev/null || true && gh repo clone chitinhq/chitin . && gh pr checkout 305';
+    const result = precheckShellCommand(cmd);
+    expect(result.ok).toBe(false);
+    expect(result.event_kind).toBe('bootstrap-rejected');
+    expect(result.reason).toMatch(/SKILL\.md step 1/);
+    expect(result.reason).toMatch(/subdirectory/);
+  });
+
+  it('rejects `rm -rf ./* && gh repo clone .` minimal form', () => {
+    const result = precheckShellCommand('rm -rf ./* && gh repo clone .');
+    expect(result.ok).toBe(false);
+    expect(result.event_kind).toBe('bootstrap-rejected');
+  });
+
+  it('rejects flag variants: -fr, -Rf, -rfv', () => {
+    expect(precheckShellCommand('rm -fr ./* && gh repo clone .').ok).toBe(false);
+    expect(precheckShellCommand('rm -Rf ./* && gh repo clone .').ok).toBe(false);
+    expect(precheckShellCommand('rm -rfv ./* && gh repo clone .').ok).toBe(false);
+  });
+
+  it('rejects across `;` and `|` shell chain operators', () => {
+    expect(precheckShellCommand('rm -rf .; gh repo clone foo bar').ok).toBe(false);
+    expect(precheckShellCommand('rm -rf . | gh repo clone foo bar').ok).toBe(false);
+  });
+});
+
+describe('precheckShellCommand — must NOT false-positive', () => {
+  it('allows `rm -rf node_modules` alone (no gh repo clone)', () => {
+    expect(precheckShellCommand('rm -rf node_modules').ok).toBe(true);
+  });
+
+  it('allows `rm -rf dist && pnpm build` (no gh repo clone in chain)', () => {
+    expect(precheckShellCommand('rm -rf dist && pnpm build').ok).toBe(true);
+  });
+
+  it('allows `gh repo clone` alone (no rm -rf)', () => {
+    expect(precheckShellCommand('gh repo clone chitinhq/chitin').ok).toBe(true);
+  });
+
+  it('allows `gh repo clone foo && rm -rf bar` — rm AFTER clone is not the bootstrap shape', () => {
+    expect(precheckShellCommand('gh repo clone foo && rm -rf bar').ok).toBe(true);
+  });
+
+  it('allows multi-line script where rm and gh are on independent lines', () => {
+    const cmd = ['rm -rf node_modules', 'pnpm install', 'gh repo clone elsewhere /tmp/x'].join('\n');
+    expect(precheckShellCommand(cmd).ok).toBe(true);
+  });
+
+  it('allows empty string', () => {
+    expect(precheckShellCommand('').ok).toBe(true);
+  });
+
+  it('allows `gh repo view` + `rm -rf` chain (gh subcommand is not clone)', () => {
+    expect(precheckShellCommand('rm -rf ./* && gh repo view chitinhq/chitin').ok).toBe(true);
+    expect(precheckShellCommand('rm -rf ./* && gh repo create foo').ok).toBe(true);
+  });
+
+  it('allows benign tokens that share substrings (confirm-rf, armrf, ghclone-helper)', () => {
+    expect(precheckShellCommand('confirm-rf && ghclone-helper .').ok).toBe(true);
+  });
+});
+
+describe('precheckShellCommand — chain-event contract', () => {
+  it('returns a stable event_kind so callers can record `bootstrap-rejected` chain events', () => {
+    const cmd = 'rm -rf ./* && gh repo clone chitinhq/chitin .';
+    const result = precheckShellCommand(cmd);
+    expect(result.ok).toBe(false);
+    expect(result.event_kind).toBe('bootstrap-rejected');
+  });
+
+  it('reason cites both the lockdown history and the SKILL.md retry recipe', () => {
+    const result = precheckShellCommand('rm -rf ./* && gh repo clone .');
+    expect(result.reason).toBeDefined();
+    expect(result.reason).toMatch(/2026-05-04/);
+    expect(result.reason).toMatch(/2026-05-05/);
+    expect(result.reason).toMatch(/SKILL\.md/);
+    expect(result.reason).toMatch(/gh pr checkout/);
+  });
+
+  it('ok=true results carry no reason or event_kind', () => {
+    const result = precheckShellCommand('echo hello');
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.event_kind).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `comment-responder-executor-hard-stop-rm-rf-clone`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-comment-responder-executor-hard-stop-rm-rf-clone-1777989723987`

## Entry context

**Layer-2 follow-up to PR #336.** PR #336 (merged 2026-05-05) shipped
the prompt-fix layer — `comment-responder/SKILL.md` now contains an
explicit "CRITICAL — DO NOT use `gh repo clone .` or `rm -rf` to
clear cwd" warning quoting the 2026-05-04 + 2026-05-05 lockdowns.
This entry adds the executor hard-stop layer that catches the case
where an agent ignores the prompt.

Telemetry context (from `/mine` 2026-05-05) — what motivated the
defense-in-depth ask:

- 12 trigger events in 48h (10 untagged + comment-respond-pr-305 +
  comment-respond-pr-328), all from `copilot-cli` agent, all using
  the exact `rm -rf ./* .[^.]* 2>/dev/null || true && gh repo clone
  chitinhq/chitin . && gh pr checkout <N>` shape.
- Each trigger escalates through `normal → elevated → high →
  lockdown`; once locked, downstream `file.read` and `shell.exec`
  cascade-deny **2091 times** in 48h. The lockdown rule dominates
  the chain's deny volume — everything else is noise.
- Two PRs (#305, #328) closed-without-merge as direct casualties.
- Recurrence across days proved a prompt-only fix is necessary but
  not sufficient — agents can still emit the pattern under prompt
  drift, model swap, or context truncation.

Fix scope (this entry — layer 2 only):

1. **Skill executor pre-check** (`comment-responder.ts`): before
   forwarding any composed shell command to the agent, regex-reject
   any command line containing `rm -rf` followed (within the same
   shell chain — `&&`, `;`, `|`) by `gh repo clone`. Replace with a
   single-line error that tells the agent to use the documented
   subdir-clone recipe from SKILL.md.
2. **Test**: fixture in `comment-responder.test.ts` that feeds a
   mock LLM response containing the forbidden pattern and asserts
   the executor refuses + logs a `bootstrap-rejected` chain event.

Edge cases:

- A *legitimate* `rm -rf` in some other context (e.g. `rm -rf
  node_modules`) must not trigger — the regex is the conjunction:
  `rm -rf` AND `gh repo clone` on the same shell chain.
- Reject message must point to SKILL.md's subdir-clone recipe so the
  agent has a clear retry path.

T2 because the regex needs care (false-positive risk) and the
executor surface is load-bearing. Lands behind the existing
`no-rm-recursive` policy rule (the *generic* guardrail) and PR #336
(the *prompt* layer); this entry adds the *executor* layer. With
all three in place, the pattern needs three independent failures to
escape — sufficient depth.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-comment-responder-executor-hard-stop-rm-rf-clone-1777989723987`
Branch: `swarm/swarm-comment-responder-executor-hard-stop-rm-rf-clone-1777989723987`
Head: `5676d1f4`
Diff: `3 files changed, 207 insertions(+), 10 deletions(-)`
Commits: 2 (+ auto-committed uncommitted state)