### PR TITLE
feat(runner): add hermes driver — kanban worker spawn (gate-escalation step 5b)

### DIFF
--- a/apps/runner/src/activity.ts
+++ b/apps/runner/src/activity.ts
@@ -192,6 +192,12 @@ function resolveDispatchModel(driver: DriverId, tier: Tier | undefined): string 
       // chain rows from openclaw dispatches get role/workflow_id but no
       // model — better than guessing wrong.
       return null;
+    case 'hermes':
+      // hermes profile has a default model in ~/.hermes/config.yaml; we
+      // surface the env-var override if set, else null (chain rows get
+      // role/workflow_id but no model). Same trade as openclaw-* — better
+      // than guessing wrong.
+      return (process.env.CHITIN_MODEL_HERMES ?? '').trim() || null;
   }
 }
 
@@ -309,6 +315,52 @@ function planInvocation(req: ExecutionRequest): DriverInvocation {
           '--message', req.prompt,
         ],
       };
+    case 'hermes':
+      // Hermes Agent (the kanban dispatcher) running with the
+      // chitin-runner profile. Per docs/design/2026-05-06-kernel-gate-
+      // escalation.md core invariant: hermes IS the worker; chitin's
+      // kernel handles in-tool-call escalation via the gate (when
+      // chitin-routes.yaml's escalation.enabled = true).
+      //
+      // Profile + provider + default model live in ~/.hermes/config.yaml
+      // (operator runs `hermes model` once for interactive setup OR
+      // `hermes profile create chitin-runner --clone-from <existing>`).
+      // The chitin-governance plugin (already enabled at
+      // ~/.hermes/plugins/chitin-governance/) shells `chitin-kernel
+      // gate evaluate --hook-stdin --agent=hermes` on every
+      // pre_tool_call — same governance contract as the openclaw
+      // path, just via hermes's plugin hook system.
+      //
+      // We deliberately do NOT pass `--provider <name>` flags here:
+      // the hermes CLI rejects them as invalid even when the value
+      // matches a provider configured in hermes' config.yaml (verified
+      // 2026-05-06). The profile's preconfigured provider drives the
+      // call. `--accept-hooks` skips TTY confirmation for the
+      // chitin-governance plugin; `--yolo` skips per-tool-call
+      // permission prompts (chitin-kernel's gate is the policy
+      // boundary, not hermes' built-in prompt).
+      //
+      // Env overrides:
+      //   CHITIN_HERMES_PROFILE  → which profile (default chitin-runner)
+      //   CHITIN_MODEL_HERMES    → override model per-call (else profile default)
+      //
+      // Default driver mapping does NOT route any tier here yet — the
+      // static TIER_DRIVER_DEFAULTS map keeps openclaw/copilot/claude-
+      // code-headless until in-gate escalation is enabled. Operator
+      // opts in by setting CHITIN_TIER_DRIVER_T0=hermes (or similar)
+      // in their dispatcher env.
+      {
+        const profile = (process.env.CHITIN_HERMES_PROFILE ?? '').trim() || 'chitin-runner';
+        const args = ['-p', profile, '-z', req.prompt, '--accept-hooks', '--yolo'];
+        const model = (process.env.CHITIN_MODEL_HERMES ?? '').trim();
+        if (model) {
+          args.splice(2, 0, '-m', model);
+        }
+        return {
+          command: 'hermes',
+          args,
+        };
+      }
     default: {
       const exhaustive: never = driver;
       throw new Error(`unknown driver: ${exhaustive as string}`);

--- a/apps/runner/test/activity.test.ts
+++ b/apps/runner/test/activity.test.ts
@@ -56,6 +56,64 @@ describe('planInvocation', () => {
     expect(plan.args).not.toContain('main');
   });
 
+  it('dispatches hermes via the `hermes` CLI with the chitin-runner profile + -z prompt', () => {
+    const plan = planInvocation({ ...baseReq, allowed_drivers: ['hermes'] });
+    expect(plan.command).toBe('hermes');
+    // Profile name must be passed via -p; default is chitin-runner.
+    const pIdx = plan.args.indexOf('-p');
+    expect(pIdx).toBeGreaterThan(-1);
+    expect(plan.args[pIdx + 1]).toBe('chitin-runner');
+    // -z carries the prompt
+    expect(plan.args).toContain('-z');
+    expect(plan.args).toContain(baseReq.prompt);
+    // Hooks + permission flags must be present so the chitin-governance
+    // plugin fires without TTY confirmation.
+    expect(plan.args).toContain('--accept-hooks');
+    expect(plan.args).toContain('--yolo');
+    // We deliberately do NOT pass --provider (hermes CLI rejects it
+    // even when the value matches a configured provider — verified
+    // 2026-05-06).
+    expect(plan.args).not.toContain('--provider');
+  });
+
+  it('hermes respects CHITIN_HERMES_PROFILE env override', () => {
+    const orig = process.env.CHITIN_HERMES_PROFILE;
+    try {
+      process.env.CHITIN_HERMES_PROFILE = 'chitin-t0';
+      const plan = planInvocation({ ...baseReq, allowed_drivers: ['hermes'] });
+      const pIdx = plan.args.indexOf('-p');
+      expect(plan.args[pIdx + 1]).toBe('chitin-t0');
+    } finally {
+      if (orig === undefined) delete process.env.CHITIN_HERMES_PROFILE;
+      else process.env.CHITIN_HERMES_PROFILE = orig;
+    }
+  });
+
+  it('hermes respects CHITIN_MODEL_HERMES env override', () => {
+    const orig = process.env.CHITIN_MODEL_HERMES;
+    try {
+      process.env.CHITIN_MODEL_HERMES = 'glm-5.1:cloud';
+      const plan = planInvocation({ ...baseReq, allowed_drivers: ['hermes'] });
+      const mIdx = plan.args.indexOf('-m');
+      expect(mIdx).toBeGreaterThan(-1);
+      expect(plan.args[mIdx + 1]).toBe('glm-5.1:cloud');
+    } finally {
+      if (orig === undefined) delete process.env.CHITIN_MODEL_HERMES;
+      else process.env.CHITIN_MODEL_HERMES = orig;
+    }
+  });
+
+  it('hermes does NOT emit -m when CHITIN_MODEL_HERMES is unset (profile default takes over)', () => {
+    const orig = process.env.CHITIN_MODEL_HERMES;
+    try {
+      delete process.env.CHITIN_MODEL_HERMES;
+      const plan = planInvocation({ ...baseReq, allowed_drivers: ['hermes'] });
+      expect(plan.args).not.toContain('-m');
+    } finally {
+      if (orig !== undefined) process.env.CHITIN_MODEL_HERMES = orig;
+    }
+  });
+
   it('dispatches gemini via the `gemini` CLI with -p prompt', () => {
     const plan = planInvocation({ ...baseReq, allowed_drivers: ['gemini'] });
     expect(plan.command).toBe('gemini');

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -104,6 +104,17 @@ export const DriverIdSchema = z.enum([
   'openclaw-glm-flash',  // 3090: glm-4.7-flash:latest (~30B)
   'openclaw-glm-cloud',  // Ollama Cloud sub: glm-5.1:cloud (opus-light)
   'openclaw-deepseek',   // 3090: deepseek (kept for future use, not in defaults)
+  // `hermes` = Hermes Agent (kanban dispatcher) running with the
+  // chitin-runner profile. Per docs/design/2026-05-06-kernel-gate-
+  // escalation.md core invariant: Hermes is the worker; chitin
+  // (kernel) handles in-tool-call escalation. Profile + provider +
+  // default model must be configured in ~/.hermes/config.yaml
+  // (`hermes model` interactive setup). Opt in by setting
+  // CHITIN_TIER_DRIVER_T0=hermes (or T1/T2 as appropriate). Default
+  // mapping does NOT route any tier here yet — the static map keeps
+  // openclaw/copilot/claude-code-headless until in-gate escalation
+  // (chitin-routes.yaml) is enabled.
+  'hermes',
 ]);
 
 export const NetworkPolicySchema = z.enum(['none', 'allowlist', 'open']);


### PR DESCRIPTION
## Summary

Step 5b of the kernel-gate-escalation migration. Adds a new \`hermes\` DriverId + \`planInvocation\` case in \`activity.ts\` so chitin can dispatch through Hermes Agent (the kanban dispatcher) running with a chitin profile.

Per the core invariant in \`docs/design/2026-05-06-kernel-gate-escalation.md\`: **hermes IS the worker; chitin's kernel handles in-tool-call escalation** via the gate (when \`chitin-routes.yaml\` has \`escalation.enabled = true\`).

## Purely additive

\`TIER_DRIVER_DEFAULTS\` map is unchanged. No tier currently routes to hermes by default. Operator opts in by setting \`CHITIN_TIER_DRIVER_T0=hermes\` (or T1/T2 as appropriate) in their dispatcher env.

## Spawn shape

\`\`\`
hermes -p <profile> -z <prompt> --accept-hooks --yolo
hermes -p <profile> -m <model> -z <prompt> --accept-hooks --yolo  # if CHITIN_MODEL_HERMES set
\`\`\`

Defaults / env overrides:
- Profile: \`chitin-runner\` (\`CHITIN_HERMES_PROFILE\` overrides)
- Model: profile default (\`CHITIN_MODEL_HERMES\` overrides per-call)

## Why no \`--provider\` flag

The hermes CLI rejects it as invalid even when the value matches a provider configured in \`~/.hermes/config.yaml\` (verified 2026-05-06). The profile's preconfigured provider drives the call.

## Test plan

- [x] 4 new tests added: default profile, profile override, model override, no \`-m\` when \`CHITIN_MODEL_HERMES\` unset
- [x] All 46 activity tests pass

## What's deferred

Step 5 full — removing \`TIER_DRIVER_DEFAULTS\` — is deferred until in-gate escalation is enabled in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)