### PR TITLE
fix(gov): ResolveApprove auto-inserts remember-grant (Bug L)

### DIFF
--- a/go/execution-kernel/internal/gov/escalate.go
+++ b/go/execution-kernel/internal/gov/escalate.go
@@ -239,6 +239,18 @@ func (s *EscalateStore) ResolveTimeout(id string) error {
 
 func (s *EscalateStore) resolve(id, resolution, by, reason string, grantSeconds *int) error {
 	now := nowUnix()
+	// Read rule_id + agent BEFORE the UPDATE so we can insert the grant
+	// after a successful approve. Reading after the UPDATE works too
+	// (the row stays present, only resolved_ts changes), but reading
+	// first avoids a SELECT-after-UPDATE race window if any caller ever
+	// goes parallel against the same id.
+	var ruleID, agent string
+	if resolution == "approved" && grantSeconds != nil && *grantSeconds > 0 {
+		_ = s.db.QueryRow(
+			`SELECT rule_id, agent FROM pending_approvals WHERE id = ? AND resolved_ts IS NULL`,
+			id,
+		).Scan(&ruleID, &agent)
+	}
 	res, err := s.db.Exec(`
 		UPDATE pending_approvals
 		SET resolved_ts = ?, resolution = ?, resolution_by = ?,
@@ -251,6 +263,21 @@ func (s *EscalateStore) resolve(id, resolution, by, reason string, grantSeconds 
 	rows, _ := res.RowsAffected()
 	if rows == 0 {
 		return ErrAlreadyResolved
+	}
+	// Bug L (PR #394 dogfood, 2026-05-08): when resolution arrives via
+	// a path that is NOT the gate's Wait return (CLI approve, hermes
+	// watcher), the grant insertion gate.go does after Wait returns
+	// never runs — the original kernel subprocess that called Wait was
+	// killed by the harness's hook timeout long before the operator
+	// resolved the row. Result: row marked approved, grant_seconds
+	// stamped, but remember_grants is empty → next agent retry hits
+	// the rule again instead of short-circuiting via grant.
+	//
+	// Insert the grant here so it lands regardless of which path
+	// resolves the row. InsertGrant is idempotent (ON CONFLICT DO
+	// UPDATE), so the gate.go path inserting again is harmless.
+	if resolution == "approved" && grantSeconds != nil && *grantSeconds > 0 && ruleID != "" && agent != "" {
+		_ = s.InsertGrant(ruleID, agent, *grantSeconds)
 	}
 	return nil
 }

--- a/go/execution-kernel/internal/gov/escalate_test.go
+++ b/go/execution-kernel/internal/gov/escalate_test.go
@@ -580,3 +580,118 @@ func TestOpenEscalateStore_MigratesOlderSchema(t *testing.T) {
 	}
 	store2.Close()
 }
+
+// TestResolveApprove_AutoInsertsGrant pins the Bug L fix (PR #394
+// dogfood, 2026-05-08): ResolveApprove with grantSeconds > 0 must
+// land a row in remember_grants. Pre-fix, this insert lived only in
+// gate.go's Wait return path — when the harness killed the kernel
+// subprocess before Wait returned (typical for chitin.yaml escalates
+// where the rule's 600s timeout vastly exceeds Claude Code's ~60s
+// hook deadline), the grant was never inserted, and the next agent
+// retry hit the rule again instead of short-circuiting.
+func TestResolveApprove_AutoInsertsGrant(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenEscalateStore(filepath.Join(dir, "p.sqlite"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	const id = "01TEST0000000000000000ESCL"
+	const ruleID = "no-governance-self-modification"
+	const agent = "claude-code"
+	const window = 1800
+
+	if err := store.InsertPending(PendingApproval{
+		ID: id, Agent: agent, RuleID: ruleID,
+		ActionType: "file.write", ActionTarget: "/tmp/foo",
+		Cwd: "/tmp", Reason: "smoke",
+		Channel: "cli-only", TimeoutSeconds: 60,
+		RememberWindowSeconds: window, CreatedTs: 1700000000,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if err := store.ResolveApprove(id, "operator-cli", window); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	// Grant must be present.
+	if !store.HasUnexpiredGrant(ruleID, agent) {
+		t.Errorf("HasUnexpiredGrant(%s, %s) = false; want true after ResolveApprove with window=%d",
+			ruleID, agent, window)
+	}
+
+	// Different agent must NOT have a grant — make sure we didn't
+	// blanket-insert.
+	if store.HasUnexpiredGrant(ruleID, "different-agent") {
+		t.Errorf("HasUnexpiredGrant should be false for different agent")
+	}
+}
+
+// TestResolveApprove_NoGrantWhenWindowZero confirms the auto-insert
+// is gated on grantSeconds > 0. A bare `chitin-kernel pending approve`
+// without --window resolves the row without any remember-grant.
+func TestResolveApprove_NoGrantWhenWindowZero(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenEscalateStore(filepath.Join(dir, "p.sqlite"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	const id = "01TEST0000000000000NOWNDW"
+	const ruleID = "no-governance-self-modification"
+	const agent = "claude-code"
+
+	if err := store.InsertPending(PendingApproval{
+		ID: id, Agent: agent, RuleID: ruleID,
+		ActionType: "file.write", ActionTarget: "/tmp/foo",
+		Cwd: "/tmp", Reason: "smoke",
+		Channel: "cli-only", TimeoutSeconds: 60,
+		CreatedTs: 1700000000,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if err := store.ResolveApprove(id, "operator-cli", 0); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	if store.HasUnexpiredGrant(ruleID, agent) {
+		t.Errorf("HasUnexpiredGrant should be false when window=0")
+	}
+}
+
+// TestResolveDeny_NoGrantInserted confirms deny path doesn't land a
+// grant accidentally (defense against future refactors).
+func TestResolveDeny_NoGrantInserted(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenEscalateStore(filepath.Join(dir, "p.sqlite"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	const id = "01TEST00000000000000DENIED"
+	const ruleID = "no-governance-self-modification"
+	const agent = "claude-code"
+
+	if err := store.InsertPending(PendingApproval{
+		ID: id, Agent: agent, RuleID: ruleID,
+		ActionType: "file.write", ActionTarget: "/tmp/foo",
+		Cwd: "/tmp", Reason: "smoke",
+		Channel: "cli-only", TimeoutSeconds: 60,
+		CreatedTs: 1700000000,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if err := store.ResolveDeny(id, "operator-cli", "no thanks"); err != nil {
+		t.Fatalf("deny: %v", err)
+	}
+
+	if store.HasUnexpiredGrant(ruleID, agent) {
+		t.Errorf("deny path should not insert grant")
+	}
+}


### PR DESCRIPTION
## Summary
- \`ResolveApprove\` (called by CLI \`chitin-kernel pending approve\`, hermes watcher, etc.) now auto-inserts the remember-grant.
- Pre-fix, grant insertion lived only in gate.go's Wait return path. When the harness killed the kernel subprocess before Wait returned (typical for chitin.yaml escalates where the rule timeout is 600s but the harness hook deadline is ~60s), the grant was never inserted.

## Surfaced 2026-05-08
Direct e2e during PR #394's wrap-up:
1. Edit chitin.yaml → escalate fires, pending row inserted
2. Operator CLI-approves with --window 30m
3. Row resolution=approved, remember_grant_seconds=1800 stamped on the row
4. \`remember_grants\` table EMPTY (gate.go's InsertGrant never reached — kernel killed)
5. Retry Edit → escalate fires AGAIN, no short-circuit

The validation in PR #394 only succeeded after manually inserting the grant via raw sqlite. This PR makes the manual step unnecessary.

## Why in resolve(), not in pendingApprove() CLI handler
ALL three resolve paths suffer from the same gap:
- CLI: \`chitin-kernel pending approve\` (operator-direct)
- Hermes watcher: \`chitin-kernel pending watch-hermes\` consumes whatsapp/slack approve replies (when Bug J is fixed)
- Direct API: future callers

Putting the insert in \`resolve()\` covers all three. \`InsertGrant\` is idempotent (\`ON CONFLICT DO UPDATE\`), so gate.go's Wait-return-path call is harmless redundancy.

## Test plan
- [x] \`TestResolveApprove_AutoInsertsGrant\` — happy path
- [x] \`TestResolveApprove_NoGrantWhenWindowZero\` — bare approve doesn't silently grant
- [x] \`TestResolveDeny_NoGrantInserted\` — deny path stays grant-free
- [x] Full \`go test ./internal/gov/... ./cmd/chitin-kernel/...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)