### PR TITLE
swarm: chain-fingerprint-tagging-coverage

### DIFF
--- a/apps/temporal-worker/src/dispatcher.ts
+++ b/apps/temporal-worker/src/dispatcher.ts
@@ -118,6 +118,43 @@ const TIER_DRIVER: Record<Tier, DriverId> = (Object.keys(TIER_DRIVER_DEFAULTS) a
   {} as Record<Tier, DriverId>,
 );
 
+// Tier → model mapping. Parallel axis to TIER_DRIVER so chain events
+// emitted by the activity / apply step can attribute (driver, model)
+// independently. Without this, the /mine fingerprint-outcomes view rolls
+// 92% of dispatches into the (untagged) × (none) row because the
+// dispatcher only propagated `tier` + `role` and the model was implicit
+// in the driver — the analysis layer can't recover it.
+//
+// Sourced from the comments on TIER_DRIVER_DEFAULTS:
+//   T0/T1 openclaw-glm-flash → glm-4.7-flash (3090, ~30B)
+//   T2    copilot            → claude-haiku-4-5 (Copilot Pro, 0.33×)
+//   T3    openclaw-glm-cloud → glm-5.1:cloud (Ollama Cloud, opus-light)
+//   T4    claude-code-headless → claude-opus-4-7 (Anthropic Max)
+//
+// Operator override matches the driver-override convention:
+//   CHITIN_TIER_MODEL_T2=claude-sonnet-4-6
+const TIER_MODEL_DEFAULTS: Record<Tier, string> = {
+  T0: 'glm-4.7-flash',
+  T1: 'glm-4.7-flash',
+  T2: 'claude-haiku-4-5',
+  T3: 'glm-5.1:cloud',
+  T4: 'claude-opus-4-7',
+};
+
+function envModelOverride(tier: Tier): string | undefined {
+  const v = process.env[`CHITIN_TIER_MODEL_${tier}`];
+  if (!v || !v.trim()) return undefined;
+  return v.trim();
+}
+
+const TIER_MODEL: Record<Tier, string> = (Object.keys(TIER_MODEL_DEFAULTS) as Tier[]).reduce(
+  (acc, tier) => {
+    acc[tier] = envModelOverride(tier) ?? TIER_MODEL_DEFAULTS[tier];
+    return acc;
+  },
+  {} as Record<Tier, string>,
+);
+
 // Per-entry wall_timeout — short enough that a stuck workflow doesn't
 // hold the queue long, generous enough that real work has room. The
 // wall_timeout is enforced by activity SIGKILL (slice 7a) — stuck
@@ -648,6 +685,7 @@ async function main() {
     const { entry, effectiveTier, priorMarker } = picked;
     const tier = effectiveTier;
     const driver = TIER_DRIVER[tier];
+    const model = TIER_MODEL[tier];
     const wallTimeout = TIER_WALL_TIMEOUT_S[tier];
     const maxToolCalls = TIER_MAX_TOOL_CALLS[tier];
     const workflowId = `swarm-${sanitize(entry.id)}-${Date.now()}`;
@@ -656,6 +694,7 @@ async function main() {
       entry_id: entry.id,
       tier,
       driver,
+      model,
       wall_timeout_s: wallTimeout,
       workflow_id: workflowId,
     });
@@ -716,7 +755,13 @@ async function main() {
     // workflow.start() doesn't claim a workflow exists in Slack that
     // never actually got created.
     await notifyDispatchStart({ entry_id: entry.id, tier, driver, workflow_id: workflowId });
-    log('info', 'workflow started', { workflow_id: workflowId });
+    log('info', 'workflow started', {
+      workflow_id: workflowId,
+      tier,
+      driver,
+      model,
+      role: resolvedRole,
+    });
 
     let result: ActivityResult;
     try {
@@ -745,11 +790,29 @@ async function main() {
         {
           workflow_id: workflowId,
           result,
+          // dispatch_meta carries the (role, model, tier, driver) tuple
+          // forward to apply-workflow-result.ts and any chain-event
+          // emitters that read the envelope. This is the dispatcher's
+          // contribution to the fingerprint-tagging fix: the tuple is
+          // known at dispatch time but was previously dropped on the
+          // floor, leaving 92% of chain events in the (untagged) ×
+          // (none) bucket. role=null/system here means the entry has
+          // no role-aware skill — keep it as an explicit null rather
+          // than omitted, so downstream fingerprint hashes stay stable
+          // (lesson #287).
+          dispatch_meta: {
+            entry_id: entry.id,
+            tier,
+            driver,
+            model,
+            role: resolvedRole ?? null,
+          },
           pr_title: `swarm: ${entry.id}`,
           pr_body:
             `Picked up by the autonomous dispatcher (slice 7).\n\n` +
             `Backlog entry: \`${entry.id}\`\n` +
-            `Tier: \`${tier}\`  •  Driver: \`${driver}\`\n` +
+            `Tier: \`${tier}\`  •  Driver: \`${driver}\`  •  Model: \`${model}\`\n` +
+            `Role: \`${resolvedRole ?? 'system'}\`\n` +
             `Workflow: \`${workflowId}\`\n\n` +
             `## Entry context\n\n${entry.description.slice(0, 4000)}\n`,
         },
@@ -759,6 +822,10 @@ async function main() {
     );
     log('info', 'workflow complete', {
       workflow_id: workflowId,
+      tier,
+      driver,
+      model,
+      role: resolvedRole,
       exit_code: result.exit_code,
       duration_ms: result.duration_ms,
       worktree_present: !!result.worktree,


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `chain-fingerprint-tagging-coverage`
Tier: `T4`  •  Driver: `claude-code-headless`
Workflow: `swarm-chain-fingerprint-tagging-coverage-1777990645868`

## Entry context

Telemetry blind spot: `/mine` 2026-05-05 shows 2317 of ~2530
chain dispatches (92%) emit with empty `role`, `model`, and
fingerprint fields — the `(untagged) × (none)` row in
`fingerprint-outcomes`. The P2 fingerprint plumbing landed but
isn't reaching the dispatcher path that produces the bulk of
events; ELO leaderboard and outcomes analysis are computed against
a 8% sample.

Symptoms in the data:

- `(untagged) × (none) × (any)` ELO row: 2317 dispatches, allow%
  77.0%, 533 deny + 519 lockdown. The deny/lockdown concentration
  here is exactly the rm-rf-clone cascade — meaning we cannot
  attribute the pattern to a specific role/model from telemetry
  alone, only by reading the action_target string.
- Tagged rows total ~213 dispatches across `programmer` /
  `reviewer` / `peer-reviewer` / `comment-responder` — these have
  full ELO and allow rates. The tagged path works; the question is
  why the other path doesn't.

Fix scope:

1. **Audit the emit sites**: grep `event.jsonl` write sites in
   `dispatcher.ts`, `activity.ts`, and any direct callers in
   `libs/chain/`. Find the ones that don't pass
   `{role, model, fingerprint}` into the event constructor.
2. **Identify the source**: is it copilot-cli's bootstrap path
   (which the rm-rf-clone evidence points at)? Direct shell hooks
   bypassing the activity? An older pre-P2 dispatch route still
   live? Document each emitter and whether it has the context to
   tag.
3. **Wire the tags through**: every dispatch that goes through a
   role-aware skill must propagate `{role, model}` into the chain
   event envelope. Where the context truly isn't available (e.g.
   raw shell hook with no workflow_id), tag explicitly as
   `role=external` / `model=null` so the (untagged) bucket shrinks
   to genuinely-external events.
4. **Update `fingerprint_outcomes.py`**: rename `(untagged)` to
   `(external)` once the wiring lands; add an alarm if the
   `(external)` row exceeds 30% of dispatches, since that means a
   new untagged emitter regressed in.

Edge cases:

- Some events legitimately don't have a role (system-level
  housekeeping). Tag those `role=system` so they're separable from
  unintentional misses.
- Schema migration: `libs/chain/src/event.ts` may need a
  non-breaking field add. Make `role` and `model` optional in the
  type, required in the dispatcher path.

T3 because cross-cutting (touches dispatcher + activity + chain
schema + analysis) and the audit step is the actual work — the
code change is small once the missing emitter is identified.
This unblocks the entire P4 ELO + outcomes layer, which is
currently making decisions on an 8% sample of the chain.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-chain-fingerprint-tagging-coverage-1777990645868`
Branch: `swarm/swarm-chain-fingerprint-tagging-coverage-1777990645868`
Head: `3076e1ba`
Diff: `2 files changed, 81 insertions(+), 12 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)