### PR TITLE
auto: flip 3 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -1167,7 +1167,7 @@ fresh checkout can wire it once.
 ```yaml
 id: comment-responder-executor-hard-stop-rm-rf-clone
 tier: T2
-status: ready
+status: partial
 estimated_loc: 50
 blocks: []
 file: apps/temporal-worker/src/skills/comment-responder.ts, apps/temporal-worker/test/comment-responder.test.ts
@@ -1346,7 +1346,7 @@ across roles/models, not an 8% sample.
 ```yaml
 id: chain-fingerprint-tagging-coverage
 tier: T3
-status: ready
+status: partial
 estimated_loc: 250
 blocks: []
 file: apps/temporal-worker/src/dispatcher.ts, apps/temporal-worker/src/activity.ts, libs/chain/src/event.ts, python/analysis/fingerprint_outcomes.py
@@ -5956,7 +5956,7 @@ needs an explicit signal). When unset, fingerprint records `none`.
 ```yaml
 id: chain-fingerprint-tagging
 tier: T2
-status: ready
+status: partial
 estimated_loc: 250
 blocks: ['routing-fingerprint-helper']
 file: go/execution-kernel/internal/gov/decision.go, go/execution-kernel/cmd/chitin-kernel/hook.go, apps/temporal-worker/src/activity.ts (writeback)


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- chain-fingerprint-tagging-coverage (#344)
- chain-fingerprint-tagging (#344)
- comment-responder-executor-hard-stop-rm-rf-clone (#343)

If any of these are wrong, revert + investigate why the title matched without the work shipping.