### PR TITLE
swarm: swarm-prompt-augmentation-esm-and-tests

### DIFF
--- a/apps/runner/src/grooming/parse-backlog.ts
+++ b/apps/runner/src/grooming/parse-backlog.ts
@@ -30,6 +30,13 @@ export interface BacklogEntry {
   // programmer (the slice-7b dispatcher's pre-Phase-1 default).
   // Vocabulary matches RoleSchema in @chitin/contracts.
   role?: string;
+  // Test scenarios extracted from the description's `Tests:` /
+  // `Test plan:` / `Test cases:` section, when present. The prompt
+  // builder treats a non-empty test_plan as acceptance criteria the
+  // PR must satisfy — driven by 2026-05-06 /land batch finding that
+  // entries naming explicit test scenarios were shipping with zero
+  // tests because the worker treated them as commentary.
+  test_plan?: string[];
   rawFrontmatter: string;  // the original ```yaml block, preserved verbatim
   description: string;     // prose below the frontmatter, before next ### or ##
   rawSection: string;      // entire ### section for in-place replacement
@@ -74,6 +81,7 @@ export function crossesDebtLedger(entry: BacklogEntry, debtFiles: string[]): boo
 
 export const __test__ = {
   crossesDebtLedger,
+  parseTestPlan,
 };
 
 // Splits at ### but keeps surrounding ## headings out — only ### sections
@@ -128,10 +136,64 @@ function parseSection(section: string): BacklogEntry | null {
     referencesFinding: fields.references_finding,
     referencesSpec: fields.references_spec,
     role: fields.role,
+    test_plan: parseTestPlan(description),
     rawFrontmatter,
     description,
     rawSection: section,
   };
+}
+
+// Pulls explicit test scenarios out of the description body. We look
+// for a line whose leading content is `Tests:`, `Test plan:`, or
+// `Test cases:` (case-insensitive, optionally indented or bulleted),
+// then collect the remainder of that line plus any subsequent bullet
+// items as individual scenarios. A blank line ends the block.
+//
+// Why look here at all: backlog entries have been shipping with named
+// test scenarios in prose ("Tests: 3 fixture entries (clean, missing,
+// partial)") that swarm workers were treating as commentary. Surfacing
+// them as a structured list lets the prompt builder echo them as
+// acceptance criteria.
+export function parseTestPlan(description: string): string[] | undefined {
+  const lines = description.split('\n');
+  let startIdx = -1;
+  let inlineRest = '';
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^\s*(?:[-*]|\d+\.)?\s*(?:Tests|Test plan|Test cases)\s*:\s*(.*)$/i);
+    if (m) {
+      startIdx = i;
+      inlineRest = m[1];
+      break;
+    }
+  }
+  if (startIdx === -1) return undefined;
+
+  const items: string[] = [];
+  if (inlineRest.trim()) {
+    for (const part of inlineRest.split(/[;]/)) {
+      const t = part.trim().replace(/[.,]+$/, '');
+      if (t) items.push(t);
+    }
+  }
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    const bm = line.match(/^\s*(?:[-*]|\d+\.)\s+(.+)$/);
+    if (bm) {
+      items.push(bm[1].trim());
+      continue;
+    }
+    if (line.trim() === '') {
+      if (items.length > 0) break;
+      continue;
+    }
+    // Indented continuation of the previous bullet — fold in.
+    if (/^\s+\S/.test(line) && items.length > 0) {
+      items[items.length - 1] += ' ' + line.trim();
+      continue;
+    }
+    break;
+  }
+  return items.length > 0 ? items : undefined;
 }
 
 // Minimal YAML parser sufficient for our flat key:value-and-list frontmatter.

--- a/apps/runner/src/role-prompts.ts
+++ b/apps/runner/src/role-prompts.ts
@@ -11,7 +11,8 @@
 // doesn't crash when they're picked, but the actual per-role prompt
 // engineering lands in follow-up entries (one per role).
 
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import type { Role } from '@chitin/contracts';
 import type { BacklogEntry } from './grooming/parse-backlog.ts';
 import { RESEARCHER_OUTPUT_INSTRUCTIONS } from './researcher-prompts.ts';
@@ -27,6 +28,62 @@ const LESSONS_PROMPT_HEAD = 12;
 const LESSONS_PATH = resolve(process.cwd(), 'docs/swarm-lessons.md');
 
 export type RolePromptBuilder = (entry: BacklogEntry) => string;
+
+// Walks up from `filePath` to find the nearest package.json and
+// returns true when its `"type"` is `"module"`. Driven by the
+// 2026-05-06 finding that PR #361 introduced
+// `if (require.main === module)` into apps/runner/* — an ESM package
+// where `require` is undefined, so the module throws ReferenceError
+// at import time and even unrelated callers break. When this returns
+// true, the prompt builder prepends an ESM-pattern note so the next
+// worker reaches for `import.meta.url` instead.
+//
+// Best-effort: missing files / unreadable JSON / paths that resolve
+// outside the workspace return false rather than throwing — a wrong
+// answer here just means the note is omitted, which is recoverable.
+export function isEsmPackage(filePath: string, cwd: string = process.cwd()): boolean {
+  const cleaned = filePath.replace(/^\.\//, '');
+  const abs = cleaned.startsWith('/') ? cleaned : resolve(cwd, cleaned);
+  let dir = dirname(abs);
+  // Bounded loop so a pathological input can't spin forever.
+  for (let depth = 0; depth < 64; depth++) {
+    const pkgPath = join(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { type?: unknown };
+        return pkg.type === 'module';
+      } catch {
+        return false;
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+  return false;
+}
+
+const ESM_PATTERN_NOTE = `THIS PACKAGE IS ESM (\`"type": "module"\` in the nearest package.json). For CLI entrypoints in this package:
+
+\`\`\`ts
+import { fileURLToPath } from 'node:url';
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  // CLI body
+}
+\`\`\`
+
+NEVER use \`if (require.main === module)\` — \`require\` is undefined in ESM, so the file throws \`ReferenceError\` at import time and breaks every caller (not just the CLI path). Use \`import.meta.url\` in place of \`__dirname\` / \`__filename\` (\`fileURLToPath(import.meta.url)\` for the absolute path; \`dirname(fileURLToPath(import.meta.url))\` for the directory).
+
+`;
+
+function buildAcceptanceCriteriaNote(testPlan: readonly string[]): string {
+  const items = testPlan.map((t) => `  - ${t}`).join('\n');
+  return `THIS ENTRY'S TEST PLAN IS REQUIRED, NOT OPTIONAL — every named scenario must have a passing test in the PR. Treat as acceptance criteria:
+${items}
+A PR that ships the function/feature without these tests will be sent back by the reviewer chain.
+
+`;
+}
 
 // The pre-Phase-1 prompt template — what slice-7b's `buildPrompt`
 // produced. Wrapping it in a role registry lets future programmer-
@@ -69,7 +126,19 @@ ${lessonsBlock}
     /* graceful no-op */
   }
 
-  return `${lessonsHeader}${memoryContext}You are a swarm worker executing one backlog entry. Output text is ignored — only TOOL DISPATCHES count. If you finish without dispatching tools, the work is lost.
+  // Prompt augmentations driven by the 2026-05-06 /land batch findings
+  // (see swarm-prompt-augmentation-esm-and-tests). When ANY touched
+  // file lives in an ESM package, prepend the ESM-pattern note so the
+  // worker doesn't reach for require.main. When the entry's
+  // description named explicit test scenarios, prepend the
+  // acceptance-criteria note so they don't get treated as commentary.
+  const esmNote = filePaths.some((p) => isEsmPackage(p)) ? ESM_PATTERN_NOTE : '';
+  const acceptanceNote =
+    entry.test_plan && entry.test_plan.length > 0
+      ? buildAcceptanceCriteriaNote(entry.test_plan)
+      : '';
+
+  return `${lessonsHeader}${memoryContext}${esmNote}${acceptanceNote}You are a swarm worker executing one backlog entry. Output text is ignored — only TOOL DISPATCHES count. If you finish without dispatching tools, the work is lost.
 
 ENTRY ID: ${entry.id}
 TARGET FILE: ${targetFile}

--- a/apps/runner/test/role-prompts.test.ts
+++ b/apps/runner/test/role-prompts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildPromptForEntry,
   buildProgrammerPrompt,
+  isEsmPackage,
   resolveEntryRole,
   __test__,
 } from '../src/role-prompts.ts';
@@ -131,5 +132,66 @@ describe('buildPromptForEntry', () => {
     const fallback = buildPromptForEntry(makeEntry({ file: 'x.ts', role: 'time-traveler' }));
     expect(fallback).toContain('TOOL DISPATCHES count');  // programmer template signature
     expect(fallback).toContain('TARGET FILE: ./x.ts');
+  });
+});
+
+// Prompt augmentations from swarm-prompt-augmentation-esm-and-tests
+// (2026-05-06): the programmer prompt should carry an ESM-pattern note
+// when the entry touches files inside a `"type": "module"` package,
+// and an acceptance-criteria note when the entry names explicit test
+// scenarios.
+describe('buildProgrammerPrompt — ESM detection', () => {
+  it('prepends the ESM note when the entry file lives in an ESM package', () => {
+    // apps/runner/package.json has "type": "module" — any file under
+    // it should trip the detector.
+    const out = buildProgrammerPrompt(
+      makeEntry({ file: 'apps/runner/src/role-prompts.ts' }),
+    );
+    expect(out).toContain('THIS PACKAGE IS ESM');
+    expect(out).toContain('fileURLToPath(import.meta.url)');
+    expect(out).toContain('NEVER use `if (require.main === module)`');
+  });
+
+  it('omits the ESM note when no file in the entry resolves to an ESM package', () => {
+    // A path that doesn't resolve under any package.json with
+    // "type": "module" — the kernel binary is Go, no package.json
+    // upstream of go/cmd/* claims ESM.
+    const out = buildProgrammerPrompt(makeEntry({ file: 'go/cmd/chitin/main.go' }));
+    expect(out).not.toContain('THIS PACKAGE IS ESM');
+  });
+
+  it('isEsmPackage returns true for a path inside apps/runner', () => {
+    expect(isEsmPackage('apps/runner/src/role-prompts.ts')).toBe(true);
+  });
+
+  it('isEsmPackage returns false for a path with no enclosing package.json or a non-module package', () => {
+    // Walking up from /tmp will reach the filesystem root without
+    // finding any package.json (or hit one that is not type: module).
+    expect(isEsmPackage('/tmp/definitely-does-not-exist-12345/foo.ts')).toBe(false);
+  });
+});
+
+describe('buildProgrammerPrompt — test plan acceptance criteria', () => {
+  it('prepends the acceptance-criteria note when entry has a non-empty test_plan', () => {
+    const out = buildProgrammerPrompt(
+      makeEntry({
+        file: 'go/cmd/chitin/main.go',  // non-ESM to isolate the test_plan effect
+        test_plan: ['clean fixture passes', 'missing-path fixture flagged'],
+      }),
+    );
+    expect(out).toContain("THIS ENTRY'S TEST PLAN IS REQUIRED");
+    expect(out).toContain('clean fixture passes');
+    expect(out).toContain('missing-path fixture flagged');
+    expect(out).toContain('acceptance criteria');
+  });
+
+  it('omits the acceptance-criteria note when test_plan is absent or empty', () => {
+    const noPlan = buildProgrammerPrompt(makeEntry({ file: 'go/cmd/chitin/main.go' }));
+    expect(noPlan).not.toContain("THIS ENTRY'S TEST PLAN IS REQUIRED");
+
+    const emptyPlan = buildProgrammerPrompt(
+      makeEntry({ file: 'go/cmd/chitin/main.go', test_plan: [] }),
+    );
+    expect(emptyPlan).not.toContain("THIS ENTRY'S TEST PLAN IS REQUIRED");
   });
 });


### PR DESCRIPTION
Picked up by the autonomous dispatcher (slice 7).

Backlog entry: `swarm-prompt-augmentation-esm-and-tests`
Tier: `T4`  •  Driver: `claude-code-headless`  •  Model: `claude-opus-4-7`
Role: `programmer`
Workflow: `swarm-swarm-prompt-augmentation-esm-and-tests-1778086731658`

## Entry context

**Why this is here:** 2026-05-06 /land batch found that swarm-produced
TypeScript PRs systematically miss two things the operator catches in
review:

1. **ESM-vs-CJS pattern.** PR #361 (\`groomer-validate-paths\`) used
   \`if (require.main === module)\` for its CLI entrypoint. apps/runner
   is ESM (\`"type": "module"\`) — \`require\` is undefined, so importing
   the module from anywhere else throws \`ReferenceError\` at load time.
   Even the function the PR DEFINES becomes uncallable.

2. **Test coverage scoped to entry's request.** Entry #360 explicitly
   asked for "3 fixture entries (clean, missing-path, partially-missing)
   + assertion that validate-entry-paths flags correctly". PR #361
   delivered the function but ZERO tests. Entries that name specific
   test scenarios should be treated as acceptance criteria.

The fix is operator-side prompt augmentation, not agent-side
behavior change:

- Programmer prompts that touch \`.ts\` files in apps/runner/* (or any
  \`"type": "module"\` package) get a prepended note: "This package is
  ESM. Use \`if (process.argv[1] === fileURLToPath(import.meta.url))\`
  for CLI entrypoints, never \`require.main === module\`. Use
  \`import.meta.url\` instead of \`__dirname\`/\`__filename\`."

- For entries whose body explicitly names test scenarios, the
  prompt prepends "The entry's test plan is REQUIRED, not optional —
  every named scenario must have a passing test in the PR. Treat as
  acceptance criteria."

**Fix scope:**

1. \`role-prompts.ts\` — extend the prompt builder to:
   - Detect ESM packages by reading the touched files' nearest
     \`package.json\` for \`"type": "module"\`. Prepend the ESM-pattern
     note when found.
   - Parse the entry body for "Tests:" / "Test plan:" / similar; when
     present, prepend the acceptance-criteria note.
2. \`parse-backlog.ts\` — add an optional \`test_plan?: string[]\` field
   to BacklogEntry so the prompt builder can address requirements
   one-by-one.
3. Tests: 2 fixture cases — ESM file produces ESM note; non-ESM file
   doesn't; entry with Tests: produces acceptance-criteria note;
   entry without doesn't.

T2 because mechanical prompt-string composition; no model judgment
involved. Pays for itself within a single dispatch (catches the
class of bug PR #361 introduced).

---


---
Generated by the slice-5 swarm-worktree pipeline.
Workflow ID: `swarm-swarm-prompt-augmentation-esm-and-tests-1778086731658`
Branch: `swarm/swarm-swarm-prompt-augmentation-esm-and-tests-1778086731658`
Head: `f3005e04`
Diff: `4 files changed, 207 insertions(+), 12 deletions(-)`
Commits: 1 (+ auto-committed uncommitted state)