### PR TITLE
swarm: spawn-template-validate-all-drivers

### DIFF
--- a/go/execution-kernel/internal/router/spawn_peer_test.go
+++ b/go/execution-kernel/internal/router/spawn_peer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -299,4 +300,63 @@ func TestSpawnPeer_DefaultTimeoutApplied(t *testing.T) {
 	if err != nil {
 		t.Errorf("default timeout should be generous; got %v", err)
 	}
+}
+
+// ─── Per-driver headless smoke tests ───────────────────────────────────────
+//
+// These exercise real binaries via DefaultSpawner. They skip when the
+// binary isn't on PATH so CI without all four CLIs installed stays
+// green; operator validation runs them locally.
+//
+// Each test mirrors the in-gate path: the only thing varying between
+// them is the driver/model in the SpawnConfig — anything that fails
+// here is a template bug, not a wiring bug.
+
+func smokeConfig(driver, model string) SpawnConfig {
+	return SpawnConfig{
+		Decision: RouteDecision{
+			Rule:      RoutingRule{Name: "smoke", Signal: "smoke", Route: "smoke"},
+			Candidate: Candidate{Driver: driver, Model: model},
+			Rationale: "headless smoke test",
+		},
+		Request: RouteRequest{
+			Signal:           "smoke",
+			Severity:         "smoke",
+			WorkerWorkflowID: "smoke-" + driver,
+		},
+		PromptText:          "Reply with the single word: ok",
+		SpawnTimeoutSeconds: 30,
+	}
+}
+
+func runSmoke(t *testing.T, binary, driver, model string) {
+	t.Helper()
+	if _, err := exec.LookPath(binary); err != nil {
+		t.Skipf("%s binary not on PATH; smoke test skipped", binary)
+	}
+	cfg := smokeConfig(driver, model)
+	res, err := SpawnPeer(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("%s smoke spawn failed: %v", driver, err)
+	}
+	if res.Provenance.PeerExitCode != 0 {
+		t.Errorf("%s exit_code: got %d want 0 (stderr=%q)",
+			driver, res.Provenance.PeerExitCode, res.RawPeerStderr)
+	}
+	content, _ := res.Content.(string)
+	if strings.TrimSpace(content) == "" {
+		t.Errorf("%s Content empty — template likely produced no output", driver)
+	}
+}
+
+func TestSpawnPeer_ClaudeSmoke(t *testing.T) {
+	runSmoke(t, "claude", "claude", "claude-haiku-4-5-20251001")
+}
+
+func TestSpawnPeer_CodexSmoke(t *testing.T) {
+	runSmoke(t, "codex", "codex", "gpt-5")
+}
+
+func TestSpawnPeer_GeminiSmoke(t *testing.T) {
+	runSmoke(t, "gemini", "gemini", "gemini-2.5-flash")
 }


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `spawn-template-validate-all-drivers`
Tier: `T4`  •  Driver: `claude-code-headless`  •  Model: `claude-opus-4-7`
Role: `programmer`
Workflow: `swarm-spawn-template-validate-all-drivers-1778083736840`

## Entry context

**Why this is here:** the in-gate test on 2026-05-06 only exercised
the copilot template (failed). The other 3 templates (claude, codex,
gemini) are entirely UNTESTED for headless invocation. Same risk
class — could fail in production the moment routing maps a rule to
those drivers.

**Fix scope per driver (claude / codex / gemini):**

1. Per-driver smoke test in `spawn_peer_test.go`:
   - Build SpawnConfig with that driver
   - Run `SpawnPeer` with a real (but minimal) prompt like "echo ok"
   - Assert non-error result with exit_code=0 + non-empty Content
2. Tests skip if the driver's binary isn't on PATH (CI may not have
   all four CLIs installed; that's fine — smoke runs locally during
   operator validation).
3. If a driver's template is broken, file an entry parallel to
   `spawn-template-fix-copilot` for it.

T2 because mechanical: 3 nearly-identical smoke tests + skip-if-
missing-binary guard. Blocks on copilot fix because we want a
working template to copy the pattern from.

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-spawn-template-validate-all-drivers-1778083736840`
Branch: `swarm/swarm-spawn-template-validate-all-drivers-1778083736840`
Head: `34c578ec`
Diff: `4 files changed, 92 insertions(+), 177 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)