### PR TITLE
policy: cosmetic chitin.yaml line 251 cleanup (e2e escalate validation)

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -254,7 +254,8 @@ rules:
     effect: allow
     reason: "Single-file deletes allowed (mass recursive delete via rm -rf denied above)"
 
-  # Hermes worker plumbing: kanban_* tools used by chitin-runner (and
+  # Hermes worker plumbing: kanban_* tools used by chitin-worker (renamed
+  # from chitin-runner 2026-05-07; see PR #386) and
   # any other hermes-spawned worker profile) to manage its own card
   # lifecycle — show, complete, block, comment, heartbeat, etc. These
   # are the worker reading/writing its own status, not actions on the


### PR DESCRIPTION
## Summary
- Bumps the cosmetic comment cleanup deferred from PR #386's wrap-up.
- More importantly: this is the change that **proved the operator-approval escalate pipeline works end-to-end on 2026-05-08**.

## Pipeline validated
1. \`Edit\` of chitin.yaml fires gate → matches \`no-governance-self-modification\` (effect: escalate)
2. Pending row inserted; \`hermes kanban create\` returns \`{\"id\":\"t_xxxx\"}\` (PR #391 fix), positional title arg present (PR #392 fix)
3. \`hermes kanban notify-subscribe\` registers whatsapp routing
4. POST \`http://127.0.0.1:3000/send\` directly to whatsapp bridge (PR #393 fix; closes the gap that hermes gateway only dispatches TERMINAL kanban events)
5. Operator gets whatsapp ping with the approval template
6. Operator CLI-approves: \`chitin-kernel pending approve <id> --window 30m\` (whatsapp-reply ingestion gap is Bug J — separate)
7. \`escalate-remember-grant\` short-circuits the next attempt (after manually inserting the grant due to Bug L — separate fix coming)

## Bugs surfaced + status
- **Bug J** (whatsapp inbound ingestion): hermes gateway drains \`/messages\` queue exclusively to LLM; no path for chitin-pending-watch to see operator replies. Filed as kanban triage. Workaround: CLI fallback.
- **Bug L** (CLI-approve doesn't auto-insert grant): \`ResolveApprove\` updates the row's \`remember_grant_seconds\` field but doesn't actually \`INSERT INTO remember_grants\`. Grant insertion lives in gate.go's Wait-return path, which is dead-code when the harness kills the kernel before Wait returns. Durable fix in flight as separate PR.

## Test plan
- [x] Gate audit shows allowed=true, rule_id=escalate-remember-grant for the file.write at 02:26:29Z
- [x] chitin.yaml's line 257 comment now reads \"chitin-worker (renamed from chitin-runner 2026-05-07; see PR #386)\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)