### PR TITLE
auto: flip 1 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -2589,7 +2589,7 @@ Researcher role: read the alarm + the latest swarm-rollup JSON at `~/.cache/chit
 ```yaml
 id: nx-affected-in-ci
 tier: T1
-status: ready
+status: partial
 estimated_loc: 80
 blocks: []
 file: .github/workflows/ci.yml, nx.json


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- nx-affected-in-ci (#354)

If any of these are wrong, revert + investigate why the title matched without the work shipping.