### PR TITLE
feat(router): RouteFor decision function (gate-escalation step 2)

### DIFF
--- a/go/execution-kernel/internal/router/route_for.go
+++ b/go/execution-kernel/internal/router/route_for.go
@@ -1,0 +1,114 @@
+package router
+
+// routeFor — peer-escalation routing decision.
+//
+// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 2 of 6):
+// pure function from (signal, severity, context, policy) → RouteDecision.
+// NO peer spawning yet (that's step 3); NO live quota integration yet
+// (that's step 6 — observed dimensions feed back). This step ships
+// the deterministic decision engine reachable from tests but not wired
+// into the gate.
+//
+// Contract:
+//   - First rule whose Signal matches `req.Signal` wins. Severity is
+//     captured for telemetry but does NOT participate in matching yet
+//     (string-only, no comparator parser).
+//   - Rule's Route is looked up in policy.Routes; first candidate is
+//     returned (FUTURE step 6: walk by quota state + observed
+//     compatibility, not just first).
+//   - No matching rule → ErrNoRuleMatched. Caller falls back to the
+//     existing kernel deny+escalation_requested behavior.
+//   - No candidates in route → ErrRouteEmpty. Validation should have
+//     prevented this; treat as a config bug worth logging.
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrNoRuleMatched = errors.New("no escalation rule matched the signal")
+	ErrRouteEmpty    = errors.New("matched route has no candidates")
+	ErrPolicyOff     = errors.New("escalation policy is disabled")
+)
+
+// RouteRequest is the per-tool-call input to RouteFor.
+type RouteRequest struct {
+	// Signal that triggered the escalation: "floundering" |
+	// "blast_radius" | "drift" | "advisor_takeover".
+	Signal string
+
+	// Human-readable severity string (recorded in telemetry; not yet
+	// matched against rule.Severity programmatically — string-only
+	// today, comparator parser is a future commit).
+	Severity string
+
+	// ToolCall is the worker's pending tool-call payload. Opaque to
+	// RouteFor today; passed through to spawnPeer (step 3) which
+	// wraps it for the peer CLI's prompt.
+	ToolCall map[string]any
+
+	// Recent chain events for context. Same — opaque to RouteFor;
+	// wrapped by spawnPeer.
+	ChainTail []map[string]any
+
+	// Worker's workflow_id, for Provenance attribution downstream.
+	WorkerWorkflowID string
+}
+
+// RouteDecision is what RouteFor returns when a rule matches.
+type RouteDecision struct {
+	// Rule that matched. Useful for telemetry ("rule X fired Y times
+	// in the last hour") and for the future rate-limiter (rule.MaxPerHour).
+	Rule RoutingRule
+
+	// Picked candidate from rule's route (the head of the candidate
+	// list today; quota-aware walk is step 6).
+	Candidate Candidate
+
+	// One-line WHY this candidate won. Always populated for
+	// telemetry — "rule=floundering-loop route=patch_quality
+	// candidate=copilot/gpt-5.4 (head of route, quota check deferred)".
+	Rationale string
+}
+
+// RouteFor maps an escalation signal to a (driver, model) candidate
+// using the operator's policy. Pure function — no I/O, no clocks, no
+// subprocess. Safe to call from inside the gate hot path.
+func RouteFor(req RouteRequest, policy RoutesPolicy) (RouteDecision, error) {
+	if !policy.Enabled {
+		return RouteDecision{}, ErrPolicyOff
+	}
+	matchedRule, ok := findFirstMatchingRule(req.Signal, policy.Rules)
+	if !ok {
+		return RouteDecision{}, fmt.Errorf("%w: signal=%q", ErrNoRuleMatched, req.Signal)
+	}
+	candidates, ok := policy.Routes[matchedRule.Route]
+	if !ok || len(candidates) == 0 {
+		return RouteDecision{}, fmt.Errorf("%w: route=%q (rule=%q)",
+			ErrRouteEmpty, matchedRule.Route, matchedRule.Name)
+	}
+	picked := candidates[0]
+	return RouteDecision{
+		Rule:      matchedRule,
+		Candidate: picked,
+		Rationale: fmt.Sprintf(
+			"rule=%s signal=%s route=%s candidate=%s/%s (head of route; quota-aware walk deferred to step 6)",
+			matchedRule.Name, req.Signal, matchedRule.Route,
+			picked.Driver, picked.Model,
+		),
+	}, nil
+}
+
+// findFirstMatchingRule walks rules in declared order. First rule whose
+// Signal matches wins. Stable behavior — operator can rely on rule
+// ordering for precedence (e.g., put a more-specific blast_radius
+// rule before a catch-all drift rule).
+func findFirstMatchingRule(signal string, rules []RoutingRule) (RoutingRule, bool) {
+	for _, r := range rules {
+		if r.Signal == signal {
+			return r, true
+		}
+	}
+	return RoutingRule{}, false
+}

--- a/go/execution-kernel/internal/router/route_for_test.go
+++ b/go/execution-kernel/internal/router/route_for_test.go
@@ -1,0 +1,155 @@
+package router
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func samplePolicy() RoutesPolicy {
+	return RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules: []RoutingRule{
+			{Name: "floundering-loop", Signal: "floundering", Severity: ">= 2 loops", Route: "patch_quality", MaxPerHour: 10},
+			{Name: "blast-radius-large", Signal: "blast_radius", Severity: "> 25 files", Route: "reasoning_depth", MaxPerHour: 5},
+			{Name: "drift-takeover", Signal: "drift", Severity: "advisor.verdict=takeover", Route: "reasoning_depth", MaxPerHour: 3},
+		},
+		Routes: map[string][]Candidate{
+			"patch_quality": {
+				{Driver: "copilot", Model: "gpt-5.4"},
+				{Driver: "claude", Model: "claude-opus-4-6"},
+			},
+			"reasoning_depth": {
+				{Driver: "claude", Model: "claude-opus-4-7"},
+				{Driver: "copilot", Model: "gpt-5.5"},
+			},
+		},
+	}
+}
+
+func TestRouteFor_FlounderingMatch(t *testing.T) {
+	d, err := RouteFor(RouteRequest{Signal: "floundering"}, samplePolicy())
+	if err != nil {
+		t.Fatalf("expected match, got %v", err)
+	}
+	if d.Rule.Name != "floundering-loop" {
+		t.Errorf("rule: got %q want floundering-loop", d.Rule.Name)
+	}
+	if d.Candidate.Driver != "copilot" || d.Candidate.Model != "gpt-5.4" {
+		t.Errorf("candidate: got %s/%s want copilot/gpt-5.4", d.Candidate.Driver, d.Candidate.Model)
+	}
+	if !strings.Contains(d.Rationale, "patch_quality") {
+		t.Errorf("rationale should reference matched route; got: %s", d.Rationale)
+	}
+}
+
+func TestRouteFor_BlastRadiusMatch(t *testing.T) {
+	d, err := RouteFor(RouteRequest{Signal: "blast_radius"}, samplePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Candidate.Driver != "claude" || d.Candidate.Model != "claude-opus-4-7" {
+		t.Errorf("expected reasoning_depth head; got %s/%s", d.Candidate.Driver, d.Candidate.Model)
+	}
+}
+
+func TestRouteFor_DriftMatch(t *testing.T) {
+	d, err := RouteFor(RouteRequest{Signal: "drift"}, samplePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Rule.Name != "drift-takeover" {
+		t.Errorf("expected drift-takeover; got %q", d.Rule.Name)
+	}
+}
+
+func TestRouteFor_NoRuleMatched(t *testing.T) {
+	_, err := RouteFor(RouteRequest{Signal: "telepathy"}, samplePolicy())
+	if !errors.Is(err, ErrNoRuleMatched) {
+		t.Errorf("expected ErrNoRuleMatched; got %v", err)
+	}
+}
+
+func TestRouteFor_RuleOrderingDeterminesPrecedence(t *testing.T) {
+	// Two rules for the same signal — first one wins.
+	policy := RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules: []RoutingRule{
+			{Name: "floundering-cheap", Signal: "floundering", Route: "cheap"},
+			{Name: "floundering-deep", Signal: "floundering", Route: "deep"},
+		},
+		Routes: map[string][]Candidate{
+			"cheap": {{Driver: "copilot", Model: "gpt-4o-mini"}},
+			"deep":  {{Driver: "claude", Model: "claude-opus-4-7"}},
+		},
+	}
+	d, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Rule.Name != "floundering-cheap" {
+		t.Errorf("first-rule precedence broken: got %q want floundering-cheap", d.Rule.Name)
+	}
+}
+
+func TestRouteFor_PolicyDisabled(t *testing.T) {
+	policy := samplePolicy()
+	policy.Enabled = false
+	_, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if !errors.Is(err, ErrPolicyOff) {
+		t.Errorf("disabled policy should return ErrPolicyOff; got %v", err)
+	}
+}
+
+func TestRouteFor_RouteRefNotInRoutesMap(t *testing.T) {
+	// Validation should catch this in LoadRoutesPolicy, but RouteFor
+	// must also tolerate it (fail-open for the gate, log the bug).
+	policy := RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules: []RoutingRule{
+			{Name: "x", Signal: "floundering", Route: "missing"},
+		},
+		Routes: map[string][]Candidate{
+			"other": {{Driver: "copilot", Model: "gpt-4.1"}},
+		},
+	}
+	_, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if !errors.Is(err, ErrRouteEmpty) {
+		t.Errorf("expected ErrRouteEmpty; got %v", err)
+	}
+}
+
+func TestRouteFor_RoutePresentButEmpty(t *testing.T) {
+	policy := RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules:   []RoutingRule{{Name: "x", Signal: "floundering", Route: "empty"}},
+		Routes:  map[string][]Candidate{"empty": {}},
+	}
+	_, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if !errors.Is(err, ErrRouteEmpty) {
+		t.Errorf("expected ErrRouteEmpty; got %v", err)
+	}
+}
+
+func TestRouteFor_FirstCandidateWins(t *testing.T) {
+	// Until step 6 (quota-aware walk), the head of the candidate
+	// list always wins. Lock that in so step 6 is a deliberate
+	// behavior change.
+	policy := samplePolicy()
+	d, _ := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	wantHead := policy.Routes["patch_quality"][0]
+	if d.Candidate != wantHead {
+		t.Errorf("step 2 must always pick chain head; got %v want %v", d.Candidate, wantHead)
+	}
+}
+
+func TestRouteFor_RationaleNonEmpty(t *testing.T) {
+	d, _ := RouteFor(RouteRequest{Signal: "floundering"}, samplePolicy())
+	if d.Rationale == "" {
+		t.Error("rationale must always be populated for telemetry")
+	}
+}


### PR DESCRIPTION
## Summary

Step 2 of 6 from \`docs/design/2026-05-06-kernel-gate-escalation.md\`. Pure deterministic function from \`(signal, severity, context, policy)\` → \`RouteDecision\`.

**No peer spawning** (step 3); **no live quota integration** (step 6). Reachable from tests, not yet wired into the gate. Stacked on #349 (depends on the schema/types).

## Contract

- First rule whose \`Signal\` matches \`req.Signal\` wins (declared order = precedence)
- Rule's \`Route\` looked up in \`policy.Routes\`; first candidate returned
  - Step 6 will replace this with quota-aware walk
- No matching rule → \`ErrNoRuleMatched\` (caller falls back to today's behavior)
- No candidates → \`ErrRouteEmpty\` (config bug; defensive even though validator catches it)
- Policy disabled → \`ErrPolicyOff\`

\`Severity\` is captured for telemetry but does NOT participate in matching yet — string-only field today, comparator parser is a future commit.

## Test plan

- [x] 10 tests covering each signal, no-match, rule order precedence, policy disabled, route ref validation, empty candidate, FirstCandidateWins (locked so step 6 is deliberate), rationale always populated
- [x] go test ./internal/router/ -run RouteFor — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)