### PR TITLE
[codex] type Hermes memory and session tools

### DIFF
--- a/go/execution-kernel/internal/driver/hermes/normalize.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize.go
@@ -35,6 +35,11 @@
 //	skill_view         → file.read, target = name (skill .md path).
 //	skills_list        → file.read, target = category.
 //	skill_manage       → file.write, target = name (skill creation/edit).
+//	memory             → file.write, target = memory (durable memory write).
+//	todo               → file.write, target = todo (session task state).
+//	session_search     → file.read, target = query (past session/memory search).
+//	process            → hermes.process, target = action.
+//	kanban_*           → kanban.call, target = verb without kanban_ prefix.
 //	mcp__<server>__<tool> → mcp.call (hermes uses the same MCP convention
 //	                     as Claude Code; reuse the parsing).
 //
@@ -43,7 +48,6 @@
 //	image_generate, text_to_speech, vision_analyze — modality-side-effect
 //	cronjob — scheduling action; no clear gov-action peer
 //	clarify — chat-only, no fs/network impact
-//	process — generic process action; ambiguous
 //
 // These produce ActUnknown which fail-closes under default-deny — safer
 // than guessing wrong. Add proper types as the surface stabilizes.
@@ -202,6 +206,37 @@ func Normalize(in HookInput) (gov.Action, error) {
 			Type:   gov.ActFileWrite,
 			Target: stringField(in.ToolInput, "name"),
 			Path:   in.Cwd,
+		}, nil
+
+	case "memory":
+		// Hermes durable memory mutates operator-owned agent memory.
+		// Keep the target stable rather than action/target-specific so
+		// policy can reason about the memory surface as one governed sink.
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "memory",
+			Path:   in.Cwd,
+			Params: in.ToolInput,
+		}, nil
+
+	case "todo":
+		return gov.Action{
+			Type:   gov.ActFileWrite,
+			Target: "todo",
+			Path:   in.Cwd,
+			Params: in.ToolInput,
+		}, nil
+
+	case "session_search":
+		target := stringField(in.ToolInput, "query")
+		if target == "" {
+			target = "session_search"
+		}
+		return gov.Action{
+			Type:   gov.ActFileRead,
+			Target: target,
+			Path:   in.Cwd,
+			Params: in.ToolInput,
 		}, nil
 
 	// Kanban runtime calls — the hermes worker reading/writing its own

--- a/go/execution-kernel/internal/driver/hermes/normalize_test.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize_test.go
@@ -64,6 +64,8 @@ func TestNormalize_readWriteFileMappings(t *testing.T) {
 		{"skill_view", "name", "my-skill", gov.ActFileRead, "my-skill"},
 		{"skills_list", "category", "devops", gov.ActFileRead, "devops"},
 		{"skill_manage", "name", "new-skill", gov.ActFileWrite, "new-skill"},
+		{"memory", "content", "remember this", gov.ActFileWrite, "memory"},
+		{"todo", "todos", "[]", gov.ActFileWrite, "todo"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.tool, func(t *testing.T) {
@@ -83,6 +85,42 @@ func TestNormalize_readWriteFileMappings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalize_sessionSearchIsRead(t *testing.T) {
+	t.Run("uses_query_as_target", func(t *testing.T) {
+		a, err := Normalize(HookInput{
+			Cwd:       "/cwd",
+			ToolName:  "session_search",
+			ToolInput: map[string]any{"query": "hermes hooks"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Type != gov.ActFileRead {
+			t.Errorf("Type: got %q, want %q", a.Type, gov.ActFileRead)
+		}
+		if a.Target != "hermes hooks" {
+			t.Errorf("Target: got %q, want %q", a.Target, "hermes hooks")
+		}
+	})
+
+	t.Run("falls_back_to_tool_name_without_query", func(t *testing.T) {
+		a, err := Normalize(HookInput{
+			Cwd:       "/cwd",
+			ToolName:  "session_search",
+			ToolInput: map[string]any{},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.Type != gov.ActFileRead {
+			t.Errorf("Type: got %q, want %q", a.Type, gov.ActFileRead)
+		}
+		if a.Target != "session_search" {
+			t.Errorf("Target: got %q, want %q", a.Target, "session_search")
+		}
+	})
 }
 
 func TestNormalize_webAndBrowserToolsAreHTTPRequest(t *testing.T) {
@@ -119,7 +157,7 @@ func TestNormalize_webAndBrowserToolsAreHTTPRequest(t *testing.T) {
 
 func TestNormalize_delegateAndMixtureAreDelegateTask(t *testing.T) {
 	d, err := Normalize(HookInput{
-		ToolName: "delegate_task",
+		ToolName:  "delegate_task",
 		ToolInput: map[string]any{"goal": "summarize logs"},
 	})
 	if err != nil || d.Type != gov.ActDelegateTask || d.Target != "summarize logs" {


### PR DESCRIPTION
## Summary

Mined the recent chitin decision chain for Hermes default-deny unknowns and added typed normalizer coverage for the live gaps that still exist in source.

- Map Hermes `memory` to `file.write` with stable target `memory`.
- Map Hermes `todo` to `file.write` with stable target `todo`.
- Map Hermes `session_search` to `file.read`, using the query as the target when present.
- Refresh the Hermes normalizer surface comments so `process` and `kanban_*` are no longer documented as unmapped.
- Add regression coverage for the new mappings.

## Why

The chain mining pass found `memory`, `todo`, and `session_search` showing up as unknown Hermes actions. Some other high-volume unknowns appear to be stale installed-kernel or historical rows because source already maps them, but these three were real source gaps. Typing them keeps governance attribution precise and avoids avoidable `default-deny-unknown` counter accumulation.

## Validation

- `go test ./internal/driver/hermes ./cmd/chitin-kernel`
- `go test ./...` from `go/execution-kernel`
- `git diff --check`
