### PR TITLE
[codex] Require linked worktrees for side effects

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -28,6 +28,18 @@ escalation:
   lockdown_threshold: 10
   max_retries_per_action: 3
 
+worktree:
+  mode: guide
+  require_for:
+    - file.write
+    - file.delete
+    - file.move
+    - shell.exec
+    - file.recursive_delete
+    - git.commit
+    - git.push
+    - github.pr.create
+
 invariantModes:
   no-governance-self-modification: enforce
   no-rm-recursive: guide

--- a/docs/governance-setup.md
+++ b/docs/governance-setup.md
@@ -139,6 +139,30 @@ rules:
 
 Global `mode:` is the default. Per-rule `invariantModes:` overrides.
 
+### Worktree requirement
+
+Use `worktree:` to require selected side-effect actions to run from a linked
+git worktree instead of the primary checkout. This is a deterministic local
+gate invariant, not an approval flow or task workflow.
+
+```yaml
+worktree:
+  mode: guide              # guide | enforce
+  require_for:
+    - file.write
+    - file.delete
+    - file.move
+    - shell.exec
+    - file.recursive_delete
+    - git.commit
+    - git.push
+    - github.pr.create
+```
+
+When configured, Chitin denies matching actions unless `cwd` is a linked git
+worktree. Read-only actions and `git.worktree.add` are not blocked by this
+example, so an agent can still create a worktree before retrying from there.
+
 ## Cost-gov v3 (envelope + tier classification)
 
 On top of `gov.Gate`, three invariants govern cost across drivers:

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -157,14 +157,15 @@ func firstNonEmpty(vals ...string) string {
 // Sequence:
 //  1. Lockdown short-circuit.
 //  2. Policy evaluation.
-//  3. Bounds check (push-shaped only).
-//  4. Monitor-mode override on policy decisions.
-//  5. Envelope.Spend on allow (if envelope != nil).
-//  6. Counter increment on deny — but NOT on envelope-budget denials.
+//  3. Worktree requirement check for configured side-effect actions.
+//  4. Bounds check (push-shaped only).
+//  5. Monitor-mode override on policy decisions.
+//  6. Envelope.Spend on allow (if envelope != nil).
+//  7. Counter increment on deny — but NOT on envelope-budget denials.
 //     Caps are operator-imposed, not agent misbehavior; counting them
 //     would lockdown a compliant agent for hitting its budget.
-//  7. Stamp envelope/tier/cost fields on Decision.
-//  8. Log append.
+//  8. Stamp envelope/tier/cost fields on Decision.
+//  9. Log append.
 //
 // Envelope exhaustion is NOT subject to monitor-mode override — caps are
 // hard contracts even when policy is in monitor.
@@ -219,7 +220,20 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 	d.Agent = agent
 	d.CallerOrigin = callerOrigin
 
-	// 3. Bounds — only for push-shaped when policy allows the action so far.
+	// 3. Worktree requirement — only when policy allows the action so far.
+	// This keeps explicit denies authoritative and makes the worktree
+	// invariant a deterministic post-policy guard, not a workflow system.
+	if d.Allowed {
+		wd := CheckWorktreeRequirement(a, g.Policy, g.Cwd)
+		if !wd.Allowed {
+			d = wd
+			d.Ts = now
+			d.Agent = agent
+			d.CallerOrigin = callerOrigin
+		}
+	}
+
+	// 4. Bounds — only for push-shaped when policy allows the action so far.
 	// Caught in PR #79 review: overwriting d with bd dropped both Agent and
 	// CallerOrigin from the bounds-deny audit row. Preserve them explicitly.
 	if d.Allowed && (a.Type == ActGitPush || a.Type == ActGithubPRCreate) {
@@ -232,18 +246,18 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		}
 	}
 
-	// 4. Monitor mode override: if we're in monitor mode and the rule
+	// 5. Monitor mode override: if we're in monitor mode and the rule
 	// would deny, flip to allow (log-only). Do NOT override on enforce/guide.
 	if !d.Allowed && d.Mode == "monitor" {
 		d.Allowed = true
 	}
 
-	// (Step 4.5 — escalate-effect resolution — removed in cull Phase 3,
+	// (Step 5.5 — escalate-effect resolution — removed in cull Phase 3,
 	// 2026-05-08. Hermes' tools/approval.py provides the operator-
 	// prompt + reply-parse natively; chitin no longer maintains its
 	// own pending_approvals + Wait + bridge POST + grant table.)
 
-	// 5. Envelope spend on allow. Compute delta via callbacks even when
+	// 6. Envelope spend on allow. Compute delta via callbacks even when
 	// the policy denies — so the audit row records what would have been
 	// spent for telemetry. But only call Spend when allowed.
 	var delta CostDelta
@@ -281,7 +295,7 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		}
 	}
 
-	// 6. Counter on deny — but skip envelope-budget denials. Operators
+	// 7. Counter on deny — but skip envelope-budget denials. Operators
 	// imposing caps is not the agent misbehaving; counting envelope hits
 	// against the lockdown ladder would force-lock a perfectly compliant
 	// agent after ~10 budget-denied calls. All envelope-* RuleIDs
@@ -313,16 +327,16 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		d.Escalation = g.Counter.Level(agent)
 	}
 
-	// 7. Stamp envelope/tier/cost fields on the Decision row. We do this
+	// 8. Stamp envelope/tier/cost fields on the Decision row. We do this
 	// for both allow and deny so audit-log analytics can join cost-
 	// classified decisions regardless of outcome.
 	stampEnvelopeWith(&d, envelope, tier, delta)
-	// 7a. Stamp fingerprint dims (P2 routing-as-learning-system) so the
+	// 8a. Stamp fingerprint dims (P2 routing-as-learning-system) so the
 	// row carries (model, role, workflow_id, fingerprint) for joining
 	// against PR/review outcomes downstream.
 	stampFingerprint(&d, g.Fingerprint)
 
-	// 8. Log. Suppressed by NoRecord so smoke evaluations don't pollute
+	// 9. Log. Suppressed by NoRecord so smoke evaluations don't pollute
 	// daily chain rollups (fingerprint_outcomes, swarm_health) with
 	// synthetic deny rows. The Decision still flows back to the caller
 	// via the named return — what changes is durability.
@@ -330,7 +344,7 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		_ = WriteLog(d, g.LogDir)
 	}
 
-	// 9. F4 addendum: OnDecision callback fires from the deferred
+	// 10. F4 addendum: OnDecision callback fires from the deferred
 	// callsite at the top of Evaluate (single-source-of-truth so a
 	// future short-circuit can't skip the callback). Order is preserved:
 	// WriteLog runs before the deferred OnDecision because defers fire

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -295,11 +295,14 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		}
 	}
 
-	// 7. Counter on deny — but skip envelope-budget denials. Operators
-	// imposing caps is not the agent misbehaving; counting envelope hits
-	// against the lockdown ladder would force-lock a perfectly compliant
-	// agent after ~10 budget-denied calls. All envelope-* RuleIDs
-	// (exhausted, closed, not-found) are budget-class and exempt.
+	// 7. Counter on deny — but skip envelope-budget denials and
+	// worktree-requirement denials. Operator-imposed constraints (caps,
+	// worktree policy) are not agent misbehavior; counting them against
+	// the lockdown ladder would force-lock a compliant agent. All
+	// envelope-* RuleIDs (exhausted, closed, not-found) are budget-class
+	// and exempt. worktree-required is exempt for the same reason — the
+	// operator asked for the worktree invariant, the agent just called
+	// from the wrong directory. (#414 review)
 	weight := 1
 	for _, r := range g.Policy.Rules {
 		if r.ID == d.RuleID && r.EscalationWeight > 0 {
@@ -310,7 +313,8 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 	envelopeDeny := d.RuleID == "envelope-exhausted" ||
 		d.RuleID == "envelope-closed" ||
 		d.RuleID == "envelope-not-found"
-	if !d.Allowed && !envelopeDeny && g.Counter != nil {
+	opDeny := envelopeDeny || d.RuleID == "worktree-required"
+	if !d.Allowed && !opDeny && g.Counter != nil {
 		if !g.NoRecord {
 			// Log on failure rather than silently swallow — a SQLite
 			// failure here is the "agent never locks" path. We still

--- a/go/execution-kernel/internal/gov/inherit.go
+++ b/go/execution-kernel/internal/gov/inherit.go
@@ -132,6 +132,15 @@ func mergePolicies(parent, child Policy) Policy {
 	if child.Escalation.MaxRetriesPerFp > 0 {
 		out.Escalation.MaxRetriesPerFp = child.Escalation.MaxRetriesPerFp
 	}
+	if child.Worktree.Mode != "" {
+		out.Worktree.Mode = child.Worktree.Mode
+	}
+	if len(child.Worktree.RequireFor) > 0 {
+		out.Worktree.RequireFor = mergeActionMatchers(out.Worktree.RequireFor, child.Worktree.RequireFor)
+	}
+	if len(child.Worktree.ProtectedRoots) > 0 {
+		out.Worktree.ProtectedRoots = mergeStrings(out.Worktree.ProtectedRoots, child.Worktree.ProtectedRoots)
+	}
 	if out.InvariantModes == nil {
 		out.InvariantModes = make(map[string]string)
 	}
@@ -149,6 +158,36 @@ func mergePolicies(parent, child Policy) Policy {
 			out.Rules[idx] = r
 		} else {
 			out.Rules = append(out.Rules, r)
+		}
+	}
+	return out
+}
+
+func mergeActionMatchers(parent, child ActionMatcher) ActionMatcher {
+	out := append(ActionMatcher{}, parent...)
+	seen := make(map[string]bool, len(out)+len(child))
+	for _, a := range out {
+		seen[a] = true
+	}
+	for _, a := range child {
+		if !seen[a] {
+			out = append(out, a)
+			seen[a] = true
+		}
+	}
+	return out
+}
+
+func mergeStrings(parent, child []string) []string {
+	out := append([]string{}, parent...)
+	seen := make(map[string]bool, len(out)+len(child))
+	for _, s := range out {
+		seen[s] = true
+	}
+	for _, s := range child {
+		if !seen[s] {
+			out = append(out, s)
+			seen[s] = true
 		}
 	}
 	return out

--- a/go/execution-kernel/internal/gov/inherit_test.go
+++ b/go/execution-kernel/internal/gov/inherit_test.go
@@ -168,10 +168,10 @@ rules: []
 // 500-line global instead of the 5000-line override.
 //
 // Boundaries:
-//   1. parent has no PerAction, child has one — child's PerAction wins.
-//   2. parent has PerAction, child has none — parent survives.
-//   3. both have PerAction with overlapping keys — child overrides on
-//      collision, parent-only keys survive.
+//  1. parent has no PerAction, child has one — child's PerAction wins.
+//  2. parent has PerAction, child has none — parent survives.
+//  3. both have PerAction with overlapping keys — child overrides on
+//     collision, parent-only keys survive.
 func TestMergePolicies_PerActionMergedAdditively(t *testing.T) {
 	t.Run("parent_empty_child_has_perAction", func(t *testing.T) {
 		parent := Policy{}
@@ -222,6 +222,45 @@ func TestMergePolicies_PerActionMergedAdditively(t *testing.T) {
 		// Parent-only key survives.
 		if effPR := out.Bounds.effectiveBounds("github.pr.create"); effPR.MaxLinesChanged != 2000 {
 			t.Errorf("parent-only github.pr.create should survive merge, got %d", effPR.MaxLinesChanged)
+		}
+	})
+}
+
+func TestMergePolicies_WorktreeRequirementMergedAdditively(t *testing.T) {
+	t.Run("parent_requirement_survives_child_without_worktree", func(t *testing.T) {
+		parent := Policy{Worktree: WorktreeConfig{
+			Mode:       "guide",
+			RequireFor: ActionMatcher{string(ActFileWrite)},
+		}}
+		child := Policy{}
+		out := mergePolicies(parent, child)
+		if !out.Worktree.RequireFor.Matches(ActFileWrite) {
+			t.Fatalf("parent worktree.require_for should survive child without worktree: %+v", out.Worktree)
+		}
+		if out.Worktree.Mode != "guide" {
+			t.Fatalf("mode=%q want guide", out.Worktree.Mode)
+		}
+	})
+	t.Run("child_requirement_adds_action_and_overrides_mode", func(t *testing.T) {
+		parent := Policy{Worktree: WorktreeConfig{
+			Mode:           "guide",
+			RequireFor:     ActionMatcher{string(ActFileWrite)},
+			ProtectedRoots: []string{"/repo"},
+		}}
+		child := Policy{Worktree: WorktreeConfig{
+			Mode:           "enforce",
+			RequireFor:     ActionMatcher{string(ActGitCommit)},
+			ProtectedRoots: []string{"/repo-child"},
+		}}
+		out := mergePolicies(parent, child)
+		if !out.Worktree.RequireFor.Matches(ActFileWrite) || !out.Worktree.RequireFor.Matches(ActGitCommit) {
+			t.Fatalf("worktree.require_for should merge additively, got %+v", out.Worktree.RequireFor)
+		}
+		if out.Worktree.Mode != "enforce" {
+			t.Fatalf("child mode should override parent, got %q", out.Worktree.Mode)
+		}
+		if len(out.Worktree.ProtectedRoots) != 2 {
+			t.Fatalf("protected roots should merge additively, got %+v", out.Worktree.ProtectedRoots)
 		}
 	})
 }

--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -20,14 +20,15 @@ type Policy struct {
 	InvariantModes map[string]string `yaml:"invariantModes,omitempty"` // ruleID → mode
 	Bounds         Bounds            `yaml:"bounds,omitempty"`
 	Escalation     EscalationConfig  `yaml:"escalation,omitempty"`
+	Worktree       WorktreeConfig    `yaml:"worktree,omitempty"`
 	Rules          []Rule            `yaml:"rules"`
 }
 
 // Rule is one entry in the policy. Evaluated top-to-bottom; first match wins.
 type Rule struct {
 	ID               string        `yaml:"id"`
-	Action           ActionMatcher `yaml:"action"` // single type OR list of types
-	Effect           string        `yaml:"effect"` // allow | deny | guide | monitor
+	Action           ActionMatcher `yaml:"action"`                 // single type OR list of types
+	Effect           string        `yaml:"effect"`                 // allow | deny | guide | monitor
 	Target           string        `yaml:"target,omitempty"`       // substring match on Action.Target
 	TargetRegex      string        `yaml:"target_regex,omitempty"` // regex match on Action.Target
 	Branches         []string      `yaml:"branches,omitempty"`     // for git.push — match if Action.Target ∈ list
@@ -80,6 +81,16 @@ type ActionBounds struct {
 	MaxLinesChanged int `yaml:"max_lines_changed"`
 }
 
+// WorktreeConfig requires selected side-effect action types to run from a
+// linked git worktree instead of the protected primary checkout. This is a
+// deterministic local invariant: no approvals, no orchestration, no workflow
+// creation. Empty RequireFor disables the check.
+type WorktreeConfig struct {
+	RequireFor     ActionMatcher `yaml:"require_for,omitempty"`
+	Mode           string        `yaml:"mode,omitempty"` // guide | enforce; default guide
+	ProtectedRoots []string      `yaml:"protected_roots,omitempty"`
+}
+
 // effectiveBounds returns the bounds that apply to actionType — the
 // PerAction override merged with the top-level defaults. Zero values
 // in the override fall back to the default; non-zero values win.
@@ -101,10 +112,10 @@ func (b Bounds) effectiveBounds(actionType string) ActionBounds {
 
 // EscalationConfig overrides the default escalation thresholds.
 type EscalationConfig struct {
-	ElevatedThreshold  int `yaml:"elevated_threshold"`  // default 3
-	HighThreshold      int `yaml:"high_threshold"`      // default 7
-	LockdownThreshold  int `yaml:"lockdown_threshold"`  // default 10
-	MaxRetriesPerFp    int `yaml:"max_retries_per_action"` // default 3
+	ElevatedThreshold int `yaml:"elevated_threshold"`     // default 3
+	HighThreshold     int `yaml:"high_threshold"`         // default 7
+	LockdownThreshold int `yaml:"lockdown_threshold"`     // default 10
+	MaxRetriesPerFp   int `yaml:"max_retries_per_action"` // default 3
 }
 
 // Decision is the result of evaluating an Action against a Policy.
@@ -276,6 +287,26 @@ func (p *Policy) ApplyDefaults() error {
 	}
 	if p.Escalation.MaxRetriesPerFp == 0 {
 		p.Escalation.MaxRetriesPerFp = 3
+	}
+	if len(p.Worktree.RequireFor) > 0 {
+		if p.Worktree.Mode == "" {
+			p.Worktree.Mode = "guide"
+		}
+		switch p.Worktree.Mode {
+		case "guide", "enforce":
+		default:
+			return fmt.Errorf("worktree.mode=%q: must be guide or enforce", p.Worktree.Mode)
+		}
+		for j, a := range p.Worktree.RequireFor {
+			if a == "" {
+				return fmt.Errorf("worktree.require_for[%d] is empty; remove the entry or fill it in", j)
+			}
+		}
+		for j, root := range p.Worktree.ProtectedRoots {
+			if strings.TrimSpace(root) == "" {
+				return fmt.Errorf("worktree.protected_roots[%d] is empty; remove the entry or fill it in", j)
+			}
+		}
 	}
 	for i := range p.Rules {
 		if p.Rules[i].EscalationWeight == 0 {

--- a/go/execution-kernel/internal/gov/worktree.go
+++ b/go/execution-kernel/internal/gov/worktree.go
@@ -1,0 +1,111 @@
+package gov
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func CheckWorktreeRequirement(a Action, p Policy, cwd string) Decision {
+	if len(p.Worktree.RequireFor) == 0 || !p.Worktree.RequireFor.Matches(a.Type) {
+		return Decision{Allowed: true, RuleID: "worktree:not-required", Action: a}
+	}
+	mode := p.Worktree.Mode
+	if mode == "" {
+		mode = "guide"
+	}
+	if insideProtectedRoot(cwd, p.Worktree.ProtectedRoots) {
+		return worktreeDenied(a, mode, "cwd is inside a protected primary checkout")
+	}
+	linked, err := isLinkedGitWorktree(cwd)
+	if err != nil {
+		return worktreeDenied(a, mode, fmt.Sprintf("unable to verify linked git worktree: %v", err))
+	}
+	if !linked {
+		return worktreeDenied(a, mode, "cwd is the primary git checkout, not a linked worktree")
+	}
+	return Decision{Allowed: true, RuleID: "worktree:linked", Action: a}
+}
+
+func worktreeDenied(a Action, mode, reason string) Decision {
+	return Decision{
+		Allowed: false,
+		Mode:    mode,
+		RuleID:  "worktree-required",
+		Reason:  reason,
+		Suggestion: "Create a task branch in a linked worktree, then retry from there: " +
+			"git worktree add ../<repo>-<task> -b <branch>",
+		Action: a,
+	}
+}
+
+func isLinkedGitWorktree(cwd string) (bool, error) {
+	inside, err := gitOutput(cwd, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(inside) != "true" {
+		return false, fmt.Errorf("not inside a git worktree")
+	}
+	gitDir, err := gitOutput(cwd, "rev-parse", "--git-dir")
+	if err != nil {
+		return false, err
+	}
+	commonDir, err := gitOutput(cwd, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return false, err
+	}
+	absGitDir, err := absGitPath(cwd, strings.TrimSpace(gitDir))
+	if err != nil {
+		return false, err
+	}
+	absCommonDir, err := absGitPath(cwd, strings.TrimSpace(commonDir))
+	if err != nil {
+		return false, err
+	}
+	return absGitDir != absCommonDir, nil
+}
+
+func gitOutput(cwd string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return string(out), nil
+}
+
+func absGitPath(cwd, p string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("empty git path")
+	}
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(cwd, p)
+	}
+	return filepath.Abs(p)
+}
+
+func insideProtectedRoot(cwd string, roots []string) bool {
+	if len(roots) == 0 {
+		return false
+	}
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return false
+	}
+	for _, root := range roots {
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(absRoot, absCwd)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/execution-kernel/internal/gov/worktree.go
+++ b/go/execution-kernel/internal/gov/worktree.go
@@ -41,26 +41,22 @@ func worktreeDenied(a Action, mode, reason string) Decision {
 }
 
 func isLinkedGitWorktree(cwd string) (bool, error) {
-	inside, err := gitOutput(cwd, "rev-parse", "--is-inside-work-tree")
+	out, err := gitOutput(cwd, "rev-parse", "--is-inside-work-tree", "--git-dir", "--git-common-dir")
 	if err != nil {
 		return false, err
 	}
-	if strings.TrimSpace(inside) != "true" {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		return false, fmt.Errorf("unexpected git rev-parse output: got %d lines", len(lines))
+	}
+	if strings.TrimSpace(lines[0]) != "true" {
 		return false, fmt.Errorf("not inside a git worktree")
 	}
-	gitDir, err := gitOutput(cwd, "rev-parse", "--git-dir")
+	absGitDir, err := absGitPath(cwd, strings.TrimSpace(lines[1]))
 	if err != nil {
 		return false, err
 	}
-	commonDir, err := gitOutput(cwd, "rev-parse", "--git-common-dir")
-	if err != nil {
-		return false, err
-	}
-	absGitDir, err := absGitPath(cwd, strings.TrimSpace(gitDir))
-	if err != nil {
-		return false, err
-	}
-	absCommonDir, err := absGitPath(cwd, strings.TrimSpace(commonDir))
+	absCommonDir, err := absGitPath(cwd, strings.TrimSpace(lines[2]))
 	if err != nil {
 		return false, err
 	}

--- a/go/execution-kernel/internal/gov/worktree_counter_test.go
+++ b/go/execution-kernel/internal/gov/worktree_counter_test.go
@@ -1,0 +1,25 @@
+package gov
+
+import (
+	"testing"
+)
+
+func TestWorktreeDenyDoesNotEscalateInGuideMode(t *testing.T) {
+	repo, _ := newWorktreeFixture(t) // primary checkout
+
+	g := newWorktreeGate(t, repo, "guide") // guide mode on primary checkout
+
+	// Before the fix: 12 worktree denials would push to lockdown.
+	// After the fix: counter should stay at "normal".
+	initialLevel := g.Counter.Level("agent1")
+	for i := 0; i < 12; i++ {
+		g.Evaluate(Action{Type: ActFileWrite, Target: "test.md"}, "agent1", nil)
+	}
+	finalLevel := g.Counter.Level("agent1")
+
+	t.Logf("After 12 worktree denials (guide mode): level=%s (was %s)", finalLevel, initialLevel)
+
+	if finalLevel != initialLevel {
+		t.Errorf("worktree-denied decision incremented escalation counter — expect %s, got %s", initialLevel, finalLevel)
+	}
+}

--- a/go/execution-kernel/internal/gov/worktree_test.go
+++ b/go/execution-kernel/internal/gov/worktree_test.go
@@ -55,6 +55,23 @@ func TestGate_WorktreeRequirementFailsClosedOutsideGit(t *testing.T) {
 	}
 }
 
+func TestGate_WorktreeRequirementDeniesProtectedRoot(t *testing.T) {
+	repo, _ := newWorktreeFixture(t)
+	g := newWorktreeGate(t, repo, "guide")
+	g.Policy.Worktree.ProtectedRoots = []string{repo}
+
+	d := g.Evaluate(Action{Type: ActFileWrite, Target: "README.md"}, "agent1", nil)
+	if d.Allowed {
+		t.Fatalf("file.write inside protected root should be denied, got %+v", d)
+	}
+	if d.RuleID != "worktree-required" {
+		t.Fatalf("RuleID=%q want worktree-required", d.RuleID)
+	}
+	if !strings.Contains(d.Reason, "protected primary checkout") {
+		t.Fatalf("Reason=%q should mention protected primary checkout", d.Reason)
+	}
+}
+
 func TestGate_WorktreeRequirementSkipsUnlistedReadActions(t *testing.T) {
 	repo, _ := newWorktreeFixture(t)
 	g := newWorktreeGate(t, repo, "guide")

--- a/go/execution-kernel/internal/gov/worktree_test.go
+++ b/go/execution-kernel/internal/gov/worktree_test.go
@@ -1,0 +1,168 @@
+package gov
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGate_WorktreeRequirementDeniesPrimaryCheckout(t *testing.T) {
+	repo, _ := newWorktreeFixture(t)
+	g := newWorktreeGate(t, repo, "guide")
+
+	d := g.Evaluate(Action{Type: ActFileWrite, Target: "README.md"}, "agent1", nil)
+	if d.Allowed {
+		t.Fatalf("file.write in primary checkout should be denied, got %+v", d)
+	}
+	if d.RuleID != "worktree-required" {
+		t.Fatalf("RuleID=%q want worktree-required", d.RuleID)
+	}
+	if d.Mode != "guide" {
+		t.Fatalf("Mode=%q want guide", d.Mode)
+	}
+	if !strings.Contains(d.Suggestion, "git worktree add") {
+		t.Fatalf("suggestion should guide toward git worktree add, got %q", d.Suggestion)
+	}
+}
+
+func TestGate_WorktreeRequirementAllowsLinkedWorktree(t *testing.T) {
+	_, linked := newWorktreeFixture(t)
+	g := newWorktreeGate(t, linked, "guide")
+
+	d := g.Evaluate(Action{Type: ActFileWrite, Target: "README.md"}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("file.write in linked worktree should be allowed, got %+v", d)
+	}
+	if d.RuleID != "allow-write" {
+		t.Fatalf("RuleID=%q want allow-write", d.RuleID)
+	}
+}
+
+func TestGate_WorktreeRequirementFailsClosedOutsideGit(t *testing.T) {
+	g := newWorktreeGate(t, t.TempDir(), "enforce")
+
+	d := g.Evaluate(Action{Type: ActGitCommit, Target: "commit"}, "agent1", nil)
+	if d.Allowed {
+		t.Fatalf("git.commit outside git should be denied, got %+v", d)
+	}
+	if d.RuleID != "worktree-required" {
+		t.Fatalf("RuleID=%q want worktree-required", d.RuleID)
+	}
+	if d.Mode != "enforce" {
+		t.Fatalf("Mode=%q want enforce", d.Mode)
+	}
+}
+
+func TestGate_WorktreeRequirementSkipsUnlistedReadActions(t *testing.T) {
+	repo, _ := newWorktreeFixture(t)
+	g := newWorktreeGate(t, repo, "guide")
+
+	d := g.Evaluate(Action{Type: ActFileRead, Target: "README.md"}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("file.read should not require a linked worktree, got %+v", d)
+	}
+	if d.RuleID != "allow-read" {
+		t.Fatalf("RuleID=%q want allow-read", d.RuleID)
+	}
+}
+
+func TestPolicy_LoadsWorktreeRequirement(t *testing.T) {
+	p, err := parsePolicyYAML([]byte(`
+id: worktree-policy
+mode: enforce
+worktree:
+  require_for: [file.write, git.commit]
+  mode: guide
+  protected_roots:
+    - /home/red/workspace/chitin
+rules:
+  - id: allow-write
+    action: file.write
+    effect: allow
+`))
+	if err != nil {
+		t.Fatalf("parsePolicyYAML: %v", err)
+	}
+	if !p.Worktree.RequireFor.Matches(ActFileWrite) || !p.Worktree.RequireFor.Matches(ActGitCommit) {
+		t.Fatalf("worktree require_for did not parse: %+v", p.Worktree.RequireFor)
+	}
+	if p.Worktree.Mode != "guide" {
+		t.Fatalf("worktree mode=%q want guide", p.Worktree.Mode)
+	}
+	if len(p.Worktree.ProtectedRoots) != 1 {
+		t.Fatalf("protected_roots=%v want one root", p.Worktree.ProtectedRoots)
+	}
+}
+
+func newWorktreeGate(t *testing.T, cwd, mode string) *Gate {
+	t.Helper()
+	p := Policy{
+		Mode: "enforce",
+		Worktree: WorktreeConfig{
+			RequireFor: ActionMatcher{
+				string(ActFileWrite),
+				string(ActFileDelete),
+				string(ActFileMove),
+				string(ActShellExec),
+				string(ActGitCommit),
+				string(ActGitPush),
+				string(ActGithubPRCreate),
+			},
+			Mode: mode,
+		},
+		Rules: []Rule{
+			{ID: "allow-read", Action: ActionMatcher{string(ActFileRead)}, Effect: "allow"},
+			{ID: "allow-write", Action: ActionMatcher{string(ActFileWrite)}, Effect: "allow"},
+			{ID: "allow-commit", Action: ActionMatcher{string(ActGitCommit)}, Effect: "allow"},
+		},
+	}
+	if err := p.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	counter, err := OpenCounter(filepath.Join(t.TempDir(), "gov.db"))
+	if err != nil {
+		t.Fatalf("OpenCounter: %v", err)
+	}
+	t.Cleanup(func() { counter.Close() })
+	return &Gate{
+		Policy:  p,
+		Counter: counter,
+		LogDir:  filepath.Join(t.TempDir(), "decisions"),
+		Cwd:     cwd,
+	}
+}
+
+func newWorktreeFixture(t *testing.T) (primary, linked string) {
+	t.Helper()
+	root := t.TempDir()
+	primary = filepath.Join(root, "repo")
+	linked = filepath.Join(root, "repo-task")
+
+	runWorktreeGit(t, root, "init", primary)
+	runWorktreeGit(t, primary, "config", "user.email", "test@example.com")
+	runWorktreeGit(t, primary, "config", "user.name", "Test User")
+	runWorktreeGit(t, primary, "checkout", "-b", "main")
+	writeWorktreeFile(t, filepath.Join(primary, "README.md"), "base\n")
+	runWorktreeGit(t, primary, "add", "README.md")
+	runWorktreeGit(t, primary, "commit", "-m", "base")
+	runWorktreeGit(t, primary, "worktree", "add", "-b", "task/worktree-policy", linked)
+	return primary, linked
+}
+
+func runWorktreeGit(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func writeWorktreeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a deterministic `worktree:` policy invariant to the Go governance kernel. When configured, selected side-effect action types are denied unless the gate `cwd` is a linked git worktree rather than the primary checkout.

## Why

The operator wants Chitin to force agents into isolated worktrees before edits, shell execution, commits, pushes, or PR creation. This keeps the behavior in Chitin's kernel boundary: deterministic local policy, no approvals, no orchestration, no workflow scheduling.

## Changes

- Adds `WorktreeConfig` to `chitin.yaml` policy parsing.
- Adds `CheckWorktreeRequirement` with local git worktree detection.
- Wires the invariant into `Gate.Evaluate` after policy allow and before bounds.
- Merges inherited `worktree:` policy blocks additively across parent/child policies.
- Enables the baseline policy for side-effect actions while leaving `git.worktree.add` unblocked so agents can create the required worktree.
- Documents the policy block in `docs/governance-setup.md`.

## Validation

- `(cd go/execution-kernel && go test ./...)`
