### PR TITLE
test(cmd): isolate runCLI tests via per-test CHITIN_HOME

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go
@@ -13,11 +13,17 @@ import (
 // runCLIWithEnv mirrors runCLI from main_test.go but appends the given
 // env entries (KEY=value strings) to os.Environ() before exec — so we
 // can validate env-var-driven flag defaults like --policy-file.
+//
+// Test isolation: CHITIN_HOME defaults to a per-test temp dir so the
+// kernel uses a fresh gov.db (mirrors runCLI's isolation contract). If
+// the caller passes their own CHITIN_HOME via env, it overrides the
+// default — the last KEY=VALUE in cmd.Env wins, per Go's exec docs.
 func runCLIWithEnv(t *testing.T, wd string, env []string, args ...string) (string, string, int) {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), testBinary, args...)
 	cmd.Dir = wd
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(os.Environ(), "CHITIN_HOME="+t.TempDir())
+	cmd.Env = append(cmd.Env, env...)
 	stdout, err := cmd.Output()
 	var stderr []byte
 	if ee, ok := err.(*exec.ExitError); ok {

--- a/go/execution-kernel/cmd/chitin-kernel/main_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main_test.go
@@ -41,10 +41,21 @@ func TestMain(m *testing.M) {
 
 // runCLI invokes the built chitin-kernel binary with the given args, inside
 // the given working directory. Returns stdout, stderr, exit code.
+//
+// Test isolation: CHITIN_HOME is injected as a per-test temp dir so the
+// kernel subprocess uses a fresh ~/.chitin/gov.db rather than the
+// operator's real one. Without this, test-agent escalation-counter rows
+// from prior runs can persist into ~/.chitin/gov.db and trip lockdown
+// in subsequent tests (observed 2026-05-07: `TestCLI_GateEvaluate_*`
+// failed with rule_id=lockdown until the operator manually cleared the
+// agent row). All runCLI-invoking tests get isolation for free; tests
+// that need to share state across calls within a single test should
+// pre-set t-scoped state via runCLIWithEnv with an explicit CHITIN_HOME.
 func runCLI(t *testing.T, wd string, args ...string) (string, string, int) {
 	t.Helper()
 	cmd := exec.Command(testBinary, args...)
 	cmd.Dir = wd
+	cmd.Env = append(os.Environ(), "CHITIN_HOME="+t.TempDir())
 	stdout, err := cmd.Output()
 	var stderr []byte
 	if ee, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
## Summary
- \`runCLI\` and \`runCLIWithEnv\` in \`cmd/chitin-kernel\` now inject \`CHITIN_HOME=t.TempDir()\` into the kernel subprocess env so each test gets a fresh, isolated \`~/.chitin/gov.db\`.
- Closes the cross-test contamination surfaced 2026-05-07 in PR #385's dogfood: a stale lockdown row for \`test-agent\` from a prior test run could leak into the operator's real \`~/.chitin/gov.db\`, then short-circuit subsequent test runs with \`rule_id=lockdown\` instead of the expected rule.

## Test plan
- [x] \`go test ./cmd/chitin-kernel/ -run 'TestCLI_GateEvaluate_PolicyFileFlag|TestCLI_GateEvaluate_PolicyFileEnvFallback' -count=1\` — passes.
- [x] Full \`go test ./cmd/chitin-kernel/... -count=1\` — green.
- [x] Manually attempted to lock \`test-agent\` in real \`~/.chitin/gov.db\` before re-running the test — still passes (proves the kernel subprocess is reading the temp-dir db, not the real one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)