### PR TITLE
swarm: skill-runtime-cost-report-cli

### DIFF
--- a/apps/cli/src/commands/skill-cost-report.ts
+++ b/apps/cli/src/commands/skill-cost-report.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander';
+import { printTable } from '../utils/print-table';
+import { getSkillCostRollup } from 'libs/telemetry/src/skill-cost-rollup';
+import { writeFileSync } from 'fs';
+
+export const skillCostReport = new Command('skill-cost-report')
+  .description('Report skill runtime cost and tool-call stats by skill/tier')
+  .option('--skill <name>', 'Skill name to filter')
+  .option('--since <duration>', 'Limit to events since duration (e.g. 7d, 24h)')
+  .option('--tier <tier>', 'Tier to filter (T0, T1, T2, ...)')
+  .option('--format <format>', 'Output format: text|json|markdown', 'text')
+  .action(async (opts) => {
+    const { skill, since, tier, format } = opts;
+    const rollup = await getSkillCostRollup({ skill, since, tier });
+    if (format === 'json') {
+      console.log(JSON.stringify(rollup, null, 2));
+    } else if (format === 'markdown') {
+      // Simple markdown table output
+      console.log('# Skill Cost Report\n');
+      for (const entry of rollup) {
+        console.log(`## ${entry.skill} (Tier ${entry.tier})`);
+        console.log();
+        console.log('| Metric | Value |');
+        console.log('|--------|-------|');
+        for (const [k, v] of Object.entries(entry.metrics)) {
+          console.log(`| ${k} | ${v} |`);
+        }
+        if (entry.flags.length) {
+          console.log('\n**Flags:** ' + entry.flags.join(', '));
+        }
+        console.log();
+      }
+    } else {
+      // Text table output
+      printTable(rollup.map(entry => ({
+        Skill: entry.skill,
+        Tier: entry.tier,
+        'Dispatches': entry.metrics.dispatches,
+        'Tokens (cached)': entry.metrics.tokens_cached,
+        'Tokens (uncached)': entry.metrics.tokens_uncached,
+        'Tool calls (mean)': entry.metrics.tool_calls_mean,
+        'Tool calls (p95)': entry.metrics.tool_calls_p95,
+        'Output size (med)': entry.metrics.output_size_median,
+        'Output size (p95)': entry.metrics.output_size_p95,
+        'Cache hit %': entry.metrics.cache_hit_rate,
+        'Cost (USD)': entry.metrics.cost_usd,
+        'Advisor consults': entry.metrics.advisor_consult_rate,
+        'Flags': entry.flags.join(', ')
+      })));
+    }
+  });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `skill-runtime-cost-report-cli`
Tier: `T2`  •  Driver: `copilot`  •  Model: `claude-haiku-4-5`
Role: `programmer`
Workflow: `swarm-skill-runtime-cost-report-cli-1778079785626`

## Entry context

`chitin skill-cost-report --skill <name> [--since <duration>] [--tier <T>]`
queries the canonical chain for skill-tagged tool-call events and
produces a cost summary per skill / tier:

- Tokens per dispatch (prompt + completion) split into cached vs
  uncached.
- Tool-call count per dispatch (mean, p95).
- Tool-call output size (median, p95) — surfaces tools returning
  mostly-discardable structure (MCP candidates).
- Cache hit rate (post-hoc).
- Cost in USD if applicable.
- Lower-tier degradation flag: T0/T1 dispatches with notably
  higher retry rate vs T2+ → "tier model under-fit" signal.
- Advisor-consultation count per dispatch — reads the
  advisor_consultation events from `tier-router-with-advisor-
  consultation` (#5). High consultation rate at a tier suggests
  the tier model is being asked work it can't do alone.

The MCP-decision rubric falls out of the data: when a tool
consistently returns large output the model only summarizes,
that's an MCP-shaped opportunity.

Steps:
1. libs/telemetry: add a query helper for skill + tier rollups.
2. apps/cli: add the skill-cost-report command, output options
   (--format text|json|markdown).
3. Document the queries; common presets (--last-week, --tier T0).
4. Tests against a synthesized chain.

**Acceptance:**
- [ ] Report runs against current main's chain data and produces
      sensible per-skill rollups
- [ ] MCP-candidate flag fires for at least one skill
- [ ] Tier-degradation flag fires correctly on synthesized chain
      with T0 retries
- [ ] Advisor-consultation rate visible per skill / tier


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-skill-runtime-cost-report-cli-1778079785626`
Branch: `swarm/swarm-skill-runtime-cost-report-cli-1778079785626`
Head: `c246d6a4`
Diff: `1 file changed, 51 insertions(+)`
Commits: 1