### PR TITLE
auto: flip 5 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/debt-ledger.md
+++ b/docs/debt-ledger.md
@@ -116,3 +116,183 @@ description: |
   shipped in PR #134 via `agent-adversarial-review-pass`). Track
   here so progress is visible across the role taxonomy.
 ```
+
+---
+
+```yaml
+id: stale-doc-docs-archive-map-go-execution-kernel-internal-g-a01c3fad
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/archive-map.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/archive-map.md:19.
+  Reference: go/execution-kernel/internal/governance/ (no longer exists in the working tree).
+  Context: `internal/policy`, `internal/invariant`, `internal/drift`, `internal/gate`, `in…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-decisions-2026-05-03-no-g-apps-scheduler-dashboard-20199f38
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/decisions/2026-05-03-no-github-issues.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/decisions/2026-05-03-no-github-issues.md:12.
+  Reference: apps/scheduler-dashboard (no longer exists in the working tree).
+  Context: The flat-file backlog is an interim solution. The upcoming `libs/scheduler` lib…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-design-2026-05-04-bounded-go-execution-kernel-internal-b-909dc9f5
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/design/2026-05-04-bounded-context-v1.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/design/2026-05-04-bounded-context-v1.md:413.
+  Reference: go/execution-kernel/internal/blobs/ (no longer exists in the working tree).
+  Context: - [ ] `go/execution-kernel/internal/blobs/` package: `Write(payload)
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-2026-04-20-p-libs-contracts-src-chitindir-r-71cb6ab4
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/2026-04-20-phase-a-restart-notes.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/2026-04-20-phase-a-restart-notes.md:36.
+  Reference: libs/contracts/src/chitindir-resolve.test.ts (no longer exists in the working tree).
+  Context: The plan writes `libs/contracts/src/chitindir-resolve.test.ts`.
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-2026-04-22-a-docs-superpowers-specs-2026-04-416d4c68
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/2026-04-22-autonomy-v1-post-mortem.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/2026-04-22-autonomy-v1-post-mortem.md:24.
+  Reference: docs/superpowers/specs/2026-04-21-hermes-autonomy-v1-design.md (no longer exists in the working tree).
+  Context: Spec: `docs/superpowers/specs/2026-04-21-hermes-autonomy-v1-design.md`
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-2026-05-03-s-tests-backlog-entry-shape-test-6ec96526
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/2026-05-03-skill-mining-report.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/2026-05-03-skill-mining-report.md:148.
+  Reference: tests/backlog-entry-shape.test.ts (no longer exists in the working tree).
+  Context: - cat /home/red/workspace/chitin/tools/lint/tests/backlog-entry-shape.test.ts |…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-2026-05-03-s-apps-tempor-67d957e4
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/2026-05-03-skill-mining-report.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/2026-05-03-skill-mining-report.md:180.
+  Reference: apps/tempor (no longer exists in the working tree).
+  Context: - /home/red/workspace/chitin/.claude/worktrees/agent-af63538e4b495669b/apps/tem…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-2026-05-03-s-docs-observations-2026-05-02-o-c492a4d0
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/2026-05-03-skill-mining-report.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/2026-05-03-skill-mining-report.md:180.
+  Reference: docs/observations/2026-05-02-openclaw-usage- (no longer exists in the working tree).
+  Context: - /home/red/workspace/chitin/.claude/worktrees/agent-af63538e4b495669b/apps/tem…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-2026-05-03-s-apps-tempor-8df11f23
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/2026-05-03-skill-mining-report.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/2026-05-03-skill-mining-report.md:181.
+  Reference: apps/tempor (no longer exists in the working tree).
+  Context: - /home/red/workspace/chitin/.claude/worktrees/agent-af76f3397321eabbc/apps/tem…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```
+
+---
+
+```yaml
+id: stale-doc-docs-observations-research-202-docs-reference-templates-SOUL--c68668fb
+discovered_at: 2026-05-05T04:00:08.751Z
+discovered_by: swarm
+severity: low
+category: doc-debt
+file: docs/observations/research/2026-04-19-openclaw-soul-verification-suntzu.md
+status: open
+shipped_in:
+description: |
+  Stale doc reference detected at docs/observations/research/2026-04-19-openclaw-soul-verification-suntzu.md:46.
+  Reference: docs/reference/templates/SOUL.md (no longer exists in the working tree).
+  Context: The canonical bootstrap template, **`docs/reference/templates/SOUL.md`** in `op…
+  Surfaced by chitin-stale-doc-detector.timer; operator updates the doc to remove or repoint the reference.
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,3 +112,23 @@ Renamed `chitinhq/chitin → chitinhq/chitin-archive` at `v1.0.0`; archived ever
 - [reddit] [1t1judm](https://reddit.com/r/LocalLLaMA/comments/1t1judm/qwen3627b_at_72_toks_on_rtx_3090_on_windows_using/) — Qwen3.6-27B at 72 tok/s on RTX 3090 on Windows using native vLLM (no WSL, no Docker), portable launcher and installer
 - [reddit] [1t1jc1d](https://reddit.com/r/LocalLLaMA/comments/1t1jc1d/have_qwen_said_anything_about_further_qwen_36/) — Have Qwen said anything about further Qwen 3.6 models?
 - [reddit] [1t1a8gf](https://reddit.com/r/LocalLLaMA/comments/1t1a8gf/qwen3627bnvfp4_images/) — Qwen3.6-27B-NVFP4 - images
+- [arxiv] [2605.00179](https://arxiv.org/abs/2605.00179) — DEPTEX: Organization-First, Open Source Dependency Risk Monitoring
+- [arxiv] [2605.00191](https://arxiv.org/abs/2605.00191) — What Characterizes a Software Leader? Identifying Leadership Practices from Practitioners Social Media
+- [arxiv] [2605.00352](https://arxiv.org/abs/2605.00352) — Integrating Log-Based Security Analytics in Agile Workflows: A Real-World Experience Report
+- [arxiv] [2605.00382](https://arxiv.org/abs/2605.00382) — Social Bias in LLM-Generated Code: Benchmark and Mitigation
+- [arxiv] [2605.00413](https://arxiv.org/abs/2605.00413) — ClozeMaster: Fuzzing Rust Compiler by Harnessing LLMs for Infilling Masked Real Programs
+- [arxiv] [2605.00433](https://arxiv.org/abs/2605.00433) — Improving LLM Code Generation via Requirement-Aware Curriculum Reinforcement Learning
+- [arxiv] [2605.00447](https://arxiv.org/abs/2605.00447) — Think Harder and Don't Overlook Your Options: Revisiting Issue-Commit Linking with LLM-Assisted Retrieval
+- [arxiv] [2605.00472](https://arxiv.org/abs/2605.00472) — Q-ARE: An Evaluation Dataset for Query Based API Recommendation
+- [arxiv] [2605.00504](https://arxiv.org/abs/2605.00504) — EnCoDe: Energy Estimation of Source Code At Design-Time
+- [arxiv] [2605.00531](https://arxiv.org/abs/2605.00531) — From Research to Practice: An Interactive Rapid Review of Autonomous Driving System Testing in Industry
+- [arxiv] [2605.00922](https://arxiv.org/abs/2605.00922) — To Vibe Research or Not to Vibe Research? Generative AI in Qualitative Research
+- [arxiv] [2605.00932](https://arxiv.org/abs/2605.00932) — Code World Model Preparedness Report
+- [arxiv] [2605.00942](https://arxiv.org/abs/2605.00942) — PPO guided Agentic Pipeline for Adaptive Prompt Selection and Test Case Generation
+- [arxiv] [2605.01008](https://arxiv.org/abs/2605.01008) — Semantics-Based Verification of an Implemented Shor Oracle for ECDLP in Qrisp
+- [arxiv] [2605.01042](https://arxiv.org/abs/2605.01042) — ProMoTA: a model-driven framework for end-to-end traceability analysis
+- [arxiv] [2605.01104](https://arxiv.org/abs/2605.01104) — RECAP: An End-to-End Platform for Capturing, Replaying, and Analyzing AI-Assisted Programming Interactions
+- [arxiv] [2605.01159](https://arxiv.org/abs/2605.01159) — A Domain-Driven Design Simulator for Business Logic-Rich Microservice Systems
+- [arxiv] [2605.01160](https://arxiv.org/abs/2605.01160) — The Productivity-Reliability Paradox: Specification-Driven Governance for AI-Augmented Software Development
+- [arxiv] [2605.01209](https://arxiv.org/abs/2605.01209) — ClarifySTL: An Interactive LLM Agent Framework for STL Transformation through Requirements Clarification
+- [arxiv] [2605.01264](https://arxiv.org/abs/2605.01264) — FeedbackLLM: Metadata driven Multi-Agentic Language Agnostic Test Case Generator with Evolving prompt and Coverage Feedback

--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -939,7 +939,7 @@ operator's call.
 ```yaml
 id: install-kernel-restart-worker-on-ts-change
 tier: T2
-status: ready
+status: partial
 estimated_loc: 50
 blocks: []
 file: scripts/install-kernel.sh
@@ -1005,7 +1005,7 @@ issue, not a chitin source issue, so the trigger differs.
 ```yaml
 id: apply-step-exclude-openclaw-bootstrap-files
 tier: T1
-status: ready
+status: partial
 estimated_loc: 30
 blocks: []
 file: apps/temporal-worker/src/grooming/apply-workflow-result.ts, apps/temporal-worker/src/activity.ts (writeWorktreeIndex pattern), apps/temporal-worker/test/grooming-list-real-untracked.test.ts (extend)
@@ -1092,7 +1092,7 @@ the apply-step).
 ```yaml
 id: hermes-whatsapp-alarm-relay
 tier: T2
-status: ready
+status: partial
 estimated_loc: 250
 blocks: []
 file: scripts/chitin-alarm-relay.sh (new), infra/systemd/chitin-alarm-relay.service (new), infra/systemd/chitin-alarm-relay.timer (new), apps/temporal-worker/src/alarm-feeder.ts (extend with hermes hook)
@@ -5562,7 +5562,7 @@ Filed after PRs #267 (gemini-cli governance), #268 (codex_mine), #269 (universal
 ```yaml
 id: gemini-usage-feed-producer
 tier: T2
-status: ready
+status: partial
 estimated_loc: 200
 blocks: []
 file: apps/temporal-worker/src/activity.ts, python/analysis/gemini_mine.py (new)
@@ -5583,7 +5583,7 @@ Activity-layer integration: when an activity spawns gemini, pipe stderr through 
 ```yaml
 id: ollama-cloud-usage-capture
 tier: T2
-status: ready
+status: partial
 estimated_loc: 250
 blocks: []
 file: apps/temporal-worker/src/activity.ts, libs/adapters/openclaw/ (existing)

--- a/docs/swarm-lessons.md
+++ b/docs/swarm-lessons.md
@@ -13,6 +13,21 @@ Curated by:
   missed; preserved across runs (the extractor only appends, never
   rewrites existing entries)
 
+- 2026-05-04 #291 — When provisioning context for analyst drivers from generators, filter chain history by affected files; discard rows entirely if no files are known to prevent prompt bloat from unrelated signals.
+- 2026-05-04 #287 — Explicit nulls in fingerprints, not omitted fields, keep hash space stable when joining across different system layers.
+- 2026-05-04 #284 — Allowlist owned paths for destructive ops; `relative()` checks true containment—`startsWith()` prefix matching is a trap (`/tmp` vs `/tmp-backup`).
+- 2026-05-04 #283 — Signal parsing for deduplication must be pure: use stable sentinels for missing data, not generated timestamps, or idempotence breaks.
+- 2026-05-04 #282 — Envelope-class denials bypass the denials table (gate.go RecordDenial exemption), so auto-recovery must classify recent denials via JSONL parsing separately from lifetime policy checks to avoid false recovery on infrast…
+- 2026-05-04 #276 — Nx's typecheck inference breaks when tsconfig has `noEmit: true`; define explicit per-project targets with dependsOn to restore visibility.
+- 2026-05-04 #273 — Set PYTHONPATH explicitly in systemd service Environment= for repo-local Python modules; default sys.path skips subdirectories.
+- 2026-05-04 #265 — Entry IDs can contain regex metacharacters (dots, parens); `git log --grep` silently mis-matches them — scan PR subjects in-memory with word-boundary checks instead.
+- 2026-05-04 #264 — Decision branching in procedural loops escapes test coverage; extract to pure helpers with structured skip-reasons to expose gaps in the decision matrix.
+- 2026-05-04 #251 — Calendar-triggered systemd timers shouldn't add OnBootSec—it fires on both boot and the calendar schedule, almost never what operators intend; reserve OnBootSec for interval timers.
+- 2026-05-04 #238 — Nx Tree.exists() includes pending writes from the generator invocation, not just on-disk files—always validate before writing to prevent silent collision errors.
+- 2026-05-03 #195 — Verify Slack signatures uniformly across all endpoints; admin allowlist is checked post-verification only for destructive operations.
+- 2026-05-03 #192 — Every item must produce exactly one item_decision telemetry record with explicit rationale code (slotted/unslotted:reason); enables observability of all scheduling outcomes including failures.
+- 2026-05-03 #191 — Spawning chitin-kernel: errors are in stderr JSON with error.kind; parse stderr before stdout or real errors become silent parse failures.
+- 2026-05-03 #189 — nx-angular-workspace-install
 - 2026-05-02 #145 — chitin-researcher-systemd-units
 - 2026-05-02 #144 — dispatcher-respect-blocks-field
 - 2026-05-02 #143 — researcher-role-prompt-template


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- hermes-whatsapp-alarm-relay (#342)
- apply-step-exclude-openclaw-bootstrap-files (#335)
- install-kernel-restart-worker-on-ts-change (#333)
- ollama-cloud-usage-capture (#325)
- gemini-usage-feed-producer (#323)

If any of these are wrong, revert + investigate why the title matched without the work shipping.