### PR TITLE
docs: refresh README + roadmap to post-2026-05-08 narrative (audit Tier 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,126 @@
 # Chitin
 
-**Execution kernel for AI coding agents.** Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack. Nx monorepo (Go + TypeScript + Python). Apache 2.0 licensed.
+**Execution governance runtime for heterogeneous AI coding agents.**
 
-> Principle: real execution before policy. Policy before automation. Automation gated by the same kernel.
+Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and OpenClaw passes through one declarative policy and lands in a hash-linked audit chain that emits OTEL spans into your existing observability stack. Apache 2.0 licensed.
 
-## What chitin is today
+> Stable primitives (tool invocation, execution authority, policy enforcement, observability, escalation) wrapped around an unstable substrate (drivers, models, benchmarks). Composes with whatever orchestrator you already run.
 
-The kernel and the contract it enforces:
+## What chitin IS
 
-- **Kernel + governance** — Go binary that adjudicates every tool call across the integration points it's wired into: Claude Code / Codex / Gemini PreToolUse hooks (`--agent=<id>`), the Copilot CLI driver (`chitin-kernel drive copilot`), and the OpenClaw `before_tool_call` plugin path. Each evaluates `chitin.yaml` and writes a hash-linked JSONL chain. Gate decisions are auditable; chain integrity is SHA-256-verified.
-- **OTEL emit (F4, 2026-05-02)** — kernel projects every chain event onto an OTLP/HTTP JSON span after the canonical write succeeds. One-way bridge: chain authoritative, OTEL non-authoritative. Opt-in via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+The kernel and the contract it enforces — exhaustively three things:
 
-Chitin is *not* a tick-loop, not an agent runner, not an OTEL ingest target, not a cloud product — see [`docs/thesis.md`](./docs/thesis.md) for the full set of refusals.
+1. **The kernel** — `chitin-kernel` Go binary. Gate, escalation counter, lockdown, envelope, audit. Single side-effect authority.
+2. **Driver plugins** — `go/execution-kernel/internal/driver/{claudecode,codex,gemini,hermes,copilot}/normalize.go`. Adapters between vendor tool vocabularies and the kernel's canonical action enum.
+3. **The data** — `~/.chitin/{gov-decisions-*.jsonl, events-*.jsonl, gov.db, chain_index.sqlite}`. Tamper-evident chain + the read-side analysis surface (`python/analysis/`).
 
-## Reference consumers (hosted in the monorepo for dogfooding)
+Plus the scaffolding to keep those healthy: systemd timers for kernel redeploy, agent-unlock, chain-watch, envelope-rotate. Internal, not orchestration.
 
-These are downstream consumers of the kernel — they run *on* chitin, they aren't chitin. Hosted in the same repo so they share `libs/contracts/` schemas and the Nx project graph; governed by the same kernel via the per-driver integration points (Claude Code PreToolUse for `claude-code-headless`, the Copilot CLI driver for `copilot`, the OpenClaw plugin for the `local-*` drivers, the Codex/Gemini PreToolUse hooks where applicable).
+## What chitin is NOT
 
-- **Autonomous swarm runtime** (`apps/runner/`) — Temporal-backed dispatcher + worker that picks ready backlog entries, dispatches role-typed agents (programmer, reviewer, researcher, analyst, …), runs the §5 review-tier escalation chain (R1→R2→R3→operator), and (with `CHITIN_GATEKEEPER_AUTO_MERGE=1`) auto-merges PRs that pass the §6 gate matrix. Design: [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md).
-- **Self-feeding telemetry loop** (cron scripts under `apps/runner/`) — periodic researcher / lessons / debt-curator / groomer / alarm-feeder / stale-doc detector keep the backlog hydrated from external signals + internal alarms; the analyst role runs deterministic Python recipes against the chain to investigate regressions.
+- Not an agent framework. The agent runs in Claude Code / Codex / Gemini / Copilot / OpenClaw / Hermes. Chitin gates each one's tool calls; it doesn't host a session.
+- Not an orchestrator. Work tracking, dispatch, scheduling, workflows, kanban — that's hermes (or whatever orchestrator you run). Chitin is agnostic to it.
+- Not a model router. The driver picks the model; chitin observes the decision via fingerprint dimensions in the chain.
+- Not an approval system. Hermes' `tools/approval.py` provides operator-prompt + reply-parse + persistent allowlist natively. Chitin's gate denies; hermes prompts. See `docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`.
+- Not a SaaS. Local-only. Operator's box, operator's data.
+
+## The moat
+
+Asymmetric strengths nothing else in the ecosystem provides:
+
+1. **Cross-driver canonical action vocabulary.** Hermes' `pre_tool_call` fires only inside Hermes; OpenClaw's `before_tool_call` only inside its pi-runtime. Chitin alone gates Claude Code, Codex, Gemini, Copilot, OpenClaw, and Hermes against one shared enum (`internal/gov/action.go`).
+2. **Typed-action policy** with `path_under` and `bounds`. `chitin.yaml` evaluates a structured action against typed predicates, not regex-on-shell-string.
+3. **Tamper-evident chain across all drivers + sessions.** SHA-256-linked JSONL with SQLite materialized index. Replay-able. Cross-driver, cross-session, cross-day.
+4. **Per-agent severity ladder + lockdown counter.** `agent_state` in `gov.db` tracks behavior across all tasks and drivers. Hermes has per-task retry budgets; chitin's counter spans the agent's lifetime.
+5. **Bounds enforcement on push-shaped actions** (lines/files changed). No equivalent in any substrate.
+6. **Heuristic + LLM-advisor pipeline** (`internal/router/`). Blast-radius + floundering-detector + drift signals + LLM second-opinion. Justifies itself for non-Hermes drivers and for chain-derived signals Hermes' `smart` mode can't see.
+
+## How chitin composes with what you already run
+
+```
+        Claude Code   Codex CLI   Gemini CLI   Copilot CLI   OpenClaw   Hermes
+              │           │            │            │            │         │
+              └─────┬─────┴─────┬──────┴──────┬─────┴─────┬──────┴────┬────┘
+                    │ tool calls (PreToolUse / SDK / hook / plugin)
+                    ▼
+            ┌──────────────────────────────────────────┐
+            │ chitin-kernel gate                       │  ◄── chitin.yaml (declarative policy)
+            │   normalize → policy → bounds → counter  │
+            │   → envelope → audit → OTEL              │
+            └──────────────────────────────────────────┘
+                    │
+                    ▼
+            ~/.chitin/{events-*.jsonl, gov-decisions-*.jsonl,
+                       gov.db, chain_index.sqlite}
+```
+
+Hermes runs the orchestration substrate (kanban, cron, approvals). OpenClaw runs the personal-AI gateway. Chitin gates every tool call from both, plus the standalone CLI drivers, against one policy.
 
 ## Quick start
 
 ```bash
-pnpm install
-pnpm exec nx run execution-kernel:build
-pnpm exec nx run cli:build
-./dist/apps/cli/main.js init claude-code
-# Run a Claude Code session...
-./dist/apps/cli/main.js events list
-./dist/apps/cli/main.js replay <run_id>
-./dist/apps/cli/main.js health
+# Build the kernel
+go build -o ~/.local/bin/chitin-kernel ./go/execution-kernel/cmd/chitin-kernel/
+
+# Install hooks for your driver(s)
+chitin-kernel install-hook            # default: claude-code
+chitin-kernel install-hook --agent codex
+chitin-kernel install-hook --agent gemini
+
+# Inspect activity
+chitin-kernel chain-info --chain-id <id>
+chitin-kernel envelope tail
+chitin-kernel health
 ```
 
-To run the autonomous swarm on your own rig, see [`infra/systemd/README.md`](./infra/systemd/README.md).
-
-## Architecture
+## Repo layout
 
 ```
 .
-├── apps/
-│   ├── cli/                          # operator CLI (`chitin`)
-│   ├── runner/              # autonomous swarm runtime + cron-fired scripts
-│   └── openclaw-plugin-governance/   # openclaw integration: chitin gates every openclaw tool call
+├── go/execution-kernel/         # Go kernel — only layer with side effects
+│   ├── cmd/chitin-kernel/       #   binary + subcommands
+│   └── internal/
+│       ├── gov/                 #   gate, policy, bounds, escalation, chain
+│       ├── driver/              #   per-driver normalize.go (claudecode, codex,
+│       │                        #   gemini, hermes, copilot)
+│       ├── router/              #   heuristic + LLM-advisor pipeline
+│       ├── chain/               #   audit chain + SQLite index
+│       └── canon/               #   canonical-JSON SHA-256
 ├── libs/
-│   ├── contracts/                    # canonical schemas (event chain, ExecutionRequest, envelope)
-│   └── telemetry/                    # JSONL tailer + SQLite indexer + replay streamer
-├── go/execution-kernel/              # the Go kernel — only layer allowed side effects
-├── python/analysis/                  # decisions / debt / souls streams + daily rollup + analyst recipes
-└── infra/systemd/                    # user-mode systemd units for the swarm
+│   ├── contracts/               # canonical wire schemas (TS)
+│   ├── governance/              # TS mirror of policy schema
+│   └── adapters/                # per-driver TS shims for read-side tooling
+├── apps/cli/                    # operator CLI (`chitin` — events, replay, health, ledger)
+├── python/analysis/             # gate-derived analyzers (decisions, debt, predict, detect)
+├── infra/systemd/               # user-mode timers (redeploy, agent-unlock, chain-watch,
+│                                # envelope-rotate, codex-chain-ingest, codex-usage-feed)
+├── docs/decisions/              # durable boundary docs (positioning, scope, culls)
+├── chitin.yaml                  # policy
+└── bin/chitin-router-hook       # PreToolUse shim
 ```
-
-| Package | What it owns |
-|---------|--------------|
-| `apps/cli` | Operator CLI (`init`, `events list/tail/tree`, `replay`, `health`, `ledger`, `review`, `install`). [README](./apps/cli/README.md) |
-| `apps/runner` | Dispatcher, review-graph workflow, gatekeeper, role-typed prompts, all cron scripts. [README](./apps/runner/README.md) |
-| `apps/openclaw-plugin-governance` | openclaw plugin that wires chitin's policy gate into openclaw's tool-call lifecycle. [README](./apps/openclaw-plugin-governance/README.md) |
-| `libs/contracts` | Canonical schemas every chitin component agrees on. [README](./libs/contracts/README.md) |
-| `libs/telemetry` | Read-side of the event chain. [README](./libs/telemetry/README.md) |
-| `go/execution-kernel` | The Go kernel binary — `canon`, `normalize`, `emit`, `gov`, `hook`, `health`. The only layer allowed side effects. |
-| `python/analysis` | Decisions / debt / souls / swarm-runs / swarm-health / daily rollup + the analyst-role investigation recipe. |
-| `infra/systemd` | User-mode systemd units (worker + 7 cron timers). [README](./infra/systemd/README.md) |
 
 ## Where chitin writes data
 
-Chitin emits append-only JSONL and a SQLite materialized view to a `.chitin/` directory. The kernel resolves the path in this order: `--chitin-dir` flag → repo-local `.chitin/` (walking up from cwd) → fallback `$HOME/.chitin/`. **The Go kernel is the only writer.** TS adapters are read-only against the filesystem (see [architecture.md](./docs/architecture.md#hard-rule)).
+The kernel resolves the chitin dir via `CHITIN_HOME` env → fallback `$HOME/.chitin/`. Every chitin process writes only there.
 
 ```
-$HOME/.chitin/                       # global state — used when no repo-local .chitin/ exists
-├── flow_events.jsonl                # governance flow events (gov decisions, swarm ticks)
-├── gov-decisions-YYYY-MM-DD.jsonl   # daily gov decision logs (one file per day)
-├── gov.db                           # SQLite gov state
-├── hook-capture/                    # raw Pre/PostToolUse JSON captures (one file per hook fire)
-├── kernel-errors.log                # kernel-side errors (read by `chitin health`)
-└── current-envelope                 # active cost envelope
-
-<repo>/.chitin/                      # repo-local capture (created by `chitin-kernel init`)
-├── events-<run_id>.jsonl            # canonical event stream — one file per run
-└── session_state.json
+$HOME/.chitin/
+├── events-<run_id>.jsonl              # canonical event chain (one file per run)
+├── gov-decisions-YYYY-MM-DD.jsonl     # daily gate decisions
+├── gov.db                             # SQLite: envelope state + agent_state (severity counter)
+├── chain_index.sqlite                 # materialized view of events for fast lookup
+├── current-envelope                   # active cost envelope
+└── kernel-errors.log                  # kernel-side errors (read by `chitin health`)
 ```
 
-For diagnostics, run `chitin health` — it reports on the resolved dir and exits non-zero on `[FAIL]` rows. The [health runbook](./docs/observations/runbooks/health.md) explains every row and what to do when it's red.
+## Documentation
 
-## Toolchain
-
-- **Nx** — orchestrator (project graph, affected, module boundaries)
-- **Vite+** (`vp`) — TypeScript test/lint/format/build (Vitest, Oxlint, Oxfmt, Rolldown, tsgo)
-- **Go 1.22+** — execution kernel, run via `nx:run-commands`
-- **uv + pytest** — Python analysis lib (`python/analysis/`)
-- **Temporal** — workflow durability for the autonomous swarm
-
-## Docs
-
-Core:
-- [`docs/thesis.md`](./docs/thesis.md) — what chitin is + isn't
-- [`docs/operating-model.md`](./docs/operating-model.md) — how chitin runs against an agent surface
-- [`docs/architecture.md`](./docs/architecture.md) — three-plane model (Temporal control / OpenClaw execution / Chitin enforcement)
-- [`docs/event-model.md`](./docs/event-model.md) — canonical event chain + OTEL projection
-- [`docs/toolchain.md`](./docs/toolchain.md)
-- [`docs/roadmap.md`](./docs/roadmap.md)
-
-Autonomous swarm (factory model):
-- [`docs/design/2026-05-02-swarm-as-software-factory.md`](./docs/design/2026-05-02-swarm-as-software-factory.md) — the full §3-§9 station-taxonomy + review-tier escalation + auto-merge gates
-- [`docs/swarm-backlog.md`](./docs/swarm-backlog.md) — what the swarm picks up next
-- [`docs/swarm-lessons.md`](./docs/swarm-lessons.md) — auto-distilled lessons prepended to programmer prompts
-- [`docs/debt-ledger.md`](./docs/debt-ledger.md) — operator-curated + auto-curated debt
-- [`infra/systemd/README.md`](./infra/systemd/README.md) — install + operate the worker + 7 cron timers
-
-Archive: [`docs/archive-map.md`](./docs/archive-map.md)
+- [`docs/decisions/2026-05-06-execution-governance-runtime-positioning.md`](./docs/decisions/2026-05-06-execution-governance-runtime-positioning.md) — the moat
+- [`docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`](./docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md) — the boundary
+- [`docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`](./docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md) — why operator-approval lives in hermes, not chitin
+- [`docs/architecture.md`](./docs/architecture.md) — kernel internals
+- [`docs/roadmap.md`](./docs/roadmap.md) — strategic arc + what's in flight
 
 ## License
 
-[Apache 2.0](./LICENSE)
+Apache 2.0.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,124 +1,120 @@
 # Roadmap
 
-The strategic arc, what's shipped, what's in flight, and what's deferred. Updated 2026-05-01.
-
-> Companion: [`swarm-backlog.md`](./swarm-backlog.md) — tier-tagged execution backlog
-> the local 24/7 swarm chews through. Roadmap = *strategy*. Backlog = *execution*.
+The strategic arc, what's shipped, what's in flight, what's deferred. Updated 2026-05-08 (post-cull rewrite).
 
 ## Strategic arc
 
 ```
-   1. Aggregate          2. Align policy        3. Ecosystem
-      capture across       to data (debt          distribution
-      all drivers          ledger → rules)        (openclaw, …)
+   1. Aggregate          2. Align policy        3. Compose with
+      capture across       to data (debt          orchestrators
+      all drivers          ledger → rules)        (hermes, openclaw)
           │                    │                      │
           └────────►───────────┴────────►─────────────┤
                                                       │
    4. Policy packs      5. Cloud offering      6. North star
-      reusable             centralized            autonomous swarm +
-      governance           trace/policy           self-building product
-      bundles              SaaS                   governed by chitin
+      reusable             centralized            execution governance
+      governance           trace + policy         as the auditable layer
+      bundles              SaaS                   under whatever the
+                                                  orchestration ecosystem
+                                                  picks next
           │                    │                      │
           └────────►───────────┴────────►─────────────┘
 ```
 
-Each step funds and de-risks the next. We're between 1 and 2 today: aggregation is always-on; the policy layer is shipped but the rules are still mostly hand-written rather than ledger-derived.
+Each step funds and de-risks the next. We're between 1 and 2 today: aggregation is always-on across 6 drivers; the policy layer is shipped but the rules are still mostly hand-written rather than ledger-derived.
+
+The 2026-05-06 narrowing (`docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`) and the 2026-05-08 cull (`docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`) are the load-bearing positioning moves: chitin = kernel + plugins + data; orchestration / approvals / scheduling all live in the substrate (hermes today; whatever tomorrow).
 
 ## Shipped
 
 ### Phase 1 — Claude Code capture → replay (single-surface)
 
-Nx + Vite+ scaffold, Go execution kernel (canon, normalize, emit, hook), `libs/contracts` (zod schema + generated Go types), `libs/telemetry` (JSONL tailer, SQLite indexer, replay), `libs/adapters/claude-code` (monitor-only PreToolUse hook), `apps/cli`. Local-only, fully offline.
+Go execution kernel (canon, normalize, emit, hook), `libs/contracts` (zod schema + generated Go types), `libs/telemetry` (JSONL tailer, SQLite indexer, replay), `libs/adapters/claude-code` (PreToolUse hook), `apps/cli`. Local-only.
 
 ### Phase 1.5 — surface-neutral event chain (merged 2026-04-19)
 
-- v2 envelope: `chain_id` / `chain_type` / `parent_chain_id` / `seq` / `prev_hash` / `this_hash` / `schema_version: "2"`
-- Go kernel: `init`, `emit`, `chain-info`, `ingest-transcript`, `install-hook`, `uninstall-hook`; transactional emit (`BEGIN IMMEDIATE`); JSONL→SQLite reconcile; canonical-JSON SHA-256 parity with TS
+- v2 envelope: `chain_id` / `chain_type` / `parent_chain_id` / `seq` / `prev_hash` / `this_hash`
+- Go kernel: `init`, `emit`, `chain-info`, `ingest-transcript`, `install-hook`; transactional emit (`BEGIN IMMEDIATE`); JSONL→SQLite reconcile; canonical-JSON SHA-256 parity with TS
 - Claude Code adapter: 7-hook forwarder (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PreCompact / SubagentStop / SessionEnd)
-- Ollama-local adapter: wrapper-mode session-chain
-- Souls library: `souls/canonical/` (8 promoted) + `souls/experimental/` (7 provisional); `soul_id` + `soul_hash` populate `session_start.payload`
-
-PR #1 (chain contract) + PR #2 (souls) merged into main.
 
 ### Governance v1 (merged 2026-04-28)
 
 `gov.Gate.Evaluate(action, agent) → Decision` with closed-enum action vocabulary, policy evaluator, audit log to `gov-decisions-YYYY-MM-DD.jsonl`, escalation counter sticky in `~/.chitin/gov.db`. Three modes: monitor / enforce / guide. Kill switches: soft (`mode: monitor`) and hard (`gate lockdown`).
 
-### Drivers (all three live)
+### Drivers (six live)
 
-- **Claude Code hook driver** — PR #66, cost-gov milestone C
+- **Claude Code hook driver** — PR #66
+- **Codex CLI hook driver** — `--agent=codex` PreToolUse handler
+- **Gemini CLI hook driver** — `--agent=gemini` PreToolUse handler
 - **Copilot CLI in-kernel SDK driver** — PR #51 (`chitin-kernel drive copilot`)
-- **openclaw acpx config-override** — one-line install, no chitin-side wrapper code
+- **OpenClaw before_tool_call plugin** — `~/.openclaw/plugins/chitin-governance/`
+- **Hermes pre_tool_call plugin** — `~/.hermes/plugins/chitin-governance/`
 
-The hero sentence names these three drivers. Bitrot in any is a hero-sentence bug.
+The hero sentence names six drivers. Bitrot in any is a hero-sentence bug.
 
 ### Layer Contracts v1 (locked 2026-04-29)
 
-Four invariants documented at [`architecture/layer-contracts.md`](./architecture/layer-contracts.md): kernel authority, driver constraint (`AllowedDrivers` primitive), routing scope, aggregation role.
+Four invariants: kernel authority, driver constraint (`AllowedDrivers` primitive), routing scope, aggregation role. See `docs/architecture/layer-contracts.md`.
 
-### `AllowedDrivers` primitive + Temporal swarm (merged 2026-05-01)
+### F4 — OTEL emit MVP (merged 2026-05-02)
 
-Three coordinated PRs ship the local 24/7 swarm:
+Kernel projects every chain event onto an OTLP/HTTP JSON span after the canonical write succeeds. One-way bridge: chain authoritative, OTEL non-authoritative. Opt-in via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
 
-- **PR #81 — slice 1+2** — Temporal worker (`apps/runner/`) + chitin-governance openclaw plugin (`apps/openclaw-plugin-governance/`). `ExecutionRequest` is the `AllowedDrivers` primitive in concrete form (`libs/contracts/src/execution-request.schema.ts`). End-to-end verified: Temporal → openclaw → plugin's `before_tool_call` hook → kernel deny.
-- **PR #83 — slice 3a (core normalizer)** — openclaw pi-runtime tool names (`exec`, `process`, `read`, `write`, `edit`) mapped to canonical action types in `gov.Normalize()`.
-- **PR #84 — slice 3 (chat-domain + routing + default-enforce)** — 14 chat-domain tools mapped (memory, sessions, image, ollama_web, cron, subagents) plus per-driver agent routing in `activity.ts` (`local-qwen → qwen-agent`, etc.) and default mode flipped from `observe` to `enforce`. End-to-end verified with qwen3-coder:30b dispatching the `read` tool.
+### Cost-gov v3 — bounded enforcement (merged 2026-05-04)
 
-Three planes locked: **Temporal** (control), **OpenClaw** (execution), **Chitin** (enforcement). Per the post-talk plan, this is the load-bearing piece for autonomous-swarm ops; the talk demos it live.
+`MaxToolCalls`, `MaxInputBytes`, tier classification (T0/T2 audit-log labels), cross-process envelope (`gov.db` WAL). Supersedes v2.
+
+### 2026-05-06 narrowing
+
+Chitin scope narrowed from "execution governance + autonomous swarm runtime" to "execution governance only." Removed: `apps/runner` (Temporal-backed swarm dispatcher), `docs/swarm-backlog.md`, 11 orchestration systemd timers. Boundary: `docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`.
+
+### 2026-05-07 → 2026-05-08 escalate-effect cull
+
+Built an in-gate operator-approval escalate flow (PRs #380–#396, ~16 PRs, ~1500 LOC). External recipe survey on 2026-05-08 surfaced that hermes' `tools/approval.py` already provides operator-prompt + reply-parse + persistent-allowlist natively. Culled the entire chitin parallel implementation (PRs #397–#400). Decision: `docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`.
+
+### 2026-05-08 audit-driven cuts (this rev)
+
+External-survey audit through three lenses (Knuth correctness, da Vinci architecture, Sun Tzu positioning). Findings convergent across lenses:
+
+- Half-finished orchestration cull: `apps/runner/` shells, `apps/slack-app/` shells, `infra/temporal/`, 122 stale `tmp/result-swarm-*.json`, 7 swarm-flavored Python analyzers. Finished in this rev.
+- `libs/scheduler/` + `apps/cli/src/commands/scheduler.ts` — orchestration in disguise. Deleted.
+- `internal/router/spawn_peer.go` + `cmd/chitin-kernel/router_hook_escalate.go` — out-of-loop peer-spawn weaker than hermes' in-loop `delegate_task`. Deleted (~1055 LOC).
+- 4 specs marked `superseded`: predictive-execution, local-worker (+addendum), scheduler-design, escalate-design. Moved to `docs/superpowers/superseded/`.
+- Knuth correctness fixes: `RecordDenial` error propagation, `LoadWithInheritance` policy validation, empty-entry rejection in `path_under` / `branches` / `action`.
+
+Net result: ~5000+ LOC removed; chitin's surface tightened to the moat.
 
 ## In flight
 
-Forcing function: **2026-05-07 talk** ("Copilot CLI Without Fear"). Eight days from this update.
-
 | ID | Slice | Why it ships now |
 |----|-------|------------------|
-| **F4** | Thin OTEL emit MVP | Demo beat in talk. 4 event types only (`session_start`, `pre_tool_use`, `decision`, `post_tool_use`), OTLP HTTP JSON, async. Kernel-write-survives-OTEL-failure invariant. Parallel slice — does not bloat cost-gov v3. |
-| **G2** | Memory rewrites + Layer Contracts doc + supersede headers + README first paragraph | Talk-readiness cleanup. **This roadmap rewrite is part of G2.** |
-| **H** | Plan-enforcement design (committed f127b4f) | Spec-only pre-talk; implementation post-talk |
-| **Cost-gov v3** | Bounded enforcement (`MaxToolCalls`, `MaxInputBytes`), tier classification (T0/T2 audit-log labels), cross-process envelope (`gov.db` WAL) | Supersedes v2. Spec/plan committed 2026-04-29 (c1ecbf9) |
+| **G3** | Documentation refresh — README + roadmap to post-2026-05-08 narrative | This rev |
+| **R1** | Router advisor asymmetry doc | Disclaim where chitin's advisor justifies itself vs hermes' `smart` mode (non-hermes drivers + chain-derived signals) |
 
-Cut order if F4 slips: README first, then strategic-roadmap polish. Never cut Layer Contracts doc, supersede headers, or memory rewrites.
+## Deferred
 
-## Next slice (post slice-3 swarm merge)
+These are real ideas that wait for either operator demand or an asymmetric-strength signal:
 
-The `AllowedDrivers` primitive shipped with slices 1–3 above. The swarm now runs but eats its own backlog (`swarm-backlog.md`); these are the strategic slices that aren't groomable to a tier yet:
+- **Action vocabulary expansion** — extend `internal/gov/action.go` to cover the predictive-execution spec's `rewrite` / `redirect` / `stage` decisions. Lean into asymmetry without growing surface.
+- **Chain summarization + causal slicing** — surface in the positioning doc's "replay hydration" note. Make the chain useful at higher abstraction than per-event.
+- **Driver coverage** — add new drivers as the ecosystem's tool-call vocabulary stabilizes.
+- **Policy packs** — per-domain rule bundles (security, cost, compliance) operators install via `chitin-kernel install-pack`. Step 4 of the strategic arc.
 
-1. **Pre-activity policy gate** — `chitin-kernel task validate` subcommand. The spec addendum committed to it; submit.ts currently bypasses (zod parse only). Tracked as `task-validate-command-pre-activity-gate` in the swarm backlog.
-2. **Wall-timeout SIGKILL propagation** — current activity hangs to Temporal's 15-min `startToCloseTimeout` because openclaw's grandchildren keep stdout pipes open after parent dies. Blocking the swarm from running on slow models without retry pollution. Tracked in swarm backlog.
-3. **Slice 4 scope decision** — open. Candidates on the deferred list below; needs a Jared+Claude Code interactive call to pick.
+## What chitin will NOT do
 
-When (1) and (2) ship, terrain B (compute fabric / placement-as-policy) becomes a real public roadmap item with the swarm dogfooding it.
+Per the 2026-05-06 boundary doc:
 
-## Deferred (post-talk)
+- Work tracking, kanban, board state — **hermes**
+- Dispatch, spawning runners — **hermes**
+- Scheduling (cron, intervals) — **hermes**
+- Workflow definitions, retries, durable state — **hermes**
+- PR-merge → status-flip pipelines — **hermes**
+- Operator approvals — **hermes' tools/approval.py**
+- Model routing — **driver-side**
+- Mirroring between work-tracking surfaces — **operator's choice**
 
-- Full `gen_ai.*` semconv compliance, OTLP-grpc, batching, multi-exporter, retries
-- octi v2 spec edits to consume `AllowedDrivers` (pre-plan-handoff)
-- A2 (platform/infra) and A4 (security/compliance) audience expansion — gated on A1 traction signals
-- Terrain B formal milestones (compute-fabric public roadmap)
-- Copilot CLI v2 spike — open-vendor in-process extension via `joinSession({tools, hooks})`. Earliest start: 2026-05-08.
+Whatever orchestrator the operator runs is *agnostic* — chitin doesn't know or care. The orchestrator dispatches, agents do work, every tool call passes through chitin's gate, every decision lands in chitin's chain.
 
-## Audience sequencing (locked)
+## Cut order if scope tightens further
 
-A1 (agent framework builders) → A2 (platform/infra) → A4 (security/compliance). A3 (solo operators) is a side channel. A1 messaging is not diluted with platform/dashboard/cost narratives.
-
-## Phase 0 — archive predecessors (complete)
-
-Renamed `chitinhq/chitin → chitinhq/chitin-archive` at `v1.0.0`; archived every other v1 repo in the org; created the new public Apache 2.0 `chitinhq/chitin` monorepo. Hermes (the predecessor driver) was killed as a chitin component on 2026-04-23 — chitin is governance around openclaw + Claude Code, not a tick loop. See [`archive-map.md`](./archive-map.md) for what was extracted vs left behind.
-
-## Candidates from external signal
-
-- [reddit] [1t1n6o8](https://reddit.com/r/LocalLLaMA/comments/1t1n6o8/we_are_finally_there_qwen3627b_agentic_search_957/) — We are finally there: Qwen3.6-27B + agentic search; 95.7% SimpleQA on a single 3090, fully local
-- [reddit] [1t19iil](https://reddit.com/r/LocalLLaMA/comments/1t19iil/been_using_qwen3627bq8_k_xl_vscode_rtx_6000_pro/) — Been using Qwen-3.6-27B-q8_k_xl + VSCode + RTX 6000 Pro As Daily Driver
-- [reddit] [1t1judm](https://reddit.com/r/LocalLLaMA/comments/1t1judm/qwen3627b_at_72_toks_on_rtx_3090_on_windows_using/) — Qwen3.6-27B at 72 tok/s on RTX 3090 on Windows using native vLLM (no WSL, no Docker), portable launcher and installer
-- [reddit] [1t1jc1d](https://reddit.com/r/LocalLLaMA/comments/1t1jc1d/have_qwen_said_anything_about_further_qwen_36/) — Have Qwen said anything about further Qwen 3.6 models?
-- [reddit] [1t1a8gf](https://reddit.com/r/LocalLLaMA/comments/1t1a8gf/qwen3627bnvfp4_images/) — Qwen3.6-27B-NVFP4 - images
-- [arxiv] [2605.00922](https://arxiv.org/abs/2605.00922) — To Vibe Research or Not to Vibe Research? Generative AI in Qualitative Research
-- [arxiv] [2605.00932](https://arxiv.org/abs/2605.00932) — Code World Model Preparedness Report
-- [arxiv] [2605.00942](https://arxiv.org/abs/2605.00942) — PPO guided Agentic Pipeline for Adaptive Prompt Selection and Test Case Generation
-- [arxiv] [2605.01008](https://arxiv.org/abs/2605.01008) — Semantics-Based Verification of an Implemented Shor Oracle for ECDLP in Qrisp
-- [arxiv] [2605.01042](https://arxiv.org/abs/2605.01042) — ProMoTA: a model-driven framework for end-to-end traceability analysis
-- [arxiv] [2605.01104](https://arxiv.org/abs/2605.01104) — RECAP: An End-to-End Platform for Capturing, Replaying, and Analyzing AI-Assisted Programming Interactions
-- [arxiv] [2605.01159](https://arxiv.org/abs/2605.01159) — A Domain-Driven Design Simulator for Business Logic-Rich Microservice Systems
-- [arxiv] [2605.01160](https://arxiv.org/abs/2605.01160) — The Productivity-Reliability Paradox: Specification-Driven Governance for AI-Augmented Software Development
-- [arxiv] [2605.01209](https://arxiv.org/abs/2605.01209) — ClarifySTL: An Interactive LLM Agent Framework for STL Transformation through Requirements Clarification
-- [arxiv] [2605.01264](https://arxiv.org/abs/2605.01264) — FeedbackLLM: Metadata driven Multi-Agentic Language Agnostic Test Case Generator with Evolving prompt and Coverage Feedback
+When the next external-substrate survey shows another chitin surface that re-implements a substrate primitive, the answer is the same as 2026-05-08: cull it. The pattern: invest deeper into asymmetric strengths (canonical vocabulary, chain depth, driver coverage); divest from anything symmetric with the substrate (orchestration, approvals, scheduling, model routing).


### PR DESCRIPTION
Refreshes README + docs/roadmap.md to match post-2026-05-06 narrowing + post-2026-05-08 escalate-cull state. Both predated the audit-driven cuts and marketed deleted features as live. Audit lenses that flagged: da Vinci (README) + Sun Tzu (roadmap arc).

Net: 2 files changed, 160 insertions, 152 deletions.