### PR TITLE
policy: default-allow kanban.call + hermes.process

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -248,6 +248,30 @@ rules:
     effect: allow
     reason: "Single-file deletes allowed (mass recursive delete via rm -rf denied above)"
 
+  # Hermes worker plumbing: kanban_* tools used by chitin-runner (and
+  # any other hermes-spawned worker profile) to manage its own card
+  # lifecycle — show, complete, block, comment, heartbeat, etc. These
+  # are the worker reading/writing its own status, not actions on the
+  # world. Without an explicit allow, ActKanbanCall (added 2026-05-07
+  # in internal/driver/hermes/normalize.go) falls through to no-
+  # matching-allow → deny → counter accumulation → lockdown loop. Add
+  # specific kanban-verb deny rules ABOVE this if a particular verb
+  # ever needs to be restricted; this rule is a default allow.
+  - id: default-allow-kanban-call
+    action: kanban.call
+    effect: allow
+    reason: "Hermes kanban runtime call — worker plumbing on its own card lifecycle"
+
+  # Hermes process tool: runtime helper for background process
+  # management inside the agent's session. Same plumbing class as
+  # kanban_*; allowed by default. Specific dangerous sub-verbs (kill,
+  # signal-with-arbitrary-pid) can be intercepted at gov.Normalize
+  # before they ever reach this rule.
+  - id: default-allow-hermes-process
+    action: hermes.process
+    effect: allow
+    reason: "Hermes process tool — runtime worker plumbing"
+
   - id: default-deny-unknown
     action: unknown
     effect: deny


### PR DESCRIPTION
## Summary
- Companion to PR #383 (Go-side recognition of hermes-internal tool names).
- Adds `default-allow-kanban-call` and `default-allow-hermes-process` rules so `ActKanbanCall` and `ActHermesProcess` resolve to allow instead of falling through to no-matching-allow → deny.
- Closes the chitin-runner lockdown loop where every plumbing tool call (`kanban_show`, `kanban_complete`, etc.) burned the worker's escalation budget.

## Why these are default-allow
These actions are the worker reading/writing its own card lifecycle, not actions on the world. Specific deny rules for individual kanban verbs (e.g. `kanban_archive` if ever sensitive) can be added ABOVE these allows. For `hermes.process`, dangerous sub-verbs (kill with arbitrary pid) should be intercepted at `gov.Normalize` before the gate even sees them.

## Dogfood note
This PR is the first real exercise of the operator-tier escalate carve-out (PR #382). The first edit attempt (17:24Z) hit `escalate-timeout` because of a sqlite schema-drift bug in `pending_approvals` (existing db had `notify_msg_id` column from an older binary version, current code expects `hermes_task_id` + `last_event_seq` — `CREATE TABLE IF NOT EXISTS` doesn't migrate). After dropping the stale db, the second edit landed.

Three follow-up bugs surfaced during this dogfood:
1. **Schema migration missing** in `OpenEscalateStore` — needs proper ALTER TABLE / version-tracking, not just `CREATE TABLE IF NOT EXISTS`.
2. **Audit log gap** — the second (successful) `Edit` of `chitin.yaml` did not produce a `file.write` decision row in `gov-decisions-*.jsonl`. Expected behavior is every gate-evaluated action gets logged regardless of outcome.
3. **Stuck hermes lockdown** — `agent=hermes` is in lockdown from the kanban_call denials accumulated before #383 merged. Operator should run `chitin-kernel gate reset --agent=hermes` after this PR lands.

## Test plan
- [x] chitin.yaml parses (the running gate accepted the edit; no rules-load error)
- [ ] After merge: hermes worker `kanban_show` calls produce `default-allow-kanban-call` decisions (not `lockdown` or `default-deny-unknown`)
- [ ] After merge + `chitin-kernel gate reset --agent=hermes`: chitin-runner smoke #4 — claim a kanban task, do work, branch + commit + push + PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)