### PR TITLE
policy: no-governance-self-modification -> escalate

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -143,13 +143,23 @@ rules:
 
   - id: no-governance-self-modification
     action: file.write
-    effect: deny
+    effect: escalate
     # Match whether the path is relative to a chitin repo root OR absolute.
     # Previously anchored on ^ only, which missed absolute paths like
     # "/home/red/workspace/chitin/chitin.yaml" — a bypass the agent could
     # exploit by writing with the full path instead of a repo-relative one.
     target_regex: '(?:(?:^|/)chitin\.yaml$|(?:^|/)\.chitin/|(?:^|/)\.hermes/plugins/chitin-governance/)'
-    reason: "Agents may not modify their own governance policy or plugin"
+    reason: "Agents may not modify their own governance policy or plugin without operator approval"
+    # Operator-tier carve-out (closes the dogfood paradox): queue an
+    # escalation that the operator approves via `chitin-kernel pending
+    # approve <id>` instead of blanket deny. Channel cli-only (no
+    # hermes infra needed); 10min decision window; 5min remember-grant
+    # so a multi-edit session needs one approval, not N.
+    # Spec: docs/superpowers/specs/2026-05-07-operator-approval-escalation-design.md
+    escalation:
+      channel: cli-only
+      timeout_seconds: 600
+      remember_window_seconds: 300
     escalation_weight: 2
 
   - id: no-terraform-destroy


### PR DESCRIPTION
## Summary
- Switches `no-governance-self-modification` rule from `effect: deny` -> `effect: escalate` with `channel: cli-only`, `timeout_seconds: 600`, `remember_window_seconds: 300`.
- Closes the dogfood paradox observed repeatedly today (May 7): the rule that blocks gov-file writes was self-blocking — operator-approved gov edits had to bypass the gate via non-Claude-Code shell.
- Authored on a human-driven branch outside Claude Code (the gate correctly denied the agent attempt; reasoning preserved in commit message).

## Test plan
- [ ] After merge: any agent file.write to chitin.yaml / .chitin/ / .hermes/plugins/chitin-governance/ -> row in `pending_approvals` sqlite, agent blocks on Wait
- [ ] `chitin-kernel pending list` shows the row
- [ ] `chitin-kernel pending approve <id>` resolves it; agent unblocks; subsequent edits within 300s in same agent skip re-approval (remember_grants)
- [ ] `chitin-kernel pending deny <id> --reason=...` resolves with deny; agent gets denial as if effect: deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)