### PR TITLE
auto: flip 1 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -4696,7 +4696,7 @@ the agents read tomorrow, without operator transcription.
 ```yaml
 id: per-role-lessons-files
 tier: T2
-status: ready
+status: partial
 estimated_loc: 150
 blocks: []
 file: docs/swarm-lessons/, apps/runner/src/lessons.ts, apps/runner/src/role-prompts.ts, apps/runner/src/grooming/parse-backlog.ts (role label per PR)


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- per-role-lessons-files (#363)

If any of these are wrong, revert + investigate why the title matched without the work shipping.