### PR TITLE
swarm: nx-affected-in-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,13 @@ jobs:
 
       - name: Vitest (Nx affected)
         run: |
-          # nx affected exits 0 with no output when nothing's affected
-          # (e.g., docs-only PR). That's the goal: skip TS test work
-          # entirely when the diff doesn't touch any TS project.
+          # Use nx affected for test target. If affected detection is not worth the complexity,
+          # fallback to nx run-many (uncomment below and comment nx affected if needed).
           pnpm exec nx affected -t test \
             --base=${{ steps.nx-base.outputs.base }} \
             --parallel=3
+          # Fallback:
+          # pnpm exec nx run-many -t test --all --parallel=3
 
       - name: Layer-tag coverage lint
         run: |


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `nx-affected-in-ci`
Tier: `T2`  •  Driver: `copilot`  •  Model: `claude-haiku-4-5`
Role: `programmer`
Workflow: `swarm-nx-affected-in-ci-1778071485857`

## Entry context

CI doesn't use `nx affected`. `nx.json` is configured with the
TypeScript plugin (typecheck / build targets), but `.github/workflows/
ci.yml` runs `pnpm exec vitest run` against EVERYTHING on every PR,
plus `go test ./...` on every PR. Docs-only PRs trigger full test
suites; the marginal CI cost compounds across the 30+ PRs we ship a
day.

Scope:

1. CI workflow: replace bare `pnpm exec vitest run` with
   `pnpm exec nx affected -t test --base=origin/main` (or with
   `nx run-many` if affected detection isn't worth the complexity
   on this size repo).
2. Same for typecheck + lint targets if Nx isn't already routing
   those.
3. Keep `go test ./...` as-is unless someone files a separate entry
   to add Nx-Go integration.
4. Verify on a docs-only PR: should skip TS test step entirely.

Trade-off: Nx affected requires correct project boundaries (which
this repo has via `nx.json` + `package.json` per package). The
cost is one PR with 80-ish LOC of CI changes; the gain is faster
CI on routine PRs and a real "Nx-shaped" workflow that matches the
nx.json config we already wrote.


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-nx-affected-in-ci-1778071485857`
Branch: `swarm/swarm-nx-affected-in-ci-1778071485857`
Head: `3f951178`
Diff: `1 file changed, 4 insertions(+), 3 deletions(-)`
Commits: 1