### PR TITLE
policy: flip no-governance-self-modification channel to hermes

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -157,7 +157,13 @@ rules:
     # so a multi-edit session needs one approval, not N.
     # Spec: docs/superpowers/specs/2026-05-07-operator-approval-escalation-design.md
     escalation:
-      channel: cli-only
+      # Channel flipped to hermes so escalations notify the operator via
+      # whatsapp (see ~/.chitin/operator.yaml: notify_platform=whatsapp,
+      # notify_chat_id=<jid>). chitin-pending-watch.timer polls
+      # `chitin-kernel pending watch-hermes` every 30s to consume the
+      # operator's reply and resolve the row. cli-only fallback still
+      # works (chitin-kernel pending approve <id>) if hermes is down.
+      channel: hermes
       timeout_seconds: 600
       remember_window_seconds: 300
     escalation_weight: 2


### PR DESCRIPTION
## Summary
- Flips \`no-governance-self-modification\` rule's escalate channel from \`cli-only\` -> \`hermes\`.
- \`~/.chitin/operator.yaml\` is now wired with \`notify_platform: whatsapp\` and \`notify_chat_id: 139358870986999@lid\` (the existing chat_id used by hermes-cron, found in \`~/.hermes/cron/jobs.json\`).
- After merge: gov-file escalates ping the operator on whatsapp; reply \"approve\" / \"deny <reason>\" resolves the pending row via \`chitin-pending-watch.timer\` (already green post #388).

## Authoring path
Authored on a human-driven branch outside Claude Code (the rule's denial behavior, plus today's Bug D where escalate-timeout fires in <1s instead of the rule's 600s, makes in-gate escalate edits unreliable). Bug D is queued separately for design + fix.

## Test plan
- [ ] After merge: trigger a gov-file edit (e.g. trivial chitin.yaml comment). Confirm pending row appears with channel=hermes.
- [ ] Verify whatsapp ping arrives at chat 139358870986999@lid within seconds.
- [ ] Reply \"approve\" on whatsapp. Within 30s, \`chitin-kernel pending list\` shows the row resolved.
- [ ] cli-only fallback still works: \`chitin-kernel pending approve <id>\` resolves regardless of hermes path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)