### PR TITLE
swarm: swarm-prompt-augmentation-esm-and-tests

### DIFF
--- a/apps/runner/src/role-prompts.ts
+++ b/apps/runner/src/role-prompts.ts
@@ -31,6 +31,40 @@ export type RolePromptBuilder = (entry: BacklogEntry) => string;
 // The pre-Phase-1 prompt template — what slice-7b's `buildPrompt`
 // produced. Wrapping it in a role registry lets future programmer-
 // prompt tweaks happen without touching the dispatcher.
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+function findNearestPackageJsonTypeModule(filePath: string): boolean {
+  let dir = dirname(resolve(filePath));
+  while (dir !== '/' && dir !== '.' && dir !== process.cwd()) {
+    const pkgPath = join(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+        if (pkg.type === 'module') return true;
+      } catch {}
+      break;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
+}
+
+function extractTestPlanNote(entry: BacklogEntry): string {
+  // Accepts 'Tests:', 'Test plan:', 'Test Plan:', etc. at start of line
+  const desc = entry.description || '';
+  const testPlanRegex = /^(Tests?:|Test plan:)/im;
+  if (testPlanRegex.test(desc)) {
+    return "The entry's test plan is REQUIRED, not optional — every named scenario must have a passing test in the PR. Treat as acceptance criteria.\n\n";
+  }
+  if (Array.isArray(entry.test_plan) && entry.test_plan.length > 0) {
+    return "The entry's test plan is REQUIRED, not optional — every named scenario must have a passing test in the PR. Treat as acceptance criteria.\n\n";
+  }
+  return '';
+}
+
 function buildProgrammerPrompt(entry: BacklogEntry): string {
   const rawFile = entry.file?.split(',')[0]?.trim();
   let targetFile: string;


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `swarm-prompt-augmentation-esm-and-tests`
Tier: `T2`  •  Driver: `copilot`  •  Model: `claude-haiku-4-5`
Role: `programmer`
Workflow: `swarm-swarm-prompt-augmentation-esm-and-tests-1778084005790`

## Entry context

**Why this is here:** 2026-05-06 /land batch found that swarm-produced
TypeScript PRs systematically miss two things the operator catches in
review:

1. **ESM-vs-CJS pattern.** PR #361 (\`groomer-validate-paths\`) used
   \`if (require.main === module)\` for its CLI entrypoint. apps/runner
   is ESM (\`"type": "module"\`) — \`require\` is undefined, so importing
   the module from anywhere else throws \`ReferenceError\` at load time.
   Even the function the PR DEFINES becomes uncallable.

2. **Test coverage scoped to entry's request.** Entry #360 explicitly
   asked for "3 fixture entries (clean, missing-path, partially-missing)
   + assertion that validate-entry-paths flags correctly". PR #361
   delivered the function but ZERO tests. Entries that name specific
   test scenarios should be treated as acceptance criteria.

The fix is operator-side prompt augmentation, not agent-side
behavior change:

- Programmer prompts that touch \`.ts\` files in apps/runner/* (or any
  \`"type": "module"\` package) get a prepended note: "This package is
  ESM. Use \`if (process.argv[1] === fileURLToPath(import.meta.url))\`
  for CLI entrypoints, never \`require.main === module\`. Use
  \`import.meta.url\` instead of \`__dirname\`/\`__filename\`."

- For entries whose body explicitly names test scenarios, the
  prompt prepends "The entry's test plan is REQUIRED, not optional —
  every named scenario must have a passing test in the PR. Treat as
  acceptance criteria."

**Fix scope:**

1. \`role-prompts.ts\` — extend the prompt builder to:
   - Detect ESM packages by reading the touched files' nearest
     \`package.json\` for \`"type": "module"\`. Prepend the ESM-pattern
     note when found.
   - Parse the entry body for "Tests:" / "Test plan:" / similar; when
     present, prepend the acceptance-criteria note.
2. \`parse-backlog.ts\` — add an optional \`test_plan?: string[]\` field
   to BacklogEntry so the prompt builder can address requirements
   one-by-one.
3. Tests: 2 fixture cases — ESM file produces ESM note; non-ESM file
   doesn't; entry with Tests: produces acceptance-criteria note;
   entry without doesn't.

T2 because mechanical prompt-string composition; no model judgment
involved. Pays for itself within a single dispatch (catches the
class of bug PR #361 introduced).

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-swarm-prompt-augmentation-esm-and-tests-1778084005790`
Branch: `swarm/swarm-swarm-prompt-augmentation-esm-and-tests-1778084005790`
Head: `1e72b91a`
Diff: `1 file changed, 34 insertions(+)`
Commits: 0 (+ auto-committed uncommitted state)