### PR TITLE
[codex] mark router advisor runbook drift

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,8 +88,7 @@ Net result: ~5000+ LOC removed; chitin's surface tightened to the moat.
 
 | ID | Slice | Why it ships now |
 |----|-------|------------------|
-| **G3** | Documentation refresh — README + roadmap to post-2026-05-08 narrative | This rev |
-| **R1** | Router advisor asymmetry doc | Disclaim where chitin's advisor justifies itself vs hermes' `smart` mode (non-hermes drivers + chain-derived signals) |
+| **D1** | Chain-mined driver conformance gaps | The next high-leverage work comes from real `default-deny-unknown` rows: extend per-driver normalizers, then redeploy hooks/binaries so the chain proves the gap closed. |
 
 ## Deferred
 

--- a/docs/runbooks/chitin-router.md
+++ b/docs/runbooks/chitin-router.md
@@ -175,10 +175,9 @@ reason to keep it anymore.
 
 ## Related
 
-- Strategic entry: `agent-router-architecture` (in
-  `docs/swarm-backlog.md`)
-- Auto-flipper companion: `chitin-shipped-entry-flipper` (separate
-  systemd timer, separate concern — backlog hygiene)
+- Boundary decision: `docs/decisions/2026-05-08-cull-advisor-out-of-kernel-hot-path.md`
+- Router plugin sandbox: `docs/runbooks/plugin-sandbox.md`
+- Driver conformance map: `docs/driver-conformance.md`
 - Kernel binary: `chitin-kernel-redeploy.timer` keeps the
   underlying gate fresh; rebuild script at
   `scripts/install-kernel.sh`

--- a/docs/runbooks/superseded/local-glm-flash-stack.md
+++ b/docs/runbooks/superseded/local-glm-flash-stack.md
@@ -1,5 +1,12 @@
 # Local GLM-4.7-Flash Stack Runbook
 
+> **Historical note, 2026-05-09:** this runbook predates the
+> 2026-05-06/2026-05-08 scope cull. The local model and OpenClaw
+> setup details may still be useful, but all `apps/runner`,
+> dispatcher, tier-router, and in-gate advisor instructions below are
+> historical. Chitin no longer owns orchestration or model routing; it
+> gates OpenClaw/Hermes tool calls and records chain signals.
+
 > **Status: draft, pending operator validation on the 3090 rig.** This
 > runbook captures the operator-side wiring needed to make the new
 > `local-glm-flash` driver (added 2026-05-03) actually dispatch work
@@ -112,20 +119,16 @@ flipping back to `local-glm-flash` is the same env var unset.
 | Quality degradation on tasks T0 used to handle on copilot | model under-fit | flip back via `CHITIN_TIER_DRIVER_T0=copilot`; file backlog entry to either tune the prompt (skill folder) or escalate to T1 |
 | GPU OOM | model loaded alongside another model | `ollama stop <other>`; or run a second 3090, or give T0 a smaller budget so it doesn't keep two models hot |
 
-## 6. Tier-router consultation (when it ships)
+## 6. Router signals after the cull
 
-Once `tier-router-with-advisor-consultation` (filed in PR #208's
-skill-folder cohort) lands, GLM-4.7-flash hitting a judgment call
-will get a structured T2 (Sonnet) consultation rather than failing
-silently or escalating the whole task. Until then: low-confidence
-classification is just a deny-with-reason on the chain, and the
-operator (or the dispatcher's tier ladder) re-dispatches at T1.
+The in-gate tier-router advisor was removed on 2026-05-08. If
+GLM-4.7-flash hits a judgment call now, chitin's role is to stamp
+kernel decisions and router signals onto the chain. Hermes, OpenClaw,
+or an operator-wired chain reader owns any follow-up consultation,
+approval, retry, or model escalation.
 
 ## Reference
 
-- The driver definition: `libs/contracts/src/execution-request.schema.ts`
-  (`DriverIdSchema` enum)
-- Agent mapping: `apps/runner/src/activity.ts`
-  (`DRIVER_AGENT_MAP`)
-- Tier defaults + env override: `apps/runner/src/dispatcher.ts`
-  (`TIER_DRIVER_DEFAULTS` + `envDriverOverride`)
+- OpenClaw governance adapter: `libs/adapters/openclaw`
+- Hermes hook installer: `scripts/install-hermes-hook.sh`
+- Driver conformance map: `docs/driver-conformance.md`

--- a/docs/runbooks/superseded/local-qwen-stack.md
+++ b/docs/runbooks/superseded/local-qwen-stack.md
@@ -1,5 +1,12 @@
 # Local Qwen Stack Runbook
 
+> **Historical note, 2026-05-09:** this runbook predates the
+> 2026-05-06/2026-05-08 scope cull. The Ollama/OpenClaw tuning notes
+> may still be useful, but all `apps/runner`, dispatcher, and backlog
+> flip instructions below are historical. Chitin no longer owns local
+> model orchestration; it gates tool calls from OpenClaw, Hermes, and
+> the standalone drivers.
+
 > **Status: draft, pending operator validation on the 3090 rig.** This
 > runbook captures the remediations the 2026-05-01 instability
 > investigation (PR #112) recommended, scoped to commands that match


### PR DESCRIPTION
## Summary

Clean up post-cull documentation drift without touching the protected active `chitin.yaml` policy.

- Replace the roadmap's obsolete router-advisor in-flight item with the current chain-mined driver conformance workstream.
- Move local GLM and Qwen stack runbooks under `docs/runbooks/superseded/` because they still describe deleted `apps/runner`, dispatcher, backlog flip, tier-router, and in-gate advisor workflows.
- Replace the GLM tier-router consultation section with the post-cull model: chitin stamps kernel/router signal rows, while Hermes, OpenClaw, or operator-wired chain readers handle consultation and escalation.
- Refresh the live chitin-router runbook's related links so it points at the cull decision, plugin sandboxing, and driver conformance instead of deleted swarm backlog machinery.

## Why

The 2026-05-08 advisor cull removed in-gate LLM consultation from the kernel hot path. Some live docs still implied that chitin should justify or ship a tier-router advisor, and the local model runbooks still read like current runner procedures. That points future agents toward rebuilding a culled substrate feature, so this PR moves stale procedures out of the live runbook surface.

## Validation

- `git diff --check`

Docs-only change.
