### PR TITLE
fix(cmd): pass required positional title to hermes kanban create

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/notify_hermes.go
+++ b/go/execution-kernel/cmd/chitin-kernel/notify_hermes.go
@@ -133,14 +133,23 @@ func notifyHermes(id string, row gov.PendingApproval, cfg operatorConfig) (strin
 	}
 
 	// Call 1: create the kanban task. --idempotency-key gives us
-	// crash-safe retries; --json gives us the task_id back; --assignee
-	// routes to the operator's view.
+	// crash-safe retries; --json gives us the task id back; --assignee
+	// routes to the operator's view. The positional title arg is
+	// REQUIRED by hermes kanban create — without it, hermes exits
+	// status 2 with a usage error and no task is created. Surfaced
+	// 2026-05-08 in PR #391's wrap-up dogfood (the original spec was
+	// modeled on a hermes CLI draft that didn't require a title).
+	// Title is short for whatsapp legibility; the body has the full
+	// context.
+	title := fmt.Sprintf("Approval needed: %s on %s by %s",
+		row.RuleID, row.ActionType, row.Agent)
 	createArgs := []string{
 		"kanban", "create",
 		"--idempotency-key", id,
 		"--body", buf.String(),
 		"--assignee", cfg.AssigneeProfile,
 		"--json",
+		title,
 	}
 	out, err := execHermes(cfg.HermesBin, createArgs)
 	if err != nil {

--- a/go/execution-kernel/cmd/chitin-kernel/notify_hermes_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/notify_hermes_test.go
@@ -45,8 +45,9 @@ func TestNotifyHermes_TwoCallSequence(t *testing.T) {
 	defer func() { execHermes = prev }()
 
 	row := gov.PendingApproval{
-		ID: "01TEST", Agent: "claude-code", ActionType: "file.write",
-		ActionTarget: "/etc/hostname", Reason: "system path write",
+		ID: "01TEST", Agent: "claude-code", RuleID: "no-protected-write",
+		ActionType: "file.write", ActionTarget: "/etc/hostname",
+		Reason:  "system path write",
 		Channel: "hermes", TimeoutSeconds: 600,
 	}
 	cfg := operatorConfig{
@@ -78,6 +79,16 @@ func TestNotifyHermes_TwoCallSequence(t *testing.T) {
 	}
 	if !strings.Contains(create, "--idempotency-key") {
 		t.Errorf("call 1 missing --idempotency-key: %q", create)
+	}
+	// Title is REQUIRED positional arg for hermes kanban create — absence
+	// causes hermes to exit status 2 with usage error and no task is
+	// created (Bug surfaced 2026-05-08, root cause of all chitin.yaml
+	// escalates failing silently with notify_hermes_failed).
+	if !strings.Contains(create, "Approval needed") {
+		t.Errorf("call 1 missing positional title with 'Approval needed' prefix: %q", create)
+	}
+	if !strings.Contains(create, "no-protected-write") {
+		t.Errorf("call 1 title missing rule id: %q", create)
 	}
 
 	// Validate second call shape: hermes kanban notify-subscribe with platform + chat-id + task_id.


### PR DESCRIPTION
## Summary
- \`hermes kanban create\` requires a positional \`title\` arg. \`notifyHermes\` was building the args with only flags and no title — hermes exited status 2 with a usage error.
- Result: every chitin.yaml escalate created a pending row but no kanban task, no notify-subscribe, no whatsapp ping. Combined with PR #391 (id vs task_id parsing), the chitin escalate flow has been silently broken since #380 shipped.

## Verification
\`\`\`
$ hermes kanban create --json --idempotency-key '...' --body '...' --assignee operator
usage: hermes kanban create [-h] ...
exit=2
\`\`\`

After the fix, the same args + a title positional return the kanban task as JSON:
\`\`\`
$ hermes kanban create --json --idempotency-key '...' --body '...' --assignee operator 'Approval needed: ...'
{\"id\":\"t_xxxxxxxx\", ...}
\`\`\`

## Title format
\`Approval needed: <rule_id> on <action_type> by <agent>\` — short for whatsapp legibility; the body has the full context.

## Test plan
- [x] \`TestNotifyHermes_TwoCallSequence\` updated to assert title contains \"Approval needed\" + the rule id.
- [x] Full \`go test ./cmd/chitin-kernel/... ./internal/gov/...\` green.
- [ ] After merge + redeploy: chitin.yaml escalate produces a kanban task + whatsapp ping.

## Surfaced
2026-05-08, PR #391's wrap-up dogfood. Operator on remote bypass mode triggered chitin.yaml escalates that hung; pending rows queued cleanly but \`hermes_task_id\` stayed empty across multiple attempts. Direct hook invocation surfaced the actual stderr: \`{\"error\":\"hermes kanban create: exit status 2\",\"warning\":\"notify_hermes_failed\"}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)