### PR TITLE
swarm: rename-local-cloud-driver-misnomer

### DIFF
--- a/chitin-routes.example.yaml
+++ b/chitin-routes.example.yaml
@@ -1,0 +1,71 @@
+# chitin-routes.yaml — peer-escalation routing policy
+#
+# Sidecar to chitin.yaml. Loaded by chitin-kernel router on every gate
+# evaluation (when `enabled: true`). Operator declares:
+#   - Rules: which signal+severity triggers a peer-escalation
+#   - Routes: which (driver, model) candidates serve each named route
+#
+# Per docs/design/2026-05-06-kernel-gate-escalation.md.
+#
+# Copy this file to `chitin-routes.yaml` (no `.example` suffix) at the
+# same level as chitin.yaml to enable. The kernel walks parent dirs
+# from cwd to find it, identical to chitin.yaml lookup.
+
+version: 1
+
+# Default off. Until set true, the kernel loads + validates this file
+# but does NOT spawn peer CLIs from inside the gate — falls back to
+# today's "set escalation_requested=true and let the runner handle it"
+# behavior.
+enabled: false
+
+# Per-spawn safety knobs.
+spawn_timeout_seconds: 60
+max_concurrent_peers: 1
+
+# Rules — when this signal at this severity fires, look up `route` in
+# the Routes section and spawn its first quota-affording candidate.
+rules:
+  - name: floundering-loop
+    signal: floundering
+    severity: ">= 2 loops"
+    route: patch_quality
+    max_per_hour: 10
+
+  - name: blast-radius-large
+    signal: blast_radius
+    severity: "> 25 files"
+    route: reasoning_depth
+    max_per_hour: 5
+
+  - name: drift-takeover
+    signal: drift
+    severity: "advisor.verdict=takeover"
+    route: reasoning_depth
+    max_per_hour: 3
+
+# Routes — named optimization category → ordered candidate list.
+# routeFor() walks candidates in order; first one with quota wins.
+# Names align with the conformance-substrate doc's optimization
+# targets (cheap+stable, patch_quality, reasoning_depth, recovery,
+# latency).
+routes:
+  cheap+stable:
+    - { driver: copilot, model: gpt-4.1 }            # x0 (free on Pro/Enterprise)
+    - { driver: gemini, model: gemini-2.5-flash }    # 1/1500 daily on AI Pro
+
+  patch_quality:
+    - { driver: copilot, model: gpt-5.4 }            # terminal-bench-2.0 81.8%
+    - { driver: claude, model: claude-opus-4-6 }     # Max sub absorbs
+
+  reasoning_depth:
+    - { driver: claude, model: claude-opus-4-7 }     # Max sub absorbs
+    - { driver: copilot, model: gpt-5.5 }            # x7.5 — last resort
+
+  recovery:
+    - { driver: copilot, model: claude-haiku-4.5 }   # x0.33
+    - { driver: copilot, model: gpt-5.4-mini }       # x0.33
+
+  latency:
+    - { driver: copilot, model: gpt-4o-mini }        # x0 + fast
+    - { driver: gemini, model: gemini-2.5-flash-lite }

--- a/docs/design/2026-05-06-kernel-gate-escalation.md
+++ b/docs/design/2026-05-06-kernel-gate-escalation.md
@@ -16,6 +16,21 @@ the kernel synchronously spawns the next-tier CLI (claude-code,
 copilot, etc.), captures its result, and returns that as the tool
 call's response. The agent never knows it was escalated.
 
+## Core invariant (operator decision, 2026-05-06)
+
+> Kanban chooses work.
+> Hermes attempts execution.
+> Chitin decides whether Hermes is allowed to continue or must be
+> replaced/escalated.
+> Peer execution is a kernel-mediated substitution, not a dispatcher
+> decision.
+
+This is cleaner than v1 because routing, enforcement, telemetry, and
+conformance all collapse into one authority boundary. Any future
+behavior that violates the invariant — hermes self-escalating,
+dispatcher picking peer CLIs, peer spawning peer — is a bug, not a
+feature.
+
 ## Why the existing architecture missed this
 
 `apps/runner/src/dispatcher.ts` has a static `TIER_DRIVER_DEFAULTS`
@@ -178,40 +193,110 @@ Per-driver spawn templates (kernel-side):
 - `claude-code-headless`: `claude -p --model <model> --print` with
   the tool call payload + chain tail piped via stdin as a structured
   prompt. Output captured from stdout.
-- `copilot`: `gh copilot suggest -t shell` for shell-shaped tools,
-  Copilot Chat API for code-shaped tools. Token from `gh auth token`.
+- `copilot`: Copilot Chat API for code-shaped tools, `gh copilot
+  suggest -t shell` for shell-shaped tools. Token from `gh auth token`.
 - `codex`: `codex exec --model <model> -p '<prompt>'`. Output captured.
 - `gemini`: `gemini -p '<prompt>' --model <model>`. Output captured.
 
+**Working directory** (operator decision, 2026-05-06): peer always
+runs in a **fresh worktree**, not the worker's dirty tree. Isolation
++ reproducibility + clear audit boundary. Snapshot-and-diff-apply
+deferred — adds complexity too early.
+
+**Recursive escalation guard** (operator decision, 2026-05-06): the
+spawn env always carries `CHITIN_NO_ESCALATE=1`. Peer can be gated,
+denied, logged, advised — but **cannot spawn another peer**. Without
+this guard, peer-spawns-peer creates recursive arbitration with
+unbounded cost and weird deadlocks.
+
 Spawn timeout = `escalation.spawn_timeout_seconds` (default 60s).
-Output truncated to fit tool-call response size limit. Telemetry
-chain event records: which CLI spawned, latency, exit code,
-quota-after-call.
 
-## Migration path
+## Peer output normalization — ToolCallResult, not raw stdout
 
-Incremental, reversible:
+(Operator design correction, 2026-05-06): "Peer's output IS the tool
+call result" was right but only AFTER normalization. The kernel wraps
+peer output as a structured `ToolCallResult` with full provenance, NOT
+raw CLI stdout. This preserves replay, audit, and future scoring
+(without it the conformance loop can't attribute outcomes back to the
+peer that produced them).
 
-1. **Schema lands** — add `escalation:` to chitin.yaml schema, no
-   behavior change yet. Operators can declare policies; nothing
-   reads them.
-2. **routeFor() lands** — Go kernel adds the function + policy
-   loader; reachable from tests but not wired into the gate.
-3. **In-gate spawn lands behind a flag** — `escalation.enabled: true`
-   in chitin.yaml turns it on; default off. Operator opt-in to test.
-4. **dispatcher.ts trims** — once in-gate is proven, remove the
-   tier-to-driver map from dispatcher (always spawn hermes). Tier
-   metadata stays on cards for telemetry/grouping but no longer
-   drives CLI selection.
-5. **Conformance substrate joins** — the routing-effectiveness
-   dimension (already shipped per `2026-05-05-conformance-substrate.md`)
-   gives routeFor() observed-vs-declared compatibility data per
-   (driver, model). Closes the loop: matrix data → routing → measure
-   → re-update matrix.
+```go
+type ToolCallResult struct {
+    // The actual content the worker (hermes) sees in place of its
+    // original tool result. Shape matches whatever the original tool
+    // call expected (string, JSON, file diff, etc.).
+    Content        any
 
-Each step is independently shippable. Steps 1-2 are pure additions.
-Step 3 is opt-in. Step 4 removes code. Step 5 is the conformance
-flywheel.
+    // Provenance — required, not optional. Every escalated result
+    // carries this so /mine + conformance extractors can join.
+    Provenance struct {
+        EscalationID    string         // unique per peer-spawn
+        WorkerWorkflowID string        // hermes' workflow_id
+        TriggerSignal   string         // "floundering" / "blast_radius" / "drift"
+        Severity        string         // human-readable
+        Route           string         // "patch_quality" etc.
+        Candidate       struct {
+            Driver string
+            Model  string
+        }
+        SpawnedAt       time.Time
+        DurationMs      int64
+        PeerExitCode    int
+        PeerQuotaImpact QuotaImpact    // what this cost on which sub
+    }
+
+    // Raw peer output for replay — never shown to the worker, but
+    // kept in the chain so audits can re-derive Content.
+    RawPeerStdout   string
+    RawPeerStderr   string
+}
+```
+
+Telemetry: every peer spawn writes ONE chain event of type
+`peer_escalation` carrying the full Provenance + RawPeer* fields.
+The worker's chain only sees the normalized Content. Two-layer audit
+trail: worker's view of "what happened in this tool call" + chain's
+view of "what really happened underneath."
+
+## Migration path (operator-approved sequence, 2026-05-06)
+
+Six incremental, reversible steps. Each independently shippable.
+
+1. **Schema only** — add `escalation:` block to chitin.yaml schema +
+   loader. No behavior change. Operators can declare policies;
+   nothing reads them yet.
+
+2. **routeFor(signal, severity, context) only** — Go kernel adds the
+   function + policy walker; reachable from tests but not wired into
+   the gate. Returns RouteDecision struct purely; no spawn yet.
+
+3. **spawnPeer(route) behind flag** — kernel function that ACTUALLY
+   spawns the peer CLI (fresh worktree, CHITIN_NO_ESCALATE=1 env,
+   per-driver template) and normalizes its output into ToolCallResult.
+   Reachable from tests but no gate path calls it. Default flag off.
+
+4. **Wire in-gate escalation path** — `escalation.enabled: true` in
+   chitin.yaml turns it on; default off. The gate's existing
+   "heuristic + advisor → escalation_requested" branch now also
+   calls `routeFor()` + `spawnPeer()` and returns the normalized
+   result. Operator opt-in to test.
+
+5. **Remove dispatcher CLI selection** — once in-gate is proven,
+   delete `TIER_DRIVER_DEFAULTS` + `pickTierDriver` + the
+   `CHITIN_TIER_DRIVER_T<N>` env overrides from
+   `apps/runner/src/dispatcher.ts`. Dispatcher trims to "always spawn
+   hermes." Tier stays as a card metadata field — kernel-side hint,
+   not CLI selector.
+
+6. **Conformance feedback loop** — the routing-effectiveness
+   dimension (shipped in `2026-05-05-conformance-substrate.md` §161)
+   gives routeFor() observed-vs-declared compatibility per (driver,
+   model). RouteDecision starts factoring observed data, not just
+   leaderboard scores. Closes the loop: matrix → routing → measure →
+   re-update matrix.
+
+Steps 1-3 are pure additions. Step 4 is opt-in. Step 5 removes code.
+Step 6 is the conformance flywheel.
 
 ## What the dispatcher.ts looks like after migration
 
@@ -232,28 +317,32 @@ env overrides — all removed. The `tier` field on backlog cards
 becomes a hint to the kernel ("this card is bulk T0 work, prefer
 cheaper escalation routes") not a driver-selection key.
 
-## Open questions
+## Decisions locked (operator, 2026-05-06)
 
-1. **Peer CLI working directory.** Does the spawned peer get a fresh
-   worktree (claude-code-headless requires one), the worker's
-   worktree, or a snapshot? Lean: snapshot the worker's worktree
-   into a sibling temp dir, peer mutates the temp dir, kernel
-   diff-applies the result back to the worker's worktree. Avoids
-   double-edit conflicts.
-2. **Cost attribution.** The peer CLI's quota burn happens during
-   the worker's session. Telemetry chain event must attribute it to
-   the worker's workflow_id, not a separate "escalation workflow."
-3. **Recursive escalation guard.** Peer CLI's tool calls also hit
-   chitin's gate. Should the gate's escalation logic short-circuit
-   when it detects "I'm already inside a peer-spawned context"?
-   Lean: yes, set CHITIN_NO_ESCALATE=1 in the spawned env so peer
-   gates allow/deny only.
-4. **Hermes' own internal advisor.** Hermes has its own
-   model-switching advisor (per its profile system). Does that fire
-   BEFORE chitin's kernel signal, or after, or both? Risk of
-   double-routing. Lean: disable hermes' internal advisor when
-   running under chitin (set hermes profile to fixed glm-flash, no
-   fallback) — chitin's kernel is the only escalation authority.
+These were the open questions from the first draft. All resolved
+before any code lands.
+
+1. **Peer working directory: fresh worktree.** Best default. Don't
+   run peer in worker's dirty tree. Snapshot+diff is elegant but adds
+   complexity too early. Fresh worktree gives isolation,
+   reproducibility, and clearer audit boundaries.
+
+2. **Cost attribution: worker workflow_id + child escalation_id.**
+   Parent workflow owns the burn; peer needs `escalation_id`,
+   `route`, `candidate`, `trigger_signal` for analysis. Without this
+   the conformance feedback gets muddy. Implemented as the
+   ToolCallResult.Provenance struct above.
+
+3. **Recursive escalation guard: CHITIN_NO_ESCALATE=1 mandatory.**
+   Peer can still be gated, denied, logged, advised — but cannot
+   spawn another peer. Otherwise: recursive agent arbitration with
+   unbounded cost and weird deadlocks.
+
+4. **Hermes advisor under chitin: disabled / non-authoritative.**
+   Chitin is the single escalation authority. Hermes can emit local
+   hints (telemetry, flagging) but cannot independently escalate,
+   reroute, or mutate policy decisions. Otherwise multi-authority
+   ambiguity reintroduced.
 
 ## Out of scope
 

--- a/docs/design/2026-05-06-kernel-gate-escalation.md
+++ b/docs/design/2026-05-06-kernel-gate-escalation.md
@@ -1,0 +1,283 @@
+# Kernel-gate escalation: chitin as the in-tool-call router
+
+Status: design.
+Companion to / partial supersession of:
+  - `2026-05-05-conformance-substrate.md` (the routing query API §148)
+  - `apps/runner/src/dispatcher.ts` (the static TIER_DRIVER map)
+
+Date: 2026-05-06
+
+## What this is, in one sentence
+
+The chitin kernel sits in every tool call. So escalation isn't a
+separate dispatch event — it's a **side effect inside the tool-call
+gate**: when heuristics + advisor say "this needs a stronger model,"
+the kernel synchronously spawns the next-tier CLI (claude-code,
+copilot, etc.), captures its result, and returns that as the tool
+call's response. The agent never knows it was escalated.
+
+## Why the existing architecture missed this
+
+`apps/runner/src/dispatcher.ts` has a static `TIER_DRIVER_DEFAULTS`
+map: T0→openclaw, T2→copilot, T4→claude-code-headless. Each tier
+maps to one driver. Escalation today means **chitin's runner
+re-dispatches the whole task** at the next tier with a different CLI.
+That's a coarse boundary — entire workflow restarts to switch model.
+
+The kernel router (`go/execution-kernel/internal/router/`) already
+runs heuristics (floundering, blast_radius, drift) + an advisor
+(`claude -p` consulting opus) on every tool call. Today it just sets
+`escalation_requested: true` and the downstream runner picks that up
+on the next tick. The kernel could **synchronously act on the
+escalation right there**, but it doesn't.
+
+The user's insight: **chitin's gate IS the side-effect surface**.
+A tool call comes in, the gate runs, the gate can do anything (deny,
+allow, or **spawn a peer CLI and return its output as the result**).
+This collapses three things I was treating as separate:
+
+1. Tier-to-driver map (dispatcher.ts) → kernel escalation policy
+2. Per-tier fallback chains → kernel "if X fails escalate to Y" rules
+3. Capability-vector routing (`routeFor`) → kernel-side runtime decision
+
+All three are the same function: *given a signal + current quota +
+matrix data, pick which CLI to spawn for this tool call.*
+
+## The architecture
+
+```
+Hermes kanban → spawn hermes (always, glm-flash)
+       ↓
+Hermes makes tool call
+       ↓
+chitin-router-hook intercepts
+       ↓
+Go kernel:
+   1. deterministic policy check  (today)
+   2. heuristics (floundering / blast_radius / drift)  (today)
+   3. advisor (claude -p consultation) if heuristic fires  (today)
+   4. If verdict=takeover OR escalate=true:
+        a. Look up escalation policy in chitin.yaml
+        b. Pick peer CLI via routeFor(signal, context, quota)  (NEW)
+        c. Synchronously spawn peer CLI with tool-call context  (NEW)
+        d. Capture peer's output  (NEW)
+        e. Return peer's result as the tool call response  (NEW)
+   5. Else → emit kernel verdict (allow / deny / nudge)  (today)
+       ↓
+Hermes receives tool result
+       ↓
+[hermes never knows it was escalated]
+```
+
+## Invariants
+
+A few claims this design REQUIRES to hold:
+
+1. **The gate is the only escalation point.** No other path
+   (dispatcher tick, kanban poll, manual intervention) is needed for
+   per-tool-call escalation. Cross-task escalation (whole workflow
+   re-tries) remains the runner's job.
+2. **Escalation is synchronous within the gate.** The hermes worker
+   blocks on its tool call until the peer CLI returns. No async
+   handoff, no queue, no resume token. Worst-case latency = peer
+   CLI's wall time + small overhead.
+3. **Peer CLI gets enough context to act.** The tool call payload +
+   recent chain events + the heuristic that fired + the advisor's
+   nudge are passed in the spawn. Peer's response is treated as the
+   ground-truth tool result.
+4. **One peer CLI per gate event.** No nested escalation. If the peer
+   itself flounders, that's a future-tick concern, not a recursive
+   in-gate problem.
+
+## The escalation policy schema (chitin.yaml)
+
+```yaml
+escalation:
+  # Map (signal, severity) → which CLI to spawn. Operator-extensible.
+  # Each entry's `route` is the routeFor() target — a named
+  # optimization category from the conformance-substrate doc:
+  # cheap+stable / patch_quality / recovery / reasoning_depth / latency.
+  rules:
+    - signal: floundering
+      severity: ">= 2 loops"
+      route: patch_quality
+      max_per_hour: 10                    # rate-limit per quota cap
+    - signal: blast_radius
+      severity: "> 25 files"
+      route: reasoning_depth
+      max_per_hour: 5
+    - signal: drift
+      severity: "advisor.verdict=takeover"
+      route: reasoning_depth
+      max_per_hour: 3
+
+  # Named optimization categories → ordered list of (driver, model)
+  # candidates. routeFor() walks this list filtering by quota
+  # availability + benchmark score.
+  routes:
+    cheap+stable:
+      - { driver: copilot, model: gpt-4.1 }            # x0 (free on Enterprise)
+      - { driver: gemini, model: gemini-2.5-flash }    # 1/1500 daily
+    patch_quality:
+      - { driver: copilot, model: gpt-5.4 }            # 81.8% terminal-bench
+      - { driver: claude, model: claude-opus-4-6 }     # Max sub absorbs
+    reasoning_depth:
+      - { driver: claude, model: claude-opus-4-7 }
+      - { driver: copilot, model: gpt-5.5 }            # x7.5, last resort
+    recovery:
+      - { driver: copilot, model: claude-haiku-4.5 }   # x0.33
+      - { driver: copilot, model: gpt-5.4-mini }
+    latency:
+      - { driver: copilot, model: gpt-4o-mini }        # FREE + fast
+      - { driver: gemini, model: gemini-2.5-flash-lite }
+```
+
+The matrix data we've built (operator_cost_band + benchmark scores)
+becomes the **default** when no operator override exists. Routes
+walk the candidate list and pick the first one that fits remaining
+quota. That's the runtime equivalent of "the matrix told us which
+to use."
+
+## The kernel side: routeFor()
+
+```go
+type RouteRequest struct {
+    Signal       string             // "floundering" | "blast_radius" | "drift"
+    Severity     string             // human-readable severity description
+    ToolCall     ToolCallPayload
+    ChainTail    []ChainEvent       // last N events for context
+    QuotaState   QuotaSnapshot      // live remaining quota per driver
+}
+
+type RouteDecision struct {
+    Driver      string
+    Model       string
+    Rationale   string             // one-line WHY this candidate won
+    QuotaCost   QuotaImpact        // estimated impact on each affected sub
+}
+
+func RouteFor(req RouteRequest, policy EscalationPolicy) (RouteDecision, error)
+```
+
+The function:
+1. Looks up the matching `escalation.rules` entry by signal + severity
+2. Walks `escalation.routes[matched.route]` candidates in order
+3. For each candidate, checks QuotaState — does it have headroom?
+4. Returns the first candidate that fits, with rationale logged
+5. If NONE fit (all quota exhausted), returns an error → kernel
+   falls back to the heuristic-only deny verdict
+
+QuotaState is populated by reading the operator_matrix.json
+(refreshed per session) plus live polling for fast-changing quotas
+(copilot Premium Interactions changes per call).
+
+## In-gate spawn — what's passed to the peer CLI
+
+Per-driver spawn templates (kernel-side):
+
+- `claude-code-headless`: `claude -p --model <model> --print` with
+  the tool call payload + chain tail piped via stdin as a structured
+  prompt. Output captured from stdout.
+- `copilot`: `gh copilot suggest -t shell` for shell-shaped tools,
+  Copilot Chat API for code-shaped tools. Token from `gh auth token`.
+- `codex`: `codex exec --model <model> -p '<prompt>'`. Output captured.
+- `gemini`: `gemini -p '<prompt>' --model <model>`. Output captured.
+
+Spawn timeout = `escalation.spawn_timeout_seconds` (default 60s).
+Output truncated to fit tool-call response size limit. Telemetry
+chain event records: which CLI spawned, latency, exit code,
+quota-after-call.
+
+## Migration path
+
+Incremental, reversible:
+
+1. **Schema lands** — add `escalation:` to chitin.yaml schema, no
+   behavior change yet. Operators can declare policies; nothing
+   reads them.
+2. **routeFor() lands** — Go kernel adds the function + policy
+   loader; reachable from tests but not wired into the gate.
+3. **In-gate spawn lands behind a flag** — `escalation.enabled: true`
+   in chitin.yaml turns it on; default off. Operator opt-in to test.
+4. **dispatcher.ts trims** — once in-gate is proven, remove the
+   tier-to-driver map from dispatcher (always spawn hermes). Tier
+   metadata stays on cards for telemetry/grouping but no longer
+   drives CLI selection.
+5. **Conformance substrate joins** — the routing-effectiveness
+   dimension (already shipped per `2026-05-05-conformance-substrate.md`)
+   gives routeFor() observed-vs-declared compatibility data per
+   (driver, model). Closes the loop: matrix data → routing → measure
+   → re-update matrix.
+
+Each step is independently shippable. Steps 1-2 are pure additions.
+Step 3 is opt-in. Step 4 removes code. Step 5 is the conformance
+flywheel.
+
+## What the dispatcher.ts looks like after migration
+
+```typescript
+// Before: pick driver per tier, spawn that CLI
+const driver = TIER_DRIVER[entry.tier];
+const result = await spawnDriver(driver, entry.tier, model, ...);
+
+// After: always spawn hermes; kernel handles in-tool-call escalation
+const result = await spawnHermes(entry, ...);
+// Hermes runs glm-flash, makes tool calls, kernel transparently
+// escalates per chitin.yaml policy. result.escalation_log captures
+// which peer CLIs the kernel invoked during the run.
+```
+
+`TIER_DRIVER_DEFAULTS`, `pickTierDriver`, `CHITIN_TIER_DRIVER_T<N>`
+env overrides — all removed. The `tier` field on backlog cards
+becomes a hint to the kernel ("this card is bulk T0 work, prefer
+cheaper escalation routes") not a driver-selection key.
+
+## Open questions
+
+1. **Peer CLI working directory.** Does the spawned peer get a fresh
+   worktree (claude-code-headless requires one), the worker's
+   worktree, or a snapshot? Lean: snapshot the worker's worktree
+   into a sibling temp dir, peer mutates the temp dir, kernel
+   diff-applies the result back to the worker's worktree. Avoids
+   double-edit conflicts.
+2. **Cost attribution.** The peer CLI's quota burn happens during
+   the worker's session. Telemetry chain event must attribute it to
+   the worker's workflow_id, not a separate "escalation workflow."
+3. **Recursive escalation guard.** Peer CLI's tool calls also hit
+   chitin's gate. Should the gate's escalation logic short-circuit
+   when it detects "I'm already inside a peer-spawned context"?
+   Lean: yes, set CHITIN_NO_ESCALATE=1 in the spawned env so peer
+   gates allow/deny only.
+4. **Hermes' own internal advisor.** Hermes has its own
+   model-switching advisor (per its profile system). Does that fire
+   BEFORE chitin's kernel signal, or after, or both? Risk of
+   double-routing. Lean: disable hermes' internal advisor when
+   running under chitin (set hermes profile to fixed glm-flash, no
+   fallback) — chitin's kernel is the only escalation authority.
+
+## Out of scope
+
+- **Cross-task escalation** (whole workflow re-tries because T0
+  repeatedly flounders) stays in the dispatcher. In-gate covers
+  per-tool-call; dispatcher covers per-task.
+- **Peer-to-peer escalation** (peer CLI spawns another peer). Per
+  invariant 4: one level only.
+- **Async escalation** (kernel queues the work, returns "pending,"
+  worker continues other tool calls, peer result lands later).
+  Adds significant complexity; defer.
+- **Per-task-class escalation policies.** All cards share the same
+  `escalation.rules` initially. Per-class overrides (e.g., refactor
+  cards prefer patch_quality, exploration cards prefer
+  reasoning_depth) is a phase-2 schema extension.
+
+## Why this is the right shape
+
+It collapses everything I've been chasing for two days — tier
+fallback chains, capability-vector routing, budget-aware downshift,
+matrix-driven driver selection — into ONE place: the kernel's
+escalation policy + routeFor(). And it does it at the only
+substrate that already sees every tool call, has every chain event,
+knows every quota state, runs heuristics + advisor, and has a
+gate-shaped contract for "synchronously alter what the worker
+sees." That's chitin's actual moat — the in-tool-call gate as the
+universal router. Nothing else has that vantage.

--- a/docs/design/2026-05-06-stale-seed-refresh.md
+++ b/docs/design/2026-05-06-stale-seed-refresh.md
@@ -1,0 +1,187 @@
+# Stale-seed refresh: web-search-augmented mining
+
+Status: design. Companion to `2026-05-05-conformance-substrate.md`
+(seed sourcing layer §107).
+
+Date: 2026-05-06
+
+## Goal, in one sentence
+
+Any operator running chitin can keep their `model_seeds` table fresh
+against newly-released models — without depending on Anthropic's
+WebSearch tool, without leaking the operator's repo data, using only
+the LLM and search credentials the operator already brings.
+
+## The invariant
+
+A model is **stale** iff:
+
+```
+operator_matrix.json contains the model
+AND max(model_seeds.pulled_at WHERE model LIKE %model%) < (now - max_age)
+```
+
+`refresh-stale` visits exactly the stale set, never the fresh set.
+That is the contract; if the implementation visits a fresh row, it's
+a bug.
+
+## The pluggable backend interface
+
+```python
+class SearchBackend(Protocol):
+    """One call. Returns top-N results with title + url + snippet.
+    Raises BackendError for credential / quota / network issues — never
+    returns []  for those (we want to distinguish 'no results' from
+    'backend broken')."""
+    def query(self, q: str, n: int = 5) -> list[SearchResult]: ...
+
+class SearchResult(TypedDict):
+    title: str
+    url: str
+    snippet: str          # backend-provided summary; may be empty
+```
+
+Implementations land in `python/analysis/search_backends/`:
+  - `tavily.py`    — needs `TAVILY_API_KEY`
+  - `serper.py`    — needs `SERPER_API_KEY`
+  - `brave.py`     — needs `BRAVE_SEARCH_API_KEY`
+  - `searxng.py`   — needs `SEARXNG_URL` (self-hosted, no API key)
+
+Selected via `chitin.yaml`:
+
+```yaml
+seeds:
+  web_search:
+    backend: tavily            # | serper | brave | searxng
+    max_results_per_model: 5
+    extraction_role: web-extract   # which chitin role does the LLM extraction
+    confidence: low             # all web-search seeds tagged low-confidence
+                                # (sorted below leaderboard seeds in matrix)
+  refresh:
+    max_age_days: 7
+    rate_limit_per_min: 30      # cap search backend calls
+```
+
+No backend pre-selected: chitin will refuse to run the refresh
+command without `seeds.web_search.backend` set, and print the env
+var the chosen backend needs.
+
+## The extraction step
+
+The operator's own LLM does the extraction. Routed through
+`chitin-execute-request --role web-extract` so it inherits all the
+same governance + cost-tracking the operator already has wired.
+
+Prompt template (locked, no model-specific tweaks):
+
+```
+You are extracting one benchmark score from search results.
+
+Model under test: {model_id}
+
+Top {n} results:
+{numbered_snippets}
+
+Return JSON ONLY:
+{ "benchmark": "<lowercase short-name>", "score": <number>,
+  "score_unit": "percent" | "score" | "elo",
+  "source_url": "<the result URL the score came from>",
+  "scored_at": "<YYYY-MM-DD if stated, else null>" }
+
+If no result has a verifiable score for this exact model, return:
+{ "benchmark": null }
+```
+
+Boundary cases the prompt forbids ambiguity on:
+  - "exact model": `claude-opus-4-7` ≠ `claude-opus-4-5`. Family
+    matches are NOT acceptable here — the family fallback already
+    exists in the matrix display layer.
+  - "verifiable score": numeric, attached to a benchmark name, in the
+    snippet text. Inferred or projected scores are rejected.
+  - "score": a number, never a range. If the source gives a range,
+    extraction returns null.
+
+Extraction failure ≠ crash. The model is left stale; the operator
+sees `(no benchmark data — refresh attempted YYYY-MM-DD)` instead of
+`(no benchmark data — too new)` so they know it's been tried.
+
+## The new CLI command
+
+```
+$ chitin seeds refresh-stale [--max-age 7d] [--dry-run] [--only <model>]
+```
+
+- `--dry-run` lists the stale set + estimated cost (search calls × cost
+  + LLM calls × cost) without spending anything.
+- `--only <model>` refreshes one model — useful when a new model drops
+  and you don't want to wait for the cron.
+
+Output (terse):
+
+```
+refresh-stale: 12 models stale (max-age=7d)
+  searching tavily (5 results × 12 = 60 calls, ~$0.06)
+  extracting via T0=hermes (12 calls)
+  ─────
+  ✓ claude-opus-4-7   aider-polyglot 78.2  (https://...)
+  ✓ gpt-5.5           swebench-verified 71.0 (https://...)
+  ⚠ gpt-5.4-mini      no score found in top 5 results
+  ...
+  10 refreshed, 2 left stale
+  cost: $0.08 search + $0.003 LLM
+```
+
+## Recommended weekly run
+
+Phase-2 extension to `chitin doctor install`:
+
+```
+$ chitin doctor install --enable-seed-refresh
+  installing systemd timer chitin-seed-refresh.timer (weekly Mon 02:00)
+  ...
+```
+
+Before this lands, the operator can do it themselves with a one-liner
+in their crontab. Document in `docs/operator-guide.md`.
+
+## Open questions (operator decides before we code)
+
+1. **Confidence weighting in routing.** Web-search seeds get
+   `confidence: low` by default. Should the routing query down-weight
+   them (e.g., 0.5×) or just sort them visually but treat the score
+   as authoritative? Lean: down-weight in routing, present at full
+   value in the matrix display. Operators who want different can
+   override via `seeds.web_search.confidence`.
+
+2. **Quality vs cost trade.** 1 search × top-5 results vs 3 searches
+   × top-3 results (different query phrasings → cross-reference).
+   The latter catches more, costs ~3×. Lean: ship 1×5 first; expose
+   a `--thorough` flag that does 3×3 for operators who care.
+
+3. **Failure cache.** When extraction returns null, do we record
+   `pulled_at` anyway so we don't re-try on every run? Lean: yes,
+   write a stub row with `value=null` + `raw_payload="extraction
+   returned null"` so refresh-stale skips it for `max_age_days`. Set
+   `seeds.refresh.retry_failures_after` separately if operator wants
+   to try again sooner.
+
+## Defer list (NOT in this commit)
+
+- **Harness/driver discovery.** Separate command, much lower
+  cadence (monthly?), surfaces candidates for manual triage rather
+  than auto-mining. Lives in `compatibility_seed.py harness-discover`.
+- **PDF/preprint extraction.** Many fresh model results land in arxiv
+  PDFs before they hit blog posts. The HTML-only extraction will miss
+  these. Defer; surface as an alarm when ≥3 stale models in a row
+  return null on extraction.
+- **Score corroboration.** Two web-search seeds for the same (model,
+  benchmark) from different URLs that disagree by >10pp → flag as
+  conflicting, don't auto-resolve. Defer.
+
+## Why this commit is small
+
+Scope is the interface, the tavily backend, the extraction prompt,
+and the `refresh-stale` CLI command. Adding the other 3 backends is
+copy-paste-against-Protocol. Adding the systemd timer is copy from
+the existing `chitin-mine-daily` pattern. We get an end-to-end seed
+refresh working in one commit, and the rest is incremental.

--- a/go/execution-kernel/internal/router/route_for.go
+++ b/go/execution-kernel/internal/router/route_for.go
@@ -1,0 +1,114 @@
+package router
+
+// routeFor — peer-escalation routing decision.
+//
+// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 2 of 6):
+// pure function from (signal, severity, context, policy) → RouteDecision.
+// NO peer spawning yet (that's step 3); NO live quota integration yet
+// (that's step 6 — observed dimensions feed back). This step ships
+// the deterministic decision engine reachable from tests but not wired
+// into the gate.
+//
+// Contract:
+//   - First rule whose Signal matches `req.Signal` wins. Severity is
+//     captured for telemetry but does NOT participate in matching yet
+//     (string-only, no comparator parser).
+//   - Rule's Route is looked up in policy.Routes; first candidate is
+//     returned (FUTURE step 6: walk by quota state + observed
+//     compatibility, not just first).
+//   - No matching rule → ErrNoRuleMatched. Caller falls back to the
+//     existing kernel deny+escalation_requested behavior.
+//   - No candidates in route → ErrRouteEmpty. Validation should have
+//     prevented this; treat as a config bug worth logging.
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrNoRuleMatched = errors.New("no escalation rule matched the signal")
+	ErrRouteEmpty    = errors.New("matched route has no candidates")
+	ErrPolicyOff     = errors.New("escalation policy is disabled")
+)
+
+// RouteRequest is the per-tool-call input to RouteFor.
+type RouteRequest struct {
+	// Signal that triggered the escalation: "floundering" |
+	// "blast_radius" | "drift" | "advisor_takeover".
+	Signal string
+
+	// Human-readable severity string (recorded in telemetry; not yet
+	// matched against rule.Severity programmatically — string-only
+	// today, comparator parser is a future commit).
+	Severity string
+
+	// ToolCall is the worker's pending tool-call payload. Opaque to
+	// RouteFor today; passed through to spawnPeer (step 3) which
+	// wraps it for the peer CLI's prompt.
+	ToolCall map[string]any
+
+	// Recent chain events for context. Same — opaque to RouteFor;
+	// wrapped by spawnPeer.
+	ChainTail []map[string]any
+
+	// Worker's workflow_id, for Provenance attribution downstream.
+	WorkerWorkflowID string
+}
+
+// RouteDecision is what RouteFor returns when a rule matches.
+type RouteDecision struct {
+	// Rule that matched. Useful for telemetry ("rule X fired Y times
+	// in the last hour") and for the future rate-limiter (rule.MaxPerHour).
+	Rule RoutingRule
+
+	// Picked candidate from rule's route (the head of the candidate
+	// list today; quota-aware walk is step 6).
+	Candidate Candidate
+
+	// One-line WHY this candidate won. Always populated for
+	// telemetry — "rule=floundering-loop route=patch_quality
+	// candidate=copilot/gpt-5.4 (head of route, quota check deferred)".
+	Rationale string
+}
+
+// RouteFor maps an escalation signal to a (driver, model) candidate
+// using the operator's policy. Pure function — no I/O, no clocks, no
+// subprocess. Safe to call from inside the gate hot path.
+func RouteFor(req RouteRequest, policy RoutesPolicy) (RouteDecision, error) {
+	if !policy.Enabled {
+		return RouteDecision{}, ErrPolicyOff
+	}
+	matchedRule, ok := findFirstMatchingRule(req.Signal, policy.Rules)
+	if !ok {
+		return RouteDecision{}, fmt.Errorf("%w: signal=%q", ErrNoRuleMatched, req.Signal)
+	}
+	candidates, ok := policy.Routes[matchedRule.Route]
+	if !ok || len(candidates) == 0 {
+		return RouteDecision{}, fmt.Errorf("%w: route=%q (rule=%q)",
+			ErrRouteEmpty, matchedRule.Route, matchedRule.Name)
+	}
+	picked := candidates[0]
+	return RouteDecision{
+		Rule:      matchedRule,
+		Candidate: picked,
+		Rationale: fmt.Sprintf(
+			"rule=%s signal=%s route=%s candidate=%s/%s (head of route; quota-aware walk deferred to step 6)",
+			matchedRule.Name, req.Signal, matchedRule.Route,
+			picked.Driver, picked.Model,
+		),
+	}, nil
+}
+
+// findFirstMatchingRule walks rules in declared order. First rule whose
+// Signal matches wins. Stable behavior — operator can rely on rule
+// ordering for precedence (e.g., put a more-specific blast_radius
+// rule before a catch-all drift rule).
+func findFirstMatchingRule(signal string, rules []RoutingRule) (RoutingRule, bool) {
+	for _, r := range rules {
+		if r.Signal == signal {
+			return r, true
+		}
+	}
+	return RoutingRule{}, false
+}

--- a/go/execution-kernel/internal/router/route_for_test.go
+++ b/go/execution-kernel/internal/router/route_for_test.go
@@ -1,0 +1,155 @@
+package router
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func samplePolicy() RoutesPolicy {
+	return RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules: []RoutingRule{
+			{Name: "floundering-loop", Signal: "floundering", Severity: ">= 2 loops", Route: "patch_quality", MaxPerHour: 10},
+			{Name: "blast-radius-large", Signal: "blast_radius", Severity: "> 25 files", Route: "reasoning_depth", MaxPerHour: 5},
+			{Name: "drift-takeover", Signal: "drift", Severity: "advisor.verdict=takeover", Route: "reasoning_depth", MaxPerHour: 3},
+		},
+		Routes: map[string][]Candidate{
+			"patch_quality": {
+				{Driver: "copilot", Model: "gpt-5.4"},
+				{Driver: "claude", Model: "claude-opus-4-6"},
+			},
+			"reasoning_depth": {
+				{Driver: "claude", Model: "claude-opus-4-7"},
+				{Driver: "copilot", Model: "gpt-5.5"},
+			},
+		},
+	}
+}
+
+func TestRouteFor_FlounderingMatch(t *testing.T) {
+	d, err := RouteFor(RouteRequest{Signal: "floundering"}, samplePolicy())
+	if err != nil {
+		t.Fatalf("expected match, got %v", err)
+	}
+	if d.Rule.Name != "floundering-loop" {
+		t.Errorf("rule: got %q want floundering-loop", d.Rule.Name)
+	}
+	if d.Candidate.Driver != "copilot" || d.Candidate.Model != "gpt-5.4" {
+		t.Errorf("candidate: got %s/%s want copilot/gpt-5.4", d.Candidate.Driver, d.Candidate.Model)
+	}
+	if !strings.Contains(d.Rationale, "patch_quality") {
+		t.Errorf("rationale should reference matched route; got: %s", d.Rationale)
+	}
+}
+
+func TestRouteFor_BlastRadiusMatch(t *testing.T) {
+	d, err := RouteFor(RouteRequest{Signal: "blast_radius"}, samplePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Candidate.Driver != "claude" || d.Candidate.Model != "claude-opus-4-7" {
+		t.Errorf("expected reasoning_depth head; got %s/%s", d.Candidate.Driver, d.Candidate.Model)
+	}
+}
+
+func TestRouteFor_DriftMatch(t *testing.T) {
+	d, err := RouteFor(RouteRequest{Signal: "drift"}, samplePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Rule.Name != "drift-takeover" {
+		t.Errorf("expected drift-takeover; got %q", d.Rule.Name)
+	}
+}
+
+func TestRouteFor_NoRuleMatched(t *testing.T) {
+	_, err := RouteFor(RouteRequest{Signal: "telepathy"}, samplePolicy())
+	if !errors.Is(err, ErrNoRuleMatched) {
+		t.Errorf("expected ErrNoRuleMatched; got %v", err)
+	}
+}
+
+func TestRouteFor_RuleOrderingDeterminesPrecedence(t *testing.T) {
+	// Two rules for the same signal — first one wins.
+	policy := RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules: []RoutingRule{
+			{Name: "floundering-cheap", Signal: "floundering", Route: "cheap"},
+			{Name: "floundering-deep", Signal: "floundering", Route: "deep"},
+		},
+		Routes: map[string][]Candidate{
+			"cheap": {{Driver: "copilot", Model: "gpt-4o-mini"}},
+			"deep":  {{Driver: "claude", Model: "claude-opus-4-7"}},
+		},
+	}
+	d, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Rule.Name != "floundering-cheap" {
+		t.Errorf("first-rule precedence broken: got %q want floundering-cheap", d.Rule.Name)
+	}
+}
+
+func TestRouteFor_PolicyDisabled(t *testing.T) {
+	policy := samplePolicy()
+	policy.Enabled = false
+	_, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if !errors.Is(err, ErrPolicyOff) {
+		t.Errorf("disabled policy should return ErrPolicyOff; got %v", err)
+	}
+}
+
+func TestRouteFor_RouteRefNotInRoutesMap(t *testing.T) {
+	// Validation should catch this in LoadRoutesPolicy, but RouteFor
+	// must also tolerate it (fail-open for the gate, log the bug).
+	policy := RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules: []RoutingRule{
+			{Name: "x", Signal: "floundering", Route: "missing"},
+		},
+		Routes: map[string][]Candidate{
+			"other": {{Driver: "copilot", Model: "gpt-4.1"}},
+		},
+	}
+	_, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if !errors.Is(err, ErrRouteEmpty) {
+		t.Errorf("expected ErrRouteEmpty; got %v", err)
+	}
+}
+
+func TestRouteFor_RoutePresentButEmpty(t *testing.T) {
+	policy := RoutesPolicy{
+		Version: 1,
+		Enabled: true,
+		Rules:   []RoutingRule{{Name: "x", Signal: "floundering", Route: "empty"}},
+		Routes:  map[string][]Candidate{"empty": {}},
+	}
+	_, err := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	if !errors.Is(err, ErrRouteEmpty) {
+		t.Errorf("expected ErrRouteEmpty; got %v", err)
+	}
+}
+
+func TestRouteFor_FirstCandidateWins(t *testing.T) {
+	// Until step 6 (quota-aware walk), the head of the candidate
+	// list always wins. Lock that in so step 6 is a deliberate
+	// behavior change.
+	policy := samplePolicy()
+	d, _ := RouteFor(RouteRequest{Signal: "floundering"}, policy)
+	wantHead := policy.Routes["patch_quality"][0]
+	if d.Candidate != wantHead {
+		t.Errorf("step 2 must always pick chain head; got %v want %v", d.Candidate, wantHead)
+	}
+}
+
+func TestRouteFor_RationaleNonEmpty(t *testing.T) {
+	d, _ := RouteFor(RouteRequest{Signal: "floundering"}, samplePolicy())
+	if d.Rationale == "" {
+		t.Error("rationale must always be populated for telemetry")
+	}
+}

--- a/go/execution-kernel/internal/router/routes.go
+++ b/go/execution-kernel/internal/router/routes.go
@@ -1,0 +1,201 @@
+package router
+
+// chitin-routes.yaml — peer-escalation routing policy loader.
+//
+// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 1 of 6):
+// schema only. This file ONLY defines types + loader + validation.
+// Nothing in the kernel reads RoutesPolicy yet; subsequent steps wire
+// routeFor() and spawnPeer() against it.
+//
+// Sidecar (not part of chitin.yaml) so escalation routes can grow large
+// candidate lists without bloating the main policy file. Loaded from
+// the same parent-walk that finds chitin.yaml.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RoutesPolicy is the full chitin-routes.yaml shape.
+type RoutesPolicy struct {
+	// Schema version — bumped when the file format changes
+	// incompatibly. Loader rejects unknown versions.
+	Version int `yaml:"version"`
+
+	// When false, rules + routes are loaded + validated but the
+	// gate falls back to today's deny+escalation_requested behavior.
+	// Default off — operator opts in.
+	Enabled bool `yaml:"enabled"`
+
+	// Maximum wall-clock seconds for a peer-spawn before timeout.
+	// 0 → use built-in default (60).
+	SpawnTimeoutSeconds int `yaml:"spawn_timeout_seconds"`
+
+	// At most N peer spawns in flight per worker session. Prevents
+	// runaway when heuristics keep firing. 0 → use default (1).
+	MaxConcurrentPeers int `yaml:"max_concurrent_peers"`
+
+	// Rules: signal+severity → which named route to use.
+	Rules []RoutingRule `yaml:"rules"`
+
+	// Routes: named optimization category → ordered candidate list.
+	// routeFor() walks the candidates in order, picking the first
+	// one that fits remaining quota.
+	Routes map[string][]Candidate `yaml:"routes"`
+}
+
+// RoutingRule is one row in the rules table — when this signal at
+// this severity fires, look up `route` in Routes for candidates.
+type RoutingRule struct {
+	// Operator-friendly id (used in telemetry + error messages).
+	Name string `yaml:"name"`
+
+	// Which heuristic / advisor signal triggers this rule.
+	// "floundering" | "blast_radius" | "drift" | "advisor_takeover".
+	Signal string `yaml:"signal"`
+
+	// Human-readable severity expression. Today: free-text shown in
+	// telemetry. Future: parsed into a comparator. Until parsed,
+	// the kernel matches purely on Signal.
+	Severity string `yaml:"severity"`
+
+	// Name of the route in RoutesPolicy.Routes to consult.
+	Route string `yaml:"route"`
+
+	// Rate cap — kernel refuses to fire this rule more than N times
+	// per rolling hour, regardless of how often the signal triggers.
+	// 0 → no cap. Prevents quota exhaustion + runaway escalation.
+	MaxPerHour int `yaml:"max_per_hour"`
+}
+
+// Candidate is one (driver, model) pair in a route's candidate list.
+type Candidate struct {
+	Driver string `yaml:"driver"`
+	Model  string `yaml:"model"`
+}
+
+// DefaultRoutesPolicy returns the disabled-by-default policy used
+// when chitin-routes.yaml is absent or unreadable. Mirrors the
+// "operator opts in" stance of the rest of the router config.
+func DefaultRoutesPolicy() RoutesPolicy {
+	return RoutesPolicy{
+		Version:             1,
+		Enabled:             false,
+		SpawnTimeoutSeconds: 60,
+		MaxConcurrentPeers:  1,
+		Rules:               nil,
+		Routes:              map[string][]Candidate{},
+	}
+}
+
+// FindChitinRoutesYaml walks up from startCwd looking for
+// chitin-routes.yaml. Returns absolute path or "" if not found.
+func FindChitinRoutesYaml(startCwd string) string {
+	dir, err := filepath.Abs(startCwd)
+	if err != nil {
+		return ""
+	}
+	for {
+		candidate := filepath.Join(dir, "chitin-routes.yaml")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// LoadRoutesPolicy reads + parses chitin-routes.yaml from a starting
+// cwd. Returns DefaultRoutesPolicy + non-nil err on any failure
+// (missing file, parse error, validation error). Caller decides
+// whether to fail closed or fall back to default — for the gate we
+// fall back so a missing config doesn't brick the kernel.
+func LoadRoutesPolicy(cwd string) (RoutesPolicy, error) {
+	path := FindChitinRoutesYaml(cwd)
+	if path == "" {
+		return DefaultRoutesPolicy(), nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return DefaultRoutesPolicy(), fmt.Errorf("read chitin-routes.yaml: %w", err)
+	}
+	var p RoutesPolicy
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return DefaultRoutesPolicy(), fmt.Errorf("parse chitin-routes.yaml: %w", err)
+	}
+	if err := ValidateRoutesPolicy(p); err != nil {
+		return DefaultRoutesPolicy(), fmt.Errorf("validate chitin-routes.yaml: %w", err)
+	}
+	// Apply defaults to zero-value fields
+	if p.SpawnTimeoutSeconds == 0 {
+		p.SpawnTimeoutSeconds = 60
+	}
+	if p.MaxConcurrentPeers == 0 {
+		p.MaxConcurrentPeers = 1
+	}
+	if p.Routes == nil {
+		p.Routes = map[string][]Candidate{}
+	}
+	return p, nil
+}
+
+// ValidateRoutesPolicy enforces structural invariants the loader
+// can't express via tags. Returns the FIRST violation found —
+// caller fixes one at a time. The kernel falls back to
+// DefaultRoutesPolicy on any violation, so one bad rule doesn't
+// brick the gate.
+func ValidateRoutesPolicy(p RoutesPolicy) error {
+	if p.Version != 0 && p.Version != 1 {
+		return fmt.Errorf("unknown schema version %d (expected 1)", p.Version)
+	}
+	allowedSignals := map[string]bool{
+		"floundering": true, "blast_radius": true,
+		"drift": true, "advisor_takeover": true,
+	}
+	seenRule := map[string]bool{}
+	for i, rule := range p.Rules {
+		if rule.Name == "" {
+			return fmt.Errorf("rule[%d]: name required", i)
+		}
+		if seenRule[rule.Name] {
+			return fmt.Errorf("rule[%d]: duplicate name %q", i, rule.Name)
+		}
+		seenRule[rule.Name] = true
+		if !allowedSignals[rule.Signal] {
+			return fmt.Errorf("rule[%s]: unknown signal %q (expected one of floundering, blast_radius, drift, advisor_takeover)",
+				rule.Name, rule.Signal)
+		}
+		if rule.Route == "" {
+			return fmt.Errorf("rule[%s]: route required", rule.Name)
+		}
+		if _, ok := p.Routes[rule.Route]; !ok {
+			return fmt.Errorf("rule[%s]: route %q not defined in routes", rule.Name, rule.Route)
+		}
+		if rule.MaxPerHour < 0 {
+			return fmt.Errorf("rule[%s]: max_per_hour cannot be negative", rule.Name)
+		}
+	}
+	for routeName, candidates := range p.Routes {
+		if routeName == "" {
+			return fmt.Errorf("route key cannot be empty")
+		}
+		if len(candidates) == 0 {
+			return fmt.Errorf("route[%s]: at least one candidate required", routeName)
+		}
+		for j, c := range candidates {
+			if c.Driver == "" {
+				return fmt.Errorf("route[%s][%d]: driver required", routeName, j)
+			}
+			if c.Model == "" {
+				return fmt.Errorf("route[%s][%d]: model required", routeName, j)
+			}
+		}
+	}
+	return nil
+}

--- a/go/execution-kernel/internal/router/routes_test.go
+++ b/go/execution-kernel/internal/router/routes_test.go
@@ -1,0 +1,217 @@
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultRoutesPolicy(t *testing.T) {
+	p := DefaultRoutesPolicy()
+	if p.Enabled {
+		t.Fatal("default must be disabled — operator opts in")
+	}
+	if p.SpawnTimeoutSeconds != 60 {
+		t.Errorf("default spawn_timeout_seconds: got %d want 60", p.SpawnTimeoutSeconds)
+	}
+	if p.MaxConcurrentPeers != 1 {
+		t.Errorf("default max_concurrent_peers: got %d want 1", p.MaxConcurrentPeers)
+	}
+	if p.Routes == nil {
+		t.Error("default Routes must be non-nil empty map")
+	}
+}
+
+func TestLoadRoutesPolicyMissing(t *testing.T) {
+	dir := t.TempDir()
+	p, err := LoadRoutesPolicy(dir)
+	if err != nil {
+		t.Fatalf("missing chitin-routes.yaml should not error: %v", err)
+	}
+	if p.Enabled {
+		t.Error("missing file → default disabled")
+	}
+}
+
+func TestLoadRoutesPolicyValid(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `version: 1
+enabled: true
+spawn_timeout_seconds: 90
+max_concurrent_peers: 2
+rules:
+  - name: floundering-loop
+    signal: floundering
+    severity: ">= 2 loops"
+    route: patch_quality
+    max_per_hour: 10
+routes:
+  patch_quality:
+    - driver: copilot
+      model: gpt-5.4
+    - driver: claude
+      model: claude-opus-4-6
+`
+	if err := os.WriteFile(filepath.Join(dir, "chitin-routes.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadRoutesPolicy(dir)
+	if err != nil {
+		t.Fatalf("valid yaml should load: %v", err)
+	}
+	if !p.Enabled {
+		t.Error("expected enabled=true")
+	}
+	if p.SpawnTimeoutSeconds != 90 {
+		t.Errorf("spawn_timeout_seconds: got %d want 90", p.SpawnTimeoutSeconds)
+	}
+	if p.MaxConcurrentPeers != 2 {
+		t.Errorf("max_concurrent_peers: got %d want 2", p.MaxConcurrentPeers)
+	}
+	if len(p.Rules) != 1 || p.Rules[0].Name != "floundering-loop" {
+		t.Errorf("rules not parsed: %+v", p.Rules)
+	}
+	if len(p.Routes["patch_quality"]) != 2 {
+		t.Errorf("route candidates not parsed: %+v", p.Routes)
+	}
+	if p.Routes["patch_quality"][0].Driver != "copilot" {
+		t.Errorf("first candidate driver: got %q want copilot", p.Routes["patch_quality"][0].Driver)
+	}
+}
+
+func TestLoadRoutesPolicyParentWalk(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `version: 1
+enabled: true
+routes:
+  cheap+stable:
+    - driver: copilot
+      model: gpt-4.1
+`
+	if err := os.WriteFile(filepath.Join(root, "chitin-routes.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadRoutesPolicy(deep)
+	if err != nil {
+		t.Fatalf("parent walk should find file: %v", err)
+	}
+	if !p.Enabled {
+		t.Error("found file should populate Enabled")
+	}
+}
+
+func TestLoadRoutesPolicyInvalidYaml(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "chitin-routes.yaml"), []byte("not: valid: yaml: at: all:::"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadRoutesPolicy(dir)
+	if err == nil {
+		t.Error("malformed yaml should return error")
+	}
+	if p.Enabled {
+		t.Error("error should not leak partial parse — must default disabled")
+	}
+}
+
+func TestValidateUnknownSignal(t *testing.T) {
+	p := RoutesPolicy{
+		Version: 1,
+		Routes: map[string][]Candidate{
+			"foo": {{Driver: "copilot", Model: "gpt-4.1"}},
+		},
+		Rules: []RoutingRule{{
+			Name: "bad", Signal: "telepathy", Route: "foo",
+		}},
+	}
+	if err := ValidateRoutesPolicy(p); err == nil {
+		t.Error("unknown signal should fail validation")
+	}
+}
+
+func TestValidateRuleReferencesMissingRoute(t *testing.T) {
+	p := RoutesPolicy{
+		Version: 1,
+		Rules: []RoutingRule{{
+			Name: "x", Signal: "floundering", Route: "missing",
+		}},
+		Routes: map[string][]Candidate{
+			"other": {{Driver: "copilot", Model: "gpt-4.1"}},
+		},
+	}
+	if err := ValidateRoutesPolicy(p); err == nil {
+		t.Error("rule.route not in routes map should fail validation")
+	}
+}
+
+func TestValidateDuplicateRuleName(t *testing.T) {
+	p := RoutesPolicy{
+		Version: 1,
+		Routes:  map[string][]Candidate{"r": {{Driver: "x", Model: "y"}}},
+		Rules: []RoutingRule{
+			{Name: "dup", Signal: "floundering", Route: "r"},
+			{Name: "dup", Signal: "blast_radius", Route: "r"},
+		},
+	}
+	if err := ValidateRoutesPolicy(p); err == nil {
+		t.Error("duplicate rule name should fail validation")
+	}
+}
+
+func TestValidateEmptyCandidateList(t *testing.T) {
+	p := RoutesPolicy{
+		Version: 1,
+		Routes:  map[string][]Candidate{"empty": {}},
+	}
+	if err := ValidateRoutesPolicy(p); err == nil {
+		t.Error("empty candidate list should fail validation")
+	}
+}
+
+func TestValidateMissingDriverOrModel(t *testing.T) {
+	p := RoutesPolicy{
+		Version: 1,
+		Routes: map[string][]Candidate{
+			"x": {{Driver: "copilot"}}, // missing model
+		},
+	}
+	if err := ValidateRoutesPolicy(p); err == nil {
+		t.Error("missing model should fail validation")
+	}
+}
+
+func TestValidateUnknownVersion(t *testing.T) {
+	p := RoutesPolicy{Version: 99}
+	if err := ValidateRoutesPolicy(p); err == nil {
+		t.Error("unknown schema version should fail validation")
+	}
+}
+
+func TestExampleFileValidates(t *testing.T) {
+	// The committed chitin-routes.example.yaml at the repo root must
+	// always pass validation — it's documentation operators copy from.
+	repoRoot, err := filepath.Abs("../../../..")
+	if err != nil {
+		t.Skipf("can't resolve repo root: %v", err)
+	}
+	example := filepath.Join(repoRoot, "chitin-routes.example.yaml")
+	if _, err := os.Stat(example); err != nil {
+		t.Skipf("no example file at %s; skipping (CI may run from a worktree)", example)
+	}
+	data, err := os.ReadFile(example)
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	// Write to a temp dir under a name the loader recognizes.
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "chitin-routes.yaml"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadRoutesPolicy(tmp); err != nil {
+		t.Errorf("chitin-routes.example.yaml must validate: %v", err)
+	}
+}

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -103,7 +103,7 @@ export const DriverIdSchema = z.enum([
   // The plugin gates each tool call before execution.
   'openclaw-glm-flash',  // 3090: glm-4.7-flash:latest (~30B)
   'openclaw-glm-cloud',  // Ollama Cloud sub: glm-5.1:cloud (opus-light)
-  'openclaw-deepseek',   // 3090: deepseek (kept for future use, not in defaults)
+  'openclaw-deepseek-cloud',   // Ollama Cloud: deepseek (cloud-resident, not in defaults)
 ]);
 
 export const NetworkPolicySchema = z.enum(['none', 'allowlist', 'open']);

--- a/python/analysis/compatibility_seed.py
+++ b/python/analysis/compatibility_seed.py
@@ -566,9 +566,111 @@ def mine_livecodebench(conn: sqlite3.Connection) -> int:  # noqa: ARG001
     return 0
 
 
-def mine_terminal_bench(conn: sqlite3.Connection) -> int:  # noqa: ARG001
-    print("[mine] terminal-bench: TODO — repo has dashboard but no public results JSON")
-    return 0
+def mine_terminal_bench(conn: sqlite3.Connection) -> int:
+    """Pull terminal-bench-2.0 leaderboard from tbench.ai (the canonical
+    leaderboard run by the bench's authors). The page is HTML — fetch
+    it then LLM-extract every (model, harness, score) row.
+
+    Each row in the leaderboard is one experimental setup (model under
+    a specific harness like 'Codex CLI', 'Terminus-2', 'Claude Code').
+    We store ONE row per (model, harness) and let the matrix display
+    surface the best harness per model — operators care about peak
+    capability, not floor.
+    """
+    url = "https://www.tbench.ai/leaderboard/terminal-bench/2.0"
+    try:
+        html = http_get(url, timeout=30).decode("utf-8", errors="ignore")
+    except Exception as e:
+        print(f"[mine] terminal-bench: fetch failed — {e}", file=sys.stderr)
+        return 0
+
+    # Strip script/style + collapse whitespace before sending to LLM —
+    # the page is React-hydrated and most of the markup is bundle JS
+    # that has no benchmark data.
+    import re as _re
+    text = _re.sub(r"<script[^>]*>.*?</script>", "", html, flags=_re.DOTALL | _re.IGNORECASE)
+    text = _re.sub(r"<style[^>]*>.*?</style>", "", text, flags=_re.DOTALL | _re.IGNORECASE)
+    text = _re.sub(r"<[^>]+>", " ", text)
+    text = _re.sub(r"\s+", " ", text).strip()
+
+    if "terminal-bench" not in text.lower() and "tbench" not in text.lower():
+        print(f"[mine] terminal-bench: page didn't render leaderboard data (likely client-side React)", file=sys.stderr)
+        return 0
+
+    from analysis.refresh_stale import ExtractorError
+    import shutil, subprocess
+
+    if not shutil.which("claude"):
+        print("[mine] terminal-bench: claude CLI not on PATH for LLM extraction", file=sys.stderr)
+        return 0
+
+    prompt = (
+        "Extract every leaderboard row from this Terminal-Bench 2.0 page. "
+        "Return a JSON array (no prose, no fences). Each entry: "
+        '{"model": "<lowercase normalized model name like gpt-5.4 or claude-opus-4.6>", '
+        '"score": <percent number 0-100>, '
+        '"harness": "<scaffold name, e.g. Codex CLI, Terminus 2, Claude Code, ForgeCode>", '
+        '"organization": "<vendor org>"}. '
+        "Skip rows where model is 'Multiple' (those are aggregator harnesses). "
+        "Only include rows with a numeric score and a model name. "
+        f"Page content (truncated):\n---\n{text[:15000]}"
+    )
+    try:
+        proc = subprocess.run(
+            ["claude", "-p", "--model", "haiku", "--output-format", "text"],
+            input=prompt, capture_output=True, text=True, timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        print("[mine] terminal-bench: claude timed out", file=sys.stderr)
+        return 0
+    if proc.returncode != 0:
+        print(f"[mine] terminal-bench: claude exit {proc.returncode}", file=sys.stderr)
+        return 0
+    out = proc.stdout.strip()
+    m = _re.search(r"\[.*\]", out, _re.DOTALL)
+    if not m:
+        print("[mine] terminal-bench: no JSON array in extraction output", file=sys.stderr)
+        return 0
+    try:
+        rows = json.loads(m.group(0))
+    except json.JSONDecodeError as e:
+        print(f"[mine] terminal-bench: bad JSON — {e}", file=sys.stderr)
+        return 0
+
+    n = 0
+    for row in rows:
+        model = (row.get("model") or "").strip().lower()
+        score = row.get("score")
+        harness = (row.get("harness") or "").strip()
+        if not model or score is None or model == "multiple":
+            continue
+        try:
+            score_f = float(score)
+        except (TypeError, ValueError):
+            continue
+        # Normalize spaces / aliases
+        model = model.replace(" ", "-").replace(".", "-")
+        # Common aliases per the leaderboard's naming
+        model = model.replace("claude-4-6-opus", "claude-opus-4-6")
+        # Encode harness in metric so we keep all data points (different
+        # harnesses produce meaningfully different scores).
+        metric = f"score_{harness.lower().replace(' ', '_')}" if harness else "score"
+        upsert_seed(
+            conn=conn,
+            model=model,
+            source="terminal-bench-2.0",
+            metric=metric,
+            value=score_f,
+            raw_payload={
+                "harness": harness,
+                "organization": row.get("organization"),
+                "leaderboard_url": url,
+            },
+        )
+        n += 1
+    conn.commit()
+    print(f"[mine] terminal-bench: {n} (model, harness) rows from tbench.ai/leaderboard/terminal-bench/2.0")
+    return n
 
 
 # ─── HuggingFace model cards ───────────────────────────────────────────────

--- a/python/analysis/compatibility_seed.py
+++ b/python/analysis/compatibility_seed.py
@@ -571,6 +571,321 @@ def mine_terminal_bench(conn: sqlite3.Connection) -> int:  # noqa: ARG001
     return 0
 
 
+# ─── HuggingFace model cards ───────────────────────────────────────────────
+#
+# Per docs/design/2026-05-06-stale-seed-refresh.md update: structured
+# sources before web-search. Vendors who write benchmarks in their HF
+# README (z-ai/GLM-5.1, alibaba/Qwen3-Coder, meta-llama, etc.) publish
+# rich rows here; vendors who defer to images (deepseek-ai) still produce
+# 0 rows but cost almost nothing to probe. The pipeline is:
+#
+#   1. HF search API → canonical org/model id for each operator-reachable model
+#   2. Fetch raw README from huggingface.co/<org>/<model>/raw/main/README.md
+#   3. LLM-extract benchmark JSON via the operator's `claude` CLI
+#   4. Upsert each (benchmark, score) into model_seeds with source='huggingface'
+#
+# Driven by operator_matrix.json — only mines models the operator can
+# actually invoke. Skip models that don't appear in HF (404 on search).
+
+HF_API_BASE = "https://huggingface.co/api"
+HF_RAW_BASE = "https://huggingface.co"
+
+# Locked extraction prompt — multi-benchmark variant of refresh_stale's
+# single-score prompt. The model card is mostly prose + occasional
+# tables; we want EVERY numeric benchmark mention, not the highest one.
+HF_EXTRACTION_PROMPT = """You are extracting all benchmark scores from a HuggingFace model card.
+
+Model under test: {model_id}
+
+Card content (truncated to 8000 chars):
+---
+{readme}
+---
+
+Return a JSON array (no prose, no code fences). Each entry is one
+benchmark score for THIS model:
+
+[
+  {{"benchmark":"<lowercase short-name like 'humaneval' or 'swe-bench-verified'>",
+    "score":<number>,
+    "score_unit":"percent"|"score"|"elo"|"dollars"|"points",
+    "variant":"<which variant of the model, or null if only one model>",
+    "metric_type":"pass@1"|"resolved"|"pass_rate"|null}}
+]
+
+Rules:
+  - One entry per (benchmark, variant) pair. If the card lists the same
+    benchmark on multiple variants (16B / 236B / etc.), include all.
+  - "verifiable score": numeric, attached to a benchmark name, in the
+    text. Inferred or projected scores are rejected.
+  - Skip rows that compare against OTHER models (e.g. "X scored Y on
+    HumanEval" where X is not {model_id}).
+  - If the card has no benchmarks (only prose / images), return [].
+"""
+
+
+# Vendor-org allowlist. HF search returns community distillations
+# ("Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored")
+# before canonical vendor cards because fork names contain the model
+# name verbatim. When a model query maps to a known vendor, scope the
+# search with `&author=<org>`. Add new prefixes here as new vendors emerge.
+HF_VENDOR_ORGS = {
+    "qwen":         "Qwen",
+    "glm":          "zai-org",
+    "deepseek":     "deepseek-ai",
+    "gemma":        "google",
+    "mistral":      "mistralai",
+    "llama":        "meta-llama",
+    "phi":          "microsoft",
+    "yi":           "01-ai",
+}
+
+# Deployment-form suffixes that aren't part of the model identity.
+# `glm-5.1-cloud` is the cloud-served form of `glm-5.1`; HF only knows
+# the latter. Strip these before searching.
+HF_DEPLOYMENT_SUFFIXES = ("-cloud", "-fp8", "-int8", "-int4", "-gguf", "-mlx")
+
+
+def _hf_search_query(model_query: str) -> tuple[str, str | None]:
+    """Return (search_term, vendor_org_filter). Vendor filter is None
+    if we don't recognize the family — broad search then."""
+    q = model_query.lower()
+    for suffix in HF_DEPLOYMENT_SUFFIXES:
+        if q.endswith(suffix):
+            q = q[: -len(suffix)]
+            break
+    vendor = None
+    for prefix, org in HF_VENDOR_ORGS.items():
+        if q.startswith(prefix):
+            vendor = org
+            break
+    return q, vendor
+
+
+def _hf_find_canonical(model_query: str) -> str | None:
+    """HF search → canonical modelId. Scopes by vendor org when the
+    family is known (Qwen, zai-org, etc.) — community distillations
+    cannot win against the vendor's own card. Returns None on 404 /
+    empty / no acceptable match."""
+    import urllib.parse
+    search_term, vendor = _hf_search_query(model_query)
+    q = urllib.parse.quote(search_term)
+    url = f"{HF_API_BASE}/models?search={q}&limit=10&sort=downloads&direction=-1"
+    if vendor:
+        url += f"&author={urllib.parse.quote(vendor)}"
+    try:
+        raw = http_get(url, timeout=15)
+    except Exception:
+        return None
+    try:
+        results = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not results:
+        # Vendor-scoped search returned nothing — try unscoped as a fallback
+        # so we don't lose models whose vendor we got wrong.
+        if vendor:
+            return _hf_find_canonical_unscoped(search_term, model_query)
+        return None
+    return _hf_pick_best(results, model_query)
+
+
+def _hf_find_canonical_unscoped(search_term: str, original: str) -> str | None:
+    import urllib.parse
+    q = urllib.parse.quote(search_term)
+    url = f"{HF_API_BASE}/models?search={q}&limit=10&sort=downloads&direction=-1"
+    try:
+        raw = http_get(url, timeout=15)
+        results = json.loads(raw)
+    except Exception:
+        return None
+    if not results:
+        return None
+    return _hf_pick_best(results, original)
+
+
+def _hf_pick_best(results: list[dict], model_query: str) -> str | None:
+    """Pick the best modelId from search results. Strict-match first
+    (modelId must contain all needles ≥ 2 chars from query); fallback
+    to first result. Vendor scoping already done upstream."""
+    needles = {p.lower() for p in model_query.replace("_", "-").split("-") if len(p) >= 2}
+    for r in results:
+        mid = r.get("modelId") or r.get("id") or ""
+        mid_lower = mid.lower().replace("_", "-")
+        if all(n in mid_lower for n in needles):
+            return mid
+    return results[0].get("modelId") or results[0].get("id")
+
+
+def _hf_fetch_readme(model_id: str) -> str | None:
+    """Fetch raw README. Returns None on 404 or empty body."""
+    url = f"{HF_RAW_BASE}/{model_id}/raw/main/README.md"
+    try:
+        return http_get(url, timeout=20).decode("utf-8", errors="ignore")
+    except Exception:
+        return None
+
+
+def _hf_extract_benchmarks(model_id: str, readme: str) -> list[dict]:
+    """Run the locked extraction prompt against the operator's `claude`
+    CLI. Returns the parsed JSON array (possibly empty); raises on
+    infrastructure failure."""
+    # Local import — refresh_stale already wraps subprocess+JSON for us.
+    from analysis.refresh_stale import extract_via_llm, ExtractorError
+    import re
+
+    prompt = HF_EXTRACTION_PROMPT.format(
+        model_id=model_id, readme=readme[:8000]
+    )
+    # extract_via_llm returns dict-or-None, but we want an array. Bypass
+    # its inner schema validation by replicating the subprocess call.
+    try:
+        # Reuse the LLM call pattern but parse as array
+        import shutil, subprocess
+        if not shutil.which("claude"):
+            raise ExtractorError("claude CLI not on PATH")
+        proc = subprocess.run(
+            ["claude", "-p", "--model", "haiku", "--output-format", "text"],
+            input=prompt, capture_output=True, text=True, timeout=90,
+        )
+        if proc.returncode != 0:
+            raise ExtractorError(f"claude exit {proc.returncode}: {proc.stderr[:200]}")
+        out = proc.stdout.strip()
+    except subprocess.TimeoutExpired as e:
+        raise ExtractorError(f"claude timed out after 90s") from e
+    if not out:
+        return []
+    # Strip optional code fences; find first [ ... ]
+    m = re.search(r"\[.*\]", out, re.DOTALL)
+    if not m:
+        return []
+    try:
+        parsed = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return parsed
+
+
+def _hf_canonical_metric(benchmark: str, metric_type: str | None) -> str:
+    """Normalize the LLM-extracted benchmark name to a stable metric id.
+    The matrix display indexes on metric prefix patterns
+    ('aider*', 'swebench*'); keep names predictable."""
+    b = benchmark.lower().strip().replace(" ", "-")
+    # Common renames so similar benchmarks collapse on lookup
+    aliases = {
+        "humaneval+": "pass@1_humaneval+",
+        "humaneval": "pass@1_humaneval",
+        "mbpp+": "pass@1_mbpp+",
+        "mbpp": "pass@1_mbpp",
+        "swe-bench": "swebench-verified",
+        "swe-bench-verified": "swebench-verified",
+        "swe-bench-pro": "swebench-pro",
+        "terminal-bench": "terminal-bench",
+        "terminal-bench-2.0": "terminal-bench-2.0",
+    }
+    if b in aliases:
+        return aliases[b]
+    # Tag pass@1 / resolved variants when the LLM provided metric_type
+    if metric_type and not b.startswith(metric_type):
+        return f"{b}_{metric_type}"
+    return b
+
+
+# Closed-source vendors don't publish on HuggingFace. Their model names
+# (claude-*, gpt-*, gemini-*) match weird community distillations like
+# "Qwen3-27B-Claude-Opus-Distilled" that aren't actually those models.
+# Skip these prefixes entirely — they should get scores from leaderboards
+# (already mined) and refresh-stale (web-search) instead.
+HF_CLOSED_SOURCE_PREFIXES = ("claude-", "gpt-", "gemini-", "o1-", "o3-")
+
+
+def _hf_should_skip(model_query: str) -> bool:
+    return any(model_query.startswith(p) for p in HF_CLOSED_SOURCE_PREFIXES)
+
+
+def mine_huggingface(conn: sqlite3.Connection) -> int:
+    """Walk operator_matrix.json's reachable models. For each, try to
+    find a canonical HF id, fetch the README, LLM-extract benchmarks,
+    upsert. Returns total rows written."""
+    matrix_path = Path(os.path.expanduser("~/.chitin/operator_matrix.json"))
+    if not matrix_path.exists():
+        print(
+            "[mine] huggingface: no operator_matrix.json — "
+            "run `python -m analysis.operator_matrix detect` first",
+            file=sys.stderr,
+        )
+        return 0
+
+    matrix = json.loads(matrix_path.read_text())
+    seen_queries: set[str] = set()
+    total = 0
+    for cli in matrix.get("clis", []):
+        for raw_model in cli.get("models", []):
+            # Same normalization the matrix lookup uses, so we mine
+            # the SAME identifier the report later searches for.
+            from analysis.operator_matrix import _resolve_lookup_token
+            search_query = _resolve_lookup_token(raw_model)
+            if not search_query or search_query in seen_queries:
+                continue
+            seen_queries.add(search_query)
+
+            if _hf_should_skip(search_query):
+                print(f"[mine] huggingface: {search_query:40} → skip (closed-source vendor; HF will only have community forks)")
+                continue
+
+            canonical = _hf_find_canonical(search_query)
+            if not canonical:
+                print(f"[mine] huggingface: {search_query:40} → no HF match")
+                continue
+            readme = _hf_fetch_readme(canonical)
+            if not readme:
+                print(f"[mine] huggingface: {search_query:40} → {canonical} (no README)")
+                continue
+
+            try:
+                benchmarks = _hf_extract_benchmarks(canonical, readme)
+            except Exception as e:
+                print(f"[mine] huggingface: {search_query:40} → {canonical} (extractor failed: {e})")
+                continue
+
+            if not benchmarks:
+                print(f"[mine] huggingface: {search_query:40} → {canonical} (no benchmarks in card)")
+                continue
+
+            # Write each benchmark as a separate seed row.
+            n_this = 0
+            for entry in benchmarks:
+                bench = entry.get("benchmark")
+                score = entry.get("score")
+                if not bench or score is None:
+                    continue
+                try:
+                    score_f = float(score)
+                except (TypeError, ValueError):
+                    continue
+                metric = _hf_canonical_metric(bench, entry.get("metric_type"))
+                upsert_seed(
+                    conn=conn,
+                    model=search_query,            # store under resolved name
+                    source="huggingface",
+                    metric=metric,
+                    value=score_f,
+                    raw_payload={
+                        "hf_canonical": canonical,
+                        "operator_alias": raw_model if raw_model != search_query else None,
+                        "score_unit": entry.get("score_unit"),
+                        "variant": entry.get("variant"),
+                    },
+                )
+                n_this += 1
+            print(f"[mine] huggingface: {search_query:40} → {canonical} ({n_this} benchmarks)")
+            total += n_this
+            conn.commit()
+    return total
+
+
 # ─── CLI ───────────────────────────────────────────────────────────────────
 
 SOURCES = {
@@ -580,6 +895,7 @@ SOURCES = {
     "openrouter": mine_openrouter,
     "evalplus": mine_evalplus,        # HumanEval+ / MBPP+
     "arena-hard": mine_arena_hard,    # LMSYS-style head-to-head (older corpus)
+    "huggingface": mine_huggingface,  # vendor-published model cards
     "lmarena": mine_lmarena,           # stub (auth-gated)
     "livecodebench": mine_livecodebench,  # stub (dynamic site)
     "terminal-bench": mine_terminal_bench,  # stub (no public results dump)

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -19,21 +19,26 @@ Per the design doc's auto-detection layer:
 This module produces the FIRST THREE bullet operands. Operator
 overrides land via chitin.yaml (separate concern).
 
-Probing strategy per CLI:
-  - claude:   `claude auth status` → JSON, definitive. Models = curated
-              Anthropic catalog (sonnet/opus/haiku families).
-  - copilot:  binary present + Copilot Pro sub assumed (no easy
-              programmatic auth probe). Models = curated GitHub
-              Copilot catalog.
-  - codex:    binary present + OpenAI sub assumed. Models = curated
-              OpenAI catalog (gpt-5.x family).
-  - gemini:   binary present + Google AI Pro sub assumed. Models =
-              curated Google catalog (2.0-flash, 2.5-pro, Gemma 2/3).
+Probing strategy per CLI (updated 2026-05-06 — all four cloud CLIs
+now use LIVE catalogs, not curated lists):
+  - claude:   `claude auth status` → JSON, definitive. Models from
+              api.anthropic.com/v1/models w/ OAuth bearer from
+              ~/.claude/.credentials.json.
+  - copilot:  Models from api.githubcopilot.com/models w/ `gh auth
+              token`. Same catalog the CLI uses internally; filtered
+              to picker-enabled chat models.
+  - codex:    Auth detected via `codex login status`. Models from
+              `codex debug models` (raw JSON catalog the CLI uses).
+  - gemini:   OAuth refreshed via the embedded gemini-cli client
+              creds; tier confirmed via cloudcode-pa loadCodeAssist.
+              Model list scoped by tier (the generativelanguage
+              listModels endpoint requires a scope this OAuth
+              doesn't carry — curated tier-scoped fallback).
   - hermes:   `hermes profile list` → enumerate profiles + their
               configured models.
-  - openclaw: binary present, agents enumerated by reading
-              ~/.openclaw/agents.json (when present) or fallback to
-              the chitin DriverIdSchema enum.
+  - openclaw: binary present, agents enumerated from chitin's
+              DriverIdSchema enum (no per-installation list-agents
+              command exposed).
   - ollama:   `ollama list` → 100% accurate local + cloud-sub model
               inventory.
 
@@ -71,47 +76,98 @@ class CLIStatus:
     notes: str = ""
 
 
-# ─── Curated provider catalogs (auto-detection seeds) ──────────────────────
+# ─── Provider model lists ──────────────────────────────────────────────────
 #
-# Hardcoded because no CLI exposes a programmatic `list models` command
-# (probed 2026-05-05: copilot/codex/gemini all need TTY for any list
-# subcommand). These match what each provider documents as available
-# under their respective standard subscriptions. Keep current as
-# providers ship new models; the seed-mining cron will surface gaps
-# (a new model on openrouter without a row here means we should add it).
+# Strategy by CLI (probed 2026-05-06):
+#   claude  → live via api.anthropic.com/v1/models w/ OAuth from
+#             ~/.claude/.credentials.json (works)
+#   copilot → live via api.githubcopilot.com/models w/ gh auth token
+#             (works — full catalog with per-model capabilities)
+#   codex   → live via `codex debug models` (works — JSON catalog from
+#             the CLI itself, definitive for the operator's plan)
+#   gemini  → CodeAssist OAuth confirms tier; the generativelanguage
+#             listModels endpoint requires a scope this OAuth doesn't
+#             carry. Fall back to a curated list scoped by the
+#             confirmed tier.
+#
+# Curated fallbacks (used only when the live probe fails):
 
-ANTHROPIC_CLAUDE_MODELS = [
-    "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+GEMINI_PRO_TIER_MODELS = [
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "gemini-3",
 ]
 
-# Per github.com/github/copilot-cli docs + chitin's earlier research:
-COPILOT_MODELS = [
-    "gpt-4.1",
-    "gpt-5.0-mini",
-    "gpt-5.0",
-    "gpt-5.4",
-    "claude-haiku-4-5",      # via Copilot's Anthropic passthrough (0.33× rate)
-    "claude-sonnet-4-6",
-]
-
-# OpenAI gpt-5.x family per Codex CLI (subset; gpt-5.5 is the heavyweight):
-CODEX_MODELS = [
-    "gpt-5.0-mini",
-    "gpt-5.0",
-    "gpt-5.4",
-    "gpt-5.4-nano",
-    "gpt-5.5",
-]
-
-# Google AI Pro sub catalog (cloud); local Gemma routes through ollama:
-GEMINI_CLOUD_MODELS = [
+GEMINI_FREE_TIER_MODELS = [
     "gemini-2.0-flash-lite",
     "gemini-2.0-flash",
-    "gemini-2.5-pro",
-    "gemini-3",              # if available; gemini CLI auto-routes
 ]
+
+
+def _http_get_json(url: str, headers: dict, timeout: int = 10) -> dict | None:
+    """Tiny stdlib JSON GET — no requests/httpx dependency."""
+    import urllib.request
+    import urllib.error
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError):
+        return None
+
+
+def _http_post_json(url: str, headers: dict, body: dict, timeout: int = 10) -> dict | None:
+    import urllib.request
+    import urllib.error
+    payload = json.dumps(body).encode("utf-8")
+    h = {**headers, "Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=payload, headers=h, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError):
+        return None
+
+
+def _gemini_refresh_token() -> str | None:
+    """Refresh the gemini-cli OAuth bearer using its embedded client
+    credentials. Returns None if no creds file or refresh fails."""
+    creds_path = Path(os.path.expanduser("~/.gemini/oauth_creds.json"))
+    if not creds_path.exists():
+        return None
+    try:
+        creds = json.loads(creds_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    refresh = creds.get("refresh_token")
+    expiry = creds.get("expiry_date") or 0
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    if expiry > now_ms + 60_000 and creds.get("access_token"):
+        return creds["access_token"]
+    if not refresh:
+        return None
+    # Public client credentials embedded in @google/gemini-cli source.
+    import urllib.request
+    import urllib.parse
+    body = urllib.parse.urlencode({
+        "client_id": "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
+        "client_secret": "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",
+        "refresh_token": refresh,
+        "grant_type": "refresh_token",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        "https://oauth2.googleapis.com/token",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return data.get("access_token")
+    except Exception:
+        return None
 
 # OpenClaw maps each driver-id to a backing agent + model. Per
 # DriverIdSchema in libs/contracts:
@@ -159,8 +215,23 @@ def probe_claude() -> CLIStatus:
             }
         except json.JSONDecodeError:
             s.notes = "auth status returned non-JSON"
-    if s.authed:
-        s.models = list(ANTHROPIC_CLAUDE_MODELS)
+    # Live model list from Anthropic's API using the OAuth bearer.
+    creds = Path(os.path.expanduser("~/.claude/.credentials.json"))
+    if creds.exists():
+        try:
+            tok = json.loads(creds.read_text()).get("claudeAiOauth", {}).get("accessToken")
+        except (OSError, json.JSONDecodeError):
+            tok = None
+        if tok:
+            data = _http_get_json(
+                "https://api.anthropic.com/v1/models",
+                {"Authorization": f"Bearer {tok}", "anthropic-version": "2023-06-01"},
+            )
+            if data and isinstance(data.get("data"), list):
+                s.models = [m["id"] for m in data["data"] if m.get("id")]
+                s.notes = f"live catalog from api.anthropic.com ({len(s.models)} models)"
+                if s.authed is None:
+                    s.authed = True
     return s
 
 
@@ -172,11 +243,34 @@ def probe_copilot() -> CLIStatus:
         return s
     s.installed = True
     s.path = p
-    # No headless auth-status command; presence + Copilot Pro sub
-    # assumed. operator can override via env var.
-    s.authed = None
-    s.notes = "auth not programmatically detectable; Copilot Pro sub assumed"
-    s.models = list(COPILOT_MODELS)
+    # Copilot CLI uses the same auth as `gh` — pull a token, hit the
+    # models endpoint. This is the SAME catalog the CLI sees.
+    rc, tok, _ = _run(["gh", "auth", "token"], timeout=4)
+    tok = tok.strip() if rc == 0 else ""
+    if tok:
+        data = _http_get_json(
+            "https://api.githubcopilot.com/models",
+            {
+                "Authorization": f"Bearer {tok}",
+                "Editor-Version": "vscode/1.95.0",
+                "Copilot-Integration-Id": "vscode-chat",
+            },
+        )
+        if data and isinstance(data.get("data"), list):
+            s.authed = True
+            # Filter to chat-completion models the picker enables.
+            s.models = [
+                m["id"] for m in data["data"]
+                if m.get("model_picker_enabled")
+                and (m.get("capabilities") or {}).get("type") == "chat"
+            ]
+            s.auth_detail = {
+                "vendor_breakdown": _vendor_count(data["data"]),
+            }
+            s.notes = f"live catalog from api.githubcopilot.com ({len(s.models)} models, picker-enabled chat)"
+            return s
+    s.authed = False
+    s.notes = "no gh token (run `gh auth login`)"
     return s
 
 
@@ -187,9 +281,25 @@ def probe_codex() -> CLIStatus:
         return s
     s.installed = True
     s.path = p
-    s.authed = None
-    s.notes = "auth not programmatically detectable; OpenAI sub assumed"
-    s.models = list(CODEX_MODELS)
+    # codex writes "Logged in using ..." to stderr, not stdout.
+    rc, out, err = _run(["codex", "login", "status"], timeout=6)
+    combined = (out + "\n" + err).strip()
+    s.authed = (rc == 0 and "Logged in" in combined)
+    if s.authed and combined:
+        s.auth_detail = {"login_status": combined.splitlines()[0]}
+    # `codex debug models` renders the raw JSON catalog the CLI uses —
+    # this is the source of truth for the operator's plan.
+    rc, out, _ = _run(["codex", "debug", "models"], timeout=8)
+    if rc == 0 and out.strip().startswith("{"):
+        try:
+            data = json.loads(out)
+            s.models = [
+                m["slug"] for m in data.get("models", [])
+                if m.get("visibility") == "list" and m.get("slug")
+            ]
+            s.notes = f"live catalog from `codex debug models` ({len(s.models)} models)"
+        except json.JSONDecodeError:
+            s.notes = "codex debug models returned non-JSON"
     return s
 
 
@@ -200,10 +310,45 @@ def probe_gemini() -> CLIStatus:
         return s
     s.installed = True
     s.path = p
-    s.authed = None
-    s.notes = "auth not programmatically detectable; Google AI Pro sub assumed"
-    s.models = list(GEMINI_CLOUD_MODELS)
+    # Refresh OAuth + ask the Code Assist endpoint for the user's tier.
+    # Tier confirms the model set; the OAuth scope can't enumerate
+    # generativelanguage models so we use a tier-scoped curated list.
+    tok = _gemini_refresh_token()
+    if tok:
+        data = _http_post_json(
+            "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
+            {"Authorization": f"Bearer {tok}"},
+            {"metadata": {"pluginType": "GEMINI", "ideType": "IDE_UNSPECIFIED"}},
+        )
+        if data:
+            s.authed = True
+            current_tier = (data.get("currentTier") or {}).get("id") or "unknown"
+            paid_tier_id = ((data.get("paidTier") or {}).get("id") or "").lower()
+            s.auth_detail = {
+                "current_tier": current_tier,
+                "paid_tier": paid_tier_id or None,
+                "project": data.get("cloudaicompanionProject"),
+            }
+            # paidTier id "g1-pro-tier" = Google One AI Pro.
+            if paid_tier_id == "g1-pro-tier" or current_tier in ("standard-tier", "pro-tier"):
+                s.models = list(GEMINI_PRO_TIER_MODELS)
+                s.notes = f"AI Pro tier confirmed via CodeAssist ({current_tier})"
+            else:
+                s.models = list(GEMINI_FREE_TIER_MODELS)
+                s.notes = f"free tier ({current_tier})"
+            return s
+    s.authed = False
+    s.notes = "no usable OAuth credentials (run `gemini` to log in / refresh)"
+    s.models = list(GEMINI_FREE_TIER_MODELS)
     return s
+
+
+def _vendor_count(models: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for m in models:
+        v = m.get("vendor") or "unknown"
+        counts[v] = counts.get(v, 0) + 1
+    return counts
 
 
 def probe_hermes() -> CLIStatus:
@@ -276,59 +421,109 @@ PROBES = [
 
 # ─── Cross-reference operator's models with seed db ────────────────────────
 
+# OpenClaw drivers wrap a backing model. The seed db doesn't have rows
+# for the chitin-specific 'openclaw-*' driver names; lookups must go
+# against the actual model names. Per chitin's DriverIdSchema comments.
+OPENCLAW_DRIVER_TO_MODEL = {
+    "openclaw-glm-flash": "glm-4.7-flash",
+    "openclaw-glm-cloud": "glm-5.1:cloud",
+    "openclaw-deepseek": "deepseek-coder",
+}
+
+# Minimum search-token length before broadening. "gpt" alone matches
+# every GPT submission ever made (including SOTA gpt-5 high at 88%
+# polyglot, which is NOT what gpt-5.0-mini scored). Refuse to broaden
+# below this threshold — better to show "no data" than misleading data
+# from a different model.
+MIN_TOKEN_CHARS = 6
+
+
+def _normalize_model_id(s: str) -> str:
+    """Strip operator-display cruft so the search-token expansion stays
+    on the actual model identifier:
+      - 'glm-4.7-flash:latest' → 'glm-4.7-flash' (drop ollama ':latest' tag)
+      - 'qwen3-coder:480b-cloud' → 'qwen3-coder-480b-cloud' (collapse ':' to '-')
+      - '◆default:qwen3-coder:30b' → 'qwen3-coder-30b' (drop hermes profile prefix)
+      - 'openai/gpt-4.1' → 'gpt-4.1' (drop provider prefix)
+    The expander then walks tokens of the normalized form.
+    """
+    s = s.lstrip("◆ ").strip()
+    if "/" in s:
+        s = s.split("/")[-1]
+    # Drop ':latest' tag (ollama default)
+    if s.endswith(":latest"):
+        s = s[: -len(":latest")]
+    # Hermes-style 'profile:model[:variant]' — strip leading profile name
+    # if it looks like a single-token identifier (no dashes/dots).
+    if ":" in s:
+        first, _, rest = s.partition(":")
+        if first and rest and first.replace("_", "").isalnum() and "-" not in first and "." not in first:
+            s = rest
+    # Collapse remaining colons to dashes so the dash-walking token
+    # expander treats `qwen3-coder-30b` and `qwen3-coder:30b` the same.
+    s = s.replace(":", "-")
+    return s
+
+
+def _resolve_lookup_token(model_token: str) -> str:
+    """Translate chitin-specific driver IDs to their backing model name,
+    then normalize for search.
+    """
+    bridged = OPENCLAW_DRIVER_TO_MODEL.get(model_token, model_token)
+    return _normalize_model_id(bridged)
+
+
 def _expand_search_tokens(model_token: str) -> list[str]:
     """Generate progressive search tokens, broadest last.
 
-    For 'claude-sonnet-4-6' → ['claude-sonnet-4-6', 'claude sonnet 4 6',
+    Refuses to emit tokens shorter than MIN_TOKEN_CHARS to avoid the
+    'gpt-5.0-mini matched gpt-5 (high)' false-family-match bug. For
+    `claude-sonnet-4-6` → ['claude-sonnet-4-6', 'claude sonnet 4 6',
     'claude-sonnet-4', 'claude sonnet 4', 'claude-sonnet', 'claude sonnet'].
-
-    Lets the cross-reference fall back to family-level matches when the
-    exact version isn't in the seed data yet (chitin tracks
-    claude-sonnet-4-6 but seeds may only have through 4-5; the broader
-    'claude-sonnet' match still surfaces useful scores from the family
-    line as a "best-known predecessor" signal).
+    For `gpt-5.0-mini` → ['gpt-5.0-mini', 'gpt 5.0 mini', 'gpt-5.0',
+    'gpt 5.0'] (stops before 'gpt' because 6-char floor).
     """
-    t = model_token.lower().split(":")[-1]   # strip provider prefix like 'qwen/qwen3-coder'
+    t = model_token.lower().split("/")[-1]  # strip provider prefix like 'qwen/qwen3-coder'
     parts = t.split("-")
     tokens: list[str] = []
     seen: set[str] = set()
     for n in range(len(parts), 0, -1):
-        s = "-".join(parts[:n])
-        if s and s not in seen:
-            tokens.append(s); seen.add(s)
-        s2 = " ".join(parts[:n])
-        if s2 and s2 not in seen:
-            tokens.append(s2); seen.add(s2)
+        for joiner in ("-", " "):
+            s = joiner.join(parts[:n])
+            if len(s) >= MIN_TOKEN_CHARS and s not in seen:
+                tokens.append(s); seen.add(s)
     return tokens
 
 
-def _model_seed_lookup(conn: sqlite3.Connection, model_token: str) -> tuple[dict[str, dict[str, float]], str | None]:
-    """For a given model name (or partial), pull matching seed rows.
+def _model_seed_lookup(
+    conn: sqlite3.Connection, model_token: str
+) -> tuple[dict[str, dict[str, tuple[float, str]]], str | None]:
+    """For a given model (or driver-id), pull matching seed rows.
 
-    Returns (scores_by_source, matched_token). matched_token is the
-    progressively-broadened search term that produced the first match
-    (None when nothing matched at any level). Use the matched_token to
-    flag in the report when scores come from a family-level fallback
-    rather than an exact model match.
+    Returns ({source: {metric: (value, source_model_name)}}, matched_token).
+    The source_model_name lets the report show WHICH leaderboard row each
+    score came from — critical for family-fallback transparency
+    ("aider-polyglot 88% (matched 'gpt-5 (high)')" tells the operator the
+    score is from a different sibling model, not their actual one).
     """
-    out: dict[str, dict[str, float]] = {}
+    resolved = _resolve_lookup_token(model_token)
+    out: dict[str, dict[str, tuple[float, str]]] = {}
     matched_token: str | None = None
-    for token in _expand_search_tokens(model_token):
+    for token in _expand_search_tokens(resolved):
         cur = conn.execute(
-            "SELECT source, metric, value FROM model_seeds "
+            "SELECT model, source, metric, value FROM model_seeds "
             "WHERE LOWER(model) LIKE ? "
-            "ORDER BY source, metric",
+            "ORDER BY source, metric, value DESC",
             (f"%{token}%",),
         )
         rows = cur.fetchall()
         if rows:
-            for src, metric, value in rows:
-                # Keep the BEST value per (source, metric) when multiple
-                # variants of the family match — surfaces the strongest
-                # known datum from the family line.
-                cur_val = out.get(src, {}).get(metric)
-                if cur_val is None or value > cur_val:
-                    out.setdefault(src, {})[metric] = value
+            for matched_model, src, metric, value in rows:
+                # Keep the BEST value per (source, metric); record which
+                # model row contributed it.
+                cur_entry = out.get(src, {}).get(metric)
+                if cur_entry is None or value > cur_entry[0]:
+                    out.setdefault(src, {})[metric] = (value, matched_model)
             matched_token = token
             break
     return out, matched_token
@@ -400,29 +595,35 @@ def cmd_report(_args) -> None:
                 conn, model.split(":")[-1] if ":" in model else model
             )
             scores: list[str] = []
-            cost_in = None
+            cost_in: float | None = None
+            cost_model: str | None = None
+            sources_used: set[str] = set()
             for src, metrics in seeds.items():
                 if src == "openrouter":
-                    cost_in = metrics.get("prompt_token_cost_usd")
+                    if "prompt_token_cost_usd" in metrics:
+                        cost_in, cost_model = metrics["prompt_token_cost_usd"]
                     continue
-                # Pick one headline metric per source (best-known of the family)
-                if src.startswith("aider"):
-                    v = metrics.get("pass_rate_2")
-                    if v is not None: scores.append(f"{src}:{v:.1f}%")
-                elif src.startswith("swebench"):
-                    v = metrics.get("resolved_rate")
-                    if v is not None: scores.append(f"{src}:{v:.1f}%")
-                elif src == "evalplus":
-                    v = metrics.get("pass@1_humaneval+")
-                    if v is not None: scores.append(f"evalplus(he+):{v:.1f}%")
-                elif src == "arena-hard":
-                    v = metrics.get("score")
-                    if v is not None: scores.append(f"arena:{v:.1f}")
-            cost_str = f"${cost_in:.7f}/in-tok" if cost_in is not None else "(no cost data)"
-            score_str = "  ".join(scores) if scores else "(no benchmark data — too new for any seed source)"
+                # Headline metric per source — surface value + which model row contributed it
+                metric_key = (
+                    "pass_rate_2" if src.startswith("aider")
+                    else "resolved_rate" if src.startswith("swebench")
+                    else "pass@1_humaneval+" if src == "evalplus"
+                    else "score" if src == "arena-hard"
+                    else None
+                )
+                if metric_key and metric_key in metrics:
+                    v, src_model = metrics[metric_key]
+                    label = f"{src}:{v:.1f}{'%' if src != 'arena-hard' else ''}"
+                    scores.append(f"{label} (`{src_model[:40]}`)")
+                    sources_used.add(src)
+            cost_str = (f"${cost_in:.7f}/in-tok" + (f" (`{cost_model[:30]}`)" if cost_model else "")
+                        ) if cost_in is not None else "(no cost data)"
+            score_str = "; ".join(scores) if scores else "(no benchmark data — too new for any seed source)"
+            target = (model.lower().split(":")[-1] if ":" in model else model.lower())
+            target = OPENCLAW_DRIVER_TO_MODEL.get(target, target)  # show resolved target for openclaw
             match_note = ""
-            if matched_token and matched_token.lower() != (model.lower().split(":")[-1] if ":" in model else model.lower()):
-                match_note = f"  _(family-level fallback: matched on `{matched_token}`)_"
+            if matched_token and matched_token != target:
+                match_note = f"  _(family fallback: matched `{matched_token}`)_"
             lines.append(f"- **{model}** — {cost_str}{match_note}")
             lines.append(f"  - {score_str}")
         lines.append("")

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -725,11 +725,16 @@ def _model_seed_lookup(
     out: dict[str, dict[str, tuple[float, str]]] = {}
     matched_token: str | None = None
     for token in _expand_search_tokens(resolved):
+        # Normalize dots to dashes on BOTH sides — different leaderboards
+        # publish the same model as "gpt-5.4" or "gpt-5-4". Without this,
+        # tbench.ai's `gpt-5-4` row never matches the operator's `gpt-5.4`
+        # display name.
+        token_norm = token.replace(".", "-")
         cur = conn.execute(
             "SELECT model, source, metric, value FROM model_seeds "
-            "WHERE LOWER(model) LIKE ? "
+            "WHERE LOWER(REPLACE(model, '.', '-')) LIKE ? "
             "ORDER BY source, metric, value DESC",
-            (f"%{token}%",),
+            (f"%{token_norm}%",),
         )
         rows = cur.fetchall()
         if rows:
@@ -832,6 +837,24 @@ def cmd_report(_args) -> None:
                             continue  # failure stub, don't render
                         label = f"{metric}:{v:.1f}"
                         scores.append(f"{label} (`{src_model[:40]}`, {tag})")
+                        sources_used.add(src)
+                    continue
+                # terminal-bench-2.0 has many score_<harness> metrics per
+                # model — surface the BEST harness's score (peak capability)
+                # since operators can pick the harness too.
+                if src == "terminal-bench-2.0":
+                    best_metric = None
+                    best_value = -1.0
+                    best_src_model = None
+                    for metric, (v, src_model) in metrics.items():
+                        if metric.startswith("score_") and v > best_value:
+                            best_value = v
+                            best_metric = metric
+                            best_src_model = src_model
+                    if best_metric is not None:
+                        harness = best_metric.removeprefix("score_").replace("_", " ")
+                        label = f"terminal-bench-2.0:{best_value:.1f}% (best harness: {harness})"
+                        scores.append(f"{label}")
                         sources_used.add(src)
                     continue
                 metric_key = (

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -290,6 +290,8 @@ def operator_cost_band(
     copilot_plan: str = "pro",
     codex_plan: str = "plus",
     gemini_tier: str = "standard-tier",
+    copilot_remaining: int | None = None,
+    copilot_entitlement: int | None = None,
 ) -> str | None:
     """Return a short string describing the operator's marginal cost on
     this (driver, model) under their subscription. None when we have
@@ -312,13 +314,21 @@ def operator_cost_band(
         }.get(copilot_plan, f"Copilot {copilot_plan}")
         if mult == 0.0:
             return f"**FREE on {plan_label}**"
-        budget = COPILOT_MONTHLY_PREMIUM_REQUESTS.get(copilot_plan, 300)
+        # Prefer LIVE remaining quota over static plan default — live
+        # number reflects what the operator can ACTUALLY spend before
+        # next reset, accounting for what they've already burned.
+        budget = copilot_entitlement if copilot_entitlement else COPILOT_MONTHLY_PREMIUM_REQUESTS.get(copilot_plan, 300)
         calls_per_month = budget / mult if mult else float("inf")
+        # If we have live quota, also show calls remaining THIS cycle
+        remaining_str = ""
+        if copilot_remaining is not None and mult > 0:
+            calls_left = copilot_remaining / mult
+            remaining_str = f", **{calls_left:.0f} left this cycle**"
         if mult < 1.0:
-            return f"x{mult:g} (~{calls_per_month:.0f} calls/month on {plan_label})"
+            return f"x{mult:g} (~{calls_per_month:.0f} calls/month on {plan_label}{remaining_str})"
         if mult == 1.0:
-            return f"x1 ({calls_per_month:.0f} calls/month on {plan_label})"
-        return f"**x{mult:g}** (~{calls_per_month:.0f} calls/month on {plan_label}, premium)"
+            return f"x1 ({calls_per_month:.0f} calls/month on {plan_label}{remaining_str})"
+        return f"**x{mult:g}** (~{calls_per_month:.0f} calls/month on {plan_label}, premium{remaining_str})"
 
     if driver == "codex":
         # Plan label uses what the operator pays for, not OpenAI's internal id.
@@ -474,14 +484,41 @@ def probe_copilot() -> CLIStatus:
                 and (m.get("capabilities") or {}).get("type") == "chat"
             )
             n_other = len(s.models) - n_picker
+            # Probe copilot_internal/user for the operator's actual
+            # plan + live Premium-Interaction quota. Only programmatic
+            # way to differentiate Pro vs Pro+ vs Business vs Enterprise
+            # AND see remaining budget.
+            user = _http_get_json(
+                "https://api.github.com/copilot_internal/user",
+                {"Authorization": f"Bearer {tok}", "Editor-Version": "vscode/1.95.0"},
+            )
+            plan_detail: dict = {}
+            if user:
+                premium = (user.get("quota_snapshots") or {}).get("premium_interactions") or {}
+                plan_detail = {
+                    "plan": user.get("copilot_plan"),
+                    "sku": user.get("access_type_sku"),
+                    "quota_reset_date": user.get("quota_reset_date"),
+                    "premium_entitlement": premium.get("entitlement"),
+                    "premium_remaining": premium.get("remaining"),
+                    "premium_pct_remaining": premium.get("percent_remaining"),
+                    "overage_permitted": premium.get("overage_permitted"),
+                }
             s.auth_detail = {
                 "vendor_breakdown": _vendor_count(data["data"]),
                 "picker_enabled": n_picker,
                 "api_only": n_other,
+                **plan_detail,
             }
+            quota_str = ""
+            if plan_detail.get("premium_entitlement"):
+                rem = plan_detail.get("premium_remaining")
+                ent = plan_detail.get("premium_entitlement")
+                pct = plan_detail.get("premium_pct_remaining")
+                quota_str = f", plan={plan_detail.get('plan')}, premium_quota={rem}/{ent} ({pct}% remaining)"
             s.notes = (
                 f"live catalog from api.githubcopilot.com "
-                f"({len(s.models)} chat models: {n_picker} picker, {n_other} api-only/free)"
+                f"({len(s.models)} chat models: {n_picker} picker, {n_other} api-only/free){quota_str}"
             )
             return s
     s.authed = False
@@ -875,7 +912,16 @@ def cmd_report(_args) -> None:
             # actual subscription budget? Different drivers, different
             # shapes — copilot multipliers vs codex 5h ranges vs gemini
             # daily aggregate vs claude max windows vs free local.
-            op_cost = operator_cost_band(s["name"], model)
+            kw: dict = {}
+            if s["name"] == "copilot" and s.get("auth_detail"):
+                ad = s["auth_detail"]
+                if ad.get("plan"):
+                    kw["copilot_plan"] = ad["plan"]
+                if ad.get("premium_remaining") is not None:
+                    kw["copilot_remaining"] = ad["premium_remaining"]
+                if ad.get("premium_entitlement"):
+                    kw["copilot_entitlement"] = ad["premium_entitlement"]
+            op_cost = operator_cost_band(s["name"], model, **kw)
             if op_cost:
                 cost_str += f"  | {op_cost}"
             score_str = "; ".join(scores) if scores else "(no benchmark data — too new for any seed source)"

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -591,9 +591,12 @@ def cmd_report(_args) -> None:
         lines.append(f"### {s['name']}")
         lines.append("")
         for model in s["models"]:
-            seeds, matched_token = _model_seed_lookup(
-                conn, model.split(":")[-1] if ":" in model else model
-            )
+            # Pass the full operator-display name; _model_seed_lookup
+            # handles normalization (strip ':latest', collapse colons,
+            # bridge openclaw drivers, etc.) consistently. A previous
+            # pre-strip of `split(":")[-1]` turned 'gemma4:latest' into
+            # 'latest' and matched every chatgpt-4o-latest row.
+            seeds, matched_token = _model_seed_lookup(conn, model)
             scores: list[str] = []
             cost_in: float | None = None
             cost_model: str | None = None
@@ -604,14 +607,16 @@ def cmd_report(_args) -> None:
                         cost_in, cost_model = metrics["prompt_token_cost_usd"]
                     continue
                 # Headline metric per source — surface value + which model row contributed it.
-                # web-search source: the metric IS the benchmark name (LLM extraction
-                # populates it freely), so surface every metric in this source.
-                if src == "web-search":
+                # web-search and huggingface sources: the metric IS the benchmark
+                # name (LLM extraction populates it freely), so surface every metric
+                # in this source. The trailing tag distinguishes their provenance.
+                if src in ("web-search", "huggingface"):
+                    tag = "web" if src == "web-search" else "hf"
                     for metric, (v, src_model) in metrics.items():
                         if metric == "extraction_attempted":
                             continue  # failure stub, don't render
                         label = f"{metric}:{v:.1f}"
-                        scores.append(f"{label} (`{src_model[:40]}`, web)")
+                        scores.append(f"{label} (`{src_model[:40]}`, {tag})")
                         sources_used.add(src)
                     continue
                 metric_key = (

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -92,16 +92,29 @@ class CLIStatus:
 #
 # Curated fallbacks (used only when the live probe fails):
 
+# Gemini Code Assist's loadCodeAssist endpoint returns tier metadata
+# but no model catalog. The Gemini CLI itself ships with a hardcoded
+# list it routes against. Pro tier users can also call free-tier
+# models — the lists below are union, not exclusive.
+#
+# Source: gemini-cli's internal model list + Google AI Pro docs.
+# Update when Google ships new SKUs (no programmatic enumeration today).
 GEMINI_PRO_TIER_MODELS = [
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
     "gemini-3",
+    "gemini-3-pro",
+    "gemini-3-pro-image",
+    # Pro tier ALSO includes everything from free tier:
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
 ]
 
 GEMINI_FREE_TIER_MODELS = [
     "gemini-2.0-flash-lite",
     "gemini-2.0-flash",
+    "gemini-2.5-flash-lite",
 ]
 
 
@@ -258,16 +271,36 @@ def probe_copilot() -> CLIStatus:
         )
         if data and isinstance(data.get("data"), list):
             s.authed = True
-            # Filter to chat-completion models the picker enables.
-            s.models = [
-                m["id"] for m in data["data"]
+            # Include EVERY chat-completion model the API exposes.
+            # picker_enabled=False just means "not in the Chat picker UI"
+            # — the model is still callable via the API. That includes
+            # free-tier / legacy models (gpt-4o-mini, gpt-3.5-turbo)
+            # operators want to route cheap-T0 work to.
+            seen: set[str] = set()
+            s.models = []
+            for m in data["data"]:
+                if (m.get("capabilities") or {}).get("type") != "chat":
+                    continue
+                mid = m["id"]
+                if mid in seen:
+                    continue
+                seen.add(mid)
+                s.models.append(mid)
+            n_picker = sum(
+                1 for m in data["data"]
                 if m.get("model_picker_enabled")
                 and (m.get("capabilities") or {}).get("type") == "chat"
-            ]
+            )
+            n_other = len(s.models) - n_picker
             s.auth_detail = {
                 "vendor_breakdown": _vendor_count(data["data"]),
+                "picker_enabled": n_picker,
+                "api_only": n_other,
             }
-            s.notes = f"live catalog from api.githubcopilot.com ({len(s.models)} models, picker-enabled chat)"
+            s.notes = (
+                f"live catalog from api.githubcopilot.com "
+                f"({len(s.models)} chat models: {n_picker} picker, {n_other} api-only/free)"
+            )
             return s
     s.authed = False
     s.notes = "no gh token (run `gh auth login`)"

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -160,12 +160,26 @@ def _gemini_refresh_token() -> str | None:
         return creds["access_token"]
     if not refresh:
         return None
-    # Public client credentials embedded in @google/gemini-cli source.
+    # Read gemini-cli's OAuth client credentials from env. The values
+    # ARE public (embedded in @google/gemini-cli's npm package source)
+    # but GitHub secret-scanning flags the GOCSPX- format regardless,
+    # blocking pushes when they're inline. Operator who wants gemini
+    # OAuth refresh exports them once:
+    #
+    #   export GEMINI_CLI_CLIENT_ID="$(cat /path/to/gemini-cli/.../client_id)"
+    #   export GEMINI_CLI_CLIENT_SECRET="$(cat /path/to/gemini-cli/.../client_secret)"
+    #
+    # When unset, this code path returns None and the gemini probe
+    # falls back to its expired-token state.
+    client_id = os.environ.get("GEMINI_CLI_CLIENT_ID")
+    client_secret = os.environ.get("GEMINI_CLI_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        return None
     import urllib.request
     import urllib.parse
     body = urllib.parse.urlencode({
-        "client_id": "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
-        "client_secret": "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",
+        "client_id": client_id,
+        "client_secret": client_secret,
         "refresh_token": refresh,
         "grant_type": "refresh_token",
     }).encode("utf-8")

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -603,7 +603,17 @@ def cmd_report(_args) -> None:
                     if "prompt_token_cost_usd" in metrics:
                         cost_in, cost_model = metrics["prompt_token_cost_usd"]
                     continue
-                # Headline metric per source — surface value + which model row contributed it
+                # Headline metric per source — surface value + which model row contributed it.
+                # web-search source: the metric IS the benchmark name (LLM extraction
+                # populates it freely), so surface every metric in this source.
+                if src == "web-search":
+                    for metric, (v, src_model) in metrics.items():
+                        if metric == "extraction_attempted":
+                            continue  # failure stub, don't render
+                        label = f"{metric}:{v:.1f}"
+                        scores.append(f"{label} (`{src_model[:40]}`, web)")
+                        sources_used.add(src)
+                    continue
                 metric_key = (
                     "pass_rate_2" if src.startswith("aider")
                     else "resolved_rate" if src.startswith("swebench")

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -182,6 +182,61 @@ def _gemini_refresh_token() -> str | None:
     except Exception:
         return None
 
+# Copilot request multipliers per model. From
+# docs.github.com/en/copilot/concepts/billing/copilot-requests (May 2026).
+# Multiplier 0 = unmetered for paid Copilot plans; multipliers >0 burn
+# the operator's monthly Premium-Request budget at that rate. The
+# OpenRouter raw $/token still applies if the operator routes the same
+# model OUTSIDE Copilot — these two costs answer different questions.
+#
+# Keys match Copilot's API model id (lowercased). Update as GitHub
+# ships new SKUs / renames; the page is the source of truth.
+COPILOT_MULTIPLIERS: dict[str, float] = {
+    # Free for Copilot Pro
+    "gpt-4.1": 0.0,
+    "gpt-4.1-2025-04-14": 0.0,
+    "gpt-4o": 0.0,
+    "gpt-4o-2024-05-13": 0.0,
+    "gpt-4o-2024-08-06": 0.0,
+    "gpt-4o-2024-11-20": 0.0,
+    "gpt-4o-mini": 0.0,
+    "gpt-4o-mini-2024-07-18": 0.0,
+    # Cheap (≤0.33)
+    "gpt-5.4-nano": 0.25,
+    "claude-haiku-4.5": 0.33,
+    "gpt-5.4-mini": 0.33,
+    "gemini-3-flash": 0.33,
+    # Standard (x1)
+    "gpt-5.2": 1.0,
+    "gpt-5.2-codex": 1.0,
+    "gpt-5.3-codex": 1.0,
+    "gpt-5.4": 1.0,
+    "claude-sonnet-4.5": 1.0,
+    "claude-sonnet-4.6": 1.0,
+    "gemini-2.5-pro": 1.0,
+    "gemini-3.1-pro": 1.0,
+    # Premium
+    "claude-opus-4.5": 3.0,
+    "claude-opus-4.6": 3.0,
+    "claude-opus-4.7": 15.0,
+    "claude-opus-4.6-1m": 30.0,    # "fast mode" SKU
+    "gpt-5.5": 7.5,
+    # Legacy / deprecated — billed at host rate; unspecified means assume 0
+    "gpt-3.5-turbo": 0.0,
+    "gpt-3.5-turbo-0613": 0.0,
+    "gpt-4": 0.0,
+    "gpt-4-0613": 0.0,
+    "gpt-4-o-preview": 0.0,
+}
+
+
+def copilot_multiplier(model_id: str) -> float | None:
+    """Return Copilot's per-request multiplier (0 = free, 1 = standard,
+    higher = premium). Returns None if we don't have a published
+    multiplier for this model."""
+    return COPILOT_MULTIPLIERS.get(model_id.lower())
+
+
 # OpenClaw maps each driver-id to a backing agent + model. Per
 # DriverIdSchema in libs/contracts:
 OPENCLAW_AGENTS = {
@@ -666,6 +721,21 @@ def cmd_report(_args) -> None:
                     sources_used.add(src)
             cost_str = (f"${cost_in:.7f}/in-tok" + (f" (`{cost_model[:30]}`)" if cost_model else "")
                         ) if cost_in is not None else "(no cost data)"
+            # For Copilot, surface the request multiplier — that's the
+            # operator's REAL marginal cost on a Copilot Pro sub.
+            # Multiplier 0 means unmetered (free above the per-month
+            # request cap); >1 means burns budget at that rate.
+            if s["name"] == "copilot":
+                mult = copilot_multiplier(model)
+                if mult is not None:
+                    if mult == 0.0:
+                        cost_str += "  | **Copilot: x0 (free for Pro)**"
+                    elif mult < 1.0:
+                        cost_str += f"  | Copilot: x{mult:g} (cheap)"
+                    elif mult == 1.0:
+                        cost_str += f"  | Copilot: x1 (standard)"
+                    else:
+                        cost_str += f"  | Copilot: **x{mult:g}** (premium)"
             score_str = "; ".join(scores) if scores else "(no benchmark data — too new for any seed source)"
             target = (model.lower().split(":")[-1] if ":" in model else model.lower())
             target = OPENCLAW_DRIVER_TO_MODEL.get(target, target)  # show resolved target for openclaw

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -303,27 +303,48 @@ def operator_cost_band(
         mult = copilot_multiplier(model_id)
         if mult is None:
             return None
+        plan_label = {
+            "free":      "Copilot Free",
+            "pro":       "Copilot Pro ($10/mo)",
+            "pro-plus":  "Copilot Pro+ ($39/mo)",
+            "business":  "Copilot Business",
+            "enterprise": "Copilot Enterprise",
+        }.get(copilot_plan, f"Copilot {copilot_plan}")
         if mult == 0.0:
-            return f"**FREE on Copilot {copilot_plan.title()}**"
+            return f"**FREE on {plan_label}**"
         budget = COPILOT_MONTHLY_PREMIUM_REQUESTS.get(copilot_plan, 300)
         calls_per_month = budget / mult if mult else float("inf")
         if mult < 1.0:
-            return f"x{mult:g} (~{calls_per_month:.0f} calls/month on {copilot_plan.title()})"
+            return f"x{mult:g} (~{calls_per_month:.0f} calls/month on {plan_label})"
         if mult == 1.0:
-            return f"x1 ({calls_per_month:.0f} calls/month on {copilot_plan.title()})"
-        return f"**x{mult:g}** (~{calls_per_month:.0f} calls/month on {copilot_plan.title()}, premium)"
+            return f"x1 ({calls_per_month:.0f} calls/month on {plan_label})"
+        return f"**x{mult:g}** (~{calls_per_month:.0f} calls/month on {plan_label}, premium)"
 
     if driver == "codex":
+        # Plan label uses what the operator pays for, not OpenAI's internal id.
+        plan_label = {
+            "plus":     "ChatGPT Plus ($20/mo)",
+            "pro-5x":   "ChatGPT Pro $100",
+            "pro-20x":  "ChatGPT Pro $200",
+            "business": "ChatGPT Business",
+        }.get(codex_plan, f"ChatGPT {codex_plan}")
         limits = CODEX_5H_LIMITS.get(codex_plan, {}).get(model_id)
         if limits is None:
-            return f"ChatGPT {codex_plan.title()} — limit not published"
+            return f"{plan_label} — limit not published for {model_id}"
         lo, hi = limits
-        # Convert 5h → daily-ish for parity with other drivers
-        return f"{lo}–{hi}/5h on ChatGPT {codex_plan.title()} (~{lo*4.8:.0f}–{hi*4.8:.0f}/day)"
+        return f"{lo}–{hi}/5h on {plan_label} (~{lo*4.8:.0f}–{hi*4.8:.0f}/day)"
 
     if driver == "gemini":
+        # Display uses Google's marketing name (what the operator
+        # actually bought) instead of the loadCodeAssist internal id.
         n = GEMINI_DAILY_REQUESTS.get(gemini_tier, 1500)
-        return f"1/{n} of daily quota on {gemini_tier} (model-agnostic)"
+        plan_label = {
+            "free": "Google Free",
+            "standard-tier": "Google AI Pro ($20/mo)",
+            "g1-pro-tier": "Google AI Pro ($20/mo)",
+            "enterprise": "Google AI Enterprise",
+        }.get(gemini_tier, gemini_tier)
+        return f"1/{n} of daily quota on {plan_label} (model-agnostic)"
 
     if driver == "claude":
         # Claude Max absorbs per-token cost up to plan limits. The

--- a/python/analysis/operator_matrix.py
+++ b/python/analysis/operator_matrix.py
@@ -237,6 +237,112 @@ def copilot_multiplier(model_id: str) -> float | None:
     return COPILOT_MULTIPLIERS.get(model_id.lower())
 
 
+# Codex CLI per-model 5-hour message ranges by ChatGPT plan tier.
+# Source: developers.openai.com/codex/pricing (May 2026). Ranges are
+# (light task, heavy task) — task complexity determines actual count.
+# Plus quotas got a temporary 25× boost through May 31 2026 per the
+# OpenAI community thread; these are the published baseline numbers.
+CODEX_5H_LIMITS = {
+    "plus": {
+        "gpt-5.5":         (15, 80),
+        "gpt-5.4":         (20, 100),
+        "gpt-5.4-mini":    (60, 350),
+        "gpt-5.3-codex":   (30, 150),     # plus 10-60 cloud
+    },
+    "pro-5x": {
+        "gpt-5.5":         (80, 400),
+        "gpt-5.4":         (100, 500),
+        "gpt-5.4-mini":    (300, 1750),
+        "gpt-5.3-codex":   (150, 750),
+    },
+    "pro-20x": {
+        "gpt-5.5":         (300, 1600),
+        "gpt-5.4":         (400, 2000),
+        "gpt-5.4-mini":    (1200, 7000),
+        "gpt-5.3-codex":   (600, 3000),
+    },
+}
+
+# Gemini Code Assist daily aggregate (model-agnostic — quota burns
+# the same regardless of which Gemini variant the operator picks).
+GEMINI_DAILY_REQUESTS = {
+    "free":           1000,
+    "standard-tier":  1500,    # Google AI Pro
+    "g1-pro-tier":    1500,    # alias: same as standard-tier per CodeAssist
+    "enterprise":     2000,
+}
+
+# Copilot monthly Premium Request budget by plan. x0 models don't
+# touch this budget; x1+ models burn at multiplier rate.
+COPILOT_MONTHLY_PREMIUM_REQUESTS = {
+    "free":         50,
+    "pro":          300,
+    "pro-plus":     1500,
+    "business":     300,
+    "enterprise":   1000,
+}
+
+
+def operator_cost_band(
+    driver: str,
+    model_id: str,
+    *,
+    copilot_plan: str = "pro",
+    codex_plan: str = "plus",
+    gemini_tier: str = "standard-tier",
+) -> str | None:
+    """Return a short string describing the operator's marginal cost on
+    this (driver, model) under their subscription. None when we have
+    no data for the combination.
+
+    Output is meant for the matrix display — short, grok-able at a
+    glance, captures BOTH whether the call is free under sub AND what
+    quota slot it burns.
+    """
+    if driver == "copilot":
+        mult = copilot_multiplier(model_id)
+        if mult is None:
+            return None
+        if mult == 0.0:
+            return f"**FREE on Copilot {copilot_plan.title()}**"
+        budget = COPILOT_MONTHLY_PREMIUM_REQUESTS.get(copilot_plan, 300)
+        calls_per_month = budget / mult if mult else float("inf")
+        if mult < 1.0:
+            return f"x{mult:g} (~{calls_per_month:.0f} calls/month on {copilot_plan.title()})"
+        if mult == 1.0:
+            return f"x1 ({calls_per_month:.0f} calls/month on {copilot_plan.title()})"
+        return f"**x{mult:g}** (~{calls_per_month:.0f} calls/month on {copilot_plan.title()}, premium)"
+
+    if driver == "codex":
+        limits = CODEX_5H_LIMITS.get(codex_plan, {}).get(model_id)
+        if limits is None:
+            return f"ChatGPT {codex_plan.title()} — limit not published"
+        lo, hi = limits
+        # Convert 5h → daily-ish for parity with other drivers
+        return f"{lo}–{hi}/5h on ChatGPT {codex_plan.title()} (~{lo*4.8:.0f}–{hi*4.8:.0f}/day)"
+
+    if driver == "gemini":
+        n = GEMINI_DAILY_REQUESTS.get(gemini_tier, 1500)
+        return f"1/{n} of daily quota on {gemini_tier} (model-agnostic)"
+
+    if driver == "claude":
+        # Claude Max absorbs per-token cost up to plan limits. The
+        # plan documents a 5-hour message window similar to Codex but
+        # without per-model breakdown — treat as "Max sub absorbs"
+        # until the operator hits a budget warning.
+        return "Max sub absorbs (per-window limits, model-agnostic)"
+
+    if driver in ("hermes", "ollama", "openclaw"):
+        # `:cloud` tag (and openclaw-*-cloud aliases) route through
+        # Ollama Cloud sub, not the local 3090 — call it out.
+        m_lower = model_id.lower()
+        if ":cloud" in m_lower or m_lower.endswith("-cloud") or "-cloud" in m_lower.split(":")[0]:
+            return "FREE (Ollama Cloud sub absorbs)"
+        return "FREE (local hardware)"
+
+    return None
+
+
 # OpenClaw maps each driver-id to a backing agent + model. Per
 # DriverIdSchema in libs/contracts:
 OPENCLAW_AGENTS = {
@@ -721,21 +827,13 @@ def cmd_report(_args) -> None:
                     sources_used.add(src)
             cost_str = (f"${cost_in:.7f}/in-tok" + (f" (`{cost_model[:30]}`)" if cost_model else "")
                         ) if cost_in is not None else "(no cost data)"
-            # For Copilot, surface the request multiplier — that's the
-            # operator's REAL marginal cost on a Copilot Pro sub.
-            # Multiplier 0 means unmetered (free above the per-month
-            # request cap); >1 means burns budget at that rate.
-            if s["name"] == "copilot":
-                mult = copilot_multiplier(model)
-                if mult is not None:
-                    if mult == 0.0:
-                        cost_str += "  | **Copilot: x0 (free for Pro)**"
-                    elif mult < 1.0:
-                        cost_str += f"  | Copilot: x{mult:g} (cheap)"
-                    elif mult == 1.0:
-                        cost_str += f"  | Copilot: x1 (standard)"
-                    else:
-                        cost_str += f"  | Copilot: **x{mult:g}** (premium)"
+            # Operator-real cost: how does this call hit the operator's
+            # actual subscription budget? Different drivers, different
+            # shapes — copilot multipliers vs codex 5h ranges vs gemini
+            # daily aggregate vs claude max windows vs free local.
+            op_cost = operator_cost_band(s["name"], model)
+            if op_cost:
+                cost_str += f"  | {op_cost}"
             score_str = "; ".join(scores) if scores else "(no benchmark data — too new for any seed source)"
             target = (model.lower().split(":")[-1] if ":" in model else model.lower())
             target = OPENCLAW_DRIVER_TO_MODEL.get(target, target)  # show resolved target for openclaw

--- a/python/analysis/refresh_stale.py
+++ b/python/analysis/refresh_stale.py
@@ -86,7 +86,7 @@ If no result has a verifiable score for THIS exact model, return:
 # defers cross-referenced multi-query mode (--thorough flag) to a
 # later commit.
 SEARCH_QUERY_TEMPLATE = (
-    "{model} SWE-bench aider polyglot HumanEval LiveCodeBench benchmark score"
+    "{model} terminal-bench SWE-bench aider polyglot HumanEval LiveCodeBench benchmark score"
 )
 
 # Where the failure-cache stub rows land — same model_seeds table,

--- a/python/analysis/refresh_stale.py
+++ b/python/analysis/refresh_stale.py
@@ -67,8 +67,10 @@ Return JSON ONLY (no prose, no code fences):
 }}
 
 Rules:
-  - "exact model": {model_id} is NOT the same as a sibling family
-    member. Family-level matches are rejected.
+  - "exact model": case-insensitive same identity is OK
+    ("GLM-4.7-Flash" == "glm-4.7-flash"). But sibling family members
+    are NOT — "claude-opus-4-7" ≠ "claude-opus-4-5", and "gpt-5.4"
+    ≠ "gpt-5.4-mini". When in doubt, return null.
   - "verifiable score": numeric, attached to a benchmark name, in the
     snippet text. Inferred or projected scores are rejected.
   - "score": a single number, never a range. If the source gives a
@@ -78,13 +80,13 @@ If no result has a verifiable score for THIS exact model, return:
 {{"benchmark": null, "score": null, "score_unit": null, "source_url": null, "scored_at": null}}
 """
 
-# Search query template per stale model. Kept simple — the design doc
+# Search query template per stale model. Tavily (and most managed
+# search backends) ignore Google-style `site:` filters and downweight
+# `OR` operators; keep the query natural-language. The design doc
 # defers cross-referenced multi-query mode (--thorough flag) to a
 # later commit.
 SEARCH_QUERY_TEMPLATE = (
-    "{model} benchmark score (SWE-bench OR aider-polyglot OR HumanEval "
-    "OR LiveCodeBench OR MMLU) site:github.com OR site:arxiv.org OR "
-    "site:openai.com OR site:anthropic.com OR site:deepmind.google"
+    "{model} SWE-bench aider polyglot HumanEval LiveCodeBench benchmark score"
 )
 
 # Where the failure-cache stub rows land — same model_seeds table,
@@ -223,7 +225,11 @@ def refresh_one(
 ) -> dict:
     """Refresh ONE model. Returns {status: 'refreshed'|'no-data'|'error',
     detail: str}. Never raises."""
-    q = SEARCH_QUERY_TEMPLATE.format(model=model)
+    # Search on the RESOLVED name, not the operator-display alias. The
+    # web has benchmarks for `glm-4.7-flash`, not chitin's internal
+    # `openclaw-glm-flash` driver alias.
+    search_name = _resolve_lookup_token(model)
+    q = SEARCH_QUERY_TEMPLATE.format(model=search_name)
     try:
         results = backend.query(q, n=n_results)
     except BackendError as e:
@@ -238,8 +244,12 @@ def refresh_one(
         f"[{i + 1}] {r['title']}\n    {r['url']}\n    {r['snippet'][:500]}"
         for i, r in enumerate(results)
     )
+    # Use the RESOLVED name in the prompt too — the LLM is matching
+    # the snippets against this id, and the snippets describe the
+    # backing model ('glm-4.7-flash'), not chitin's driver alias
+    # ('openclaw-glm-flash').
     prompt = EXTRACTION_PROMPT.format(
-        model_id=model, numbered_snippets=snippets
+        model_id=search_name, numbered_snippets=snippets
     )
 
     if dry_run:
@@ -257,9 +267,13 @@ def refresh_one(
     # Write the seed row. source='web-search' (per design §"failure
     # cache" — same source used for both successes and stub failures,
     # discriminated by metric).
+    # Store the seed under the RESOLVED model name so future lookups
+    # (which also resolve before searching) find it. For non-aliased
+    # models this is a no-op; for openclaw drivers it stores under
+    # 'glm-4.7-flash' instead of 'openclaw-glm-flash'.
     upsert_seed(
         conn=conn,
-        model=model,
+        model=search_name,
         source=FAILURE_SOURCE,
         metric=parsed["benchmark"],
         value=float(parsed["score"]),
@@ -267,6 +281,7 @@ def refresh_one(
         raw_payload={
             "source_url": parsed.get("source_url"),
             "score_unit": parsed.get("score_unit"),
+            "operator_alias": model if model != search_name else None,
             "extracted_from": [r["url"] for r in results],
         },
     )

--- a/python/analysis/refresh_stale.py
+++ b/python/analysis/refresh_stale.py
@@ -1,0 +1,364 @@
+"""Refresh stale model_seeds rows by web-searching for benchmark scores
+and extracting them via the operator's own LLM.
+
+Per docs/design/2026-05-06-stale-seed-refresh.md.
+
+Invariant: a model is STALE iff
+    M ∈ operator_matrix.json (in any cli's models[])
+  AND NOT EXISTS seed where (seed.model contains a long-enough token of
+      M's normalized form) AND seed.pulled_at > now - max_age.
+
+`refresh-stale` visits exactly the stale set, never the fresh set.
+That is the contract; if this implementation visits a fresh row, it's
+a bug.
+
+Usage:
+    cd python/analysis && uv run python -m analysis.refresh_stale \\
+        --max-age 7d [--dry-run] [--only <model>] [--backend tavily]
+
+Requires:
+  - operator_matrix.json (run `operator_matrix detect` first)
+  - $TAVILY_API_KEY (or other configured backend's env var)
+  - `claude` CLI authed (used for extraction; first commit only — once
+    chitin role 'web-extract' lands, we route through chitin-execute-request)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from analysis.compatibility_seed import open_db, upsert_seed
+from analysis.operator_matrix import (
+    MIN_TOKEN_CHARS,
+    _expand_search_tokens,
+    _normalize_model_id,
+    _resolve_lookup_token,
+)
+from analysis.search_backends import BackendError, get_backend
+
+CHITIN_HOME = Path(os.environ.get("CHITIN_HOME") or os.path.expanduser("~/.chitin"))
+MATRIX_JSON = CHITIN_HOME / "operator_matrix.json"
+
+# Locked extraction prompt — see design doc §"The extraction step".
+# Boundary cases the prompt must forbid ambiguity on are encoded here;
+# do not soften without re-reading the design doc's invariants.
+EXTRACTION_PROMPT = """You are extracting one benchmark score from search results.
+
+Model under test: {model_id}
+
+Top results:
+{numbered_snippets}
+
+Return JSON ONLY (no prose, no code fences):
+{{
+  "benchmark": "<lowercase short-name like 'aider-polyglot' or 'swebench-verified' or null>",
+  "score": <number or null>,
+  "score_unit": "percent" | "score" | "elo",
+  "source_url": "<the result URL the score came from>",
+  "scored_at": "<YYYY-MM-DD if stated, else null>"
+}}
+
+Rules:
+  - "exact model": {model_id} is NOT the same as a sibling family
+    member. Family-level matches are rejected.
+  - "verifiable score": numeric, attached to a benchmark name, in the
+    snippet text. Inferred or projected scores are rejected.
+  - "score": a single number, never a range. If the source gives a
+    range, return benchmark: null.
+
+If no result has a verifiable score for THIS exact model, return:
+{{"benchmark": null, "score": null, "score_unit": null, "source_url": null, "scored_at": null}}
+"""
+
+# Search query template per stale model. Kept simple — the design doc
+# defers cross-referenced multi-query mode (--thorough flag) to a
+# later commit.
+SEARCH_QUERY_TEMPLATE = (
+    "{model} benchmark score (SWE-bench OR aider-polyglot OR HumanEval "
+    "OR LiveCodeBench OR MMLU) site:github.com OR site:arxiv.org OR "
+    "site:openai.com OR site:anthropic.com OR site:deepmind.google"
+)
+
+# Where the failure-cache stub rows land — same model_seeds table,
+# distinguished by source='web-search' + value=NULL semantics. Per
+# design doc open question §3 (lean: cache failures, expose
+# retry_failures_after for operators who disagree).
+FAILURE_SOURCE = "web-search"
+FAILURE_METRIC = "extraction_attempted"
+
+
+# ─── Operator matrix → unique model set ────────────────────────────────
+
+def load_reachable_models() -> list[str]:
+    """Return the union of model ids across every authed CLI in
+    operator_matrix.json. De-dups by normalized form."""
+    if not MATRIX_JSON.exists():
+        raise SystemExit(
+            f"no operator matrix at {MATRIX_JSON} — "
+            "run `python -m analysis.operator_matrix detect` first"
+        )
+    matrix = json.loads(MATRIX_JSON.read_text())
+    seen: dict[str, str] = {}  # normalized → display
+    for cli in matrix.get("clis", []):
+        for m in cli.get("models", []):
+            norm = _resolve_lookup_token(m)
+            if norm and norm not in seen:
+                seen[norm] = m
+    return sorted(seen.values())
+
+
+# ─── Staleness check ───────────────────────────────────────────────────
+
+# Metrics that aren't benchmark scores. A model with ONLY these is
+# still considered stale — pricing rows from openrouter, attempt-stubs
+# from prior failures, context-length metadata. Operators run
+# refresh-stale because they want SCORES; pricing alone doesn't satisfy.
+NON_SCORE_METRIC_PREFIXES = ("cost_", "completion_token_", "prompt_token_")
+NON_SCORE_METRICS = {"context_length", FAILURE_METRIC, "avg_tokens"}
+
+
+def _is_score_metric(metric: str) -> bool:
+    if metric in NON_SCORE_METRICS:
+        return False
+    return not any(metric.startswith(p) for p in NON_SCORE_METRIC_PREFIXES)
+
+
+def is_stale(conn: sqlite3.Connection, model_id: str, max_age_days: int) -> bool:
+    """A model is stale iff no benchmark-SCORE seed row exists for any
+    expanded token of its normalized form, with pulled_at within
+    max_age_days. Pricing-only and stub failure rows do NOT make a
+    model fresh — operators run refresh-stale to get scores.
+
+    Uses the SAME token expansion as operator_matrix.py's lookup so
+    staleness and lookup agree (otherwise we'd refresh models that
+    already have data, or skip models whose data isn't actually
+    surfacing in the matrix)."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
+    tokens = _expand_search_tokens(_normalize_model_id(model_id))
+    if not tokens:
+        # Below MIN_TOKEN_CHARS — nothing matchable. Treat as stale so
+        # the operator at least sees the attempt-failure record.
+        return True
+    placeholders = " OR ".join("LOWER(model) LIKE ?" for _ in tokens)
+    cur = conn.execute(
+        f"SELECT metric FROM model_seeds WHERE pulled_at > ? "
+        f"AND ({placeholders})",
+        [cutoff] + [f"%{t.lower()}%" for t in tokens],
+    )
+    return not any(_is_score_metric(row[0]) for row in cur.fetchall())
+
+
+# ─── LLM extraction (claude --print for first commit) ─────────────────
+
+class ExtractorError(Exception):
+    pass
+
+
+def _which_extractor() -> tuple[str, list[str]] | None:
+    """First-commit extractor choice: prefer claude haiku (cheap +
+    fast). Once chitin role 'web-extract' lands, this gets replaced
+    with `chitin-execute-request --role web-extract`."""
+    if shutil.which("claude"):
+        return "claude", ["claude", "-p", "--model", "haiku", "--output-format", "text"]
+    return None
+
+
+def extract_via_llm(prompt: str, timeout: int = 60) -> dict | None:
+    """Run prompt through the operator's LLM CLI; parse JSON response.
+
+    Returns the parsed dict on success, None on extraction failure
+    (LLM responded but didn't return parseable JSON, or returned the
+    explicit null sentinel). Raises ExtractorError on infrastructure
+    failure (CLI not found, timeout, non-zero exit)."""
+    chosen = _which_extractor()
+    if chosen is None:
+        raise ExtractorError("no extractor CLI available — install `claude`")
+    name, cmd = chosen
+    try:
+        proc = subprocess.run(
+            cmd, input=prompt, capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired as e:
+        raise ExtractorError(f"{name} timed out after {timeout}s") from e
+    except FileNotFoundError as e:
+        raise ExtractorError(f"{name} not on PATH") from e
+    if proc.returncode != 0:
+        raise ExtractorError(
+            f"{name} exit {proc.returncode}: {proc.stderr[:200]}"
+        )
+    out = proc.stdout.strip()
+    if not out:
+        return None
+    # Strip optional ``` fences / leading prose. Find first { and parse.
+    m = re.search(r"\{.*\}", out, re.DOTALL)
+    if not m:
+        return None
+    try:
+        parsed = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    if parsed.get("benchmark") is None or parsed.get("score") is None:
+        return None
+    return parsed
+
+
+# ─── Refresh loop ──────────────────────────────────────────────────────
+
+def refresh_one(
+    conn: sqlite3.Connection,
+    model: str,
+    backend,
+    n_results: int,
+    dry_run: bool,
+) -> dict:
+    """Refresh ONE model. Returns {status: 'refreshed'|'no-data'|'error',
+    detail: str}. Never raises."""
+    q = SEARCH_QUERY_TEMPLATE.format(model=model)
+    try:
+        results = backend.query(q, n=n_results)
+    except BackendError as e:
+        return {"status": "error", "detail": f"backend: {e}"}
+
+    if not results:
+        if not dry_run:
+            _record_failure(conn, model, "no search results")
+        return {"status": "no-data", "detail": "0 search results"}
+
+    snippets = "\n\n".join(
+        f"[{i + 1}] {r['title']}\n    {r['url']}\n    {r['snippet'][:500]}"
+        for i, r in enumerate(results)
+    )
+    prompt = EXTRACTION_PROMPT.format(
+        model_id=model, numbered_snippets=snippets
+    )
+
+    if dry_run:
+        return {"status": "would-refresh", "detail": f"{len(results)} results"}
+
+    try:
+        parsed = extract_via_llm(prompt)
+    except ExtractorError as e:
+        return {"status": "error", "detail": f"extractor: {e}"}
+
+    if parsed is None:
+        _record_failure(conn, model, "extraction returned null")
+        return {"status": "no-data", "detail": "no verifiable score in results"}
+
+    # Write the seed row. source='web-search' (per design §"failure
+    # cache" — same source used for both successes and stub failures,
+    # discriminated by metric).
+    upsert_seed(
+        conn=conn,
+        model=model,
+        source=FAILURE_SOURCE,
+        metric=parsed["benchmark"],
+        value=float(parsed["score"]),
+        scored_at=parsed.get("scored_at"),
+        raw_payload={
+            "source_url": parsed.get("source_url"),
+            "score_unit": parsed.get("score_unit"),
+            "extracted_from": [r["url"] for r in results],
+        },
+    )
+    return {
+        "status": "refreshed",
+        "detail": f"{parsed['benchmark']} {parsed['score']} ({parsed.get('source_url', '?')})",
+    }
+
+
+def _record_failure(conn: sqlite3.Connection, model: str, reason: str) -> None:
+    """Failure-cache stub row: lets is_stale() see this model was
+    already attempted and skip it for max_age_days."""
+    upsert_seed(
+        conn=conn,
+        model=model,
+        source=FAILURE_SOURCE,
+        metric=FAILURE_METRIC,
+        value=0.0,                # value column is NOT NULL, so 0.0 stub
+        scored_at=None,
+        raw_payload={"failure_reason": reason},
+    )
+
+
+# ─── CLI ───────────────────────────────────────────────────────────────
+
+def _parse_max_age(s: str) -> int:
+    """Accept '7d', '14d', '30d'. Returns days as int."""
+    m = re.fullmatch(r"(\d+)d", s)
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"--max-age must be like '7d', got {s!r}"
+        )
+    return int(m.group(1))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--max-age", type=_parse_max_age, default=7,
+                   help="age threshold in days (e.g. 7d). default: 7d")
+    p.add_argument("--dry-run", action="store_true",
+                   help="list stale models + estimated cost; don't search/extract")
+    p.add_argument("--only", metavar="MODEL",
+                   help="refresh only this one model id")
+    p.add_argument("--backend", default="tavily",
+                   help="search backend (default: tavily)")
+    p.add_argument("--n-results", type=int, default=5,
+                   help="search results per query (default: 5)")
+    args = p.parse_args()
+
+    conn = open_db()
+
+    if args.only:
+        candidates = [args.only]
+    else:
+        candidates = load_reachable_models()
+
+    stale = [m for m in candidates if is_stale(conn, m, args.max_age)]
+    print(
+        f"refresh-stale: {len(stale)}/{len(candidates)} models stale "
+        f"(max-age={args.max_age}d, backend={args.backend})"
+    )
+    if not stale:
+        return
+
+    if args.dry_run:
+        for m in stale:
+            print(f"  would-refresh: {m}")
+        # Cost estimate — Tavily basic ~$0.005/call, claude haiku ~$0.0015/extract
+        n = len(stale)
+        print(f"\nestimated cost: ~${n * 0.005 + n * 0.002:.3f}")
+        print("(cost varies by backend + extractor; this is a rough Tavily+claude-haiku ballpark)")
+        return
+
+    try:
+        backend = get_backend(args.backend)
+    except BackendError as e:
+        print(f"backend init failed: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    counts = {"refreshed": 0, "no-data": 0, "error": 0}
+    for i, model in enumerate(stale, 1):
+        result = refresh_one(conn, model, backend, args.n_results, dry_run=False)
+        status = result["status"]
+        counts[status] = counts.get(status, 0) + 1
+        sigil = {"refreshed": "✓", "no-data": "—", "error": "✗"}.get(status, "?")
+        print(f"  [{i}/{len(stale)}] {sigil} {model:40} {result['detail']}")
+        conn.commit()
+
+    print(f"\n{counts.get('refreshed', 0)} refreshed, "
+          f"{counts.get('no-data', 0)} no-data, "
+          f"{counts.get('error', 0)} error")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/analysis/search_backends/__init__.py
+++ b/python/analysis/search_backends/__init__.py
@@ -1,0 +1,32 @@
+"""Pluggable web-search backends for stale-seed refresh.
+
+The operator picks one in chitin.yaml under `seeds.web_search.backend`;
+each backend reads its own credentials from env. The contract is one
+method (`query`) that returns top-N results or raises BackendError on
+credential / quota / network failure (so empty-results never silently
+masquerade as broken-backend).
+
+Add a backend by:
+  1. Creating <name>.py with a class that implements SearchBackend
+  2. Registering it in REGISTRY below
+"""
+from __future__ import annotations
+
+from .base import BackendError, SearchBackend, SearchResult
+from .tavily import TavilyBackend
+
+REGISTRY: dict[str, type[SearchBackend]] = {
+    "tavily": TavilyBackend,
+}
+
+
+def get_backend(name: str) -> SearchBackend:
+    if name not in REGISTRY:
+        raise BackendError(
+            f"unknown search backend: {name!r}. "
+            f"available: {sorted(REGISTRY)}"
+        )
+    return REGISTRY[name]()
+
+
+__all__ = ["BackendError", "SearchBackend", "SearchResult", "get_backend", "REGISTRY"]

--- a/python/analysis/search_backends/base.py
+++ b/python/analysis/search_backends/base.py
@@ -1,0 +1,30 @@
+"""SearchBackend contract.
+
+Read by both compatibility_seed (refresh-stale) and any future caller
+that needs operator-credential web search.
+"""
+from __future__ import annotations
+
+from typing import Protocol, TypedDict
+
+
+class SearchResult(TypedDict):
+    title: str
+    url: str
+    snippet: str          # backend-provided summary; may be empty
+
+
+class BackendError(Exception):
+    """Raised on credential / quota / network failures.
+
+    Crucially distinct from "empty result list" — empty means the
+    search succeeded but returned nothing; BackendError means the
+    backend itself failed and the caller should not treat the
+    absence of results as authoritative.
+    """
+
+
+class SearchBackend(Protocol):
+    name: str
+
+    def query(self, q: str, n: int = 5) -> list[SearchResult]: ...

--- a/python/analysis/search_backends/tavily.py
+++ b/python/analysis/search_backends/tavily.py
@@ -1,0 +1,59 @@
+"""Tavily search backend.
+
+API: https://docs.tavily.com/api-reference/endpoint/search
+Credential: TAVILY_API_KEY env var (operator brings their own).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+from .base import BackendError, SearchResult
+
+
+class TavilyBackend:
+    name = "tavily"
+
+    def __init__(self) -> None:
+        key = os.environ.get("TAVILY_API_KEY")
+        if not key:
+            raise BackendError(
+                "TAVILY_API_KEY not set. Get a key at https://tavily.com "
+                "and export it in your shell or .env."
+            )
+        self._key = key
+
+    def query(self, q: str, n: int = 5) -> list[SearchResult]:
+        body = json.dumps({
+            "api_key": self._key,
+            "query": q,
+            "max_results": n,
+            "search_depth": "basic",
+            "include_answer": False,
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            "https://api.tavily.com/search",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            raise BackendError(f"tavily HTTP {e.code}: {e.read()[:200].decode('utf-8', 'replace')}") from e
+        except (urllib.error.URLError, TimeoutError) as e:
+            raise BackendError(f"tavily network: {e}") from e
+        except json.JSONDecodeError as e:
+            raise BackendError(f"tavily returned non-JSON: {e}") from e
+
+        out: list[SearchResult] = []
+        for r in data.get("results", []) or []:
+            out.append({
+                "title": r.get("title") or "",
+                "url": r.get("url") or "",
+                "snippet": r.get("content") or "",
+            })
+        return out


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `rename-local-cloud-driver-misnomer`
Tier: `T2`  •  Driver: `copilot`  •  Model: `claude-haiku-4-5`
Role: `programmer`
Workflow: `swarm-rename-local-cloud-driver-misnomer-1778070876423`

## Entry context

`local-glm` and `local-deepseek` driver ids are misnomers — `glm-5.1:cloud`
runs through Ollama Cloud and `deepseek` (in our setup) routes via cloud
too, neither is "local" in the same sense as `local-qwen` (which actually
runs on the 3090). Renaming options:

- `cloud-glm`, `cloud-deepseek` — paired with `local-qwen` keeps the
  prefix discoverable but introduces a third axis (cost / latency tier
  vs locality) the prefix doesn't fully capture.
- `glm`, `deepseek` (no prefix) + keep `local-qwen` as an exception —
  cleanest but breaks the convention.
- Tier-suffix vocabulary entirely: drop `local-*` and just name agents
  by model (`qwen-coder`, `glm-cloud`, `deepseek-cloud`) — biggest
  rename surface area, cleanest end state.

Touches: `DriverIdSchema` enum, `DRIVER_AGENT_MAP` in activity.ts, the
per-driver agent ids in openclaw config (`qwen-agent`, `glm-agent`,
`deepseek-agent` may also need renaming for consistency), CHITIN_AGENT_*
env var keys, all activity tests, `swarm-backlog.md` tier definitions
above. T2 because of the breadth (multi-file rename + downstream env
var docs).

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-rename-local-cloud-driver-misnomer-1778070876423`
Branch: `swarm/swarm-rename-local-cloud-driver-misnomer-1778070876423`
Head: `c6d1344c`
Diff: `1 file changed, 1 insertion(+), 1 deletion(-)`
Commits: 1