### PR TITLE
fix(gov): skip worktree-required denials in escalation counter

### DIFF
--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -295,11 +295,14 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		}
 	}
 
-	// 7. Counter on deny — but skip envelope-budget denials. Operators
-	// imposing caps is not the agent misbehaving; counting envelope hits
-	// against the lockdown ladder would force-lock a perfectly compliant
-	// agent after ~10 budget-denied calls. All envelope-* RuleIDs
-	// (exhausted, closed, not-found) are budget-class and exempt.
+	// 7. Counter on deny — but skip envelope-budget denials and
+	// worktree-requirement denials. Operator-imposed constraints (caps,
+	// worktree policy) are not agent misbehavior; counting them against
+	// the lockdown ladder would force-lock a compliant agent. All
+	// envelope-* RuleIDs (exhausted, closed, not-found) are budget-class
+	// and exempt. worktree-required is exempt for the same reason — the
+	// operator asked for the worktree invariant, the agent just called
+	// from the wrong directory. (#414 review)
 	weight := 1
 	for _, r := range g.Policy.Rules {
 		if r.ID == d.RuleID && r.EscalationWeight > 0 {
@@ -310,7 +313,8 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 	envelopeDeny := d.RuleID == "envelope-exhausted" ||
 		d.RuleID == "envelope-closed" ||
 		d.RuleID == "envelope-not-found"
-	if !d.Allowed && !envelopeDeny && g.Counter != nil {
+	opDeny := envelopeDeny || d.RuleID == "worktree-required"
+	if !d.Allowed && !opDeny && g.Counter != nil {
 		if !g.NoRecord {
 			// Log on failure rather than silently swallow — a SQLite
 			// failure here is the "agent never locks" path. We still

--- a/go/execution-kernel/internal/gov/worktree_counter_test.go
+++ b/go/execution-kernel/internal/gov/worktree_counter_test.go
@@ -1,0 +1,25 @@
+package gov
+
+import (
+	"testing"
+)
+
+func TestWorktreeDenyDoesNotEscalateInGuideMode(t *testing.T) {
+	repo, _ := newWorktreeFixture(t) // primary checkout
+
+	g := newWorktreeGate(t, repo, "guide") // guide mode on primary checkout
+
+	// Before the fix: 12 worktree denials would push to lockdown.
+	// After the fix: counter should stay at "normal".
+	initialLevel := g.Counter.Level("agent1")
+	for i := 0; i < 12; i++ {
+		g.Evaluate(Action{Type: ActFileWrite, Target: "test.md"}, "agent1", nil)
+	}
+	finalLevel := g.Counter.Level("agent1")
+
+	t.Logf("After 12 worktree denials (guide mode): level=%s (was %s)", finalLevel, initialLevel)
+
+	if finalLevel != initialLevel {
+		t.Errorf("worktree-denied decision incremented escalation counter — expect %s, got %s", initialLevel, finalLevel)
+	}
+}


### PR DESCRIPTION
## Problem

On #414, the `worktree-required` rule ID is **not** whitelisted in the escalation-counter skip list at `gate.go:310`. This means every worktree denial increments the lockdown counter — even in guide mode.

After just 12 calls from the primary checkout, an agent hits lockdown and is completely blocked, making guide mode effectively useless.

## Fix

Add `worktree-required` to the operator-constraint whitelist alongside `envelope-*` denials. Same rationale: the operator configured the constraint, the agent did not misbehave.

```go
opDeny := envelopeDeny || d.RuleID == "worktree-required"
```

## Tests

- Added `TestWorktreeDenyDoesNotEscalateInGuideMode` — confirms 12 consecutive worktree denials keep the counter at "normal" instead of escalating to lockdown
- Full `internal/gov` test suite passes (24 packages, all green)

This PR targets `feature/require-worktree-policy` — merge it into #414 before that PR lands.