### PR TITLE
fix(gov): thread --policy-file through hook-stdin path

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -54,8 +54,8 @@ func isChitinAdminCommand(a gov.Action) bool {
 // PreToolUse hook. It wires real stdin/stdout/os.Exit around the pure
 // evalHookStdin core. The split keeps evalHookStdin testable in-process
 // while production gets the full os-level behavior.
-func runHookStdin(agent, envelopeFlag string, requirePolicy, noRecord bool) {
-	code := evalHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag, requirePolicy, noRecord)
+func runHookStdin(agent, envelopeFlag, policyFile string, requirePolicy, noRecord bool) {
+	code := evalHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag, policyFile, requirePolicy, noRecord)
 	os.Exit(code)
 }
 
@@ -83,7 +83,7 @@ func runHookStdin(agent, envelopeFlag string, requirePolicy, noRecord bool) {
 // (Counter + BudgetStore). Sharing one *sql.DB would halve cold-start
 // open cost. Deferred until Milestone D's 8-shim stress test surfaces
 // real contention numbers — at 3ms p95 today the headroom is ample.
-func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag string, requirePolicy, noRecord bool) int {
+func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag, policyFile string, requirePolicy, noRecord bool) int {
 	if agent == "" {
 		agent = "claude-code"
 	}
@@ -162,7 +162,21 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag strin
 		return claudecode.ExitNonBlockError
 	}
 
-	policy, _, err := gov.LoadWithInheritance(absCwd)
+	// --policy-file (or $CHITIN_POLICY_FILE, both passed as policyFile by
+	// main.go cmdGateEvaluate) bypasses the cwd-walk inheritance lookup
+	// and loads an explicit policy. Mirrors the non-hook gate-evaluate
+	// path's behavior (main.go:843-847). Without this thread-through, an
+	// operator running `gate evaluate --hook-stdin --policy-file X` got
+	// X silently ignored — this caused 2026-05-06's hook-capture replay
+	// to apply per-cwd inherited policy instead of chitin's policy,
+	// muddying the counterfactual analysis. Found while replaying the
+	// 17-day Curie capture dataset.
+	var policy gov.Policy
+	if policyFile != "" {
+		policy, err = gov.LoadPolicyFile(policyFile)
+	} else {
+		policy, _, err = gov.LoadWithInheritance(absCwd)
+	}
 	if err != nil {
 		errMsg := err.Error()
 		if !strings.HasPrefix(errMsg, "no_policy_found") {

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -41,7 +41,7 @@ func runHookCall(t *testing.T, env *hookTestEnv, payload map[string]any, envelop
 	}
 	in := bytes.NewReader(body)
 	var out, errOut bytes.Buffer
-	exitCode = evalHookStdin(in, &out, &errOut, "claude-code", envelopeFlag, false, false)
+	exitCode = evalHookStdin(in, &out, &errOut, "claude-code", envelopeFlag, "", false, false)
 	return out.String(), errOut.String(), exitCode
 }
 
@@ -136,7 +136,7 @@ func TestEvalHookStdin_NoPolicyInCwdAllowsWithWarning(t *testing.T) {
 		"cwd":        cwd,
 	})
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", false, false)
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", "", false, false)
 	if code != 0 {
 		t.Fatalf("exit=%d want 0 (fail-open)", code)
 	}
@@ -169,7 +169,7 @@ func TestEvalHookStdin_NoPolicyInCwd_RequirePolicy_Blocks(t *testing.T) {
 		"cwd":        cwd,
 	})
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", true, false)
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", "", true, false)
 	if code != 2 {
 		t.Fatalf("exit=%d want 2 (--require-policy → block)", code)
 	}
@@ -196,7 +196,7 @@ func TestEvalHookStdin_WrongTypeField_WarnsAndProceeds(t *testing.T) {
 		"cwd":        env.cwd,
 	})
 	var out, errOut bytes.Buffer
-	_ = evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", false, false)
+	_ = evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", "", false, false)
 	if !strings.Contains(errOut.String(), "tool_input_wrong_type") {
 		t.Fatalf("stderr missing wrong-type warning: %q", errOut.String())
 	}
@@ -206,7 +206,7 @@ func TestEvalHookStdin_MalformedJSONIsExit1(t *testing.T) {
 	env := setupHookEnv(t, baselinePolicy)
 	in := bytes.NewReader([]byte("not json"))
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(in, &out, &errOut, "claude-code", "", false, false)
+	code := evalHookStdin(in, &out, &errOut, "claude-code", "", "", false, false)
 	_ = env
 	if code != 1 {
 		t.Fatalf("exit=%d want 1 (non-blocking error)", code)
@@ -510,7 +510,7 @@ func TestEvalHookStdin_ChitinAdmin_ChainedRmRfStillBlocked(t *testing.T) {
 		"cwd": env.cwd,
 	})
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", envelope.ID, false, false)
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", envelope.ID, "", false, false)
 	if code != 2 {
 		t.Fatalf("exit=%d want 2 (rm-rf rule should still apply); stdout=%q", code, out.String())
 	}
@@ -553,7 +553,7 @@ func TestEvalHookStdin_ChitinAdmin_ExemptInfoLogged(t *testing.T) {
 		"cwd":        env.cwd,
 	})
 	var out, errOut bytes.Buffer
-	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", envelope.ID, false, false)
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", envelope.ID, "", false, false)
 	if code != 0 {
 		t.Fatalf("exit=%d want 0", code)
 	}
@@ -605,7 +605,7 @@ func TestEvalHookStdin_NoRecordSuppressesAllPersistence(t *testing.T) {
 	// state-mutating side effects fire.
 	for i := 0; i < 15; i++ {
 		var out, errOut bytes.Buffer
-		code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "norecord-hook", "", false, true)
+		code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "norecord-hook", "", "", false, true)
 		if code != 2 {
 			t.Fatalf("iter %d: code=%d want 2 (block); stdout=%q", i, code, out.String())
 		}
@@ -664,8 +664,70 @@ func TestEvalHookStdin_NoRecordSkipsEnvelopeSpend(t *testing.T) {
 		"tool_input": map[string]any{"file_path": "/x"},
 		"cwd":        env.cwd,
 	})
-	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", false, true)
+	code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", "", false, true)
 	if code != 0 {
 		t.Fatalf("allow under NoRecord should exit 0, got %d (stdout=%q errOut=%q)", code, out.String(), errOut.String())
+	}
+}
+
+func TestEvalHookStdin_PolicyFileOverridesCwdInheritance(t *testing.T) {
+	// Regression for 2026-05-07: the --policy-file flag was parsed in
+	// main.go cmdGateEvaluate but never threaded to runHookStdin →
+	// evalHookStdin in --hook-stdin mode. Effect: any caller passing
+	// --policy-file with --hook-stdin got it silently dropped, and the
+	// gate fell back to the cwd-walk inheritance lookup. Found while
+	// replaying the 17-day Curie capture dataset against a pinned
+	// policy and seeing per-cwd policies apply instead.
+	//
+	// Two assertions:
+	//   1. policyFile="" → behaves as before (cwd walk applies)
+	//   2. policyFile=<explicit> with no cwd policy → explicit wins
+	//      (without the fix, this returned no_policy_found + allow)
+	tmpHome := t.TempDir()
+	prev := os.Getenv("CHITIN_HOME")
+	_ = os.Setenv("CHITIN_HOME", tmpHome)
+	t.Cleanup(func() { _ = os.Setenv("CHITIN_HOME", prev) })
+
+	// Stage a policy in a temp dir; cwd will be a SEPARATE temp dir
+	// with no chitin.yaml in its inheritance chain.
+	policyDir := t.TempDir()
+	policyPath := filepath.Join(policyDir, "chitin.yaml")
+	if err := os.WriteFile(policyPath, []byte(baselinePolicy), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	cwd := t.TempDir() // empty; no chitin.yaml here or above
+
+	body, _ := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "echo hello"},
+		"cwd":        cwd,
+		"session_id": "policy-file-test",
+	})
+
+	// Without --policy-file: hook fires no_policy_found warning, allows.
+	{
+		var out, errOut bytes.Buffer
+		code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", "", false, false)
+		if code != 0 {
+			t.Fatalf("no-policy path: code=%d want 0 (fail-open allow)", code)
+		}
+		if !strings.Contains(errOut.String(), "no_policy_found") {
+			t.Errorf("no-policy path: expected no_policy_found warn on stderr, got %q", errOut.String())
+		}
+	}
+
+	// With --policy-file: explicit policy wins; no warn, gate allows
+	// based on the policy's allow-shell rule (not the no_policy_found
+	// fail-open path).
+	{
+		var out, errOut bytes.Buffer
+		code := evalHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", policyPath, false, false)
+		if code != 0 {
+			t.Fatalf("policy-file path: code=%d want 0 (allow), stdout=%q errOut=%q", code, out.String(), errOut.String())
+		}
+		if strings.Contains(errOut.String(), "no_policy_found") {
+			t.Errorf("policy-file path: should NOT see no_policy_found (means flag was ignored), got: %q", errOut.String())
+		}
 	}
 }

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -815,7 +815,7 @@ func cmdGateEvaluate(args []string) {
 		if *agent == "" {
 			*agent = "claude-code"
 		}
-		runHookStdin(*agent, *envelopeID, *requirePolicy, *noRecord)
+		runHookStdin(*agent, *envelopeID, *policyFile, *requirePolicy, *noRecord)
 		return
 	}
 

--- a/go/execution-kernel/cmd/chitin-kernel/router_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook.go
@@ -32,12 +32,12 @@ import (
 //
 // Cold-start target: ~10ms (heuristics are pure Go); only the
 // advisor call (when fired) takes seconds (LLM latency).
-func runRouterHookStdin(agent, envelopeFlag string, requirePolicy, noRecord bool) {
-	code := evalRouterHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag, requirePolicy, noRecord)
+func runRouterHookStdin(agent, envelopeFlag, policyFile string, requirePolicy, noRecord bool) {
+	code := evalRouterHookStdin(os.Stdin, os.Stdout, os.Stderr, agent, envelopeFlag, policyFile, requirePolicy, noRecord)
 	os.Exit(code)
 }
 
-func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag string, requirePolicy, noRecord bool) int {
+func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag, policyFile string, requirePolicy, noRecord bool) int {
 	if agent == "" {
 		agent = "claude-code"
 	}
@@ -68,7 +68,7 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 
 	// Step 1: kernel verdict via evalHookStdin's pure core
 	var kernelOut bytes.Buffer
-	kernelCode := evalHookStdin(bytes.NewReader(in), &kernelOut, errOut, agent, envelopeFlag, requirePolicy, noRecord)
+	kernelCode := evalHookStdin(bytes.NewReader(in), &kernelOut, errOut, agent, envelopeFlag, policyFile, requirePolicy, noRecord)
 
 	// Fast path: router policy disabled → emit kernel verdict directly
 	if !policy.Enabled {
@@ -339,6 +339,7 @@ func cmdRouterEvaluate(args []string) {
 	// Minimal flag set — mirrors the gate evaluate hook flags
 	agent := "claude-code"
 	envelopeFlag := ""
+	policyFile := ""
 	requirePolicy := false
 	hookStdin := false
 	noRecord := false
@@ -350,6 +351,8 @@ func cmdRouterEvaluate(args []string) {
 			agent = a[len("--agent="):]
 		case strings.HasPrefix(a, "--envelope="):
 			envelopeFlag = a[len("--envelope="):]
+		case strings.HasPrefix(a, "--policy-file="):
+			policyFile = a[len("--policy-file="):]
 		case a == "--require-policy":
 			requirePolicy = true
 		case a == "--no-record":
@@ -359,5 +362,5 @@ func cmdRouterEvaluate(args []string) {
 	if !hookStdin {
 		exitErr("router_evaluate_missing_args", "--hook-stdin required (other modes deferred)")
 	}
-	runRouterHookStdin(agent, envelopeFlag, requirePolicy, noRecord)
+	runRouterHookStdin(agent, envelopeFlag, policyFile, requirePolicy, noRecord)
 }


### PR DESCRIPTION
## Summary

`main.go cmdGateEvaluate` parses `--policy-file` and `CHITIN_POLICY_FILE`
but, when `--hook-stdin` is set, never passes them to runHookStdin →
evalHookStdin. Same shape as the `--no-record` thread-through fix
shipped earlier today (commit 49fa239).

Found 2026-05-07 while replaying the 17-day Curie hook-capture
dataset (PR #378) against a pinned policy and observing
`no_policy_found` fail-opens for captures whose cwds had no
chitin.yaml in their parent chain.

## Live verification

Pre-fix: from /tmp with --policy-file pinned → `no_policy_found`
warning + fail-open allow (flag ignored).

Post-fix: same payload → empty stdout + exit 0 (default-allow-shell
rule from the pinned policy applied cleanly).

## Test plan

- [x] `TestEvalHookStdin_PolicyFileOverridesCwdInheritance` — pins
      the contract (no `no_policy_found` warn when --policy-file
      supplied)
- [x] All 9 existing test callers updated to new signature
- [x] Full `internal/driver/... internal/gov/... cmd/chitin-kernel/...`
      suite passes (464 tests)

## Followup

PR #378's replay results should be re-run after this lands — the
counterfactual will be accurate when --policy-file actually pins
the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)