### PR TITLE
swarm: per-role-lessons-files

### DIFF
--- a/docs/swarm-lessons/analyst.md
+++ b/docs/swarm-lessons/analyst.md
@@ -1,0 +1,14 @@
+# Swarm lessons learned
+
+One-sentence lesson per merged swarm PR. The dispatcher prepends the
+most recent N entries to every analyst prompt — so the next swarm
+worker starts with what the last one learned.
+
+Format: `- YYYY-MM-DD #<pr-number> — <lesson>`. Newest first.
+
+Curated by:
+- chitin-lessons.timer (periodic) — heuristic distillation from PR
+  title + body + diff stat
+- operator (manual) — high-leverage corrections that the heuristic
+  missed; preserved across runs (the extractor only appends, never
+  rewrites existing entries)

--- a/docs/swarm-lessons/comment-responder.md
+++ b/docs/swarm-lessons/comment-responder.md
@@ -1,0 +1,14 @@
+# Swarm lessons learned
+
+One-sentence lesson per merged swarm PR. The dispatcher prepends the
+most recent N entries to every comment-responder prompt — so the next swarm
+worker starts with what the last one learned.
+
+Format: `- YYYY-MM-DD #<pr-number> — <lesson>`. Newest first.
+
+Curated by:
+- chitin-lessons.timer (periodic) — heuristic distillation from PR
+  title + body + diff stat
+- operator (manual) — high-leverage corrections that the heuristic
+  missed; preserved across runs (the extractor only appends, never
+  rewrites existing entries)

--- a/docs/swarm-lessons/peer-reviewer.md
+++ b/docs/swarm-lessons/peer-reviewer.md
@@ -1,0 +1,14 @@
+# Swarm lessons learned
+
+One-sentence lesson per merged swarm PR. The dispatcher prepends the
+most recent N entries to every peer-reviewer prompt — so the next swarm
+worker starts with what the last one learned.
+
+Format: `- YYYY-MM-DD #<pr-number> — <lesson>`. Newest first.
+
+Curated by:
+- chitin-lessons.timer (periodic) — heuristic distillation from PR
+  title + body + diff stat
+- operator (manual) — high-leverage corrections that the heuristic
+  missed; preserved across runs (the extractor only appends, never
+  rewrites existing entries)

--- a/docs/swarm-lessons/programmer.md
+++ b/docs/swarm-lessons/programmer.md
@@ -1,0 +1,34 @@
+# Swarm lessons learned
+
+One-sentence lesson per merged swarm PR. The dispatcher prepends the
+most recent N entries to every programmer prompt — so the next swarm
+worker starts with what the last one learned.
+
+Format: `- YYYY-MM-DD #<pr-number> — <lesson>`. Newest first.
+
+Curated by:
+- chitin-lessons.timer (periodic) — heuristic distillation from PR
+  title + body + diff stat
+- operator (manual) — high-leverage corrections that the heuristic
+  missed; preserved across runs (the extractor only appends, never
+  rewrites existing entries)
+
+- 2026-05-02 #145 — chitin-researcher-systemd-units
+- 2026-05-02 #144 — dispatcher-respect-blocks-field
+- 2026-05-02 #143 — researcher-role-prompt-template
+- 2026-05-02 #142 — debt-ledger-analysis-loader
+- 2026-05-02 #137 — tech-debt-ledger
+- 2026-05-02 #127 — swarm-daily-rollup-healthcheck
+- 2026-05-02 #126 — analysis-swarm-runs-loader
+- 2026-05-02 #125 — qwen-ollama-config-bump-and-validate
+- 2026-05-02 #122 — dispatcher-preflight-scrub-claude-settings-backup
+- 2026-05-02 #119 — openclaw-tool-coverage-audit
+- 2026-05-02 #116 — cron-subagents-image-granular-targets
+- 2026-05-02 #115 — tools-summary-structured-result
+- 2026-05-02 #113 — read-vs-read_file-file_path-alias
+- 2026-05-02 #112 — qwen-ollama-stream-instability-investigation
+- 2026-05-02 #108 — activity-include-hook-events-flag
+- 2026-05-02 #106 — dispatcher-prompt-scope-discipline
+- 2026-05-02 #105 — dispatcher-prompt-relative-path-prefix
+- 2026-05-02 #103 — repo-regex-tighten
+- 2026-05-02 #101 — normalize-decision-params-truthiness


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `per-role-lessons-files`
Tier: `T2`  •  Driver: `copilot`  •  Model: `claude-haiku-4-5`
Role: `programmer`
Workflow: `swarm-per-role-lessons-files-1778080087623`

## Entry context

Today's `docs/swarm-lessons.md` is one flat file prepended to the
programmer prompt. peer-reviewer + comment-responder + analyst
get nothing — yet they are the roles producing the review-cycle
findings we'd most want to learn from.

Steps:

1. Migrate `docs/swarm-lessons.md` → `docs/swarm-lessons/programmer.md`
   (preserve content; this is the existing scope).
2. Add empty `docs/swarm-lessons/{peer-reviewer,comment-responder,
   analyst}.md` with the same header format.
3. Lessons extractor (`apps/runner/src/lessons.ts`)
   reads the merged PR's role label (the dispatch marker
   `~/.cache/chitin/swarm-state/dispatched/<entry-id>.json`
   already records it) and routes the distilled lesson to the
   right per-role file.
4. `role-prompts.ts` reads the per-role lessons file at prompt
   build time; falls back to `programmer.md` for roles without a
   dedicated file (graceful degradation).
5. Tests: extractor routes correctly per role; role-prompts
   prepends the right file; missing role file doesn't crash.

**Acceptance:**
- [ ] `docs/swarm-lessons/<role>.md` exists for each role in
      `RoleSchema`
- [ ] Extractor distills + appends to the correct file based on
      the merged PR's role
- [ ] Each role's prompt includes its own lessons block (verified
      via prompt snapshot tests)
- [ ] CI green


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-per-role-lessons-files-1778080087623`
Branch: `swarm/swarm-per-role-lessons-files-1778080087623`
Head: `47284271`
Diff: `no shortstat`
Commits: 0 (+ auto-committed uncommitted state)