### PR TITLE
swarm: spawn-template-fix-copilot

### DIFF
--- a/go/execution-kernel/internal/router/spawn_peer.go
+++ b/go/execution-kernel/internal/router/spawn_peer.go
@@ -283,9 +283,16 @@ var spawnTemplates = map[string]SpawnTemplate{
 	"copilot": {
 		// gh CLI's copilot extension. Exact arg shape will be tuned
 		// when step 4 wires this against a real gate path.
-		Command: "gh",
+		Command: "curl",
 		ArgsFor: func(model string) []string {
-			return []string{"copilot", "suggest", "-t", "shell"}
+			return []string{
+				"-s",
+				"-X", "POST",
+				"-H", "Authorization: Bearer $(gh auth token)",
+				"-H", "Content-Type: application/json",
+				"--url", "https://api.githubcopilot.com/chat/completions",
+				"-d", fmt.Sprintf(`{\"model\":\"%s\",\"messages\":[{\"role\":\"user\",\"content\":\"%%s\"}]}", model),
+			}
 		},
 	},
 	"codex": {


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `spawn-template-fix-copilot`
Tier: `T2`  •  Driver: `copilot`  •  Model: `claude-haiku-4-5`
Role: `programmer`
Workflow: `swarm-spawn-template-fix-copilot-1778082831538`

## Entry context

**Why this is here:** 2026-05-06 controlled in-gate test (the first
end-to-end firing of the step-3+4 path) revealed the copilot spawn
template uses `gh copilot suggest -t shell` — an INTERACTIVE Copilot
CLI mode. Spawn returned exit=1 in the test. Fail-open kicked in
correctly so no regression, but the peer-spawn path itself didn't
deliver useful output to the worker.

**Test trace (verbatim):**
```
heuristic floundering: score 1.0 (looping-tool-call x2) ✓
advisor takeover: True with rich nudge ✓
routeFor: matched floundering-loop → cheap_stable ✓
spawnPeer: copilot/gpt-4.1 → exit=1 ✗
fail-open → return advisor's deny+nudge ✓
```

**Fix scope:**

1. Replace `gh copilot suggest -t shell` with a non-interactive
   Copilot Chat API call. We already proved this works in
   `python/analysis/operator_matrix.py` (`probe_copilot`) — POST to
   `https://api.githubcopilot.com/chat/completions` with `gh auth
   token` as the bearer.
2. Spawn template needs to:
   - Build a JSON request body from the prompt (model, messages)
   - POST via curl OR shell out to `gh api` if it routes there
   - Capture the response, extract `choices[0].message.content`
   - Return as the peer's stdout
3. Tests: stub the HTTP call, verify request shape (Authorization
   header, model name in body, prompt in messages), verify response
   parsing.

T2 because mechanical — known-good API endpoint, single-purpose
template, no design judgment.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-spawn-template-fix-copilot-1778082831538`
Branch: `swarm/swarm-spawn-template-fix-copilot-1778082831538`
Head: `983c0138`
Diff: `1 file changed, 9 insertions(+), 2 deletions(-)`
Commits: 1