### PR TITLE
fix(gov): honor nested escalation block on rules (Bug G)

### DIFF
--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -37,15 +37,39 @@ type Rule struct {
 	CorrectedCommand string        `yaml:"correctedCommand,omitempty"`
 	EscalationWeight int           `yaml:"escalation_weight,omitempty"` // default 1
 
-	// Escalate-effect raw fields. Unmarshaled directly off the rule's YAML
-	// when effect == escalate; consumers should read Escalation (built by
-	// the parser with defaults applied) rather than these. Kept on Rule so
-	// the unmarshal target remains a single struct (no intermediate
-	// yamlRule indirection).
+	// Escalate-effect raw fields. Two YAML shapes are accepted:
+	//
+	//  1. Nested (canonical, used in chitin.yaml — matches the bounds:
+	//     and escalation: convention used elsewhere):
+	//
+	//         - id: foo
+	//           effect: escalate
+	//           escalation:
+	//             channel: cli-only
+	//             timeout_seconds: 600
+	//
+	//  2. Top-level (legacy, kept for backward compat with PR #380's
+	//     test fixtures):
+	//
+	//         - id: foo
+	//           effect: escalate
+	//           channel: cli-only
+	//           timeout_seconds: 600
+	//
+	// buildEscalateConfig prefers nested when both are present. Bug G
+	// (PR #382 dogfood, 2026-05-07): the nested shape was silently
+	// dropped because Rule had no `escalation:` yaml tag — the operator
+	// got hermes-default channel + 45s default timeout instead of the
+	// rule's explicit cli-only + 600s.
 	Channel               string `yaml:"channel,omitempty"`
 	TimeoutSeconds        int    `yaml:"timeout_seconds,omitempty"`
 	RememberWindowSeconds *int   `yaml:"remember_window_seconds,omitempty"` // pointer so "unset" is distinguishable from "explicit 0"
 	NotifyTemplate        string `yaml:"notify_template,omitempty"`
+
+	// EscalationYAML is the nested-form raw YAML block. Distinct from
+	// the built Escalation (next field) so the parser can detect "user
+	// supplied a nested block" vs "user used legacy top-level fields".
+	EscalationYAML *ruleEscalationYAML `yaml:"escalation,omitempty" json:"-"`
 
 	// Escalation is non-nil only when Effect == EffectEscalate. Built by
 	// the parser from the rule's optional escalate fields (channel,
@@ -58,6 +82,18 @@ type Rule struct {
 	// validate patterns at load time (fail-closed on bad regex) rather than
 	// silently-return-false at each eval.
 	compiledRegex *regexp.Regexp `yaml:"-"`
+}
+
+// ruleEscalationYAML is the nested `escalation:` block in a chitin.yaml
+// rule. Distinct from EscalateConfig (the built/validated form) so the
+// parser can detect "user supplied a nested block" vs "user used legacy
+// top-level fields". RememberWindowSeconds is a pointer so explicit 0
+// is distinguishable from unset (matches Rule.RememberWindowSeconds).
+type ruleEscalationYAML struct {
+	Channel               string `yaml:"channel,omitempty"`
+	TimeoutSeconds        int    `yaml:"timeout_seconds,omitempty"`
+	RememberWindowSeconds *int   `yaml:"remember_window_seconds,omitempty"`
+	NotifyTemplate        string `yaml:"notify_template,omitempty"`
 }
 
 // Bounds are the blast-radius ceilings checked for push-shaped actions.
@@ -275,14 +311,36 @@ func buildEscalateConfig(r Rule) (*EscalateConfig, error) {
 			return nil, fmt.Errorf("effect: escalate not allowed on action: unknown — use deny instead")
 		}
 	}
+	// Source preference: nested `escalation:` block (chitin.yaml's
+	// canonical shape) > top-level fields (legacy). Bug G fix:
+	// previously the nested block was dropped silently because Rule
+	// had no yaml tag for it, leaving every chitin.yaml escalate rule
+	// running with the parser defaults instead of the operator's
+	// configured values.
 	channel := r.Channel
+	timeout := r.TimeoutSeconds
+	rememberPtr := r.RememberWindowSeconds
+	notifyTemplate := r.NotifyTemplate
+	if r.EscalationYAML != nil {
+		if r.EscalationYAML.Channel != "" {
+			channel = r.EscalationYAML.Channel
+		}
+		if r.EscalationYAML.TimeoutSeconds != 0 {
+			timeout = r.EscalationYAML.TimeoutSeconds
+		}
+		if r.EscalationYAML.RememberWindowSeconds != nil {
+			rememberPtr = r.EscalationYAML.RememberWindowSeconds
+		}
+		if r.EscalationYAML.NotifyTemplate != "" {
+			notifyTemplate = r.EscalationYAML.NotifyTemplate
+		}
+	}
 	if channel == "" {
 		channel = "hermes"
 	}
 	if channel != "hermes" && channel != "cli-only" {
 		return nil, fmt.Errorf("channel: %q invalid (allowed: hermes, cli-only)", channel)
 	}
-	timeout := r.TimeoutSeconds
 	if timeout == 0 {
 		// Default lowered from 600 → 45 (PR #382 dogfood, 2026-05-07):
 		// Claude Code's PreToolUse hook timeout is ~60s by default, so a
@@ -308,8 +366,8 @@ func buildEscalateConfig(r Rule) (*EscalateConfig, error) {
 		return nil, fmt.Errorf("timeout_seconds: %d out of range [30, 86400]", timeout)
 	}
 	window := 300
-	if r.RememberWindowSeconds != nil {
-		window = *r.RememberWindowSeconds
+	if rememberPtr != nil {
+		window = *rememberPtr
 		if window < 0 {
 			return nil, fmt.Errorf("remember_window_seconds: %d (must be >= 0)", window)
 		}
@@ -318,7 +376,7 @@ func buildEscalateConfig(r Rule) (*EscalateConfig, error) {
 		Channel:               channel,
 		TimeoutSeconds:        timeout,
 		RememberWindowSeconds: window,
-		NotifyTemplate:        r.NotifyTemplate,
+		NotifyTemplate:        notifyTemplate,
 	}, nil
 }
 

--- a/go/execution-kernel/internal/gov/policy_escalate_test.go
+++ b/go/execution-kernel/internal/gov/policy_escalate_test.go
@@ -153,3 +153,85 @@ rules:
 		})
 	}
 }
+
+// TestParseEscalateRule_NestedBlockShape pins the chitin.yaml-canonical
+// nested form for escalate config:
+//
+//   - id: foo
+//     effect: escalate
+//     escalation:
+//       channel: cli-only
+//       timeout_seconds: 600
+//
+// Bug G (PR #382 dogfood, 2026-05-07): this nested form was silently
+// dropped because Rule had no yaml tag for the `escalation:` key —
+// every chitin.yaml escalate rule ran with parser defaults instead of
+// operator-configured values. After fix, nested form takes priority
+// over the legacy top-level shape.
+func TestParseEscalateRule_NestedBlockShape(t *testing.T) {
+	yaml := `
+id: parse-test
+mode: enforce
+rules:
+  - id: foo
+    action: shell.exec
+    effect: escalate
+    escalation:
+      channel: cli-only
+      timeout_seconds: 1200
+      remember_window_seconds: 0
+      notify_template: "nested template body"
+`
+	p, err := parsePolicyYAML([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	r := p.Rules[0]
+	if r.Escalation == nil {
+		t.Fatal("Escalation: got nil")
+	}
+	if r.Escalation.Channel != "cli-only" {
+		t.Errorf("Channel: got %q, want cli-only", r.Escalation.Channel)
+	}
+	if r.Escalation.TimeoutSeconds != 1200 {
+		t.Errorf("TimeoutSeconds: got %d, want 1200", r.Escalation.TimeoutSeconds)
+	}
+	if r.Escalation.RememberWindowSeconds != 0 {
+		t.Errorf("RememberWindowSeconds: got %d, want 0", r.Escalation.RememberWindowSeconds)
+	}
+	if r.Escalation.NotifyTemplate != "nested template body" {
+		t.Errorf("NotifyTemplate: got %q, want %q", r.Escalation.NotifyTemplate, "nested template body")
+	}
+}
+
+// TestParseEscalateRule_NestedOverridesTopLevel verifies precedence: when
+// a rule has BOTH legacy top-level fields AND the nested escalation:
+// block (e.g. mid-migration), nested takes priority. Top-level fields
+// are kept for backward compat with PR #380's test fixtures but should
+// not be relied on for new policies.
+func TestParseEscalateRule_NestedOverridesTopLevel(t *testing.T) {
+	yaml := `
+id: parse-test
+mode: enforce
+rules:
+  - id: foo
+    action: shell.exec
+    effect: escalate
+    channel: hermes
+    timeout_seconds: 100
+    escalation:
+      channel: cli-only
+      timeout_seconds: 800
+`
+	p, err := parsePolicyYAML([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	r := p.Rules[0]
+	if r.Escalation.Channel != "cli-only" {
+		t.Errorf("Channel: got %q, want cli-only (nested wins)", r.Escalation.Channel)
+	}
+	if r.Escalation.TimeoutSeconds != 800 {
+		t.Errorf("TimeoutSeconds: got %d, want 800 (nested wins)", r.Escalation.TimeoutSeconds)
+	}
+}


### PR DESCRIPTION
## Summary
- The Rule struct from PR #380 declared escalate-config fields as TOP-LEVEL yaml keys, but chitin.yaml has always used the nested \`escalation:\` block convention (matching \`bounds:\` and the policy-level \`escalation:\` ladder). Result: every rule's nested block was silently dropped on YAML unmarshal — operator config replaced with parser defaults.
- Adds \`Rule.EscalationYAML\` field with \`yaml:\"escalation,omitempty\"\` tag. \`buildEscalateConfig\` prefers nested over legacy top-level. Existing top-level form preserved for backward compat with PR #380's tests.

## Production impact (verified pre-fix)
\`gov.LoadPolicyFile(\"/home/red/workspace/chitin/chitin.yaml\")\` of the \`no-governance-self-modification\` rule:

Before fix:
\`\`\`
rule.Channel=\"\" rule.TimeoutSeconds=0
built EscalateConfig.Channel=\"hermes\" TimeoutSeconds=45 RememberWindowSeconds=300
\`\`\`

After fix:
\`\`\`
built EscalateConfig.Channel=\"hermes\" TimeoutSeconds=600 RememberWindowSeconds=300
\`\`\`

The 45s default was a workaround landed in PR #385; the rule's explicit 600s now actually applies.

## Why this matters
This is the root cause of half of Bug D (escalate-pending and escalate-timeout audit rows landing in the same second). With the actual rule timeout being 45s instead of the expected 600s, plus the harness hook timeout being ~60s, plus the operator.yaml-missing notify failure — every single dogfood escalate today ran the wrong path.

## Test plan
- [x] \`TestParseEscalateRule_NestedBlockShape\` — pins the chitin.yaml-canonical nested form.
- [x] \`TestParseEscalateRule_NestedOverridesTopLevel\` — pins precedence (nested wins when both present).
- [x] Existing tests still pass (\`TestParseEscalateRule_AllFieldsExplicit\`, \`TestParseEscalateRule_DefaultsApplied\`, \`TestParseEscalateRule_ValidationErrors\`).
- [x] Full \`go test ./internal/gov/... ./cmd/chitin-kernel/...\` green.

## Bug D follow-up
With this fix landed, a clean repro of Bug D (if it persists) can be diagnosed against the rule's actual 600s timeout, vs the 45s noise we were chasing. May resolve entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)