### PR TITLE
fix(cmd): direct bridge ping for kanban-created event (closes whatsapp gap)

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/notify_hermes.go
+++ b/go/execution-kernel/cmd/chitin-kernel/notify_hermes.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,6 +68,18 @@ type operatorConfig struct {
 	// Routes the task into the operator's view (e.g., "operator",
 	// "default").
 	AssigneeProfile string
+
+	// BridgeURL is the whatsapp-bridge HTTP send endpoint, used to
+	// deliver a one-shot creation ping to the operator. Default:
+	// http://127.0.0.1:3000/send. Hermes's gateway-side notifier only
+	// dispatches TERMINAL kanban events (completed / blocked / etc) to
+	// whatsapp — the `created` event needed for operator approval is
+	// not in that set, so notify-subscribe alone won't ping the
+	// operator at task-creation time. Posting directly to the bridge
+	// closes that gap. Failure is non-fatal: the kanban task still
+	// exists and the operator can resolve via CLI fallback. Surfaced
+	// 2026-05-08 in PR #392's wrap-up dogfood.
+	BridgeURL string
 }
 
 // builtinNotifyTemplate is the default kanban-task body when the rule
@@ -191,7 +204,66 @@ func notifyHermes(id string, row gov.PendingApproval, cfg operatorConfig) (strin
 	if _, subErr := execHermes(cfg.HermesBin, subArgs); subErr != nil {
 		return created.ID, fmt.Errorf("hermes kanban notify-subscribe: %w (id %s created OK)", subErr, created.ID)
 	}
+
+	// Call 3: direct bridge ping for the creation event. Hermes's
+	// gateway-side _kanban_notifier_watcher only dispatches TERMINAL
+	// kanban events to whatsapp (completed, blocked, gave_up, crashed,
+	// timed_out). The `created` event isn't in that set, so the
+	// operator never gets pinged at task-creation time — exactly the
+	// moment they need to see the approval prompt. Posting directly
+	// to the whatsapp bridge HTTP endpoint closes that gap.
+	//
+	// Failure is non-fatal: the kanban task still exists and the
+	// operator can resolve via CLI fallback (`chitin-kernel pending
+	// approve <id>`). Return the id with a wrapped error so the
+	// caller can stamp notify_failed_reason but still attach the
+	// task_id to the pending row.
+	bridgeURL := cfg.BridgeURL
+	if bridgeURL == "" {
+		bridgeURL = "http://127.0.0.1:3000/send"
+	}
+	if cfg.NotifyPlatform == "whatsapp" {
+		if pErr := pingBridge(bridgeURL, cfg.NotifyChatID, buf.String()); pErr != nil {
+			return created.ID, fmt.Errorf("bridge ping: %w (id %s created + subscribed OK)", pErr, created.ID)
+		}
+	}
 	return created.ID, nil
+}
+
+// pingBridge POSTs a single message to the whatsapp bridge HTTP send
+// endpoint. Mirrors the bridge's documented contract:
+//
+//	POST /send
+//	{"chatId":"<jid>","message":"<text>"}
+//	-> {"success":true, "messageId":"..."} | {"error":"..."}
+//
+// Mockable via httpPostJSON for unit tests.
+func pingBridge(url, chatID, message string) error {
+	body := map[string]string{"chatId": chatID, "message": message}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return httpPostJSON(url, b)
+}
+
+// httpPostJSON is mockable so tests don't depend on a live bridge.
+var httpPostJSON = func(url string, body []byte) error {
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("bridge returned %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // HermesReplyParse is what parseHermesReply returns on a successful parse.

--- a/go/execution-kernel/cmd/chitin-kernel/notify_hermes_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/notify_hermes_test.go
@@ -44,6 +44,17 @@ func TestNotifyHermes_TwoCallSequence(t *testing.T) {
 	}
 	defer func() { execHermes = prev }()
 
+	// Mock the bridge POST too — without this the test would hit the
+	// real whatsapp bridge on localhost (flaky / fails on CI without
+	// a bridge running). Asserted below.
+	var bridgeCalls []string
+	prevHTTP := httpPostJSON
+	httpPostJSON = func(url string, body []byte) error {
+		bridgeCalls = append(bridgeCalls, url+"|"+string(body))
+		return nil
+	}
+	defer func() { httpPostJSON = prevHTTP }()
+
 	row := gov.PendingApproval{
 		ID: "01TEST", Agent: "claude-code", RuleID: "no-protected-write",
 		ActionType: "file.write", ActionTarget: "/etc/hostname",
@@ -104,6 +115,25 @@ func TestNotifyHermes_TwoCallSequence(t *testing.T) {
 	}
 	if !strings.Contains(sub, "t_FAKE001") {
 		t.Errorf("call 2 missing task_id from call 1: %q", sub)
+	}
+
+	// Validate third call: direct POST to whatsapp bridge so the
+	// operator gets pinged at task-creation time (hermes gateway only
+	// dispatches TERMINAL kanban events to whatsapp; `created` is not
+	// in that set, so notify-subscribe alone never pings the operator
+	// at the moment they need to approve).
+	if len(bridgeCalls) != 1 {
+		t.Fatalf("expected 1 bridge POST, got %d", len(bridgeCalls))
+	}
+	bc := bridgeCalls[0]
+	if !strings.Contains(bc, "127.0.0.1:3000/send") {
+		t.Errorf("bridge call URL not localhost:3000/send: %q", bc)
+	}
+	if !strings.Contains(bc, `"chatId":"1234567890"`) {
+		t.Errorf("bridge call missing chatId: %q", bc)
+	}
+	if !strings.Contains(bc, "Operator approval needed") {
+		t.Errorf("bridge call body missing approval template: %q", bc)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Hermes gateway's \`_kanban_notifier_watcher\` only dispatches TERMINAL kanban events to whatsapp/slack subscribers (\`completed\`, \`blocked\`, \`gave_up\`, \`crashed\`, \`timed_out\`). The \`created\` event isn't in that set — so notify-subscribe alone never pings the operator at task-creation time.
- This PR adds a direct POST to the whatsapp bridge HTTP send endpoint (default \`http://127.0.0.1:3000/send\`, configurable via \`operator.yaml\`'s optional \`bridge_url\` field) right after kanban_create + notify-subscribe.

## Three-call sequence
1. \`hermes kanban create --json ... <title>\` → returns \`{\"id\": \"t_xxxx\"}\`
2. \`hermes kanban notify-subscribe --platform whatsapp --chat-id <jid> <task_id>\` → still useful for terminal-event auto-cleanup
3. \`POST http://127.0.0.1:3000/send {\"chatId\":..., \"message\":...}\` → immediate whatsapp ping at creation time

## Why bridge-direct
\`hermes/gateway/run.py:3292\` lists \`TERMINAL_KINDS = (\"completed\", \"blocked\", \"gave_up\", \"crashed\", \"timed_out\")\`. The watcher loop only fetches events with kind in that tuple. Adding \`created\` to that set is hermes-side scope. Bridge-direct is in chitin's code and works today.

## Failure mode
Non-fatal: if the bridge POST fails, the kanban task still exists and the operator can resolve via CLI fallback (\`chitin-kernel pending approve <id>\`). The error is wrapped and surfaced to the gate's \`notify_hermes_failed\` warning.

## Test plan
- [x] \`TestNotifyHermes_TwoCallSequence\` extended with bridge-call assertions (URL, chatId, body content).
- [x] \`httpPostJSON\` mockable so the test doesn't depend on a live bridge.
- [x] Full \`go test ./cmd/chitin-kernel/... ./internal/gov/...\` green.
- [ ] After merge + redeploy: chitin.yaml escalate produces a whatsapp ping within seconds.

## Surfaced
2026-05-08, PR #392's wrap-up dogfood. Operator confirmed test ping to chat \`139358870986999@lid\` arrived (bridge works directly), but the chitin escalate's notify-subscribe did not (gateway watcher's terminal-only filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)