### PR TITLE
fix(cmd): parse hermes kanban-create response field id not task_id

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/notify_hermes.go
+++ b/go/execution-kernel/cmd/chitin-kernel/notify_hermes.go
@@ -146,8 +146,18 @@ func notifyHermes(id string, row gov.PendingApproval, cfg operatorConfig) (strin
 	if err != nil {
 		return "", fmt.Errorf("hermes kanban create: %w", err)
 	}
+	// Hermes `kanban create --json` returns the task object with the
+	// task id under the field `id` (e.g. "id": "t_b0cdbd6c"). The
+	// original spec used `task_id` based on a draft of the hermes CLI
+	// that was never shipped — actual hermes returns `id`. Without
+	// this fix every escalate's notify-subscribe failed silently because
+	// TaskID was always "" (parsed from a missing field), gate_hook.go
+	// stamped `notify_hermes_failed`, and no whatsapp ping fired.
+	// Surfaced 2026-05-08 in PR #389's wrap-up dogfood — operator on
+	// remote bypass mode triggered escalates that hung on Wait while
+	// hermes_task_id stayed empty in pending_approvals.
 	var created struct {
-		TaskID string `json:"task_id"`
+		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(out, &created); err != nil {
 		// Hermes returned non-JSON output. Without a task_id we can't
@@ -155,8 +165,8 @@ func notifyHermes(id string, row gov.PendingApproval, cfg operatorConfig) (strin
 		// Surface to caller; they stamp notify_failed_reason.
 		return "", fmt.Errorf("hermes kanban create: parse JSON: %w (output: %s)", err, out)
 	}
-	if created.TaskID == "" {
-		return "", fmt.Errorf("hermes kanban create: empty task_id (output: %s)", out)
+	if created.ID == "" {
+		return "", fmt.Errorf("hermes kanban create: empty id (output: %s)", out)
 	}
 
 	// Call 2: subscribe operator's chat to task notifications. Failure
@@ -167,12 +177,12 @@ func notifyHermes(id string, row gov.PendingApproval, cfg operatorConfig) (strin
 		"kanban", "notify-subscribe",
 		"--platform", cfg.NotifyPlatform,
 		"--chat-id", cfg.NotifyChatID,
-		created.TaskID,
+		created.ID,
 	}
 	if _, subErr := execHermes(cfg.HermesBin, subArgs); subErr != nil {
-		return created.TaskID, fmt.Errorf("hermes kanban notify-subscribe: %w (task_id %s created OK)", subErr, created.TaskID)
+		return created.ID, fmt.Errorf("hermes kanban notify-subscribe: %w (id %s created OK)", subErr, created.ID)
 	}
-	return created.TaskID, nil
+	return created.ID, nil
 }
 
 // HermesReplyParse is what parseHermesReply returns on a successful parse.

--- a/go/execution-kernel/cmd/chitin-kernel/notify_hermes_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/notify_hermes_test.go
@@ -31,9 +31,10 @@ func TestNotifyHermes_TwoCallSequence(t *testing.T) {
 	prev := execHermes
 	execHermes = func(bin string, args []string) ([]byte, error) {
 		c := call{bin: bin, args: args}
-		// First call (kanban create) returns a task id.
+		// First call (kanban create) returns a task id. Hermes
+		// uses field name `id` (not `task_id` — see PR #391 dogfood).
 		if len(calls) == 0 {
-			c.out = []byte(`{"task_id":"t_FAKE001"}`)
+			c.out = []byte(`{"id":"t_FAKE001"}`)
 		} else {
 			// Second call (notify-subscribe) returns ok.
 			c.out = []byte(`{"ok":true}`)


### PR DESCRIPTION
## Summary
- \`hermes kanban create --json\` returns \`{\"id\": \"t_xxxxxxxx\", ...}\` — the task ID is under field \`id\`, not \`task_id\`.
- \`notifyHermes\` was parsing \`task_id\` per a draft of the hermes CLI that never shipped. Result: empty TaskID, returns error, \`notify_hermes_failed\` warning logged, no notify-subscribe fires, no whatsapp ping.
- Pending rows sit with \`hermes_task_id\` blank forever. \`chitin-pending-watch\` has nothing to poll. The cli-only fallback (\`chitin-kernel pending approve <id>\`) still works manually.

## Verification
\`\`\`
$ hermes kanban create --json --idempotency-key '...' --body '...' --assignee operator 'probe'
{
  \"id\": \"t_b0cdbd6c\",
  \"title\": \"probe\",
  ...
}
\`\`\`

## Test
- Mock in \`notify_hermes_test.go\` updated from \`{\"task_id\":\"t_FAKE001\"}\` → \`{\"id\":\"t_FAKE001\"}\` to match real hermes output. Test still passes (it asserts on the value, not the field name).
- Full \`go test ./cmd/chitin-kernel/... ./internal/gov/...\` green.

## Surfaced
2026-05-08, PR #389's wrap-up dogfood. Operator on remote bypass mode triggered chitin.yaml escalates; pending rows queued cleanly but \`hermes_task_id\` stayed empty across 5 attempts, no whatsapp pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)