### PR TITLE
[codex] align driver conformance and Copilot setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,3 +37,5 @@
 - Nx TypeScript typecheck targets are wired through `@nx/js:typescript-sync`, so interactive runs may prompt for `nx sync` before the task executes.
 - Other assistant configs in this repo already assume Nx-aware tooling (`.claude/settings.json` enables the Nx plugin and `.codex/config.toml` registers `nx-mcp`). If the current client supports Nx MCP or Nx workspace introspection, use that instead of guessing targets.
 - Claude global install verification depends on wrapper entries in `~/.claude/settings.json` shaped like Chitin's `_tag: "chitin"` hook wrappers with an empty `matcher` and nested `hooks` command entries.
+- VS Code Copilot should use this file, `AGENTS.md`, and `.github/instructions/chitin-*.instructions.md`. These files guide IDE behavior only; enforceable Copilot execution uses `chitin-kernel drive copilot`.
+- For driver/tool-call questions, check `docs/driver-conformance.md` before adding policy or normalizer behavior.

--- a/.github/instructions/chitin-kernel.instructions.md
+++ b/.github/instructions/chitin-kernel.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "go/execution-kernel/**,chitin.yaml,chitin-routes.example.yaml,bin/chitin-router-hook,scripts/install-*hook.sh"
+---
+
+Read `AGENTS.md` before touching these files. The Go kernel is the
+canonical execution-governance runtime; do not add orchestration,
+approval prompting, in-gate LLM calls, model routing, or MCP hosting here.
+
+When changing a driver normalizer, keep the canonical action vocabulary in
+`go/execution-kernel/internal/gov/action.go` closed and deliberate. Unknown
+vendor tools must fail closed as `unknown` until a fixture and test justify
+the mapping.
+
+Every driver mapping change needs a focused normalizer test in the same
+driver package. Shell-shaped tools should route through `gov.Normalize`
+so git, infra, npm, test, and remote-code-exec classifications stay shared.
+
+Router heuristics are advisory signal rows. Do not reintroduce `claude -p`,
+advisor takeover, peer spawning, or approval flows in the kernel hot path.

--- a/.github/instructions/chitin-typescript.instructions.md
+++ b/.github/instructions/chitin-typescript.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "apps/**,libs/**,scripts/hermes/**,*.ts,*.tsx,*.mts,*.cts,*.mjs"
+---
+
+Respect the Nx layer boundaries in `eslint.config.mjs`: contracts has no
+internal deps, telemetry depends only on contracts, adapters and CLI depend
+only on contracts plus telemetry, and the Go kernel stays separate.
+
+Use existing workspace package links through the package manager instead of
+patching around resolution with ad hoc `tsconfig` paths.
+
+Keep TypeScript strict and ESM-friendly. Avoid CommonJS assumptions, unused
+locals, and broad refactors unrelated to the task.
+
+Hermes orchestration, approvals, kanban, and scheduling belong downstream
+from chitin. Chitin-side TS packages should be analytics, contracts,
+telemetry readers, adapters, plugins, or the operator CLI.

--- a/.github/instructions/chitin-vscode-copilot.instructions.md
+++ b/.github/instructions/chitin-vscode-copilot.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: ".vscode/**,.github/copilot-instructions.md,.github/instructions/**,AGENTS.md,docs/driver-conformance.md,docs/governance-setup.md"
+---
+
+VS Code Copilot instructions are guidance, not enforcement. Do not describe
+them as a chitin gate or policy boundary.
+
+For enforceable Copilot execution, use the kernel wrapper
+`chitin-kernel drive copilot`. For IDE use, keep Copilot pointed at
+`AGENTS.md`, `.github/copilot-instructions.md`, and these path-specific
+instruction files so it follows the same product boundary as other agents.
+
+When documenting IDE setup, state that Copilot's VS Code agent mode does not
+currently expose the same pre-tool hook surface as Claude Code, Codex CLI,
+Gemini CLI, Hermes, or OpenClaw.

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 .nx/workspace-data
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+!.github/instructions/chitin-*.instructions.md
 
 .claude/worktrees
 .claude/settings.local.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["nrwl.angular-console", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "github.copilot",
+    "github.copilot-chat",
+    "nrwl.angular-console",
+    "esbenp.prettier-vscode"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "chat.useAgentsMdFile": true,
+  "github.copilot.chat.codeGeneration.useInstructionFiles": true
+}

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and OpenClaw passes through one declarative policy and lands in a hash-linked audit chain that emits OTEL spans into your existing observability stack. Apache 2.0 licensed.
 
-> Stable primitives (tool invocation, execution authority, policy enforcement, observability, escalation) wrapped around an unstable substrate (drivers, models, benchmarks). Composes with whatever orchestrator you already run.
+> Stable primitives (tool invocation, execution authority, policy enforcement, observability, heuristic signals) wrapped around an unstable substrate (drivers, models, benchmarks). Composes with whatever orchestrator you already run.
 
 ## What chitin IS
 
 The kernel and the contract it enforces — exhaustively three things:
 
-1. **The kernel** — `chitin-kernel` Go binary. Gate, escalation counter, lockdown, envelope, audit. Single side-effect authority.
+1. **The kernel** — `chitin-kernel` Go binary. Gate, severity counter, lockdown, envelope, audit, router signals. Single side-effect authority.
 2. **Driver plugins** — `go/execution-kernel/internal/driver/{claudecode,codex,gemini,hermes,copilot}/normalize.go`. Adapters between vendor tool vocabularies and the kernel's canonical action enum.
 3. **The data** — `~/.chitin/{gov-decisions-*.jsonl, events-*.jsonl, gov.db, chain_index.sqlite}`. Tamper-evident chain + the read-side analysis surface (`python/analysis/`).
 
@@ -33,7 +33,7 @@ Asymmetric strengths nothing else in the ecosystem provides:
 3. **Tamper-evident chain across all drivers + sessions.** SHA-256-linked JSONL with SQLite materialized index. Replay-able. Cross-driver, cross-session, cross-day.
 4. **Per-agent severity ladder + lockdown counter.** `agent_state` in `gov.db` tracks behavior across all tasks and drivers. Hermes has per-task retry budgets; chitin's counter spans the agent's lifetime.
 5. **Bounds enforcement on push-shaped actions** (lines/files changed). No equivalent in any substrate.
-6. **Heuristic + LLM-advisor pipeline** (`internal/router/`). Blast-radius + floundering-detector + drift signals + LLM second-opinion. Justifies itself for non-Hermes drivers and for chain-derived signals Hermes' `smart` mode can't see.
+6. **Heuristic signals stamped onto the chain** (`internal/router/`). Blast-radius, floundering, and drift are pure-Go signals emitted as advisory decision rows. LLM consultation lives downstream in Hermes `approvals.mode: smart` or operator-wired chain consumers, not in the kernel hot path.
 
 ## How chitin composes with what you already run
 
@@ -80,16 +80,17 @@ chitin-kernel health
 ├── go/execution-kernel/         # Go kernel — only layer with side effects
 │   ├── cmd/chitin-kernel/       #   binary + subcommands
 │   └── internal/
-│       ├── gov/                 #   gate, policy, bounds, escalation, chain
+│       ├── gov/                 #   gate, policy, bounds, severity, chain
 │       ├── driver/              #   per-driver normalize.go (claudecode, codex,
 │       │                        #   gemini, hermes, copilot)
-│       ├── router/              #   heuristic + LLM-advisor pipeline
+│       ├── router/              #   pure-Go heuristic signals + plugin checks
 │       ├── chain/               #   audit chain + SQLite index
 │       └── canon/               #   canonical-JSON SHA-256
 ├── libs/
 │   ├── contracts/               # canonical wire schemas (TS)
-│   ├── governance/              # TS mirror of policy schema
-│   └── adapters/                # per-driver TS shims for read-side tooling
+│   ├── telemetry/               # read/query side over the event chain
+│   ├── router-plugin-api/       # typed API for external router plugins
+│   └── adapters/                # operator-installed driver-side adapters
 ├── apps/cli/                    # operator CLI (`chitin` — events, replay, health, ledger)
 ├── python/analysis/             # gate-derived analyzers (decisions, debt, predict, detect)
 ├── infra/systemd/               # user-mode timers (redeploy, agent-unlock, chain-watch,
@@ -120,6 +121,7 @@ $HOME/.chitin/
 - [`docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`](./docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md) — why operator-approval lives in hermes, not chitin
 - [`docs/architecture.md`](./docs/architecture.md) — kernel internals
 - [`docs/roadmap.md`](./docs/roadmap.md) — strategic arc + what's in flight
+- [`docs/driver-conformance.md`](./docs/driver-conformance.md) — current driver hook matrix and normalizer gaps
 
 ## License
 

--- a/apps/openclaw-plugin-governance/src/index.mjs
+++ b/apps/openclaw-plugin-governance/src/index.mjs
@@ -143,10 +143,10 @@ export function resolveConfig(raw) {
     mode: r.mode === 'observe' ? 'observe' : 'enforce',
     workerMode: r.workerMode === true,
     denyOnError: r.denyOnError !== false,
-    // Default 30s: covers the router pipeline including a possible advisor
-    // (claude -p) round-trip which can take 5-15s. The pre-router gate path
-    // was 5s — bumped because evaluateRouter replaced evaluateGate as the
-    // default invocation surface.
+    // Default 30s: covers the router pipeline, including pure-Go signals and
+    // optional plugin subprocess checks. The pre-router gate path was 5s,
+    // bumped because evaluateRouter replaced evaluateGate as the default
+    // invocation surface.
     timeoutMs: typeof r.timeoutMs === 'number' && r.timeoutMs >= 100 ? r.timeoutMs : 30000,
   };
 }

--- a/chitin-routes.example.yaml
+++ b/chitin-routes.example.yaml
@@ -1,11 +1,14 @@
-# chitin-routes.yaml — peer-escalation routing policy
+# chitin-routes.yaml — advisory routing policy
 #
-# Sidecar to chitin.yaml. Loaded by chitin-kernel router on every gate
-# evaluation (when `enabled: true`). Operator declares:
-#   - Rules: which signal+severity triggers a peer-escalation
+# Sidecar to chitin.yaml. Loaded by chitin-kernel router when a chain
+# consumer wants route candidates for stamped router signals. Operator
+# declares:
+#   - Rules: which signal+severity suggests a route
 #   - Routes: which (driver, model) candidates serve each named route
 #
-# Per docs/design/2026-05-06-kernel-gate-escalation.md.
+# This file does not cause the kernel to spawn peer CLIs. Chitin emits
+# gate decisions and router signals; Hermes, OpenClaw, or another
+# operator-wired chain consumer decides how to react.
 #
 # Copy this file to `chitin-routes.yaml` (no `.example` suffix) at the
 # same level as chitin.yaml to enable. The kernel walks parent dirs
@@ -14,12 +17,11 @@
 version: 1
 
 # Default off. Until set true, the kernel loads + validates this file
-# but does NOT spawn peer CLIs from inside the gate — falls back to
-# today's "set escalation_requested=true and let the runner handle it"
-# behavior.
+# but does NOT stamp routing candidates.
 enabled: false
 
-# Per-spawn safety knobs.
+# Historical no-op fields retained for compatibility with early route
+# policy experiments. The kernel does not spawn peers from this file.
 spawn_timeout_seconds: 60
 max_concurrent_peers: 1
 
@@ -40,7 +42,7 @@ rules:
 
   - name: drift-takeover
     signal: drift
-    severity: "advisor.verdict=takeover"
+    severity: "score>=0.6"
     route: reasoning_depth
     max_per_hour: 3
 

--- a/chitin-routes.example.yaml
+++ b/chitin-routes.example.yaml
@@ -26,7 +26,8 @@ spawn_timeout_seconds: 60
 max_concurrent_peers: 1
 
 # Rules — when this signal at this severity fires, look up `route` in
-# the Routes section and spawn its first quota-affording candidate.
+# the Routes section and return its candidate list to downstream
+# consumers.
 rules:
   - name: floundering-loop
     signal: floundering

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,7 @@ chitin-kernel uninstall-hook
 chitin-kernel install / uninstall   # surface-aware install (`--surface claude-code --global`)
 chitin-kernel health                # report on resolved .chitin/ state
 chitin-kernel gate <evaluate|status|lockdown|reset>
-chitin-kernel router evaluate       # router pipeline (kernel verdict → heuristics → optional advisor → composed verdict)
+chitin-kernel router evaluate       # router pipeline (kernel verdict -> pure-Go signals/plugin checks -> advisory telemetry)
 chitin-kernel simulate              # what-if a single hook input without executing
 chitin-kernel envelope <…>          # cost-gov v3 envelope (cross-process, sqlite WAL)
 chitin-kernel drive copilot         # in-kernel Copilot CLI driver

--- a/docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md
+++ b/docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md
@@ -55,7 +55,7 @@ the outcome via `post_approval_response`.
 - **`chitin-kernel gate` per-tool-call evaluation.** Universal cross-driver gate; Hermes' `pre_tool_call` is local to Hermes only. Chitin gates Claude Code, Codex, Gemini, and Hermes from one canonical action vocabulary.
 - **Cross-driver `normalize.go`** (claudecode/codex/gemini/hermes). Canonical action vocabulary; no Hermes equivalent.
 - **`chitin.yaml` declarative policy schema.** Typed actions + `path_under` + bounds; Hermes is regex-on-shell-string only.
-- **`chitin-router-hook` + advisor pipeline.** Heuristics (blast-radius, floundering) + LLM second-opinion; unique to chitin.
+- **`chitin-router-hook` signal stamping.** Heuristics (blast-radius, floundering, drift) + tamper-evident chain rows; LLM consultation belongs downstream.
 - **`gov-decisions.jsonl` audit log + chain replay.** Tamper-evident chain shape; Hermes has logs but not this.
 - **Severity ladder + lockdown counter** (`agent_state` in gov.db). Per-agent escalation across all tasks; Hermes has per-task retry budgets only.
 - **Bounds enforcement** (lines/files changed on git push). No Hermes equivalent.

--- a/docs/design/2026-05-03-mid-task-continuation.md
+++ b/docs/design/2026-05-03-mid-task-continuation.md
@@ -1,6 +1,18 @@
 # Mid-task continuation — design proposal
 
-Status: design only. This PR ships the kernel-side wire (the `escalation_requested` flag in the chain envelope + router-hook telemetry). The Temporal workflow loop that consumes it is intentionally deferred — the architectural commit is large enough that it warrants discussion before code.
+Status: superseded by the 2026-05-06 scope narrowing and the 2026-05-08 router/advisor cull. This document is historical context only.
+
+The accepted current boundary is narrower: chitin emits gate decisions
+and router signals, but it does not run Temporal workflows, continue
+tasks at higher tiers, spawn peer CLIs, or carry an in-kernel
+`escalation_requested` approval/continuation loop. Hermes or another
+substrate owns work continuation and orchestration.
+
+See:
+
+- `docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`
+- `docs/decisions/2026-05-08-cull-advisor-out-of-kernel-hot-path.md`
+- `docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`
 
 Date: 2026-05-03
 Driving need: when the router/advisor decides "this action shape exceeds the current driver's competence, escalate to a higher tier", the kernel should hand the in-flight task off to a higher-tier worker rather than killing the session and surfacing a human-pickup nudge.

--- a/docs/design/2026-05-06-kernel-gate-escalation.md
+++ b/docs/design/2026-05-06-kernel-gate-escalation.md
@@ -1,11 +1,32 @@
 # Kernel-gate escalation: chitin as the in-tool-call router
 
-Status: design.
+Status: superseded by the 2026-05-08 cull.
 Companion to / partial supersession of:
   - `2026-05-05-conformance-substrate.md` (the routing query API §148)
   - `apps/runner/src/dispatcher.ts` (the static TIER_DRIVER map)
 
 Date: 2026-05-06
+
+## Superseded note
+
+This proposal is retained as historical context only. Its core shape
+is no longer allowed: the kernel must not synchronously spawn peer CLIs
+or run an LLM advisor inside the tool-call hot path. The accepted
+post-cull shape is:
+
+1. `chitin-kernel gate` produces the authoritative allow/deny decision.
+2. `internal/router` computes pure-Go blast-radius, floundering, and
+   drift signals, plus deterministic plugin pre-block checks.
+3. The router stamps advisory `router.signal` decision rows onto the
+   chain.
+4. Hermes, OpenClaw, or an operator-wired chain consumer decides what
+   to do with those signals.
+
+See:
+
+- `docs/decisions/2026-05-08-cull-advisor-out-of-kernel-hot-path.md`
+- `docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`
+- `docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`
 
 ## What this is, in one sentence
 

--- a/docs/design/2026-05-06-mob-programming-escalation.md
+++ b/docs/design/2026-05-06-mob-programming-escalation.md
@@ -1,10 +1,10 @@
 # Mob-programming escalation: T0 worker + T1-T4 recursive consultants
 
-Status: design extension. Updates and partially supersedes
-`2026-05-06-kernel-gate-escalation.md` (the original peer-spawn design,
-which assumed one-level-only escalation with `CHITIN_NO_ESCALATE=1`
-recursive guard). This doc extends that to bounded recursive
-escalation with tier-graded consultants.
+Status: superseded historical design. The 2026-05-08 cull removed
+in-kernel advisor consultation and peer spawning from the hot path;
+bounded consultant routing belongs in downstream substrates such as
+hermes. This document remains as context for the rejected recursive
+escalation shape.
 
 Date: 2026-05-06 (later than the original)
 

--- a/docs/driver-conformance.md
+++ b/docs/driver-conformance.md
@@ -1,0 +1,52 @@
+# Driver conformance matrix
+
+Status: active operator reference. Keep this file aligned with
+`go/execution-kernel/internal/driver/*/normalize.go` and the installer
+scripts.
+
+Chitin's moat is one canonical action vocabulary across heterogeneous
+agent drivers. A driver is conformant when every tool-call surface lands
+in one of these outcomes:
+
+- A canonical `gov.ActionType` with a meaningful target.
+- `unknown`, deliberately fail-closed, with a documented gap.
+- A structured cross-driver warning when another driver's tool name leaked
+  through the wrong hook.
+
+## Current surfaces
+
+| Driver | Integration | Normalizer | Coverage | Current gaps |
+|---|---|---|---|---|
+| Claude Code | `PreToolUse` hook via `chitin-kernel install --surface claude-code --global` | `internal/driver/claudecode` | Bash, read/write/edit, web, MCP, task/delegate, task-state, worktree, cron/schedule, browse tools, todo | Future Anthropic tools intentionally hit `unknown` until mapped. |
+| Codex CLI | `PreToolUse` hook via `scripts/install-codex-hook.sh` | `internal/driver/codex` | Bash, `apply_patch`, `read_file`, MCP, Claude-tool leak fallback | Narrow native enum; any new Codex tool should be added from live hook captures before policy loosening. |
+| Gemini CLI | `BeforeTool` hook via `scripts/install-gemini-hook.sh` | `internal/driver/gemini` | Shell, read/list/search, edit/replace/write, web/search, memory/topic, Claude-tool leak fallback | Last tool-registry check in comments was Gemini CLI `0.40.1`; reverify on upgrade. |
+| Hermes | `pre_tool_call` shell hook via `scripts/install-hermes-hook.sh` | `internal/driver/hermes` | Terminal/code, file, patch/search, web/browser, delegation, skills, kanban plumbing, process, MCP, Claude-tool leak fallback | `image_generate`, `text_to_speech`, `vision_analyze`, `cronjob`, and `clarify` are intentionally unmapped. Decide canonical types before allowing them. |
+| Copilot CLI | In-kernel SDK wrapper via `chitin-kernel drive copilot` | `internal/driver/copilot` | SDK permission kinds: shell, write, read, MCP, URL, memory, custom tool, hook | Closed-vendor wrapper only. This does not cover VS Code Copilot agent-mode tool execution. |
+| OpenClaw | `before_tool_call` plugin via `apps/openclaw-plugin-governance` | Plugin bridge into `chitin-kernel gate evaluate` | Tool calls dispatched by OpenClaw's native pi-agent-core runtime | Does not gate standalone Claude/Codex/Gemini/Copilot processes; use their native driver integrations. |
+| VS Code Copilot | Repository instructions + `AGENTS.md` context | No execution normalizer | Uses repo guidance to steer agent behavior in the IDE | No pre-tool hook surface. Treat this as guidance only; route terminal-side agent execution through chitin-aware CLIs where enforcement is required. |
+
+## Near-term work
+
+1. Mine `default-deny` / `unknown` rows from `~/.chitin/gov-decisions-*.jsonl`
+   by `(agent, tool_name, action_target)` and map the highest-volume real
+   tools first.
+2. Add a fixture and normalizer test for each mapped tool before changing
+   `chitin.yaml`.
+3. For Hermes modality tools, decide whether the canonical vocabulary needs
+   new action types (`media.generate`, `speech.generate`, `vision.analyze`,
+   `schedule.job`) or whether they should stay fail-closed as substrate
+   features.
+4. For VS Code Copilot, keep instructions current and explicit that IDE
+   guidance is not governance. The enforceable Copilot path remains
+   `chitin-kernel drive copilot`.
+
+## External status notes
+
+- VS Code and GitHub Copilot support repository-wide instructions at
+  `.github/copilot-instructions.md`, path-specific files in
+  `.github/instructions/*.instructions.md`, and `AGENTS.md` for agent
+  context.
+- VS Code currently exposes `github.copilot.chat.codeGeneration.useInstructionFiles`
+  and `chat.useAgentsMdFile` settings for these instruction surfaces.
+- None of those instruction files are a security boundary. They improve
+  behavior but do not replace chitin's gate.

--- a/docs/governance-setup.md
+++ b/docs/governance-setup.md
@@ -1,6 +1,6 @@
 # Chitin Governance Setup
 
-The `gov.Gate.Evaluate(action, agent) → Decision` API is the single enforcement point. Every tool call across every driver evaluates against `chitin.yaml`. Five install paths — one per supported vendor surface — wire this API into the driver's tool-call lifecycle.
+The `gov.Gate.Evaluate(action, agent) → Decision` API is the single enforcement point. Every tool call across every supported execution driver evaluates against `chitin.yaml`. Install paths wire this API into each driver's tool-call lifecycle where the vendor exposes a hook or SDK boundary.
 
 ## Install paths by driver
 
@@ -8,16 +8,16 @@ The `gov.Gate.Evaluate(action, agent) → Decision` API is the single enforcemen
                  chitin.yaml (single policy)
                           │
                           ▼
-                  gov.Gate.Evaluate ◄──────────────┐
-       ▲       ▲      ▲       ▲       ▲             │
-       │       │      │       │       │             │
-   Claude   Codex  Gemini   Copilot  openclaw       │
-    Code     CLI    CLI      CLI      plugin        │
-   PreToo  PreToo  BeforeT   SDK      before_       │
-   Use     Use     ool       wrap     tool_call     │
-   hook    hook    hook                             │
-       │       │      │       │       │             │
-       ▼       ▼      ▼       ▼       ▼             │
+                  gov.Gate.Evaluate ◄────────────────────────┐
+       ▲       ▲      ▲       ▲        ▲        ▲             │
+       │       │      │       │        │        │             │
+   Claude   Codex  Gemini  Hermes   Copilot  openclaw        │
+    Code     CLI    CLI     Agent     CLI      plugin         │
+   PreToo  PreToo  BeforeT pre_tool   SDK      before_        │
+   Use     Use     ool     _call      wrap     tool_call      │
+   hook    hook    hook    hook                              │
+       │       │      │       │        │        │             │
+       ▼       ▼      ▼       ▼        ▼        ▼             │
                    tool calls  ───────────────────  │
 ```
 
@@ -55,7 +55,21 @@ Writes a `BeforeTool` block to `~/.gemini/settings.json`. Stdin payload is byte-
 
 Both `install-codex-hook.sh` and `install-gemini-hook.sh` are idempotent and refused-on-malformed-config; they run after each `install-kernel.sh` invocation so kernel rebuilds refresh the hook wiring automatically.
 
-### 4. Copilot CLI (in-kernel driver — wrapping orchestrator)
+### 4. Hermes (`pre_tool_call` shell hook)
+
+```bash
+bash scripts/install-hermes-hook.sh
+```
+
+Writes a `pre_tool_call` entry into `~/.hermes/config.yaml` pointing at
+`chitin-router-hook --agent=hermes`. Hermes' shell-hook payload is byte-
+compatible with Claude Code's PreToolUse shape; per-tool normalization lives
+in `internal/driver/hermes/normalize.go`.
+
+The installer also writes the matching entry to Hermes' shell-hook allowlist
+so the worker service does not block on first-run consent.
+
+### 5. Copilot CLI (in-kernel driver — wrapping orchestrator)
 
 ```bash
 chitin-kernel drive copilot "<prompt>"
@@ -63,7 +77,7 @@ chitin-kernel drive copilot "<prompt>"
 
 The kernel spawns Copilot CLI as a child of a chitin-driven harness (closed-vendor pattern: see [architecture.md](./architecture.md#vendor-integration-patterns-open-vs-closed-vendor)). Tool calls are gated via the SDK; chitin enforces the same `gov.Gate` policy.
 
-### 5. openclaw (`local-*` drivers via `before_tool_call` plugin)
+### 6. openclaw (`local-*` drivers via `before_tool_call` plugin)
 
 ```yaml
 # ~/.config/openclaw/openclaw.json
@@ -73,6 +87,20 @@ plugins:
 ```
 
 The plugin is loaded by openclaw at startup; every tool call dispatched by openclaw-managed agents (qwen / glm / glm-flash / deepseek) passes through `before_tool_call` → `chitin-kernel gate evaluate`. Same policy file.
+
+### 7. VS Code Copilot (IDE guidance, not enforcement)
+
+VS Code Copilot uses repository instructions rather than a chitin hook. This
+repo provides:
+
+- `AGENTS.md` as the universal product boundary.
+- `.github/copilot-instructions.md` for repository-wide Copilot context.
+- `.github/instructions/chitin-*.instructions.md` for path-specific guidance.
+- `.vscode/settings.json` enabling instruction files and `AGENTS.md` loading.
+
+This setup helps Copilot in the IDE follow the same boundary as other agents,
+but it is not a security boundary. Use `chitin-kernel drive copilot` when
+Copilot execution must be governed by the kernel.
 
 ## Build the kernel
 
@@ -161,6 +189,17 @@ Exit codes: `0` = allow, `1` = deny, `2` = internal error.
 
 Every gate call appends one JSON line to `~/.chitin/gov-decisions-<YYYY-MM-DD>.jsonl`. These are folded into the chitin event chain via `decision` events emitted by the kernel. The on-disk JSONL is the audit log; the in-chain `decision` event is the canonical record for replay and policy backtesting.
 
+## Driver conformance
+
+See [driver-conformance.md](./driver-conformance.md) for the current driver
+matrix, known normalizer gaps, and the next mapping work to prioritize from
+live `default-deny` / `unknown` chain rows.
+
 ## Closed-enum action vocabulary
 
-`action_type` is a closed enum of 6 classes: `read | write | exec | git | net | dangerous`. Unknown actions are **denied**, not allowed-by-default. If `Normalize()` returns `ActUnknown`, the fix is to extend the normalizer — never to broaden the rule. See [event-model.md](./event-model.md#field-ownership).
+`action_type` is the closed enum in `go/execution-kernel/internal/gov/action.go`:
+file, shell, git, GitHub, delegation, HTTP, npm, test, MCP, memory, custom
+tool, hook, Hermes plumbing, infra, and `unknown`. Unknown actions are
+**denied**, not allowed-by-default. If `Normalize()` returns `ActUnknown`, the
+fix is to extend the normalizer with tests — never to broaden the rule. See
+[event-model.md](./event-model.md#field-ownership).

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -39,26 +39,26 @@ Single-box. One Linux workstation with an RTX 3090 hosts the entire dev + dogfoo
 | Predictive model (chain-predict-outcome) | Python `analysis/predict.py` | ✅ shipped 2026-05-03 (#256) |
 | Governance (`gov.Gate`) | Go kernel `internal/gov` | ✅ shipped 2026-04-28 (PR #45 + #51) |
 | Cost envelope (cross-process) | Go kernel `internal/envelope` | ✅ cost-gov v3 |
-| Universal usage feed (codex 5h/weekly, gemini calls, ollama-cloud rpm/tpm) | `chitin-budget` + `~/.cache/chitin/usage/` | ✅ schema + codex producer shipped 2026-05-04 (#269); gemini/ollama producers in backlog |
+| Universal usage feed (codex 5h/weekly, gemini calls, ollama-cloud rpm/tpm) | `python/analysis/codex_mine.py` + `~/.cache/chitin/usage/` | ✅ schema + codex producer shipped 2026-05-04 (#269); gemini/ollama producers in backlog |
 | Drivers — Claude Code hook | `internal/driver/claudecode/normalize.go` + kernel install path | ✅ shipped (PR #66) |
 | Drivers — Codex CLI (PreToolUse) | `internal/driver/codex/normalize.go` + `scripts/install-codex-hook.sh` | ✅ shipped 2026-05-04 (#272) |
 | Drivers — Gemini CLI (BeforeTool) | `internal/driver/gemini/normalize.go` + `scripts/install-gemini-hook.sh` | ✅ shipped 2026-05-04 (#267) |
-| Drivers — Codex as activity-spawned reviewer (env-overridable per tier) | `apps/runner` `planInvocation` + `REVIEW_TIER_DRIVER` | ✅ shipped 2026-05-04 (#270) |
 | Drivers — Copilot CLI (wrapping) | Kernel `drive copilot` | ✅ shipped (PR #51) |
 | Drivers — openclaw (`local-*`) | openclaw `before_tool_call` plugin | ✅ shipped |
 | Plugin runtime (Python + TS heuristic plugins) | `internal/router/plugins` + opt-in side-effect gate libs | ✅ shipped (#235, #237, #241, #250) |
 | Plugin sandbox (bubblewrap, opt-in) | `internal/router/plugins/sandbox.go` | ✅ shipped 2026-05-03 (#255) |
 | OTEL emit (projection) | Go kernel `internal/emit` | ✅ F4 shipped before 2026-05-07 talk |
-| Worktree index (dispatcher writes `WORKTREE_INDEX.md`) | `apps/runner/src/activity.ts` | ✅ shipped 2026-05-03 (#261) |
-| Souls library | `souls/canonical/` + `souls/experimental/` | ✅ shipped Phase 1.5 |
+| Router signal stamping | Go kernel `internal/router` + `cmd/chitin-kernel/router_hook.go` | ✅ post-cull shape: pure-Go signals, no in-gate LLM advisor |
+| Removed orchestration surfaces | `apps/runner`, scheduler, Temporal, Slack app, in-gate peer spawn | ❌ culled 2026-05-06 to 2026-05-08; Hermes owns orchestration |
+| Souls library | `souls/canonical/` + `souls/experimental/` | historical analytics/reference artifact; not a kernel runtime surface |
 
 ## Order of operations (current, not aspirational)
 
-Older docs stated "observability → governance → automation, in that order, per surface." That ordering described Phase 1's implementation sequence; it is not a design constraint anymore. Today all three coexist:
+Older docs stated "observability → governance → automation, in that order, per surface." That ordering described Phase 1's implementation sequence; it is not a design constraint anymore. Today chitin owns the first two and emits signals for downstream automation:
 
 1. **Observability** is always-on. Every driver emits events to the chain by default.
-2. **Governance** is on by default in `mode: guide`. Policies start permissive and tighten as the debt ledger surfaces real-world denials worth enforcing.
-3. **Automation** (the swarm / self-building product north star) lives downstream of both.
+2. **Governance** is on by default in `mode: enforce` for the baseline policy. Policies tighten as the debt ledger surfaces real-world denials worth enforcing.
+3. **Automation** lives downstream in Hermes, OpenClaw, or operator wiring. Chitin does not run the agent loop, scheduler, kanban, approval flow, or peer-spawn workflow.
 
 ## The three analysis output streams
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -79,5 +79,5 @@ All capture and gating works fully offline. OTEL emit (post-F4) is opt-in and re
 ## What chitin does not do
 
 - It does not run an agent loop. The drivers do.
-- It does not ship a cloud SaaS. That is step 5 on the strategic arc, not today.
+- It does not ship a cloud SaaS. Local-only is the product boundary.
 - It does not replace the agent. It observes and gates.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,10 +11,10 @@ The strategic arc, what's shipped, what's in flight, what's deferred. Updated 20
           │                    │                      │
           └────────►───────────┴────────►─────────────┤
                                                       │
-   4. Policy packs      5. Cloud offering      6. North star
-      reusable             centralized            execution governance
-      governance           trace + policy         as the auditable layer
-      bundles              SaaS                   under whatever the
+   4. Policy packs      5. Local operator      6. North star
+      reusable             leverage               execution governance
+      governance           replay + analytics     as the auditable layer
+      bundles              on operator data       under whatever the
                                                   orchestration ecosystem
                                                   picks next
           │                    │                      │
@@ -48,7 +48,7 @@ Go execution kernel (canon, normalize, emit, hook), `libs/contracts` (zod schema
 - **Gemini CLI hook driver** — `--agent=gemini` PreToolUse handler
 - **Copilot CLI in-kernel SDK driver** — PR #51 (`chitin-kernel drive copilot`)
 - **OpenClaw before_tool_call plugin** — `~/.openclaw/plugins/chitin-governance/`
-- **Hermes pre_tool_call plugin** — `~/.hermes/plugins/chitin-governance/`
+- **Hermes pre_tool_call hook** — `scripts/install-hermes-hook.sh` wires `~/.hermes/config.yaml`
 
 The hero sentence names six drivers. Bitrot in any is a hero-sentence bug.
 

--- a/docs/runbooks/chitin-router.md
+++ b/docs/runbooks/chitin-router.md
@@ -21,12 +21,14 @@ it). As of 2026-05-04 that's all of:
 | `claude-code-headless` | `PreToolUse` | `~/.claude/settings.json` | `chitin-kernel install --surface claude-code` |
 | `codex` | `PreToolUse` (codex 0.128.0+) | `~/.codex/config.toml` (`[features] codex_hooks=true`) | `scripts/install-codex-hook.sh` |
 | `gemini` | `BeforeTool` (same wire shape; renamed event) | `~/.gemini/settings.json` | `scripts/install-gemini-hook.sh` |
+| `hermes` | `pre_tool_call` (same wire shape) | `~/.hermes/config.yaml` | `scripts/install-hermes-hook.sh` |
 | `copilot` | n/a — wrapping driver | (in-kernel) | `chitin-kernel drive copilot` |
 | `local-*` (qwen/glm/glm-flash/deepseek) | `before_tool_call` plugin | openclaw plugin config | openclaw-side |
 
 The `chitin-router-hook` shim is the same binary across all hook-
 surface drivers; per-vendor tool-name normalization lives in
-`internal/driver/<vendor>/normalize.go` (claudecode, codex, gemini).
+`internal/driver/<vendor>/normalize.go` (claudecode, codex, gemini,
+hermes).
 
 ## What it does
 
@@ -115,7 +117,8 @@ router:
   plugins:
     - name: tests-required-before-commit
       type: pre-action
-      command: ["python3", "scripts/check-tests-before-commit.py"]
+      runtime: python3
+      module: scripts/check-tests-before-commit.py
       timeout_ms: 750
       allowlist_paths: ["."]
 ```

--- a/docs/runbooks/chitin-router.md
+++ b/docs/runbooks/chitin-router.md
@@ -1,10 +1,11 @@
 # chitin-router runbook
 
-> The router wraps the kernel's `PreToolUse` hook with a heuristic
-> + advisor pipeline. When enabled, it scores each tool call for
-> blast radius / floundering / drift; if any heuristic fires, it
-> consults a higher-tier advisor (via `claude -p`) for a nudge or
-> takeover verdict.
+> The router wraps the kernel's `PreToolUse` hook with advisory
+> signal stamping. When enabled, it scores each tool call for blast
+> radius / floundering / drift and writes a second `router.signal`
+> decision row to the chain. The router never spawns an LLM in the
+> gate; downstream consumers such as hermes can read the signal rows
+> and decide what to do.
 >
 > **Off by default** — operator opts in via a sentinel file. Hot
 > path stays fast (kernel only) until then.
@@ -34,23 +35,26 @@ For each `PreToolUse` hook call from any chitin-governed agent:
 1. **Kernel verdict (deterministic)** — `chitin-kernel gate evaluate
    --hook-stdin`. If the kernel denies, the router returns the deny
    immediately.
-2. **Heuristics** — pure functions over the hook input + recent chain
+2. **Signals** — pure functions over the hook input + recent chain
    events:
    - `blast_radius` — scores actions on reversibility / scope /
      visibility / counterparties (0.0–1.0; > threshold = fired)
    - `floundering` — detects looping tool calls, stalled progress,
      denial cascades over the agent's chain
-3. **Advisor (optional)** — if any heuristic fires AND the policy
-   triggers match, calls `claude -p` with a structured prompt
-   asking for a nudge + verdict (continue / takeover) + escalate
-   bool. The advisor's response is composed into the hook reply.
-4. **Compose** — kernel decision + advisor nudge → Claude Code
-   sees the nudge in the tool-call result and continues.
+   - `drift` — detects high-risk actions that diverge from the
+     recent task/session context
+3. **Plugins (optional)** — operator-declared subprocess checks can
+   add advisory scores. Pre-action plugins may return `block=true`
+   for deterministic checks.
+4. **Stamp** — non-zero signal scores are written as a second
+   `gov.Decision` row with action type `router.signal`.
+5. **Return** — the kernel verdict is emitted unchanged. Heuristics
+   do not deny or allow; kernel policy and pre-action plugin blocks
+   are the only authoritative verdicts.
 
 Hot path performance: when the sentinel file is absent, the
 wrapper is a single `exec chitin-kernel` — adds ~0ms. When the
-sentinel is present, the TS pipeline runs (~500ms cold, but most
-tool calls don't fire heuristics so the advisor isn't invoked).
+sentinel is present, the Go router evaluates heuristics in-process.
 
 ## Install
 
@@ -81,17 +85,17 @@ echo '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_pat
 # Expect: {"decision":"allow","source":"kernel-allow"}
 ```
 
-Smoke a high-blast action (should fire blast_radius + try advisor):
+Smoke a high-blast action (should fire blast_radius and stamp a
+router signal row):
 
 ```bash
 echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git push --force origin main"},"cwd":"'"$PWD"'","session_id":"smoke"}' \
   | ~/workspace/chitin/bin/chitin-router-hook --agent=smoke
-# Expect: {"decision":"allow|deny","message":"<nudge>","source":"advisor-allow|advisor-deny"}
-# (Takes ~30-60s if advisor is reachable.)
+# Expect: the kernel verdict on stdout; router telemetry on stderr.
 ```
 
-If the advisor errors / times out, the wrapper falls through to
-the kernel verdict (fail-open) — the agent isn't blocked.
+Signal rows are written to the same chain as normal kernel
+decisions. Use the chain readers to inspect `router.signal` rows.
 
 ## Configure
 
@@ -108,19 +112,15 @@ router:
       enabled: true
       max_loop_count: 3             # same tool+target N times → fire
       max_stall_seconds: 600        # no writes in N seconds → fire
-  advisor:
-    enabled: true
-    when:                           # which signals trigger the advisor
-      - blast_radius_above_threshold
-      - floundering_detected
-      - kernel_denied               # advise on every deny too
-    chain:
-      max_depth: 3                  # cap on advisor-chain depth
-      tier_steps: [T2, T3, T4]      # tier ladder for chained advice
-    model: claude-code-headless     # advisor model id
+  plugins:
+    - name: tests-required-before-commit
+      type: pre-action
+      command: ["python3", "scripts/check-tests-before-commit.py"]
+      timeout_ms: 750
+      allowlist_paths: ["."]
 ```
 
-Most edits don't require restarting anything — the TS hook reads
+Most edits don't require restarting anything — the router reads
 `chitin.yaml` per-call (with a small cache, but cache is per-
 process and the hook is per-process).
 
@@ -133,10 +133,10 @@ to stderr; journald captures it for the systemd-driven hooks):
 journalctl --user -u chitin-worker -f | grep '"component":"router-'
 ```
 
-Read the per-workflow shared memory (advisor nudges):
+Read stamped router signal rows:
 
 ```bash
-cat ~/.chitin/shared-memory/<workflow-id>.json | jq .
+chitin-kernel chain stats --action router.signal
 ```
 
 Disable a heuristic without touching policy YAML — set the env var
@@ -151,9 +151,9 @@ override on the worker:
 | Failure | Impact | Fix |
 |---|---|---|
 | `chitin-kernel` binary missing | Wrapper logs warn, falls open (allow). Agent unaffected. | Rebuild kernel; `chitin-kernel-redeploy.timer` should catch this. |
-| Advisor (`claude -p`) times out | Wrapper logs warn, returns kernel verdict only. Agent gets no nudge but isn't blocked. | Increase `--timeoutMs` in `advisor.ts` (default 60s); verify Claude Code auth. |
-| `chitin.yaml` unreadable / missing `router:` | Wrapper uses `DEFAULT_ROUTER_POLICY` (advisor disabled). | Add or fix the section. |
-| TS hook crashes | Wrapper catches, falls open (allow). Agent unaffected. | Check stderr; report bug. |
+| Plugin times out or errors | Router logs warn and ignores that plugin result. | Fix the plugin command or lower its scope. |
+| `chitin.yaml` unreadable / missing `router:` | Wrapper uses `DefaultPolicy` (router disabled). | Add or fix the section. |
+| Router hook crashes | Wrapper returns a non-blocking hook error. Agent unaffected. | Check stderr; report bug. |
 
 ## Why a sentinel file (not a config flag)
 

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -1,25 +1,26 @@
 # Thesis
 
-> Chitin is an execution kernel for AI coding agents. Every tool call across Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack.
+> Chitin is an execution kernel for AI coding agents. Every tool call across Claude Code, Codex CLI, Gemini CLI, Hermes, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack.
 
 ## What chitin is
 
-A small Go kernel that sits between AI coding agents and the operating system. Five vendor surfaces are gated through it today:
+A small Go kernel that sits between AI coding agents and the operating system. Six vendor surfaces are gated through it today:
 
 - **Claude Code** — `PreToolUse` hook in `~/.claude/settings.json`.
 - **Codex CLI** — `PreToolUse` hook in `~/.codex/config.toml` (`[features] codex_hooks=true` + `[[hooks.PreToolUse]]`); same wire shape as Claude Code.
 - **Gemini CLI** — `BeforeTool` hook in `~/.gemini/settings.json`; same wire shape as Claude Code (renamed event).
+- **Hermes** — `pre_tool_call` hook in `~/.hermes/config.yaml`; same wire shape as Claude Code.
 - **Copilot CLI** — in-kernel SDK driver (`chitin-kernel drive copilot`); wrapping orchestrator pattern (closed vendor).
 - **openclaw** (`local-*` drivers: qwen / glm / glm-flash / deepseek) — `before_tool_call` plugin path.
 
-Same `gov.Gate` API across all five. Same canonical event chain on disk. Same OTEL projection out the back. Vendor-specific normalization lives in `internal/driver/<vendor>/normalize.go`.
+Same `gov.Gate` API across all six. Same canonical event chain on disk. Same OTEL projection out the back. Vendor-specific normalization lives in `internal/driver/<vendor>/normalize.go`.
 
 ## What chitin is not
 
-- Not a tick-loop / agent-runner. Hermes is dead (2026-04-23). Drivers run on their own surfaces; chitin gates their tool calls.
+- Not a tick-loop / agent-runner. Hermes owns orchestration, approvals, kanban, and scheduling; chitin gates the tool calls Hermes and the standalone drivers attempt.
 - Not an OTEL ingest target. Chitin **emits** spans as a projection of its canonical chain. The chain is the source of truth; OTEL is one-way out.
 - Not an LLM provider abstraction. Chitin doesn't proxy or re-call models. Each vendor's CLI talks to its own backend (codex → OpenAI under your ChatGPT Plus auth; gemini → Google under Pro auth; etc.); chitin governs the actions those CLIs take.
-- Not a cloud product (yet). Phase 1 is local-only. Cloud is the monetization step on the strategic arc — it follows ecosystem distribution, not the other way around.
+- Not a SaaS. Chitin is local-only: the operator's box, the operator's data.
 
 ## The closed loop
 
@@ -43,12 +44,11 @@ Most agent-observability tools are open-loop (capture only) or heuristic (LLM-ju
 
 ## Strategic arc
 
-1. **Aggregate** — always-on capture across the three drivers.
+1. **Aggregate** — always-on capture across supported drivers.
 2. **Align policies to data** — governance rules emerge from the debt ledger, not from a-priori spec.
 3. **Ecosystem distribution** — chitin runs inside agent ecosystems (openclaw, future frameworks), not just Claude Code.
 4. **Policy packs** — reusable governance bundles for everyone running chitin-instrumented agents.
-5. **Cloud offering** — centralized trace/policy surface as a service.
-6. **North star** — autonomous swarm, plus a product that builds itself, both governed by chitin.
+5. **Local operator leverage** — better policy packs, replay, and chain-derived analytics without sending the operator's governance data to a service.
 
 ## Audience sequencing
 

--- a/go/execution-kernel/internal/driver/copilot/normalize.go
+++ b/go/execution-kernel/internal/driver/copilot/normalize.go
@@ -104,19 +104,19 @@ func Normalize(req copilotsdk.PermissionRequest, cwd string) gov.Action {
 		}
 
 	case copilotsdk.PermissionRequestKindMemory:
-		action.Type = "memory.access"
+		action.Type = gov.ActMemoryAccess
 		if req.Subject != nil {
 			action.Target = *req.Subject
 		}
 
 	case copilotsdk.PermissionRequestKindCustomTool:
-		action.Type = "tool.custom"
+		action.Type = gov.ActCustomTool
 		if req.ToolName != nil {
 			action.Target = *req.ToolName
 		}
 
 	case copilotsdk.PermissionRequestKindHook:
-		action.Type = "hook.invoke"
+		action.Type = gov.ActHookInvoke
 		if req.HookMessage != nil {
 			action.Target = *req.HookMessage
 		}

--- a/go/execution-kernel/internal/driver/copilot/normalize_test.go
+++ b/go/execution-kernel/internal/driver/copilot/normalize_test.go
@@ -147,7 +147,7 @@ func TestNormalize_Memory(t *testing.T) {
 		Subject: ptr("user preferences"),
 	}
 	got := Normalize(req, "/work")
-	if got.Type != "memory.access" {
+	if got.Type != gov.ActMemoryAccess {
 		t.Errorf("Type: got %q, want memory.access", got.Type)
 	}
 }
@@ -158,7 +158,7 @@ func TestNormalize_CustomTool(t *testing.T) {
 		ToolName: ptr("my-custom-tool"),
 	}
 	got := Normalize(req, "/work")
-	if got.Type != "tool.custom" {
+	if got.Type != gov.ActCustomTool {
 		t.Errorf("Type: got %q, want tool.custom", got.Type)
 	}
 }
@@ -169,7 +169,7 @@ func TestNormalize_Hook(t *testing.T) {
 		HookMessage: ptr("pre-commit hook needs approval"),
 	}
 	got := Normalize(req, "/work")
-	if got.Type != "hook.invoke" {
+	if got.Type != gov.ActHookInvoke {
 		t.Errorf("Type: got %q, want hook.invoke", got.Type)
 	}
 }

--- a/go/execution-kernel/internal/gov/action.go
+++ b/go/execution-kernel/internal/gov/action.go
@@ -54,6 +54,9 @@ const (
 	ActNPMRun            ActionType = "npm.script.run"
 	ActTestRun           ActionType = "test.run"
 	ActMCPCall           ActionType = "mcp.call"
+	ActMemoryAccess      ActionType = "memory.access"
+	ActCustomTool        ActionType = "tool.custom"
+	ActHookInvoke        ActionType = "hook.invoke"
 	// ActKanbanCall: Hermes Agent's per-tool kanban API calls
 	// (`kanban_show`, `kanban_complete`, `kanban_block`, `kanban_comment`,
 	// `kanban_heartbeat`, `kanban_create`, `kanban_link`, `kanban_unlink`,

--- a/go/execution-kernel/internal/gov/action_test.go
+++ b/go/execution-kernel/internal/gov/action_test.go
@@ -11,7 +11,8 @@ func TestActionType_ClosedEnum(t *testing.T) {
 		ActShellExec, ActFileRead, ActFileWrite, ActFileDelete,
 		ActGitPush, ActGitForcePush, ActGitCommit, ActGitCheckout,
 		ActGitWorktreeAdd, ActGithubPRCreate, ActGithubIssueView,
-		ActDelegateTask, ActHTTPRequest, ActUnknown,
+		ActDelegateTask, ActHTTPRequest, ActMCPCall, ActMemoryAccess,
+		ActCustomTool, ActHookInvoke, ActUnknown,
 	}
 	for _, a := range wantPresent {
 		if a == "" {

--- a/go/execution-kernel/internal/replay/summary.go
+++ b/go/execution-kernel/internal/replay/summary.go
@@ -19,7 +19,7 @@ import (
 //   ## Prior session <id> summary
 //   - <N> tool calls (M denied), files touched: a.ts, b.go, ...
 //   - Last decision: <ts> <tool> on <target> [allow|deny rule]
-//   - Open questions / advisor nudges (from shared memory)
+//   - Router signals / open questions (from chain-derived context)
 //   - Outcome (if known): commit_sha, error, ...
 //
 // Designed to be SHORT — agents have limited prompt budget.

--- a/go/execution-kernel/internal/router/plugin_runner.go
+++ b/go/execution-kernel/internal/router/plugin_runner.go
@@ -107,15 +107,15 @@ func RunPlugins(ctx context.Context, pluginConfigs []PluginConfig, trust Plugins
 }
 
 // NamedHeuristicScore wraps a HeuristicScore with the plugin's
-// name + type + block flag so the router can route fired-plugin
-// signals into advisor triggers OR direct blocks.
+// name + type + block flag so the router can distinguish advisory
+// signals from deterministic pre-action blocks.
 type NamedHeuristicScore struct {
 	Name  string
 	Type  string
 	// Block — when true AND Score.Fired is true, the router denies
 	// the action directly with Score.Reason as the deny message
-	// (pre-action analysis verdict). When false, the firing is a
-	// heuristic signal that may trigger advisor consultation.
+	// (pre-action analysis verdict). When false, the firing is an
+	// advisory heuristic signal stamped onto the chain.
 	Block bool
 	Score HeuristicScore
 }

--- a/go/execution-kernel/internal/router/plugins/loader.go
+++ b/go/execution-kernel/internal/router/plugins/loader.go
@@ -15,10 +15,9 @@
 //                have bun installed)
 //   bash     →  shell scripts (fastest, ~10ms; for prototyping)
 //
-// Cost model: per-call subprocess spawn. Most tool calls SKIP
-// plugins (gated by policy.advisor.when triggers). Plugin authors
-// should keep their work fast — heavy compute belongs in advisor
-// LLM calls, not heuristic plugins.
+// Cost model: per-call subprocess spawn. Plugin authors should keep
+// their work fast; heavy judgment loops belong downstream in Hermes,
+// OpenClaw, or operator-wired chain consumers, not in the gate.
 package plugins
 
 import (
@@ -36,8 +35,9 @@ import (
 type PluginManifest struct {
 	// Name identifies the plugin in telemetry (operator-readable).
 	Name string `yaml:"name" json:"name"`
-	// Type — heuristic | advisor. Heuristics fire pre-advisor; advisors
-	// receive the heuristic outcome and return a verdict + nudge.
+	// Type identifies the plugin shape. "heuristic" emits an advisory
+	// score; other values are preserved for backward-compatible config
+	// loading but do not reintroduce an in-gate LLM advisor.
 	Type string `yaml:"type" json:"type"`
 	// Runtime — which interpreter to spawn (python3, node, bun, bash).
 	Runtime string `yaml:"runtime" json:"runtime"`
@@ -96,16 +96,14 @@ type PluginInput struct {
 //
 // Two plugin shapes are supported:
 //
-//  1. HEURISTIC plugins — score the action; firing flags it for
-//     advisor consultation but doesn't block on its own. Set
-//     Fired but leave Block false.
+//  1. HEURISTIC plugins — score the action; firing stamps a signal
+//     row but doesn't block on its own. Set Fired but leave Block
+//     false.
 //
 //  2. PRE-ACTION ANALYSIS plugins — block the action directly
 //     based on a deterministic check (e.g., "no commit until tests
 //     pass"). Set both Fired AND Block=true. The router emits a
-//     kernel-level deny with the plugin's Reason as the message;
-//     no advisor consultation is needed (plugin verdict is
-//     authoritative).
+//     kernel-level deny with the plugin's Reason as the message.
 //
 // A plugin can switch shape per-invocation: heuristic-fire on
 // one input and block-fire on another.
@@ -115,8 +113,7 @@ type PluginOutput struct {
 	Reason string                 `json:"reason"`
 	Axis   map[string]interface{} `json:"axis,omitempty"`
 	// Block — when true AND Fired is true, the router denies the
-	// action directly with Reason as the deny message; advisor
-	// not consulted.
+	// action directly with Reason as the deny message.
 	Block bool `json:"block,omitempty"`
 }
 

--- a/go/execution-kernel/internal/router/route_for.go
+++ b/go/execution-kernel/internal/router/route_for.go
@@ -1,23 +1,21 @@
 package router
 
-// routeFor — peer-escalation routing decision.
+// routeFor — advisory routing decision.
 //
-// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 2 of 6):
-// pure function from (signal, severity, context, policy) → RouteDecision.
-// NO peer spawning yet (that's step 3); NO live quota integration yet
-// (that's step 6 — observed dimensions feed back). This step ships
-// the deterministic decision engine reachable from tests but not wired
-// into the gate.
+// Pure function from (signal, severity, context, policy) to
+// RouteDecision. It never spawns a peer CLI, shells out, or consults an
+// LLM. The result is a candidate label that can be stamped on the
+// chain for downstream consumers.
 //
 // Contract:
 //   - First rule whose Signal matches `req.Signal` wins. Severity is
 //     captured for telemetry but does NOT participate in matching yet
 //     (string-only, no comparator parser).
 //   - Rule's Route is looked up in policy.Routes; first candidate is
-//     returned (FUTURE step 6: walk by quota state + observed
-//     compatibility, not just first).
-//   - No matching rule → ErrNoRuleMatched. Caller falls back to the
-//     existing kernel deny+escalation_requested behavior.
+//     returned. A future chain consumer can walk by quota state +
+//     observed compatibility instead of taking the head.
+//   - No matching rule → ErrNoRuleMatched. Caller emits no routing
+//     candidate.
 //   - No candidates in route → ErrRouteEmpty. Validation should have
 //     prevented this; treat as a config bug worth logging.
 
@@ -27,15 +25,15 @@ import (
 )
 
 var (
-	ErrNoRuleMatched = errors.New("no escalation rule matched the signal")
+	ErrNoRuleMatched = errors.New("no routing rule matched the signal")
 	ErrRouteEmpty    = errors.New("matched route has no candidates")
-	ErrPolicyOff     = errors.New("escalation policy is disabled")
+	ErrPolicyOff     = errors.New("routing policy is disabled")
 )
 
 // RouteRequest is the per-tool-call input to RouteFor.
 type RouteRequest struct {
-	// Signal that triggered the escalation: "floundering" |
-	// "blast_radius" | "drift" | "advisor_takeover".
+	// Signal that triggered routing: "floundering" | "blast_radius" |
+	// "drift".
 	Signal string
 
 	// Human-readable severity string (recorded in telemetry; not yet
@@ -44,12 +42,10 @@ type RouteRequest struct {
 	Severity string
 
 	// ToolCall is the worker's pending tool-call payload. Opaque to
-	// RouteFor today; passed through to spawnPeer (step 3) which
-	// wraps it for the peer CLI's prompt.
+	// RouteFor today; downstream consumers may use it for context.
 	ToolCall map[string]any
 
-	// Recent chain events for context. Same — opaque to RouteFor;
-	// wrapped by spawnPeer.
+	// Recent chain events for context. Same — opaque to RouteFor.
 	ChainTail []map[string]any
 
 	// Worker's workflow_id, for Provenance attribution downstream.
@@ -72,7 +68,7 @@ type RouteDecision struct {
 	Rationale string
 }
 
-// RouteFor maps an escalation signal to a (driver, model) candidate
+// RouteFor maps a router signal to a (driver, model) candidate
 // using the operator's policy. Pure function — no I/O, no clocks, no
 // subprocess. Safe to call from inside the gate hot path.
 func RouteFor(req RouteRequest, policy RoutesPolicy) (RouteDecision, error) {

--- a/go/execution-kernel/internal/router/route_for_test.go
+++ b/go/execution-kernel/internal/router/route_for_test.go
@@ -13,7 +13,7 @@ func samplePolicy() RoutesPolicy {
 		Rules: []RoutingRule{
 			{Name: "floundering-loop", Signal: "floundering", Severity: ">= 2 loops", Route: "patch_quality", MaxPerHour: 10},
 			{Name: "blast-radius-large", Signal: "blast_radius", Severity: "> 25 files", Route: "reasoning_depth", MaxPerHour: 5},
-			{Name: "drift-takeover", Signal: "drift", Severity: "advisor.verdict=takeover", Route: "reasoning_depth", MaxPerHour: 3},
+			{Name: "drift-high", Signal: "drift", Severity: "score>=0.6", Route: "reasoning_depth", MaxPerHour: 3},
 		},
 		Routes: map[string][]Candidate{
 			"patch_quality": {
@@ -59,8 +59,8 @@ func TestRouteFor_DriftMatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d.Rule.Name != "drift-takeover" {
-		t.Errorf("expected drift-takeover; got %q", d.Rule.Name)
+	if d.Rule.Name != "drift-high" {
+		t.Errorf("expected drift-high; got %q", d.Rule.Name)
 	}
 }
 

--- a/go/execution-kernel/internal/router/routes.go
+++ b/go/execution-kernel/internal/router/routes.go
@@ -1,15 +1,16 @@
 package router
 
-// chitin-routes.yaml — peer-escalation routing policy loader.
+// chitin-routes.yaml — advisory routing policy loader.
 //
-// Per docs/design/2026-05-06-kernel-gate-escalation.md (step 1 of 6):
-// schema only. This file ONLY defines types + loader + validation.
-// Nothing in the kernel reads RoutesPolicy yet; subsequent steps wire
-// routeFor() and spawnPeer() against it.
+// This sidecar maps router signals to candidate downstream handlers
+// (driver/model labels). It is intentionally pure data: no subprocess,
+// no peer spawn, no LLM consultation. The kernel may stamp a
+// RoutingDecision string derived from this policy; Hermes, OpenClaw,
+// or another chain consumer decides whether to act on that signal.
 //
-// Sidecar (not part of chitin.yaml) so escalation routes can grow large
-// candidate lists without bloating the main policy file. Loaded from
-// the same parent-walk that finds chitin.yaml.
+// Sidecar (not part of chitin.yaml) so routing candidate lists can grow
+// without bloating the main policy file. Loaded from the same parent
+// walk that finds chitin.yaml.
 
 import (
 	"fmt"
@@ -26,16 +27,16 @@ type RoutesPolicy struct {
 	Version int `yaml:"version"`
 
 	// When false, rules + routes are loaded + validated but the
-	// gate falls back to today's deny+escalation_requested behavior.
-	// Default off — operator opts in.
+	// gate does not stamp routing candidates. Default off — operator
+	// opts in.
 	Enabled bool `yaml:"enabled"`
 
-	// Maximum wall-clock seconds for a peer-spawn before timeout.
-	// 0 → use built-in default (60).
+	// Historical no-op retained for schema compatibility with early
+	// route files. The kernel no longer spawns peers from this policy.
 	SpawnTimeoutSeconds int `yaml:"spawn_timeout_seconds"`
 
-	// At most N peer spawns in flight per worker session. Prevents
-	// runaway when heuristics keep firing. 0 → use default (1).
+	// Historical no-op retained for schema compatibility with early
+	// route files. The kernel no longer spawns peers from this policy.
 	MaxConcurrentPeers int `yaml:"max_concurrent_peers"`
 
 	// Rules: signal+severity → which named route to use.
@@ -53,8 +54,8 @@ type RoutingRule struct {
 	// Operator-friendly id (used in telemetry + error messages).
 	Name string `yaml:"name"`
 
-	// Which heuristic / advisor signal triggers this rule.
-	// "floundering" | "blast_radius" | "drift" | "advisor_takeover".
+		// Which router signal triggers this rule.
+		// "floundering" | "blast_radius" | "drift".
 	Signal string `yaml:"signal"`
 
 	// Human-readable severity expression. Today: free-text shown in
@@ -65,9 +66,8 @@ type RoutingRule struct {
 	// Name of the route in RoutesPolicy.Routes to consult.
 	Route string `yaml:"route"`
 
-	// Rate cap — kernel refuses to fire this rule more than N times
-	// per rolling hour, regardless of how often the signal triggers.
-	// 0 → no cap. Prevents quota exhaustion + runaway escalation.
+	// Advisory rate cap retained for future chain consumers. The
+	// kernel's current loader validates but does not enforce it.
 	MaxPerHour int `yaml:"max_per_hour"`
 }
 
@@ -156,7 +156,7 @@ func ValidateRoutesPolicy(p RoutesPolicy) error {
 	}
 	allowedSignals := map[string]bool{
 		"floundering": true, "blast_radius": true,
-		"drift": true, "advisor_takeover": true,
+		"drift": true,
 	}
 	seenRule := map[string]bool{}
 	for i, rule := range p.Rules {
@@ -168,7 +168,7 @@ func ValidateRoutesPolicy(p RoutesPolicy) error {
 		}
 		seenRule[rule.Name] = true
 		if !allowedSignals[rule.Signal] {
-			return fmt.Errorf("rule[%s]: unknown signal %q (expected one of floundering, blast_radius, drift, advisor_takeover)",
+			return fmt.Errorf("rule[%s]: unknown signal %q (expected one of floundering, blast_radius, drift)",
 				rule.Name, rule.Signal)
 		}
 		if rule.Route == "" {

--- a/go/execution-kernel/internal/router/types.go
+++ b/go/execution-kernel/internal/router/types.go
@@ -34,7 +34,7 @@ type HookInput struct {
 type HookOutput struct {
 	Decision string `json:"decision"`          // "allow" | "deny"
 	Message  string `json:"message,omitempty"` // shown to the agent
-	Source   string `json:"source,omitempty"`  // kernel | heuristic-deny | advisor-* | kernel-allow
+	Source   string `json:"source,omitempty"`  // kernel | heuristic-deny | plugin-block | kernel-allow
 }
 
 // HeuristicScore is the result of one heuristic running over a HookInput.
@@ -88,7 +88,7 @@ type AdvisorConfig struct {
 // wire protocol.
 type PluginConfig struct {
 	Name      string                 `yaml:"name" json:"name"`
-	Type      string                 `yaml:"type" json:"type"`           // heuristic | advisor
+	Type      string                 `yaml:"type" json:"type"`           // heuristic | pre-action
 	Runtime   string                 `yaml:"runtime" json:"runtime"`     // python3 | node | bun | bash
 	Module    string                 `yaml:"module" json:"module"`       // path to script
 	Config    map[string]interface{} `yaml:"config,omitempty" json:"config,omitempty"`
@@ -141,13 +141,13 @@ func DefaultPolicy() Policy {
 			},
 		},
 		Advisor: AdvisorConfig{
-			Enabled: true,
-			When:    []string{"blast_radius_above_threshold", "floundering_detected"},
+			Enabled: false,
+			When:    nil,
 			Chain: struct {
 				MaxDepth  int      `yaml:"max_depth" json:"max_depth"`
 				TierSteps []string `yaml:"tier_steps" json:"tier_steps"`
-			}{MaxDepth: 3, TierSteps: []string{"T2", "T3", "T4"}},
-			Model: "claude-code-headless",
+			}{},
+			Model: "",
 		},
 	}
 }

--- a/python/analysis/codex_mine.py
+++ b/python/analysis/codex_mine.py
@@ -1,9 +1,9 @@
-"""Mine ~/.codex/sessions/**/*.jsonl into chitin-shaped chain events
-and a per-session usage rollup.
+"""Mine ~/.codex/sessions/**/*.jsonl for Codex usage and post-hoc events.
 
-Codex doesn't have a PreToolUse hook, so chitin can't gate codex
-calls in real time. But codex DOES emit a structured session
-JSONL with everything we need post-hoc:
+Chitin now has a live Codex PreToolUse integration via
+``scripts/install-codex-hook.sh`` and ``internal/driver/codex``. This
+module is still useful for the data Codex exposes only in its session
+JSONL, especially quota/rate-limit state and post-hoc session mining:
 
   - session_meta:        cwd, model_provider, cli_version
   - event_msg.task_started:   turn_id, started_at, model_context_window


### PR DESCRIPTION
## What changed

- Added an active driver conformance matrix covering Claude Code, Codex, Gemini, Hermes, Copilot CLI, OpenClaw, and VS Code Copilot guidance.
- Added VS Code workspace settings and path-specific Copilot instruction files so IDE Copilot follows the same chitin boundary language.
- Updated governance/setup docs to treat Hermes as a first-class hook integration and VS Code Copilot as guidance-only, not an enforcement boundary.
- Aligned router/advisor docs and comments with the 2026-05-08 cull: no in-gate LLM advisor or peer spawning, only pure-Go signal stamping plus deterministic plugin checks.
- Promoted Copilot SDK `memory.access`, `tool.custom`, and `hook.invoke` action types into canonical Go constants and updated tests.

## Why

The repo had drift between the current AGENTS.md scope and active docs/code comments. This keeps chitin focused on the kernel moat: cross-driver typed action normalization, policy, chain, bounds, severity, and advisory signals.

## Validation

- `cd go/execution-kernel && go test ./...`
- `python/analysis/.venv/bin/python -m pytest python/analysis/tests/test_codex_mine.py`
- `python3 -m json.tool .vscode/settings.json`
- `python3 -m json.tool .vscode/extensions.json`
- `git diff --check`

## Notes

`chitin.yaml` still contains stale advisor-era comments/config. I intentionally left it untouched because active chitin policy blocks agent modification of governance config; that needs an operator-side edit.
