### PR TITLE
auto: flip 1 entries ready→partial (shipped-entry-flipper)

### DIFF
--- a/docs/swarm-backlog.md
+++ b/docs/swarm-backlog.md
@@ -246,7 +246,7 @@ template, no design judgment.
 ```yaml
 id: spawn-template-validate-all-drivers
 tier: T2
-status: ready
+status: partial
 estimated_loc: 120
 blocks: [spawn-template-fix-copilot]
 file: go/execution-kernel/internal/router/spawn_peer_test.go


### PR DESCRIPTION
Auto-generated by chitin-shipped-entry-flipper.

The following backlog entries are flipped from `status: ready` to `status: partial` because their entry-id appears in a recently-merged PR's title (within the last 7 days). `partial` is the honest status — the dispatcher stops re-dispatching, but acceptance criteria may still have unshipped items the operator should review.

Flipped:
- spawn-template-validate-all-drivers (#369)

If any of these are wrong, revert + investigate why the title matched without the work shipping.