### PR TITLE
fix(gov): recognize hermes-internal tool names (kanban_call + hermes_process)

### DIFF
--- a/go/execution-kernel/internal/driver/hermes/normalize.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize.go
@@ -203,6 +203,45 @@ func Normalize(in HookInput) (gov.Action, error) {
 			Target: stringField(in.ToolInput, "name"),
 			Path:   in.Cwd,
 		}, nil
+
+	// Kanban runtime calls — the hermes worker reading/writing its own
+	// card lifecycle (`kanban_show`, `kanban_complete`, `kanban_block`,
+	// `kanban_comment`, `kanban_heartbeat`, `kanban_create`, etc.).
+	// Plumbing-shaped: not the agent doing things in the world, just
+	// the worker managing its own status. Routed to ActKanbanCall so
+	// they're auditable + governable but distinguished from real
+	// host-effect actions. Without this case, every long-running
+	// hermes worker hits ActUnknown → default-deny-unknown → lockdown
+	// in <10 plumbing calls (root cause of 2026-05-07 smoke stalls).
+	// Target = the kanban verb (`show`, `complete`, etc.) so policy
+	// rules can allow/deny per-verb if desired.
+	case "kanban_show", "kanban_list", "kanban_create", "kanban_assign",
+		"kanban_reassign", "kanban_link", "kanban_unlink", "kanban_claim",
+		"kanban_comment", "kanban_complete", "kanban_block", "kanban_unblock",
+		"kanban_archive", "kanban_tail", "kanban_dispatch", "kanban_watch",
+		"kanban_stats", "kanban_log", "kanban_runs", "kanban_heartbeat",
+		"kanban_assignees", "kanban_context", "kanban_gc", "kanban_edit",
+		"kanban_reclaim", "kanban_init", "kanban_boards":
+		// Strip the "kanban_" prefix for a clean target verb.
+		verb := in.ToolName[len("kanban_"):]
+		return gov.Action{
+			Type:   gov.ActKanbanCall,
+			Target: verb,
+			Path:   in.Cwd,
+			Params: in.ToolInput,
+		}, nil
+
+	// Hermes process tool — runtime helper for background process
+	// management inside the agent's session. Same plumbing class as
+	// kanban_*; explicit ActHermesProcess so it doesn't accumulate
+	// as default-deny-unknown.
+	case "process":
+		return gov.Action{
+			Type:   gov.ActHermesProcess,
+			Target: stringField(in.ToolInput, "action"),
+			Path:   in.Cwd,
+			Params: in.ToolInput,
+		}, nil
 	}
 
 	// MCP tool calls — `mcp__<server>__<tool>`. Same shape as the

--- a/go/execution-kernel/internal/driver/hermes/normalize_test.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize_test.go
@@ -212,10 +212,12 @@ func TestNormalize_unmappedTools_fallToUnknown(t *testing.T) {
 	// image_generate, cronjob, clarify, etc. have no clean gov-action
 	// peer; they fall through to ActUnknown which the policy
 	// default-deny rejects unless an operator opts a specific tool in.
-	for _, tool := range []string{"image_generate", "text_to_speech", "vision_analyze", "cronjob", "clarify", "process"} {
+	// Note: `process` was previously in this list; it now maps to
+	// ActHermesProcess (see TestNormalize_hermesInternalTools below).
+	for _, tool := range []string{"image_generate", "text_to_speech", "vision_analyze", "cronjob", "clarify"} {
 		t.Run(tool, func(t *testing.T) {
 			a, err := Normalize(HookInput{
-				ToolName: tool,
+				ToolName:  tool,
 				ToolInput: map[string]any{},
 			})
 			if err != nil {
@@ -229,4 +231,56 @@ func TestNormalize_unmappedTools_fallToUnknown(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNormalize_hermesInternalTools pins the kanban_* + process mapping
+// added to plug the lockdown loop observed on 2026-05-07: hermes worker
+// plumbing calls were hitting ActUnknown → default-deny-unknown and
+// crossing the lockdown threshold in <10 calls. Each kanban verb maps
+// to ActKanbanCall with target = the verb (prefix stripped); the hermes
+// `process` tool maps to ActHermesProcess with target = the action
+// sub-verb passed in tool_input.
+func TestNormalize_hermesInternalTools(t *testing.T) {
+	t.Run("kanban_show_maps_to_ActKanbanCall_with_verb_target", func(t *testing.T) {
+		a, err := Normalize(HookInput{
+			ToolName:  "kanban_show",
+			ToolInput: map[string]any{"task_id": "01ABC"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Type != gov.ActKanbanCall {
+			t.Errorf("Type: got %q, want %q", a.Type, gov.ActKanbanCall)
+		}
+		if a.Target != "show" {
+			t.Errorf("Target: got %q, want %q (verb prefix stripped)", a.Target, "show")
+		}
+	})
+	t.Run("kanban_complete_maps_to_ActKanbanCall_with_verb_target", func(t *testing.T) {
+		a, err := Normalize(HookInput{
+			ToolName:  "kanban_complete",
+			ToolInput: map[string]any{"summary": "done"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Type != gov.ActKanbanCall {
+			t.Errorf("Type: got %q, want %q", a.Type, gov.ActKanbanCall)
+		}
+		if a.Target != "complete" {
+			t.Errorf("Target: got %q, want %q", a.Target, "complete")
+		}
+	})
+	t.Run("process_maps_to_ActHermesProcess", func(t *testing.T) {
+		a, err := Normalize(HookInput{
+			ToolName:  "process",
+			ToolInput: map[string]any{"action": "list"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Type != gov.ActHermesProcess {
+			t.Errorf("Type: got %q, want %q", a.Type, gov.ActHermesProcess)
+		}
+	})
 }

--- a/go/execution-kernel/internal/gov/action.go
+++ b/go/execution-kernel/internal/gov/action.go
@@ -54,6 +54,23 @@ const (
 	ActNPMRun            ActionType = "npm.script.run"
 	ActTestRun           ActionType = "test.run"
 	ActMCPCall           ActionType = "mcp.call"
+	// ActKanbanCall: Hermes Agent's per-tool kanban API calls
+	// (`kanban_show`, `kanban_complete`, `kanban_block`, `kanban_comment`,
+	// `kanban_heartbeat`, `kanban_create`, `kanban_link`, `kanban_unlink`,
+	// `kanban_archive`, `kanban_assign`). These are runtime plumbing —
+	// the worker reading/writing its own card lifecycle — but they ARE
+	// tool calls per chitin's universal-interception rule, so they get
+	// a canonical action_type instead of falling through to ActUnknown.
+	// Without this, every long-running hermes worker accumulates 10+
+	// `default-deny-unknown` denials on plumbing alone and trips
+	// lockdown (root cause of the 2026-05-07 chitin-runner smoke
+	// stalling at deny-everything).
+	ActKanbanCall        ActionType = "kanban.call"
+	// ActHermesProcess: Hermes Agent's `process` tool — a runtime helper
+	// for managing background processes inside the agent's own session.
+	// Like ActKanbanCall, plumbing-shaped but classified explicitly so
+	// it doesn't accumulate as default-deny-unknown.
+	ActHermesProcess     ActionType = "hermes.process"
 	ActInfraDestroy      ActionType = "infra.destroy"
 	ActUnknown           ActionType = "unknown"
 )


### PR DESCRIPTION
## Summary
- Adds `ActKanbanCall` + `ActHermesProcess` action types to `gov/action.go`.
- Adds normalize cases in the hermes driver for `kanban_*` (24 verbs) → `ActKanbanCall` (target = verb with prefix stripped) and `process` → `ActHermesProcess`.
- Pins the new behavior with `TestNormalize_hermesInternalTools`; drops the stale assertion in `TestNormalize_unmappedTools_fallToUnknown` that expected `process` to fall through to `ActUnknown`.

## Why
Hermes worker plumbing tools (`kanban_show`, `kanban_complete`, `kanban_block`, `kanban_comment`, `kanban_heartbeat`, plus `process`) were hitting `ActUnknown` via the hermes driver's normalize switch and accumulating default-deny-unknown denials. Long-running workers crossed the lockdown threshold in <10 plumbing calls (root cause of 2026-05-07 chitin-runner smoke stalls). Per the universal-tool-call-interception rule, these are still tool calls and must go through chitin's gate — but with proper canonical action types so policy can grant default-allow rules without dragging in unknown-deny semantics.

## Companion follow-up
This PR is the Go half. Without companion `chitin.yaml` allow rules (`default-allow-kanban-call`, `default-allow-hermes-process`), `ActKanbanCall` / `ActHermesProcess` still fall through to no-matching-allow → deny. The policy edit is now unblocked thanks to PR #382 (operator-tier escalate carve-out on `no-governance-self-modification`); follow-up PR will route through the new escalate flow.

## Test plan
- [x] `go test ./internal/driver/hermes/... -count=1` passes
- [x] `go test ./internal/gov/... -count=1` passes
- [ ] After companion policy PR: rerun smoke #4 (chitin-runner spawn against a hermes kanban task) — agent should not lockdown on plumbing calls

## Pre-existing failures (NOT caused by this PR)
`TestSpawnPeer_CodexSmoke` and `TestSpawnPeer_GeminiSmoke` in `internal/router` fail on plain main (verified) — they spawn real codex/gemini binaries and require external infra. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)