### PR TITLE
feat(router): SpawnPeer with fresh worktree + provenance (gate-escalation step 3)

### DIFF
--- a/go/execution-kernel/internal/router/spawn_peer.go
+++ b/go/execution-kernel/internal/router/spawn_peer.go
@@ -1,0 +1,308 @@
+package router
+
+// spawnPeer — synchronously invoke a peer CLI (claude-code, copilot,
+// codex, gemini) for a routed escalation. Fresh worktree, recursive-
+// escalation guard, normalized ToolCallResult with full provenance.
+//
+// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 3 of 6).
+// Behind a flag — no gate path calls SpawnPeer yet (step 4 wires the
+// in-gate path); SpawnPeer is reachable from tests + a future
+// `chitin-kernel router test-spawn` debug subcommand.
+//
+// Invariants (the gate caller can rely on these):
+//   - Peer always runs in a fresh, empty worktree (mkdtemp). Worker's
+//     dirty tree is NEVER exposed.
+//   - Spawn env always carries CHITIN_NO_ESCALATE=1. Peer can be
+//     gated/denied/advised but cannot itself spawn another peer.
+//   - Spawn enforces a wall-clock timeout. SIGKILL on overrun, no
+//     orphaned processes.
+//   - Worktree cleanup runs on success AND failure (defer-based).
+//   - Returned ToolCallResult carries full Provenance: escalation_id,
+//     worker workflow_id, route, candidate, trigger signal, severity,
+//     spawn time + duration, peer exit code, raw peer stdout/stderr.
+//
+// The function is pure with respect to global state EXCEPT for the
+// subprocess + filesystem side effects within the temp worktree.
+// Specifically: no logging side effects, no chain writes — those are
+// the gate caller's responsibility (so SpawnPeer is unit-testable).
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+var (
+	ErrSpawnFailed       = errors.New("peer spawn failed")
+	ErrSpawnTimeout      = errors.New("peer spawn timed out")
+	ErrUnsupportedDriver = errors.New("driver has no spawn template")
+	ErrWorktreeSetup     = errors.New("worktree setup failed")
+)
+
+// ToolCallResult is what SpawnPeer returns when the peer succeeds.
+// The Content field is what the worker sees in place of its own tool
+// result; Provenance is the full audit trail the chain layer records.
+type ToolCallResult struct {
+	// Content is the worker-visible output. For claude-code/codex/etc
+	// this is typically the peer's stdout text body — what the peer
+	// said in response to the routed prompt. Type is `any` so future
+	// per-driver shapes (file diffs, JSON envelopes, etc.) can land
+	// without breaking the contract.
+	Content any
+
+	// Provenance — required, never optional. Every escalated result
+	// carries this so /mine + conformance extractors can join peer
+	// outcomes back to the workflow that triggered them.
+	Provenance Provenance
+
+	// Raw stdout/stderr — kept in chain for replay/audit, never shown
+	// to the worker.
+	RawPeerStdout string
+	RawPeerStderr string
+}
+
+// Provenance — full attribution for one peer-spawn event.
+type Provenance struct {
+	EscalationID     string
+	WorkerWorkflowID string
+	TriggerSignal    string
+	Severity         string
+	Route            string
+	Candidate        Candidate
+	SpawnedAt        time.Time
+	DurationMs       int64
+	PeerExitCode     int
+	WorktreePath     string
+}
+
+// SpawnConfig is what SpawnPeer needs from the caller. Held separate
+// from RouteRequest because the gate caller has additional context
+// (workflow_id, route metadata from the matched rule) that RouteRequest
+// alone doesn't carry.
+type SpawnConfig struct {
+	Decision RouteDecision
+	Request  RouteRequest
+
+	// SpawnTimeoutSeconds — passed in from RoutesPolicy. 0 = use default 60.
+	SpawnTimeoutSeconds int
+
+	// PromptText — what to ask the peer. Built by the gate caller from
+	// the worker's tool call + advisor nudge + chain tail. SpawnPeer
+	// just pipes it in; doesn't compose it.
+	PromptText string
+
+	// Spawner is dependency-injected so unit tests can stub out the
+	// real subprocess execution. Production wires defaultSpawner.
+	Spawner Spawner
+}
+
+// Spawner is the seam for unit testing — production uses execSpawner;
+// tests use a stub that returns canned output without touching the
+// filesystem or spawning real processes.
+type Spawner interface {
+	Run(ctx context.Context, name string, args []string, env []string, workDir string, stdin string) (stdout, stderr string, exitCode int, err error)
+}
+
+// execSpawner is the production implementation — uses os/exec.
+type execSpawner struct{}
+
+func (execSpawner) Run(ctx context.Context, name string, args []string, env []string, workDir string, stdin string) (string, string, int, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = workDir
+	cmd.Env = env
+	if stdin != "" {
+		cmd.Stdin = newStringReader(stdin)
+	}
+	out, err := cmd.Output()
+	stdout := string(out)
+	stderr := ""
+	exitCode := -1
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = string(exitErr.Stderr)
+	}
+	return stdout, stderr, exitCode, err
+}
+
+// newStringReader returns a stdin-shaped Reader for the given string.
+// Inlined to avoid pulling strings/bytes packages just for one call.
+type stringReader struct {
+	s string
+	i int
+}
+
+func newStringReader(s string) *stringReader { return &stringReader{s: s} }
+func (r *stringReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.s) {
+		return 0, errIO_EOF
+	}
+	n := copy(p, r.s[r.i:])
+	r.i += n
+	return n, nil
+}
+
+var errIO_EOF = fmt.Errorf("EOF")
+
+// DefaultSpawner — real subprocess spawn. Use in production.
+func DefaultSpawner() Spawner { return execSpawner{} }
+
+// SpawnPeer is the step-3 entry point. Fresh worktree, recursive-
+// escalation guard, per-driver template, timeout, normalized result.
+func SpawnPeer(ctx context.Context, cfg SpawnConfig) (*ToolCallResult, error) {
+	if cfg.Spawner == nil {
+		cfg.Spawner = DefaultSpawner()
+	}
+	timeout := cfg.SpawnTimeoutSeconds
+	if timeout <= 0 {
+		timeout = 60
+	}
+
+	tmpl, ok := spawnTemplate(cfg.Decision.Candidate.Driver)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedDriver, cfg.Decision.Candidate.Driver)
+	}
+
+	// Fresh worktree. Cleanup runs on success AND failure.
+	worktree, err := os.MkdirTemp("", "chitin-peer-spawn-")
+	if err != nil {
+		return nil, fmt.Errorf("%w: mkdtemp: %v", ErrWorktreeSetup, err)
+	}
+	defer os.RemoveAll(worktree)
+
+	// Recursive escalation guard. Even if the peer is itself a chitin-
+	// gated CLI, it cannot spawn another peer — its gate sees this env
+	// var and short-circuits the escalation logic.
+	env := append(os.Environ(), "CHITIN_NO_ESCALATE=1")
+
+	escalationID := newEscalationID()
+	startedAt := time.Now()
+
+	spawnCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	stdout, stderr, exitCode, runErr := cfg.Spawner.Run(
+		spawnCtx,
+		tmpl.Command,
+		tmpl.ArgsFor(cfg.Decision.Candidate.Model),
+		env,
+		worktree,
+		cfg.PromptText,
+	)
+	durationMs := time.Since(startedAt).Milliseconds()
+
+	prov := Provenance{
+		EscalationID:     escalationID,
+		WorkerWorkflowID: cfg.Request.WorkerWorkflowID,
+		TriggerSignal:    cfg.Request.Signal,
+		Severity:         cfg.Request.Severity,
+		Route:            cfg.Decision.Rule.Route,
+		Candidate:        cfg.Decision.Candidate,
+		SpawnedAt:        startedAt,
+		DurationMs:       durationMs,
+		PeerExitCode:     exitCode,
+		WorktreePath:     worktree,
+	}
+
+	// Distinguish timeout from generic spawn failure — they have
+	// different operational meanings (timeout = peer was alive but
+	// slow; failure = peer didn't run or crashed).
+	if errors.Is(spawnCtx.Err(), context.DeadlineExceeded) {
+		return nil, fmt.Errorf("%w after %ds (escalation_id=%s)",
+			ErrSpawnTimeout, timeout, escalationID)
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf("%w (escalation_id=%s, exit=%d): %v",
+			ErrSpawnFailed, escalationID, exitCode, runErr)
+	}
+
+	return &ToolCallResult{
+		Content:       stdout,
+		Provenance:    prov,
+		RawPeerStdout: stdout,
+		RawPeerStderr: stderr,
+	}, nil
+}
+
+// newEscalationID — short, URL-safe, sortable. 16 bytes hex = 32 chars.
+// Not a UUID because we don't need cross-machine uniqueness; locally-
+// unique per process is enough (escalations are recorded with the
+// worker's workflow_id which adds external uniqueness).
+func newEscalationID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: timestamp-based. Not collision-safe under high
+		// concurrency but the gate is single-tool-call-at-a-time per
+		// worker so the worst case is a duplicate ID across runs.
+		return fmt.Sprintf("esc-%d", time.Now().UnixNano())
+	}
+	return "esc-" + hex.EncodeToString(b)
+}
+
+// ─── Per-driver spawn templates ────────────────────────────────────────────
+//
+// Each template is the SHAPE of how to invoke that CLI for an
+// escalation. Templates are intentionally minimal — the prompt
+// composition (which is the operator-tunable part) is the gate
+// caller's job; templates just carry the raw command + arg shape.
+//
+// Add new drivers by:
+//   1. Define a SpawnTemplate value
+//   2. Register in spawnTemplates map
+// Tests in spawn_peer_test.go cover each driver's args.
+
+type SpawnTemplate struct {
+	// Command is the binary name (PATH-resolved by exec).
+	Command string
+
+	// ArgsFor returns the argv tail for this template, with `model`
+	// substituted. Returned slice is fresh per call (no shared state).
+	ArgsFor func(model string) []string
+}
+
+// spawnTemplates registers the supported drivers. Drivers absent from
+// this map return ErrUnsupportedDriver — explicit fail-closed.
+var spawnTemplates = map[string]SpawnTemplate{
+	"claude": {
+		Command: "claude",
+		ArgsFor: func(model string) []string {
+			return []string{
+				"-p",
+				"--model", model,
+				"--output-format", "text",
+				"--dangerously-skip-permissions",
+			}
+		},
+	},
+	"copilot": {
+		// gh CLI's copilot extension. Exact arg shape will be tuned
+		// when step 4 wires this against a real gate path.
+		Command: "gh",
+		ArgsFor: func(model string) []string {
+			return []string{"copilot", "suggest", "-t", "shell"}
+		},
+	},
+	"codex": {
+		Command: "codex",
+		ArgsFor: func(model string) []string {
+			return []string{"exec", "-m", model, "--skip-git-repo-check"}
+		},
+	},
+	"gemini": {
+		Command: "gemini",
+		ArgsFor: func(model string) []string {
+			return []string{"-p", "", "--model", model, "--yolo"}
+		},
+	},
+}
+
+func spawnTemplate(driver string) (SpawnTemplate, bool) {
+	t, ok := spawnTemplates[driver]
+	return t, ok
+}

--- a/go/execution-kernel/internal/router/spawn_peer_test.go
+++ b/go/execution-kernel/internal/router/spawn_peer_test.go
@@ -1,0 +1,242 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubSpawner records the most recent invocation and returns canned
+// output. Used by tests so we never spawn a real subprocess.
+type stubSpawner struct {
+	stdout, stderr string
+	exitCode       int
+	err            error
+
+	// Captured for assertions:
+	gotName    string
+	gotArgs    []string
+	gotEnv     []string
+	gotWorkDir string
+	gotStdin   string
+
+	// Optional: simulate a slow spawn (Sleep) so timeout tests fire.
+	sleep time.Duration
+}
+
+func (s *stubSpawner) Run(ctx context.Context, name string, args []string, env []string, workDir string, stdin string) (string, string, int, error) {
+	s.gotName, s.gotArgs, s.gotEnv, s.gotWorkDir, s.gotStdin = name, args, env, workDir, stdin
+	if s.sleep > 0 {
+		select {
+		case <-time.After(s.sleep):
+		case <-ctx.Done():
+			return "", "", -1, ctx.Err()
+		}
+	}
+	return s.stdout, s.stderr, s.exitCode, s.err
+}
+
+func sampleConfig(spawner Spawner) SpawnConfig {
+	return SpawnConfig{
+		Decision: RouteDecision{
+			Rule:      RoutingRule{Name: "floundering-loop", Signal: "floundering", Route: "patch_quality"},
+			Candidate: Candidate{Driver: "claude", Model: "claude-opus-4-7"},
+			Rationale: "test",
+		},
+		Request: RouteRequest{
+			Signal:           "floundering",
+			Severity:         ">= 2 loops",
+			WorkerWorkflowID: "swarm-test-12345",
+		},
+		PromptText:          "Worker is stuck. Please make progress.",
+		SpawnTimeoutSeconds: 5,
+		Spawner:             spawner,
+	}
+}
+
+func TestSpawnPeer_Success(t *testing.T) {
+	stub := &stubSpawner{stdout: "I made progress.", exitCode: 0}
+	cfg := sampleConfig(stub)
+	res, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if res.Content != "I made progress." {
+		t.Errorf("Content: got %q want %q", res.Content, "I made progress.")
+	}
+	if res.RawPeerStdout != "I made progress." {
+		t.Errorf("RawPeerStdout not preserved")
+	}
+	if res.Provenance.PeerExitCode != 0 {
+		t.Errorf("ExitCode: got %d want 0", res.Provenance.PeerExitCode)
+	}
+}
+
+func TestSpawnPeer_FreshWorktreeUsed(t *testing.T) {
+	stub := &stubSpawner{stdout: "ok", exitCode: 0}
+	cfg := sampleConfig(stub)
+	_, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stub.gotWorkDir, "chitin-peer-spawn-") {
+		t.Errorf("workDir should be a chitin-peer-spawn-* tempdir; got %s", stub.gotWorkDir)
+	}
+	if stub.gotWorkDir == "" {
+		t.Error("workDir empty — spawnPeer must always set a fresh worktree")
+	}
+}
+
+func TestSpawnPeer_RecursiveEscalationGuard(t *testing.T) {
+	stub := &stubSpawner{stdout: "ok", exitCode: 0}
+	cfg := sampleConfig(stub)
+	_, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range stub.gotEnv {
+		if e == "CHITIN_NO_ESCALATE=1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("CHITIN_NO_ESCALATE=1 must always be in spawn env (recursive guard)")
+	}
+}
+
+func TestSpawnPeer_PromptPipedToStdin(t *testing.T) {
+	stub := &stubSpawner{stdout: "ok", exitCode: 0}
+	cfg := sampleConfig(stub)
+	cfg.PromptText = "specific worker prompt content"
+	_, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.gotStdin != "specific worker prompt content" {
+		t.Errorf("stdin: got %q want %q", stub.gotStdin, "specific worker prompt content")
+	}
+}
+
+func TestSpawnPeer_ProvenancePopulated(t *testing.T) {
+	stub := &stubSpawner{stdout: "ok", exitCode: 0}
+	cfg := sampleConfig(stub)
+	res, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := res.Provenance
+	if p.EscalationID == "" || !strings.HasPrefix(p.EscalationID, "esc-") {
+		t.Errorf("EscalationID: got %q want esc-*", p.EscalationID)
+	}
+	if p.WorkerWorkflowID != "swarm-test-12345" {
+		t.Errorf("WorkerWorkflowID: got %q", p.WorkerWorkflowID)
+	}
+	if p.TriggerSignal != "floundering" {
+		t.Errorf("TriggerSignal: got %q", p.TriggerSignal)
+	}
+	if p.Severity != ">= 2 loops" {
+		t.Errorf("Severity: got %q", p.Severity)
+	}
+	if p.Route != "patch_quality" {
+		t.Errorf("Route: got %q", p.Route)
+	}
+	if p.Candidate.Driver != "claude" || p.Candidate.Model != "claude-opus-4-7" {
+		t.Errorf("Candidate: got %v", p.Candidate)
+	}
+	if p.SpawnedAt.IsZero() {
+		t.Error("SpawnedAt not set")
+	}
+	if p.WorktreePath == "" {
+		t.Error("WorktreePath not recorded for audit")
+	}
+	if p.DurationMs < 0 {
+		t.Errorf("DurationMs negative: %d", p.DurationMs)
+	}
+}
+
+func TestSpawnPeer_UnsupportedDriver(t *testing.T) {
+	stub := &stubSpawner{}
+	cfg := sampleConfig(stub)
+	cfg.Decision.Candidate.Driver = "made-up-driver"
+	_, err := SpawnPeer(context.Background(), cfg)
+	if !errors.Is(err, ErrUnsupportedDriver) {
+		t.Errorf("expected ErrUnsupportedDriver; got %v", err)
+	}
+}
+
+func TestSpawnPeer_TimeoutDistinctFromFailure(t *testing.T) {
+	stub := &stubSpawner{sleep: 200 * time.Millisecond}
+	cfg := sampleConfig(stub)
+	cfg.SpawnTimeoutSeconds = 0  // 0 → default 60, but we want a real test
+	// Rebuild with a tiny ctx instead so we can test timeout behavior:
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := SpawnPeer(ctx, cfg)
+	if !errors.Is(err, ErrSpawnTimeout) && !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Errorf("expected timeout-class error; got %v", err)
+	}
+}
+
+func TestSpawnPeer_ErrorOnFailedSpawn(t *testing.T) {
+	stub := &stubSpawner{
+		stdout:   "",
+		stderr:   "boom",
+		exitCode: 1,
+		err:      errors.New("simulated spawn failure"),
+	}
+	cfg := sampleConfig(stub)
+	_, err := SpawnPeer(context.Background(), cfg)
+	if !errors.Is(err, ErrSpawnFailed) {
+		t.Errorf("expected ErrSpawnFailed; got %v", err)
+	}
+}
+
+func TestSpawnTemplate_KnownDrivers(t *testing.T) {
+	for _, driver := range []string{"claude", "copilot", "codex", "gemini"} {
+		tmpl, ok := spawnTemplate(driver)
+		if !ok {
+			t.Errorf("driver %q should have a template", driver)
+			continue
+		}
+		if tmpl.Command == "" {
+			t.Errorf("driver %q template has empty Command", driver)
+		}
+		args := tmpl.ArgsFor("test-model")
+		if len(args) == 0 {
+			t.Errorf("driver %q template returned no args", driver)
+		}
+	}
+}
+
+func TestSpawnTemplate_UnknownDriver(t *testing.T) {
+	if _, ok := spawnTemplate("nonexistent"); ok {
+		t.Error("unknown driver should not return template")
+	}
+}
+
+func TestEscalationID_Unique(t *testing.T) {
+	a := newEscalationID()
+	b := newEscalationID()
+	if a == b {
+		t.Errorf("EscalationIDs should be unique; got %q twice", a)
+	}
+	if !strings.HasPrefix(a, "esc-") {
+		t.Errorf("EscalationID format: got %q want esc-*", a)
+	}
+}
+
+func TestSpawnPeer_DefaultTimeoutApplied(t *testing.T) {
+	// When SpawnTimeoutSeconds <= 0, default 60s is used. We assert
+	// indirectly: a 0-value timeout should NOT fire on a fast spawn.
+	stub := &stubSpawner{stdout: "ok", exitCode: 0, sleep: 10 * time.Millisecond}
+	cfg := sampleConfig(stub)
+	cfg.SpawnTimeoutSeconds = 0
+	_, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Errorf("default timeout should be generous; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Step 3 of 6 from \`docs/design/2026-05-06-kernel-gate-escalation.md\`. Synchronously invokes a peer CLI (claude/copilot/codex/gemini) for a routed escalation. Returns a normalized \`ToolCallResult\` with full \`Provenance\`. **NOT yet wired into the gate** — step 4 does that.

## Invariants enforced

- **Fresh worktree** (\`mkdtemp\`) — peer NEVER sees worker's dirty tree. Auto-cleanup via \`defer\` on success AND failure.
- **Recursive-escalation guard**: spawn env always carries \`CHITIN_NO_ESCALATE=1\`. Peer can be gated/denied/advised but cannot itself trigger another peer-spawn.
- **Wall-clock timeout** via \`context.WithTimeout\`. SIGKILL on overrun (\`exec.CommandContext\` kills the process group on cancel).
- **Distinct error types**: \`ErrSpawnTimeout\` (alive but slow), \`ErrSpawnFailed\` (didn't run / crashed), \`ErrUnsupportedDriver\`.
- **Pure w.r.t global state** — no logging, no chain writes, no telemetry side effects. Caller (gate) owns those for composability.

## Provenance struct (per design doc)

\`EscalationID\`, \`WorkerWorkflowID\`, \`TriggerSignal\`, \`Severity\`, \`Route\`, \`Candidate\`, \`SpawnedAt\`, \`DurationMs\`, \`PeerExitCode\`, \`WorktreePath\` + \`RawPeerStdout/Stderr\` for replay.

## Driver templates

\`claude\`, \`copilot\`, \`codex\`, \`gemini\` — each carries \`Command\` + \`ArgsFor(model)\`. Prompt composition is the gate caller's responsibility.

## Test plan

- [x] 12 tests covering success, fresh-worktree, recursive guard, prompt piping, provenance, unsupported driver, timeout (distinct from failure), spawn failure, all 4 driver templates, escalation ID uniqueness, default timeout
- [x] \`go test ./internal/router/\` all green
- [x] \`go build ./...\` passes
- [x] \`Spawner\` interface lets tests stub subprocess execution; production uses \`execSpawner\` (os/exec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)