### PR TITLE
auto: flip 1 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -1288,7 +1288,7 @@ fires the new kernel rule with a `rewrite` outcome before
 ```yaml
 id: kernel-chain-event-read-dispatch-meta-for-tagging
 tier: T3
-status: ready
+status: partial
 estimated_loc: 200
 blocks: []
 file: go/execution-kernel/internal/governance/, libs/chain/src/event.ts, python/analysis/fingerprint_outcomes.py


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- kernel-chain-event-read-dispatch-meta-for-tagging (#346)

If any of these are wrong, revert + investigate why the title matched without the work shipping.