### PR TITLE
cleanup: rm empty drift dirs (apps/runner, apps/slack-app, libs/scheduler)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -36,9 +36,8 @@ subcommand by:
 
 ## Layer
 
-`@chitin/cli` is the operator surface. It's NOT used by the swarm
-worker (that's `apps/runner`). Both compose against the
-same kernel + libs.
+`@chitin/cli` is the operator surface. It composes against the same
+kernel + libs as the runtime drivers (hermes/openclaw/copilot/etc.).
 
 ## Test suite
 
@@ -48,7 +47,6 @@ pnpm exec vitest run apps/cli/tests
 
 ## Related
 
-- `apps/runner/README.md` — the autonomous swarm runtime
 - `go/execution-kernel/cmd/chitin-kernel/` — the Go kernel binary
   the CLI wraps
 - `libs/contracts/README.md` — the schemas the CLI consumes

--- a/go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go
@@ -112,8 +112,8 @@ rules:
 
 // TestCLI_GateEvaluate_PolicyFileEnvFallback proves the CHITIN_POLICY_FILE
 // env var is honored when --policy-file is not passed. This is the path
-// the hermes plugin will use after we update apps/runner/src/activity.ts
-// to set CHITIN_POLICY_FILE in the spawned-process env.
+// the hermes plugin uses to set CHITIN_POLICY_FILE in the spawned-process
+// env.
 func TestCLI_GateEvaluate_PolicyFileEnvFallback(t *testing.T) {
 	policyDir := t.TempDir()
 	policyPath := filepath.Join(policyDir, "chitin.yaml")

--- a/go/execution-kernel/internal/gov/action.go
+++ b/go/execution-kernel/internal/gov/action.go
@@ -66,7 +66,7 @@ const (
 	// lockdown (root cause of the 2026-05-07 chitin-worker smoke
 	// stalling at deny-everything; profile renamed from chitin-runner
 	// to chitin-worker the same day to disambiguate from the deleted
-	// apps/runner TypeScript orchestration runner).
+	// TypeScript orchestration runner).
 	ActKanbanCall        ActionType = "kanban.call"
 	// ActHermesProcess: Hermes Agent's `process` tool — a runtime helper
 	// for managing background processes inside the agent's own session.

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -88,8 +88,7 @@ type FingerprintContext struct {
 }
 
 // FingerprintContextFromEnv reads the CHITIN_* env vars that the
-// dispatching agent sets on its spawn (see
-// apps/runner/src/activity.ts). Single helper so every Gate
+// dispatching agent sets on its spawn. Single helper so every Gate
 // constructor in the kernel + drivers populates the same way; before
 // this helper, gate_hook.go was the only caller, leaving copilot
 // driver runs and the operator-CLI gate-evaluate path writing

--- a/go/execution-kernel/internal/router/blast_radius.go
+++ b/go/execution-kernel/internal/router/blast_radius.go
@@ -7,8 +7,6 @@ import (
 )
 
 // blastRadiusAxes computes the four-axis breakdown for a hook input.
-// Mirrors the TS implementation in
-// apps/runner/src/router/heuristics/blast-radius.ts.
 //
 // Axes (each 0.0-1.0):
 //   - reversibility: 1.0=fully reversible, 0.0=irreversible

--- a/go/execution-kernel/internal/router/drift_test.go
+++ b/go/execution-kernel/internal/router/drift_test.go
@@ -18,11 +18,11 @@ func TestDetectDrift_InScope(t *testing.T) {
 		Payload: map[string]interface{}{
 			"entry_id":   "foo",
 			"task_class": "refactor",
-			"file_paths": []interface{}{"apps/runner/src/dispatcher.ts"},
+			"file_paths": []interface{}{"apps/cli/src/main.ts"},
 		},
 	}
 	res := DetectDrift(
-		HookInput{ToolName: "Edit", ToolInput: map[string]interface{}{"file_path": "apps/runner/src/dispatcher.ts"}},
+		HookInput{ToolName: "Edit", ToolInput: map[string]interface{}{"file_path": "apps/cli/src/main.ts"}},
 		[]ChainEvent{intent},
 		0.5,
 	)
@@ -37,7 +37,7 @@ func TestDetectDrift_OutOfScope(t *testing.T) {
 		Payload: map[string]interface{}{
 			"entry_id":   "foo",
 			"task_class": "refactor",
-			"file_paths": []interface{}{"apps/runner/src/dispatcher.ts"},
+			"file_paths": []interface{}{"apps/cli/src/main.ts"},
 		},
 	}
 	res := DetectDrift(
@@ -56,7 +56,7 @@ func TestDetectDrift_OutOfScopeHighBlast(t *testing.T) {
 		Payload: map[string]interface{}{
 			"entry_id":   "foo",
 			"task_class": "refactor",
-			"file_paths": []interface{}{"apps/runner/src/dispatcher.ts"},
+			"file_paths": []interface{}{"apps/cli/src/main.ts"},
 		},
 	}
 	res := DetectDrift(

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -119,16 +119,15 @@ systemctl --user stop chitin-dispatcher.timer chitin-researcher.timer chitin-swa
 ## Manual one-shot
 
 ```bash
-# Dispatch a single tick on demand (no timer)
-systemctl --user start chitin-dispatcher.service
-systemctl --user start chitin-researcher.service
-
-# Or run dispatcher directly (dry-run available)
-cd ~/workspace/chitin
-pnpm exec tsx apps/runner/src/dispatcher.ts --dry-run
-pnpm exec tsx apps/runner/src/dispatcher.ts
-pnpm exec tsx apps/runner/src/researcher.ts
+# Trigger a single tick on demand (no timer)
+systemctl --user start chitin-<unit>.service
 ```
+
+(NOTE 2026-05-08: the `apps/runner/` TS dispatcher/researcher were
+culled in the orchestration-deletion wave; sections of this README
+referencing `chitin-dispatcher`/`chitin-researcher`/`chitin-worker`
+units describe the pre-cull world. The unit list at the top of this
+file is the source of truth for what's installed today.)
 
 ## What gets dispatched
 

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -44,8 +44,5 @@ has a paired `tests/<name>.schema.test.ts`.
 
 ## Related
 
-- `apps/runner/src/review-graph-workflow.ts` — illustrative
-  consumer of the type-only import pattern (hotfix #150 added the
-  workflow-bundler note).
 - `go/execution-kernel/internal/event/` — the Go-side mirror of the
   event schema; chitin-kernel writes events the TS schemas validate.

--- a/libs/contracts/src/execution-request.schema.ts
+++ b/libs/contracts/src/execution-request.schema.ts
@@ -73,8 +73,7 @@ export const RoleSchema = z.enum([
 //    Each spawns the vendor CLI (chitin-kernel drive copilot, claude,
 //    codex, gemini) and gates per-tool-call via PreToolUse hooks. Model
 //    selection is per-call via the driver-specific flag: `--model` for
-//    copilot and claude-code-headless, `-m` for codex and gemini (see
-//    apps/runner/src/activity.ts planInvocation).
+//    copilot and claude-code-headless, `-m` for codex and gemini.
 //
 // 2. Via openclaw plugin: `openclaw-glm-flash` (3090 local, glm-4.7-flash),
 //    `openclaw-glm-cloud` (Ollama Cloud, glm-5.1:cloud), `openclaw-deepseek`
@@ -106,7 +105,7 @@ export const DriverIdSchema = z.enum([
   'openclaw-deepseek',   // 3090: deepseek (kept for future use, not in defaults)
   // `hermes` = Hermes Agent (kanban dispatcher) running with the
   // chitin-worker profile (renamed from chitin-runner on 2026-05-07
-  // to disambiguate from the deleted apps/runner orchestration
+  // to disambiguate from the deleted TypeScript orchestration
   // runner). Per docs/design/2026-05-06-kernel-gate-
   // escalation.md core invariant: Hermes is the worker; chitin
   // (kernel) handles in-tool-call escalation. Profile + provider +

--- a/python/analysis/floundering_calibration.py
+++ b/python/analysis/floundering_calibration.py
@@ -17,7 +17,7 @@ Result: silent failure with no advisor engagement.
 This script computes per-driver thresholds from the actual chain
 event distributions so the operator can drop calibrated values into
 chitin.yaml. Drivers map to tiers via the well-known
-TIER_DRIVER_DEFAULTS in apps/runner/src/dispatcher.ts:
+TIER_DRIVER_DEFAULTS:
     T0/T1 → openclaw-glm-flash
     T2    → copilot
     T3    → openclaw-glm-cloud

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -251,59 +251,9 @@ fi
 
 emit ok redeploy-success "old_sha=$old_sha" "new_sha=$new_sha" "build_dur_ms=$build_dur_ms" "changed=$relevant_changes_since_last"
 
-# --- Chitin worker restart logic for TS changes ---
-# Track last-applied SHA for apps/runner/src/ in ~/.cache/chitin/install-kernel-state.json
-STATE_FILE="$HOME/.cache/chitin/install-kernel-state.json"
-TS_PATH="apps/runner/src/"
-
-restart_worker=0
-restart_reason=""
-
-# Get current HEAD
-current_head=$(git rev-parse HEAD)
-
-# Read last-applied SHA for TS worker (if exists)
-last_ts_sha=""
-if [[ -f "$STATE_FILE" ]]; then
-  last_ts_sha=$(jq -r '.ts_worker_sha // empty' "$STATE_FILE" 2>/dev/null || true)
-fi
-
-# If no prior state, record baseline and skip restart
-if [[ -z "$last_ts_sha" ]]; then
-  jq -n --arg sha "$current_head" '{ts_worker_sha: $sha}' > "$STATE_FILE"
-  emit noop "ts-worker baseline set" "ts_worker_sha=$current_head"
-else
-  # Check for changes in apps/runner/src/ since last applied
-  if ! git diff --quiet "$last_ts_sha" "$current_head" -- "$TS_PATH"; then
-    restart_worker=1
-    restart_reason="ts-changed"
-  fi
-fi
-
-if [[ $restart_worker -eq 1 ]]; then
-  old_sha="$last_ts_sha"
-  new_sha="$current_head"
-  commits_in_diff=$(git rev-list --count "$old_sha".."$new_sha" -- "$TS_PATH")
-  restart_start=$(date +%s%3N)
-  if systemctl --user restart chitin-worker.service; then
-    # Wait for active (running)
-    for i in {1..10}; do
-      if systemctl --user is-active --quiet chitin-worker.service; then
-        break
-      fi
-      sleep 1
-    done
-    restart_end=$(date +%s%3N)
-    restart_dur_ms=$((restart_end - restart_start))
-    emit worker-restarted "worker restarted after TS change" \
-      "old_sha=$old_sha" "new_sha=$new_sha" "restart_dur_ms=$restart_dur_ms" "commits_in_diff=$commits_in_diff"
-    # Update state file
-    jq -n --arg sha "$new_sha" '{ts_worker_sha: $sha}' > "$STATE_FILE"
-  else
-    restart_end=$(date +%s%3N)
-    restart_dur_ms=$((restart_end - restart_start))
-    emit fail worker-restart-failed "old_sha=$old_sha" "new_sha=$new_sha" "restart_dur_ms=$restart_dur_ms"
-  fi
-fi
+# (apps/runner/src/ TS worker restart logic removed 2026-05-08 — the
+# TS dispatcher/worker source was culled in the orchestration deletion
+# wave. The Go kernel rebuild above is the only artifact this script
+# ships now; hermes/openclaw drivers manage their own process lifecycle.)
 
 exit 0

--- a/tools/generators/systemd-unit/README.md
+++ b/tools/generators/systemd-unit/README.md
@@ -20,7 +20,7 @@ Generates a chitin service/timer pair from `service.tmpl` and `timer.tmpl`.
 bash tools/generators/systemd-unit/generate.sh \
   --name <unit-name> \
   --description "<text>" \
-  ( --ts-script <script> | --exec <full-cmd> ) \
+  --exec <full-cmd> \
   ( --interval <duration> | --calendar "<spec>" ) \
   [--boot-delay <dur>] \
   [--timeout <sec>] \
@@ -33,8 +33,7 @@ bash tools/generators/systemd-unit/generate.sh \
 Per-flag:
 - `--name` — e.g. `pr-event-ingester` (becomes `chitin-pr-event-ingester.{service,timer}`)
 - `--description` — human label (appears in `systemctl status`)
-- `--ts-script` — shorthand: `pnpm exec tsx apps/runner/src/<script>.ts`
-- `--exec` — full ExecStart path (alternative to `--ts-script`)
+- `--exec` — full ExecStart path
 - `--interval` — e.g. `5min`, `1h`, `24h` (`OnUnitActiveSec`)
 - `--calendar` — e.g. `'*-*-* 06:00:00'` (`OnCalendar`)
 - `--boot-delay` — `OnBootSec` for interval timers (default: `5min`); ignored on calendar timers (which fire only per `OnCalendar`)
@@ -52,7 +51,7 @@ Per-flag:
 bash tools/generators/systemd-unit/generate.sh \
   --name pr-event-ingester \
   --description "PR event ingester" \
-  --ts-script pr-event-ingester \
+  --exec '%h/workspace/chitin/scripts/pr-event-ingester.sh' \
   --interval 5min \
   --after worker
 ```
@@ -63,7 +62,7 @@ bash tools/generators/systemd-unit/generate.sh \
 bash tools/generators/systemd-unit/generate.sh \
   --name nightly-report \
   --description "nightly summary report" \
-  --ts-script nightly-report \
+  --exec '%h/workspace/chitin/scripts/nightly-report.sh' \
   --calendar '*-*-* 02:00:00' \
   --boot-delay 10min \
   --persistent

--- a/tools/generators/systemd-unit/generate.sh
+++ b/tools/generators/systemd-unit/generate.sh
@@ -11,8 +11,7 @@
 # Options:
 #   --name <name>          Unit name, e.g. pr-event-ingester (required)
 #   --description <text>   Human-readable description (required)
-#   --exec <path>          ExecStart command (required unless --ts-script)
-#   --ts-script <name>     Shorthand for pnpm exec tsx apps/runner/src/<name>.ts
+#   --exec <path>          ExecStart command (required)
 #   --interval <duration>  OnUnitActiveSec, e.g. 5min, 1h, 24h (mutually exclusive with --calendar)
 #   --calendar <spec>      OnCalendar spec, e.g. '*-*-* 06:00:00' (mutually exclusive with --interval)
 #   --boot-delay <dur>     OnBootSec (default: 5min)
@@ -49,10 +48,6 @@ while [[ $# -gt 0 ]]; do
     --name)        NAME="$2";                                                                  shift 2 ;;
     --description) DESCRIPTION="$2";                                                          shift 2 ;;
     --exec)        EXEC_START="$2";                                                            shift 2 ;;
-    # Use bare `pnpm` and rely on the unit's PATH (set in service.tmpl
-    # to include %h/.vite-plus/bin). Avoids hardcoding /home/red/...
-    # which breaks on every other operator's machine.
-    --ts-script)   EXEC_START="pnpm exec tsx apps/runner/src/$2.ts"; shift 2 ;;
     --interval)    INTERVAL="$2";                                                              shift 2 ;;
     --calendar)    CALENDAR="$2";                                                              shift 2 ;;
     --boot-delay)  BOOT_DELAY="$2";                                                            shift 2 ;;
@@ -68,7 +63,7 @@ done
 
 [[ -z "$NAME"        ]] && { echo "error: --name is required"                    >&2; exit 1; }
 [[ -z "$DESCRIPTION" ]] && { echo "error: --description is required"             >&2; exit 1; }
-[[ -z "$EXEC_START"  ]] && { echo "error: --exec or --ts-script is required"     >&2; exit 1; }
+[[ -z "$EXEC_START"  ]] && { echo "error: --exec is required"                    >&2; exit 1; }
 [[ -z "$INTERVAL" && -z "$CALENDAR" ]] && { echo "error: --interval or --calendar is required" >&2; exit 1; }
 [[ -n "$INTERVAL" && -n "$CALENDAR" ]] && { echo "error: --interval and --calendar are mutually exclusive" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary

Filesystem-leftover audit after the 2026-05-06 narrowing + 2026-05-08
audit Tier 1 culls. The source for `apps/runner/`, `apps/slack-app/`,
and `libs/scheduler/` was deleted in earlier PRs (most recently
fb9eaff for `libs/scheduler`), but non-doc references survived in
scripts, generator tooling, Go/TS/Py source comments, and one Go test
fixture. The dirs themselves are already absent from `origin/main` —
nothing to `git rm` here. Lockfile + workspace globs needed no edits.

## What changed

**Live broken refs scrubbed** (functional code pointing at deleted paths):
- `scripts/install-kernel.sh` — dead TS-worker restart block (the `git
  diff` against `apps/runner/src/` was always empty after the cull, so
  the branch never fired)
- `tools/generators/systemd-unit/generate.sh` — `--ts-script` flag that
  generated `pnpm exec tsx apps/runner/src/<name>.ts`
- `tools/generators/systemd-unit/README.md` — matching docs + examples
- `infra/systemd/README.md` — `pnpm exec tsx apps/runner/...` snippets
  in the Manual one-shot section (added a tombstone note that broader
  parts of this README still describe pre-cull units; out of scope for
  this PR)

**Stale comment refs cleaned** (Go/TS/Python comments pointing at
deleted TS files as historical/design references):
- `go/execution-kernel/internal/router/{blast_radius,types}.go`
- `go/execution-kernel/internal/gov/{action,gate}.go`
- `go/execution-kernel/cmd/chitin-kernel/gate_policy_file_test.go`
- `libs/contracts/README.md` + `libs/contracts/src/execution-request.schema.ts`
- `python/analysis/floundering_calibration.py`
- `apps/cli/README.md`

**Test fixtures retargeted:**
- `go/execution-kernel/internal/router/drift_test.go` — fixture path
  string `apps/runner/src/dispatcher.ts` → `apps/cli/src/main.ts`
  (the path-overlap logic doesn't care which extant path it gets)

Doc references under `docs/` are left intact per the cleanup spec
(historical record).

## Test plan

- [x] `go build ./...` clean from `go/execution-kernel/`
- [x] `go test ./...` green for the full kernel suite
- [x] `pnpm install` settles with no `pnpm-lock.yaml` delta
- [x] `pnpm exec tsc --build` clean
- [x] `pnpm exec vitest run libs/contracts` — 119 tests green
- [x] `pnpm exec vitest run apps/cli` — 81 tests green
- [x] `bash -n scripts/install-kernel.sh` — syntax OK
- [x] `python3 -c 'import ast; ast.parse(...)'` on calibration script — OK
- [x] Smoke-tested the modified systemd-unit generator with `--exec`
  + `--dry-run`, both unit files render correctly
- [x] Re-grep for `apps/runner|apps/slack-app|libs/scheduler|@chitin/scheduler|@chitinhq/runner|@chitinhq/slack-app` excluding `node_modules`/`dist`/`docs` returns only the two tombstone notes the cleanup itself added

🤖 Generated with [Claude Code](https://claude.com/claude-code)