### PR TITLE
refactor: rename chitin-runner hermes profile to chitin-worker

### DIFF
--- a/docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md
+++ b/docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md
@@ -136,7 +136,7 @@ Justification:
 
 - **Work tracking + dispatch:** hermes kanban + `hermes kanban
   daemon`. Operator (or a hermes-side promotion job) keeps the
-  spawnable lanes (`chitin-runner`, `default`) populated with ready
+  spawnable lanes (`chitin-worker`, `default`) populated with ready
   tasks. Chitin doesn't see this surface at all.
 - **Status reflection:** hermes ingests PR-merged events and updates
   its own kanban. If chitin's chain is the source of "PR merged,"

--- a/go/execution-kernel/internal/gov/action.go
+++ b/go/execution-kernel/internal/gov/action.go
@@ -63,8 +63,10 @@ const (
 	// a canonical action_type instead of falling through to ActUnknown.
 	// Without this, every long-running hermes worker accumulates 10+
 	// `default-deny-unknown` denials on plumbing alone and trips
-	// lockdown (root cause of the 2026-05-07 chitin-runner smoke
-	// stalling at deny-everything).
+	// lockdown (root cause of the 2026-05-07 chitin-worker smoke
+	// stalling at deny-everything; profile renamed from chitin-runner
+	// to chitin-worker the same day to disambiguate from the deleted
+	// apps/runner TypeScript orchestration runner).
 	ActKanbanCall        ActionType = "kanban.call"
 	// ActHermesProcess: Hermes Agent's `process` tool — a runtime helper
 	// for managing background processes inside the agent's own session.

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -105,7 +105,9 @@ export const DriverIdSchema = z.enum([
   'openclaw-glm-cloud',  // Ollama Cloud sub: glm-5.1:cloud (opus-light)
   'openclaw-deepseek',   // 3090: deepseek (kept for future use, not in defaults)
   // `hermes` = Hermes Agent (kanban dispatcher) running with the
-  // chitin-runner profile. Per docs/design/2026-05-06-kernel-gate-
+  // chitin-worker profile (renamed from chitin-runner on 2026-05-07
+  // to disambiguate from the deleted apps/runner orchestration
+  // runner). Per docs/design/2026-05-06-kernel-gate-
   // escalation.md core invariant: Hermes is the worker; chitin
   // (kernel) handles in-tool-call escalation. Profile + provider +
   // default model must be configured in ~/.hermes/config.yaml


### PR DESCRIPTION
## Summary
- Renames the hermes worker profile from \`chitin-runner\` → \`chitin-worker\` to disambiguate from the deleted \`apps/runner/\` TypeScript orchestration runner.
- Same agent, same SOUL — just a less-overloaded name.

## Filesystem ops applied alongside this commit
Outside the chitin repo (operator's hermes config), already done:
- \`cp -r ~/.hermes/profiles/chitin-runner ~/.hermes/profiles/chitin-worker\`
- SOUL.md updated to self-identify as chitin-worker (with rename note).
- Old dir moved to \`~/.hermes/profiles/.archive-chitin-runner-2026-05-07\` so any tooling that scans active profiles no longer sees it.
- 4 archived/done kanban tasks updated: \`UPDATE tasks SET assignee = 'chitin-worker' WHERE assignee = 'chitin-runner'\`.

## What's in this PR
Three structural comment refs in the chitin repo:
- \`internal/gov/action.go\` — historical-context comment about the 2026-05-07 lockdown smoke (now correctly attributes the renamed profile).
- \`libs/contracts/src/execution-request.schema.ts\` — driver doc referencing the profile name.
- \`docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md\` — spawnable-lanes example.

## Deferred
\`chitin.yaml\` line 251 still has a comment referencing chitin-runner. Editing chitin.yaml triggers \`no-governance-self-modification\` → escalate flow → operator approval — not worth the ceremony for a cosmetic comment. Will be picked up in any future policy PR that touches that section.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [ ] Future kanban tasks assigned to \`chitin-worker\` lane spawn correctly (next chitin-runner-class task to be claimed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)