### PR TITLE
feat(router): wire in-gate peer-escalation behind enabled flag (gate-escalation step 4)

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/router_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook.go
@@ -229,6 +229,20 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 		if advice.Escalate {
 			composed["escalation_requested"] = true
 		}
+
+		// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 4):
+		// when chitin-routes.yaml has escalation.enabled=true AND the
+		// gate would have escalated, ALSO synchronously spawn a peer
+		// CLI and return its output as the deny message body.
+		// CHITIN_NO_ESCALATE=1 in the spawned env prevents recursive
+		// peer-spawn (peer can be gated/denied/advised but cannot
+		// itself trigger another peer).
+		// Fail-open: ANY error in the spawn path falls back to today's
+		// deny+escalation_requested behavior. The kernel never bricks.
+		if advice.Escalate && os.Getenv("CHITIN_NO_ESCALATE") != "1" {
+			tryInGateSpawn(out, errOut, &composed, payload, advice, outcome, cwd)
+		}
+
 		body, _ := json.Marshal(composed)
 		_, _ = out.Write(body)
 		_, _ = out.Write([]byte{'\n'})

--- a/go/execution-kernel/cmd/chitin-kernel/router_hook_escalate.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook_escalate.go
@@ -1,0 +1,193 @@
+package main
+
+// In-gate peer-escalation glue. Step 4 of
+// docs/design/2026-05-06-kernel-gate-escalation.md.
+//
+// tryInGateSpawn is called when the advisor wants to escalate AND
+// the operator has chitin-routes.yaml with `enabled: true`. It loads
+// the routes policy, calls routeFor() to pick a candidate, then
+// spawnPeer() to run the peer CLI synchronously. On success it
+// rewrites the deny composition so the worker sees the peer's output
+// as the deny reason — claude-code-compatible (the worker reads the
+// reason text, can adapt accordingly).
+//
+// Fail-open: ANY error in this path returns silently. The caller's
+// existing deny+escalation_requested behavior is preserved. The
+// kernel never bricks because of an in-gate spawn failure — operator
+// safety is paramount.
+//
+// Telemetry is written to errOut so /mine + the conformance loop
+// can attribute peer outcomes back to the worker workflow.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/router"
+)
+
+// tryInGateSpawn — best-effort peer-escalation. Mutates `composed` to
+// include the peer's output when spawn succeeds. No-op on any failure.
+//
+// Return value: nothing — caller doesn't change behavior based on
+// success/failure (the deny composition is mutated in-place when
+// successful).
+func tryInGateSpawn(
+	out, errOut io.Writer,
+	composed *map[string]interface{},
+	payload claudecode.HookInput,
+	advice *router.AdvisorResponse,
+	outcome router.HeuristicOutcome,
+	cwd string,
+) {
+	policy, err := router.LoadRoutesPolicy(cwd)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{
+			"warning": "in_gate_spawn_skipped_bad_policy",
+			"err":     err.Error(),
+		})
+		return
+	}
+	if !policy.Enabled {
+		// Operator has not opted in. Silent skip; today's
+		// escalation_requested-based ladder still fires.
+		return
+	}
+
+	// Determine which signal triggered. Priority: floundering >
+	// blast_radius > drift (most-likely-actionable first). The
+	// advisor's escalation indicates SOME signal fired; we surface
+	// the heuristic's name when present, else fall back to the
+	// generic "advisor_takeover" signal.
+	signal := "advisor_takeover"
+	severity := "advisor.verdict=takeover"
+	if outcome.Floundering != nil && outcome.Floundering.Fired {
+		signal = "floundering"
+		severity = outcome.Floundering.Reason
+	} else if outcome.BlastRadius != nil && outcome.BlastRadius.Fired {
+		signal = "blast_radius"
+		severity = outcome.BlastRadius.Reason
+	}
+
+	req := router.RouteRequest{
+		Signal:           signal,
+		Severity:         severity,
+		WorkerWorkflowID: payload.SessionID,
+	}
+	decision, err := router.RouteFor(req, policy)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{
+			"warning": "in_gate_spawn_no_route",
+			"signal":  signal,
+			"err":     err.Error(),
+		})
+		return
+	}
+
+	// Compose the prompt the peer sees. Includes the worker's pending
+	// tool call, the advisor's nudge, and the heuristic context. The
+	// peer is asked to provide the corrective action / answer the
+	// worker should adopt.
+	prompt := fmt.Sprintf(
+		`You are escalating a stuck worker. The worker (a chitin agent) was about to run a tool call but our heuristics + advisor flagged it.
+
+Context:
+  Tool: %s
+  Tool input: %s
+  Heuristic signal: %s
+  Severity: %s
+  Advisor nudge: %s
+
+Your job: think about what the worker SHOULD do instead, and respond with your guidance. Be concrete (specific tool names, file paths, code snippets). The worker will read your response as a deny-reason and adapt.
+
+You must NOT yourself spawn additional peers — your CHITIN_NO_ESCALATE=1 env var enforces this. If you need help yourself, say so in your response and stop.
+
+Respond now.`,
+		payload.ToolName,
+		toolInputSummary(payload.ToolInput),
+		signal,
+		severity,
+		advice.Nudge,
+	)
+
+	cfg := router.SpawnConfig{
+		Decision:            decision,
+		Request:             req,
+		PromptText:          prompt,
+		SpawnTimeoutSeconds: policy.SpawnTimeoutSeconds,
+		// Spawner left nil → SpawnPeer uses production execSpawner.
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(policy.SpawnTimeoutSeconds+5)*time.Second)
+	defer cancel()
+	res, err := router.SpawnPeer(ctx, cfg)
+	if err != nil {
+		writeJSONLine(errOut, map[string]string{
+			"warning":     "in_gate_spawn_peer_failed",
+			"escalation":  decision.Rule.Name,
+			"driver":      decision.Candidate.Driver,
+			"model":       decision.Candidate.Model,
+			"err":         err.Error(),
+		})
+		return
+	}
+
+	// Success — rewrite the deny composition so the worker sees the
+	// peer's output as the reason. Telemetry: full provenance line so
+	// the conformance loop can join.
+	peerText, _ := res.Content.(string)
+	(*composed)["reason"] = fmt.Sprintf(
+		"%s\n\n[Peer escalation %s/%s says]\n%s",
+		advice.Nudge,
+		decision.Candidate.Driver,
+		decision.Candidate.Model,
+		peerText,
+	)
+	(*composed)["peer_escalation_id"] = res.Provenance.EscalationID
+	(*composed)["peer_driver"] = res.Provenance.Candidate.Driver
+	(*composed)["peer_model"] = res.Provenance.Candidate.Model
+
+	// Telemetry — keys/values are stringified to fit writeJSONLine's
+	// map[string]string contract. The values flow into /mine + the
+	// conformance loop where they're parsed back to typed fields.
+	writeJSONLine(errOut, map[string]string{
+		"event":             "peer_escalation",
+		"escalation_id":     res.Provenance.EscalationID,
+		"worker_workflow":   res.Provenance.WorkerWorkflowID,
+		"trigger_signal":    res.Provenance.TriggerSignal,
+		"severity":          res.Provenance.Severity,
+		"route":             res.Provenance.Route,
+		"driver":            res.Provenance.Candidate.Driver,
+		"model":             res.Provenance.Candidate.Model,
+		"duration_ms":       fmt.Sprintf("%d", res.Provenance.DurationMs),
+		"peer_exit_code":    fmt.Sprintf("%d", res.Provenance.PeerExitCode),
+		"peer_stdout_bytes": fmt.Sprintf("%d", len(res.RawPeerStdout)),
+		"peer_stderr_bytes": fmt.Sprintf("%d", len(res.RawPeerStderr)),
+	})
+	_ = out // intentional: out is the worker-facing stream; the caller writes the composed body
+}
+
+// toolInputSummary — short string rendering of the worker's tool
+// input for the peer's prompt. JSON marshaled, truncated to fit a
+// reasonable prompt budget (4000 chars). Long file contents in tool
+// inputs (e.g., Edit's new_string) get clipped — the peer doesn't
+// need byte-perfect reproduction, just enough context.
+func toolInputSummary(toolInput map[string]interface{}) string {
+	if toolInput == nil {
+		return "(none)"
+	}
+	body, err := json.Marshal(toolInput)
+	if err != nil {
+		return fmt.Sprintf("(unparseable: %v)", err)
+	}
+	const maxLen = 4000
+	if len(body) > maxLen {
+		return string(body[:maxLen]) + " …(truncated)"
+	}
+	return string(body)
+}

--- a/go/execution-kernel/cmd/chitin-kernel/router_hook_escalate_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook_escalate_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/router"
+)
+
+// Each test sets up a temp cwd with a chitin-routes.yaml of its
+// choosing, then calls tryInGateSpawn directly and asserts on the
+// mutation of `composed` plus the telemetry written to errOut.
+
+func writeRoutesYAML(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "chitin-routes.yaml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func samplePayload() claudecode.HookInput {
+	return claudecode.HookInput{
+		HookEventName: "PreToolUse",
+		ToolName:      "Edit",
+		ToolInput:     map[string]interface{}{"file_path": "/tmp/foo.go", "old_string": "x", "new_string": "y"},
+		Cwd:           "/tmp",
+		SessionID:     "session-123",
+	}
+}
+
+func sampleAdvice() *router.AdvisorResponse {
+	return &router.AdvisorResponse{
+		Nudge:    "you're going in circles",
+		Verdict:  "takeover",
+		Escalate: true,
+	}
+}
+
+func sampleOutcome() router.HeuristicOutcome {
+	return router.HeuristicOutcome{
+		Floundering: &router.HeuristicScore{
+			Fired:  true,
+			Reason: "loop_count=3",
+		},
+		AnyFired: true,
+	}
+}
+
+func TestTryInGateSpawn_PolicyDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeRoutesYAML(t, dir, `version: 1
+enabled: false
+routes:
+  patch_quality:
+    - {driver: claude, model: claude-opus-4-7}
+`)
+	composed := map[string]interface{}{"decision": "block", "reason": "original"}
+	var errOut bytes.Buffer
+	tryInGateSpawn(&bytes.Buffer{}, &errOut, &composed, samplePayload(), sampleAdvice(), sampleOutcome(), dir)
+	if composed["reason"] != "original" {
+		t.Errorf("disabled policy should NOT mutate reason; got %v", composed["reason"])
+	}
+	if strings.Contains(errOut.String(), "peer_escalation") {
+		t.Error("disabled policy should not emit peer_escalation telemetry")
+	}
+}
+
+func TestTryInGateSpawn_NoMatchingRule(t *testing.T) {
+	dir := t.TempDir()
+	writeRoutesYAML(t, dir, `version: 1
+enabled: true
+rules:
+  - name: blast-only
+    signal: blast_radius
+    route: patch_quality
+routes:
+  patch_quality:
+    - {driver: claude, model: claude-opus-4-7}
+`)
+	composed := map[string]interface{}{"decision": "block", "reason": "original"}
+	var errOut bytes.Buffer
+	tryInGateSpawn(&bytes.Buffer{}, &errOut, &composed, samplePayload(), sampleAdvice(), sampleOutcome(), dir)
+	// outcome is floundering — only blast_radius rule defined → no match
+	if composed["reason"] != "original" {
+		t.Errorf("no rule match should leave reason intact; got %v", composed["reason"])
+	}
+	if !strings.Contains(errOut.String(), "in_gate_spawn_no_route") {
+		t.Errorf("expected 'in_gate_spawn_no_route' warning; got %q", errOut.String())
+	}
+}
+
+func TestTryInGateSpawn_NoPolicyFile(t *testing.T) {
+	dir := t.TempDir()
+	// No chitin-routes.yaml at all → DefaultRoutesPolicy (disabled)
+	composed := map[string]interface{}{"decision": "block", "reason": "original"}
+	var errOut bytes.Buffer
+	tryInGateSpawn(&bytes.Buffer{}, &errOut, &composed, samplePayload(), sampleAdvice(), sampleOutcome(), dir)
+	if composed["reason"] != "original" {
+		t.Errorf("no policy file → silent skip; got %v", composed["reason"])
+	}
+}
+
+func TestTryInGateSpawn_SignalSelectionPriority(t *testing.T) {
+	// When multiple heuristics fire, floundering > blast_radius > advisor_takeover.
+	tests := []struct {
+		name    string
+		outcome router.HeuristicOutcome
+		want    string
+	}{
+		{
+			name:    "floundering wins over nothing",
+			outcome: router.HeuristicOutcome{Floundering: &router.HeuristicScore{Fired: true, Reason: "x"}},
+			want:    "floundering",
+		},
+		{
+			name:    "blast_radius wins when no floundering",
+			outcome: router.HeuristicOutcome{BlastRadius: &router.HeuristicScore{Fired: true, Reason: "y"}},
+			want:    "blast_radius",
+		},
+		{
+			name: "floundering wins over blast_radius",
+			outcome: router.HeuristicOutcome{
+				Floundering: &router.HeuristicScore{Fired: true, Reason: "x"},
+				BlastRadius: &router.HeuristicScore{Fired: true, Reason: "y"},
+			},
+			want: "floundering",
+		},
+		{
+			name:    "neither fired → advisor_takeover signal",
+			outcome: router.HeuristicOutcome{},
+			want:    "advisor_takeover",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// Define rules for ALL signals so we can confirm WHICH one routed.
+			writeRoutesYAML(t, dir, `version: 1
+enabled: true
+rules:
+  - {name: f, signal: floundering, route: patch_quality}
+  - {name: b, signal: blast_radius, route: patch_quality}
+  - {name: a, signal: advisor_takeover, route: patch_quality}
+routes:
+  patch_quality:
+    - {driver: nonexistent-driver, model: x}
+`)
+			composed := map[string]interface{}{"decision": "block", "reason": "original"}
+			var errOut bytes.Buffer
+			tryInGateSpawn(&bytes.Buffer{}, &errOut, &composed, samplePayload(), sampleAdvice(), tc.outcome, dir)
+			// Spawn will fail (driver unsupported) — that's fine, we're
+			// asserting on the SIGNAL the routeFor saw, captured in the
+			// in_gate_spawn_peer_failed warning OR no_route.
+			out := errOut.String()
+			if !strings.Contains(out, `"signal":"`+tc.want+`"`) && !strings.Contains(out, `signal=`+tc.want) {
+				// The peer_failed path doesn't include signal; check the
+				// rule name as proxy (a/f/b matches signal a/f/b).
+				want := map[string]string{"floundering": "f", "blast_radius": "b", "advisor_takeover": "a"}[tc.want]
+				if !strings.Contains(out, `"escalation":"`+want+`"`) {
+					t.Errorf("expected signal %q or rule %q in telemetry; got: %s", tc.want, want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestToolInputSummary(t *testing.T) {
+	t.Run("nil → (none)", func(t *testing.T) {
+		if s := toolInputSummary(nil); s != "(none)" {
+			t.Errorf("got %q want (none)", s)
+		}
+	})
+	t.Run("small map → JSON", func(t *testing.T) {
+		s := toolInputSummary(map[string]interface{}{"a": "b"})
+		if !strings.Contains(s, `"a":"b"`) {
+			t.Errorf("got %q", s)
+		}
+	})
+	t.Run("oversized → truncated", func(t *testing.T) {
+		big := strings.Repeat("X", 5000)
+		s := toolInputSummary(map[string]interface{}{"big": big})
+		if !strings.HasSuffix(s, "(truncated)") {
+			t.Errorf("expected truncation marker; got tail %q", s[len(s)-30:])
+		}
+		if len(s) > 4050 {
+			t.Errorf("truncated string too long: %d", len(s))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Step 4 of 6 from \`docs/design/2026-05-06-kernel-gate-escalation.md\`. Wires \`routeFor()\` + \`spawnPeer()\` into the router hook's takeover branch so the gate can substitute a peer CLI's output as the deny reason **when the operator opts in**.

## Default OFF

The policy file ships with \`enabled: false\`. Operator opts in by editing \`chitin-routes.yaml\`. With the flag off, behavior is **identical to today** (deny + \`escalation_requested\` marker; downstream runner handles the tier-bump as before).

## Trigger condition

In-gate spawn fires only when ALL true:
1. Heuristic + advisor reaches \`verdict=takeover\` with \`Escalate=true\` (today's escalation point — unchanged)
2. \`CHITIN_NO_ESCALATE != "1"\` in env (recursive guard)
3. \`chitin-routes.yaml\` present, parseable, \`enabled=true\`
4. \`routeFor()\` finds a rule matching the signal
5. Matched rule's route has at least one candidate
6. SpawnPeer succeeds (within timeout, peer exits 0)

## Failure modes — fail-open

ANY error in the spawn path → silent fall-through to today's deny+escalation_requested. Operator never sees a brick. Telemetry warnings written to stderr for each fall-through reason (\`in_gate_spawn_skipped_bad_policy\`, \`*_no_route\`, \`*_peer_failed\`) so \`/mine\` + the conformance loop can attribute.

## Signal priority

\`floundering > blast_radius > advisor_takeover\`. Locked in tests.

## Test plan

- [x] 5 tests + 4 sub-cases for signal priority + 3 sub-cases for tool input summary — all green
- [x] \`go test ./...\` across the entire kernel — all green
- [x] \`go build ./...\` clean

After this lands: 4 of 6 design steps merged. Steps 5 (trim dispatcher.ts) + 6 (conformance feedback loop) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)