### PR TITLE
fix(cmd): graceful no-op for pending watch-hermes when operator.yaml missing

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/pending.go
+++ b/go/execution-kernel/cmd/chitin-kernel/pending.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -187,6 +188,19 @@ func cmdPending(args []string) {
 	case "watch-hermes":
 		cfg, err := loadOperatorConfig()
 		if err != nil {
+			// Missing operator.yaml is the steady state until the
+			// operator wires up channel: hermes for at least one rule.
+			// Don't fail the systemd timer over it — every 30s of
+			// "no operator.yaml" log noise crowds out real signals,
+			// and the timer's only job is polling for hermes-channel
+			// approvals (none exist if no rule uses that channel).
+			// Surfaced 2026-05-07 in PR #382's wrap-up: timer was
+			// failed for hours because the cli-only escalate flow
+			// didn't need operator.yaml at all.
+			if errors.Is(err, os.ErrNotExist) {
+				fmt.Println(`{"ok":true,"action":"watch-hermes","skipped":"operator_config_missing","resolved":0}`)
+				return
+			}
 			exitErr("operator_config_missing", err.Error())
 		}
 		store, err := gov.OpenEscalateStore(dbPath)

--- a/go/execution-kernel/cmd/chitin-kernel/pending_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/pending_test.go
@@ -140,3 +140,32 @@ func TestPendingAuth_RejectsWrongUID(t *testing.T) {
 		t.Errorf("err = %v, want substring pending_unauthorized", err)
 	}
 }
+
+// TestCLI_PendingWatchHermes_GracefulNoopWhenOperatorConfigMissing pins
+// the fix for the chitin-pending-watch.timer failure observed
+// 2026-05-07: with no rule using channel: hermes, ~/.chitin/operator.yaml
+// doesn't exist (the cli-only escalate flow doesn't need it), and the
+// timer was failing every 30s with "operator_config_missing" — burying
+// real signals under hours of noise. Now the watch-hermes command
+// returns a structured noop instead, so the timer stays green and the
+// log line names what's missing.
+func TestCLI_PendingWatchHermes_GracefulNoopWhenOperatorConfigMissing(t *testing.T) {
+	stdout, stderr, code := runCLIWithEnv(t, t.TempDir(), nil, "pending", "watch-hermes")
+	if code != 0 {
+		t.Fatalf("exit code = %d (stderr=%q stdout=%q)", code, stderr, stdout)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal stdout %q: %v", stdout, err)
+	}
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Errorf(`stdout missing "ok":true: %q`, stdout)
+	}
+	if skipped, _ := out["skipped"].(string); skipped != "operator_config_missing" {
+		t.Errorf(`expected "skipped":"operator_config_missing", got %q`, skipped)
+	}
+	// resolved must be 0 — nothing to do.
+	if resolved, _ := out["resolved"].(float64); resolved != 0 {
+		t.Errorf("resolved = %v, want 0", resolved)
+	}
+}


### PR DESCRIPTION
## Summary
- \`chitin-kernel pending watch-hermes\` now returns a structured noop when \`~/.chitin/operator.yaml\` is missing, instead of failing the systemd timer with \`operator_config_missing\` every 30s.
- Closes the noisy-timer state observed today (2026-05-07): with no rule using \`channel: hermes\`, operator.yaml is intentionally absent, but the timer kept firing exit-code-2 every 30s and cluttering journalctl.

## Why noop, not error
The watch-hermes command's only job is polling hermes-channel pending_approvals rows for operator replies. If no rule uses that channel, there's nothing to watch — missing operator.yaml is the steady state, not a misconfiguration. Other parse / IO failures (e.g. malformed YAML, permissions) still go through the original error path with exit code 2.

## Test plan
- [x] \`TestCLI_PendingWatchHermes_GracefulNoopWhenOperatorConfigMissing\` passes (asserts \`{"ok":true,"skipped":"operator_config_missing","resolved":0}\` shape).
- [x] Full \`go test ./cmd/chitin-kernel/... ./internal/gov/...\` green.
- [ ] After merge: \`systemctl --user status chitin-pending-watch.service\` shows active/exited (success) and the timer fires without burning the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)