### PR TITLE
fix(gov): make hermes plugin policy enforcement cwd-independent

### DIFF
--- a/apps/runner/src/activity.ts
+++ b/apps/runner/src/activity.ts
@@ -815,6 +815,26 @@ export async function runAgentTurn(req: ExecutionRequest): Promise<ActivityResul
           // tuple. Until then, the kernel sees an empty fingerprint
           // and chain rows omit the field via omitempty.
           CHITIN_FINGERPRINT: process.env.CHITIN_FINGERPRINT ?? '',
+          // Policy file + fail-closed mode for any agent that calls
+          // chitin-kernel's gate from inside the spawned process.
+          // Necessary because the spawn cwd is a per-task worktree
+          // (e.g. ~/swarm/worktrees/<workflow_id>/) which is a
+          // checkout of the TARGET repo — most of which don't have
+          // chitin.yaml at root. Without these, the kernel's
+          // cwd-walk-upward returns no_policy_found and the hermes
+          // plugin's lenient default lets every tool call through —
+          // the gap that PR #N (this PR) closes.
+          //
+          // CHITIN_POLICY_FILE is the operator's authoritative
+          // chitin.yaml; the kernel's gate evaluate honors --policy-file
+          // (or this env fallback) and skips the inheritance walk.
+          //
+          // CHITIN_REQUIRE_POLICY=1 makes the chitin-governance hermes
+          // plugin treat no_policy_found as a hard deny instead of
+          // silently allowing — defense-in-depth for the case where
+          // CHITIN_POLICY_FILE is unset or points to a missing file.
+          CHITIN_POLICY_FILE: resolvePolicySrc(),
+          CHITIN_REQUIRE_POLICY: '1',
         },
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: true,

--- a/docs/governance-setup-extras/hermes-plugin.py
+++ b/docs/governance-setup-extras/hermes-plugin.py
@@ -1,0 +1,198 @@
+"""chitin-governance — hermes plugin that calls chitin-kernel gate on every
+pre_tool_call and blocks denied actions.
+
+Spec: docs/superpowers/specs/2026-04-22-chitin-governance-v1-design.md
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from typing import Any, Dict, Optional
+
+_CHITIN_KERNEL = os.environ.get("CHITIN_KERNEL_PATH") or shutil.which("chitin-kernel") or os.path.expanduser("~/.local/bin/chitin-kernel")
+_GATE_TIMEOUT_SEC = 5
+
+# CHITIN_POLICY_FILE — explicit path to the operator's chitin.yaml. When set,
+# the plugin passes --policy-file to chitin-kernel so cwd doesn't matter for
+# policy lookup. Required when hermes runs from worktrees of non-chitin repos
+# or scratch dirs (the common case for swarm spawns); without this, the
+# kernel's cwd-walk-upward returns no_policy_found and enforcement disappears.
+#
+# CHITIN_REQUIRE_POLICY=1 — fail-closed when no policy is found. Pairs with
+# CHITIN_POLICY_FILE: with both set, the explicit file always loads (no
+# fall-through); with only REQUIRE_POLICY set, the cwd-walk still happens
+# but no_policy_found becomes a hard deny instead of an allow.
+def _truthy(v: str) -> bool:
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+# Hermes's pre_tool_call runs in the gateway/agent process cwd, which is
+# typically the hermes install dir — not where the shell command will
+# actually execute. Hermes tool calls almost always start with
+#   cd <path> && ...
+# so we walk every `cd` in the chain and use the LAST one (shells update
+# cwd left-to-right before running the final command). Any earlier cd is
+# a stopover. Using the first cd (previous impl) was a bypass surface:
+# `cd ~/scratch && cd ~/governed && rm -rf go/` would pick up ~/scratch.
+#
+# Patterns matched (all of these produce a capture):
+#   cd /abs/path         → /abs/path
+#   cd relative/path     → abs(getcwd()/relative/path)
+#   cd ~/path            → expanded
+#   cd "path with space" → path with space (I1 fix)
+#   cd 'path with space' → path with space
+_CD_RE = re.compile(
+    r'\bcd\s+(?:"([^"]+)"|\'([^\']+)\'|([^\s;&|]+))'
+)
+
+
+def _resolve_cwd(tool_name: str, args: Dict[str, Any]) -> str:
+    """Return the cwd the tool call would actually execute against.
+
+    For shell tools, parse every `cd` in the command and return the final
+    effective cwd. For non-shell tools, return the process cwd.
+    """
+    if tool_name in ("terminal", "bash", "shell"):
+        cmd = (args or {}).get("command") or (args or {}).get("cmd") or ""
+        # Track effective cwd as we walk the chain. Start from process cwd
+        # and update on each cd (matching normal shell semantics).
+        cwd = os.getcwd()
+        for m in _CD_RE.finditer(cmd):
+            # Match groups: (double-quoted, single-quoted, unquoted).
+            # Exactly one is non-empty per match.
+            target = next((g for g in m.groups() if g), "")
+            if not target:
+                continue
+            target = os.path.expanduser(target)
+            if os.path.isabs(target):
+                cwd = target
+            else:
+                cwd = os.path.abspath(os.path.join(cwd, target))
+        return cwd
+    return os.getcwd()
+
+
+def _on_pre_tool_call(tool_name: str, args: Dict[str, Any], session_id: str = "", **kwargs):
+    """Called by hermes before every tool call.
+
+    Returns None to allow, or a dict {"action":"block","message":...} to deny.
+    Hermes uses the message as the agent's next-turn input.
+
+    cwd is resolved from the tool args (e.g., `cd X && ...` prefix) rather
+    than os.getcwd() because hermes runs in its install directory while
+    tool calls execute shell commands that cd into governed trees.
+    """
+    cwd = _resolve_cwd(tool_name, args or {})
+    cmd = [
+        _CHITIN_KERNEL, "gate", "evaluate",
+        "--tool", tool_name,
+        "--args-json", json.dumps(args or {}),
+        "--agent", "hermes",
+        "--cwd", cwd,
+    ]
+    policy_file = os.environ.get("CHITIN_POLICY_FILE", "").strip()
+    if policy_file:
+        cmd.extend(["--policy-file", policy_file])
+    try:
+        cp = subprocess.run(
+            cmd,
+            capture_output=True, text=True, timeout=_GATE_TIMEOUT_SEC,
+        )
+    except FileNotFoundError:
+        return _block_message(
+            reason="governance_disabled: chitin-kernel binary not found",
+            suggestion=f"Install or set CHITIN_KERNEL_PATH. Looked at: {_CHITIN_KERNEL}",
+            rule_id="gate_unreachable",
+        )
+    except subprocess.TimeoutExpired:
+        return _block_message(
+            reason="gate_unreachable: chitin-kernel gate timed out",
+            suggestion="Check chitin-kernel health; try `chitin-kernel gate status`.",
+            rule_id="gate_unreachable",
+        )
+    except Exception as exc:
+        return _block_message(
+            reason=f"gate_unreachable: {exc}",
+            suggestion="Check chitin-kernel logs.",
+            rule_id="gate_unreachable",
+        )
+
+    stdout = (cp.stdout or "").strip()
+    if not stdout:
+        return _block_message(
+            reason="gate returned empty output",
+            suggestion=f"Check stderr: {cp.stderr[:200] if cp.stderr else '(none)'}",
+            rule_id="gate_unreachable",
+        )
+    try:
+        decision = json.loads(stdout)
+    except json.JSONDecodeError:
+        return _block_message(
+            reason=f"gate returned non-JSON: {stdout[:200]}",
+            suggestion="",
+            rule_id="gate_unreachable",
+        )
+
+    if decision.get("allowed"):
+        return None  # allow
+
+    # Policy-scope override: if the agent is running in a cwd with no
+    # chitin.yaml up the tree, governance does not apply — fall through
+    # to allow. This is a practical deviation from the spec's strict
+    # fail-closed-on-no-policy: in practice hermes cwd is often outside
+    # any governed repo (hermes-agent install dir, scratch dirs, etc.),
+    # and blocking every tool call there breaks legitimate work. The
+    # gate binary still fails closed when invoked directly; only the
+    # plugin's auto-firing path honors this allowance.
+    #
+    # Operator opts out of the lenient default by setting
+    # CHITIN_REQUIRE_POLICY=1 (typically in the swarm runner spawn env),
+    # which makes no_policy_found a hard deny — the agent is told it
+    # cannot proceed because the operator explicitly required policy
+    # coverage. Combined with CHITIN_POLICY_FILE this is unreachable
+    # (the explicit file always loads), so the strict-mode operator
+    # effectively gets cwd-independent enforcement.
+    if decision.get("rule_id") == "no_policy_found":
+        if _truthy(os.environ.get("CHITIN_REQUIRE_POLICY", "")):
+            return _block_message(
+                reason="no chitin.yaml found in cwd and CHITIN_REQUIRE_POLICY=1; fail-closed",
+                suggestion="Set CHITIN_POLICY_FILE to an explicit policy path, or run from a directory with chitin.yaml above it.",
+                rule_id="no_policy_found",
+                escalation="elevated",
+            )
+        return None  # no governance in this cwd — allow (legacy lenient default)
+
+    mode = decision.get("mode", "enforce")
+    if mode == "monitor":
+        # Monitor mode = log-only, allow execution despite rule match.
+        return None
+
+    return _block_message(
+        reason=decision.get("reason", "action blocked"),
+        suggestion=decision.get("suggestion", ""),
+        corrected=decision.get("corrected_command", ""),
+        rule_id=decision.get("rule_id", "unknown"),
+        escalation=decision.get("escalation", "normal"),
+    )
+
+
+def _block_message(*, reason: str, suggestion: str = "", corrected: str = "",
+                   rule_id: str = "unknown", escalation: str = "normal"):
+    """Format a block directive in the shape hermes expects (dict with
+    action=block + message). Per hermes_cli/plugins.py:get_pre_tool_call_block_message,
+    a plain string is silently ignored — the hook must return a dict.
+    """
+    parts = [f"Action blocked: {reason}"]
+    if suggestion:
+        parts.append(f"Suggestion: {suggestion}")
+    if corrected:
+        parts.append(f"Try: {corrected}")
+    parts.append(f"(policy: {rule_id}, escalation: {escalation})")
+    return {"action": "block", "message": "\n".join(parts)}
+
+
+def register(ctx) -> None:
+    """Hermes plugin entry point."""
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)

--- a/docs/governance-setup-extras/hermes-plugin.yaml
+++ b/docs/governance-setup-extras/hermes-plugin.yaml
@@ -1,0 +1,5 @@
+name: chitin-governance
+version: 1.0.0
+description: "Enforces per-repo chitin.yaml policy on every pre_tool_call by shelling out to chitin-kernel gate."
+hooks:
+  - pre_tool_call

--- a/go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runCLIWithEnv mirrors runCLI from main_test.go but appends the given
+// env entries (KEY=value strings) to os.Environ() before exec — so we
+// can validate env-var-driven flag defaults like --policy-file.
+func runCLIWithEnv(t *testing.T, wd string, env []string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), testBinary, args...)
+	cmd.Dir = wd
+	cmd.Env = append(os.Environ(), env...)
+	stdout, err := cmd.Output()
+	var stderr []byte
+	if ee, ok := err.(*exec.ExitError); ok {
+		stderr = ee.Stderr
+	}
+	return string(stdout), string(stderr), cmd.ProcessState.ExitCode()
+}
+
+// TestCLI_GateEvaluate_PolicyFileFlag verifies the --policy-file flag (and
+// the CHITIN_POLICY_FILE env fallback) load policy from an explicit path
+// instead of walking up from --cwd.
+//
+// Why this matters: the chitin-governance hermes plugin shells out to
+// chitin-kernel from whatever cwd hermes runs from — typically a per-task
+// worktree of a non-chitin repo, or /tmp. Without --policy-file the
+// kernel's cwd-walk-upward returns no_policy_found and the plugin's
+// lenient default lets every tool call through. Manual test on
+// 2026-05-06 confirmed: from /tmp every dangerous call (write to
+// /etc/hostname, sudo tee /etc/hostname, write to ~/.ssh) returned
+// block=False even with the protected-system-path-* rules in place.
+func TestCLI_GateEvaluate_PolicyFileFlag(t *testing.T) {
+	// Stand up a minimal policy in one temp dir; cd into a different
+	// temp dir that has no chitin.yaml in its ancestor chain.
+	policyDir := t.TempDir()
+	policyPath := filepath.Join(policyDir, "chitin.yaml")
+	if err := os.WriteFile(policyPath, []byte(`
+id: test-policy
+mode: enforce
+invariantModes:
+  protected-system-path-write: enforce
+rules:
+  - id: protected-system-path-write
+    action: file.write
+    effect: deny
+    path_under: ["/etc/"]
+    reason: "system paths are protected"
+  - id: default-allow-file-write
+    action: file.write
+    effect: allow
+    reason: "writes allowed by default"
+`), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	noPolicyDir := t.TempDir() // no chitin.yaml here or upward (t.TempDir lives under TMPDIR with no ancestor chitin.yaml)
+
+	cases := []struct {
+		name      string
+		path      string
+		wantAllow bool
+		wantRule  string
+	}{
+		{"system path denied via explicit policy", "/etc/hostname", false, "protected-system-path-write"},
+		{"safe path allowed via explicit policy", "/tmp/scratch.txt", true, "default-allow-file-write"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			argsJSON, _ := json.Marshal(map[string]string{"path": tc.path})
+			stdout, stderr, _ := runCLI(t, noPolicyDir,
+				"gate", "evaluate",
+				"--tool", "write_file",
+				"--args-json", string(argsJSON),
+				"--agent", "test-agent",
+				"--cwd", noPolicyDir,
+				"--policy-file", policyPath,
+			)
+			if stdout == "" {
+				t.Fatalf("empty stdout (stderr=%q)", stderr)
+			}
+			var out map[string]any
+			if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+				t.Fatalf("unmarshal stdout %q: %v", stdout, err)
+			}
+			allowed, _ := out["allowed"].(bool)
+			ruleID, _ := out["rule_id"].(string)
+			if allowed != tc.wantAllow {
+				t.Errorf("allowed = %v, want %v (rule_id=%q)", allowed, tc.wantAllow, ruleID)
+			}
+			if ruleID != tc.wantRule {
+				t.Errorf("rule_id = %q, want %q", ruleID, tc.wantRule)
+			}
+		})
+	}
+}
+
+// TestCLI_GateEvaluate_PolicyFileEnvFallback proves the CHITIN_POLICY_FILE
+// env var is honored when --policy-file is not passed. This is the path
+// the hermes plugin will use after we update apps/runner/src/activity.ts
+// to set CHITIN_POLICY_FILE in the spawned-process env.
+func TestCLI_GateEvaluate_PolicyFileEnvFallback(t *testing.T) {
+	policyDir := t.TempDir()
+	policyPath := filepath.Join(policyDir, "chitin.yaml")
+	if err := os.WriteFile(policyPath, []byte(`
+id: test-policy-env
+mode: enforce
+rules:
+  - id: deny-everything
+    action: file.write
+    effect: deny
+    reason: "blanket deny via env-fallback policy"
+`), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	noPolicyDir := t.TempDir()
+
+	// We can't use runCLI here because it doesn't accept env overrides.
+	// Inline a small subprocess instead.
+	stdout, _, code := runCLIWithEnv(t, noPolicyDir,
+		[]string{"CHITIN_POLICY_FILE=" + policyPath},
+		"gate", "evaluate",
+		"--tool", "write_file",
+		"--args-json", `{"path":"/tmp/anything.txt"}`,
+		"--agent", "test-agent",
+		"--cwd", noPolicyDir,
+	)
+	if code == 0 {
+		t.Errorf("env-fallback policy should deny, got allow (stdout=%s)", stdout)
+	}
+	if !strings.Contains(stdout, "deny-everything") {
+		t.Errorf("expected env-loaded policy's rule_id=deny-everything in stdout, got: %s", stdout)
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -807,6 +807,7 @@ func cmdGateEvaluate(args []string) {
 	hookStdin := fs.Bool("hook-stdin", false, "read Claude Code PreToolUse JSON from stdin (hook driver mode)")
 	envelopeID := fs.String("envelope", "", "envelope ID (overrides CHITIN_BUDGET_ENVELOPE and ~/.chitin/current-envelope)")
 	requirePolicy := fs.Bool("require-policy", false, "fail closed when no chitin.yaml is found from cwd (default: fail open with stderr warning)")
+	policyFile := fs.String("policy-file", os.Getenv("CHITIN_POLICY_FILE"), "explicit chitin.yaml path; overrides the cwd-walk-upward lookup. Required for callers (like the hermes plugin) that run from arbitrary cwds and need policy enforcement to be cwd-independent.")
 	fs.Parse(args)
 
 	if *hookStdin {
@@ -833,7 +834,17 @@ func cmdGateEvaluate(args []string) {
 	action.Path = *cwd
 
 	absCwd, _ := filepath.Abs(*cwd)
-	policy, _, err := gov.LoadWithInheritance(absCwd)
+	// --policy-file (or $CHITIN_POLICY_FILE) bypasses the cwd-walk and loads
+	// an explicit policy. Use this when the caller cannot guarantee its cwd
+	// has chitin.yaml above it (e.g. hermes plugin invoked from a worktree
+	// of a non-chitin repo, or from /tmp). When unset, fall back to the
+	// inheritance walk so existing operator-CLI usage stays unchanged.
+	var policy gov.Policy
+	if *policyFile != "" {
+		policy, err = gov.LoadPolicyFile(*policyFile)
+	} else {
+		policy, _, err = gov.LoadWithInheritance(absCwd)
+	}
 	if err != nil {
 		// Distinguish "no policy found" (intentional deny, exit 1) from
 		// "policy invalid" (misconfiguration, exit 2) so the plugin's

--- a/scripts/install-hermes-plugin.sh
+++ b/scripts/install-hermes-plugin.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# install-hermes-plugin.sh — install the chitin-governance hermes plugin
+# from the canonical source in docs/governance-setup-extras/ into the
+# operator's ~/.hermes/plugins/chitin-governance/ directory.
+#
+# The plugin shells out to chitin-kernel on every hermes pre_tool_call.
+# Two env vars (set by the swarm runner; can also be set in the
+# operator's shell) make it cwd-independent and fail-closed:
+#
+#   CHITIN_POLICY_FILE=/path/to/chitin.yaml  → explicit policy path,
+#       skips the kernel's cwd-walk-upward lookup
+#   CHITIN_REQUIRE_POLICY=1                  → if the policy still cannot
+#       be loaded, deny instead of silently allowing
+#
+# Without these the plugin falls back to legacy lenient behavior
+# (cwd-walk + allow-on-no-policy) for backwards compat.
+#
+# Idempotent: re-runs overwrite the installed plugin files in place.
+
+set -euo pipefail
+
+REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+PLUGIN_SRC_DIR="$REPO/docs/governance-setup-extras"
+PLUGIN_DST_DIR="${HERMES_PLUGINS_DIR:-$HOME/.hermes/plugins}/chitin-governance"
+
+if [[ ! -f "$PLUGIN_SRC_DIR/hermes-plugin.py" ]]; then
+  echo "install-hermes-plugin: source not found at $PLUGIN_SRC_DIR/hermes-plugin.py" >&2
+  exit 1
+fi
+if [[ ! -f "$PLUGIN_SRC_DIR/hermes-plugin.yaml" ]]; then
+  echo "install-hermes-plugin: source not found at $PLUGIN_SRC_DIR/hermes-plugin.yaml" >&2
+  exit 1
+fi
+
+mkdir -p "$PLUGIN_DST_DIR"
+cp "$PLUGIN_SRC_DIR/hermes-plugin.py"   "$PLUGIN_DST_DIR/__init__.py"
+cp "$PLUGIN_SRC_DIR/hermes-plugin.yaml" "$PLUGIN_DST_DIR/plugin.yaml"
+echo "install-hermes-plugin: installed to $PLUGIN_DST_DIR"
+
+# Verify hermes sees it as enabled. If the user hasn't added
+# chitin-governance to plugins.enabled in their hermes config, point
+# them at the next step.
+if command -v hermes >/dev/null 2>&1; then
+  if hermes plugins list 2>/dev/null | grep -q 'chitin-governance.*enabled'; then
+    echo "install-hermes-plugin: hermes reports chitin-governance enabled — done."
+  else
+    echo "install-hermes-plugin: hermes does not yet have chitin-governance in plugins.enabled."
+    echo "  Add it to ~/.hermes/config.yaml (and any per-profile config you use):"
+    echo "    plugins:"
+    echo "      enabled:"
+    echo "        - chitin-governance"
+  fi
+fi


### PR DESCRIPTION
## Why

Manual diagnosis on 2026-05-06 (right after #375 merged) showed the chitin-governance hermes plugin **silently allowed every dangerous tool call** when invoked from any directory without `chitin.yaml` above it. Reproducer from `/tmp`:

| Call | Expected | Got (pre-fix) |
|---|---|---|
| `write_file /etc/hostname` | DENY | ALLOW ❌ |
| `terminal sudo tee /etc/hostname` | DENY | ALLOW ❌ |
| `write_file ~/.ssh/authorized_keys` | DENY | ALLOW ❌ |

The kernel returned `no_policy_found` (cwd-walk-upward found no `chitin.yaml`); the plugin's lenient default fell through to allow.

This blocks the planned `CHITIN_TIER_DRIVER_T0=hermes` flip — the runner spawns hermes inside per-task worktrees of arbitrary repos, almost none of which carry `chitin.yaml` at root, so #375's `protected-system-path-*` rules silently did nothing on those paths.

## What

Three coordinated layers:

### 1. Kernel — `--policy-file` flag (with `$CHITIN_POLICY_FILE` env fallback)
`gate evaluate` now accepts an explicit policy path. When set, it loads that file directly via `gov.LoadPolicyFile` and skips the cwd-walk inheritance lookup. Operator CLI use without the flag is unchanged.

### 2. Plugin — two new env vars
- `CHITIN_POLICY_FILE` → forwarded as `--policy-file` to `chitin-kernel`. Cwd no longer matters.
- `CHITIN_REQUIRE_POLICY=1` → defense-in-depth. If the kernel still returns `no_policy_found`, the plugin treats it as a hard deny instead of falling through.

Default behavior (neither var set) stays lenient for backwards compat.

### 3. Runner — env injection in spawn
`apps/runner/src/activity.ts` now sets both env vars on the child process for every agent spawn. `POLICY_FILE` resolves to the operator's `chitin.yaml`; `REQUIRE_POLICY=1` is always on. Closes the actual gap.

### 4. Plugin source now tracked in repo
The plugin lived only at `~/.hermes/plugins/chitin-governance/` with no in-repo source — fixes could only be applied locally. Adds:
- `docs/governance-setup-extras/hermes-plugin.py` + `hermes-plugin.yaml` — canonical source
- `scripts/install-hermes-plugin.sh` — idempotent installer

## Verification

End-to-end test from `/tmp` (no `chitin.yaml` upward):

| Mode | `/etc/hostname` | `/tmp/scratch.txt` | `~/.ssh/auth_keys` | `sudo tee /etc/...` | `cat /etc/passwd` |
|---|---|---|---|---|---|
| Neither env (legacy) | ALLOW | ALLOW | ALLOW | ALLOW | ALLOW |
| REQUIRE_POLICY=1 only | DENY (fail-closed) | DENY | DENY | DENY | DENY |
| POLICY_FILE set | DENY (system-path) | ALLOW | DENY (credential) | DENY (shell-write) | ALLOW (read) |

## Test plan

- [x] `go test ./cmd/chitin-kernel/ -run TestCLI_GateEvaluate_PolicyFile` — 4 new subtests pass
- [x] Full kernel suite — 960 pass; 2 pre-existing `TestSpawnPeer_*Smoke` failures reproduce on `main` (unrelated)
- [x] `vitest run apps/runner/test/activity.test.ts` — 47/47 pass
- [x] Live python plugin test from `/tmp` — all three env modes behave as documented
- [x] `scripts/install-hermes-plugin.sh` — idempotent, installs to operator's `~/.hermes/plugins/chitin-governance/`

## Follow-ups

- Operator post-merge: re-run `scripts/install-hermes-plugin.sh` on each box; the kernel-redeploy timer rebuilds the binary from main automatically.
- Once verified in the wild, flipping `CHITIN_TIER_DRIVER_T0=hermes` is now safe.