### PR TITLE
[codex] Preserve kernel denial details

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/router_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook.go
@@ -143,7 +143,7 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 		}
 	}
 
-	kernelDeny := kernelCode == claudecode.ExitBlock
+	kernelVerdict := parseKernelVerdict(kernelOut.Bytes(), kernelCode)
 
 	// Pre-action analysis short-circuit: if any plugin fired with
 	// block=true, deny immediately with the plugin's reason. Pre-
@@ -160,7 +160,7 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 			_, _ = out.Write(body)
 			_, _ = out.Write([]byte{'\n'})
 			stampHeuristicSignals(errOut, agent, hookInput, outcome, driftScore, true, "pre-action-block:"+r.Name, noRecord)
-			writeRouterTelemetry(errOut, "pre-action-block", outcome, false)
+			writeRouterTelemetry(errOut, "pre-action-block", outcome, kernelVerdict)
 			return claudecode.ExitBlock
 		}
 	}
@@ -172,7 +172,7 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 	// non-zero — read-only tools whose scores are trivially zero
 	// don't need a stamping row.
 	if hasNonZeroSignal(outcome, driftScore) {
-		stampHeuristicSignals(errOut, agent, hookInput, outcome, driftScore, kernelDeny, kernelDecisionLabel(kernelDeny), noRecord)
+		stampHeuristicSignals(errOut, agent, hookInput, outcome, driftScore, kernelVerdict.Denied, kernelDecisionLabel(kernelVerdict.Denied), noRecord)
 	}
 
 	// Emit kernel verdict (deny or allow) — never altered by
@@ -182,9 +182,39 @@ func evalRouterHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag
 		_, _ = out.Write(kernelOut.Bytes())
 	}
 	if outcome.AnyFired {
-		writeRouterTelemetry(errOut, "heuristic-fired", outcome, kernelDeny)
+		writeRouterTelemetry(errOut, "heuristic-fired", outcome, kernelVerdict)
 	}
 	return kernelCode
+}
+
+// KernelVerdict is the router's parsed view of the authoritative
+// kernel decision. The router remains advisory, but its telemetry must
+// preserve the kernel rule and reason so heuristic lines never obscure
+// why an action was actually blocked.
+type KernelVerdict struct {
+	Denied bool
+	RuleID string
+	Reason string
+}
+
+func parseKernelVerdict(body []byte, code int) KernelVerdict {
+	v := KernelVerdict{Denied: code == claudecode.ExitBlock}
+	if !v.Denied || len(bytes.TrimSpace(body)) == 0 {
+		return v
+	}
+	var parsed struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+		RuleID   string `json:"rule_id"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(body), &parsed); err != nil {
+		return v
+	}
+	if parsed.Decision == "block" {
+		v.RuleID = parsed.RuleID
+		v.Reason = parsed.Reason
+	}
+	return v
 }
 
 // hasNonZeroSignal returns true if any heuristic produced a non-zero
@@ -275,14 +305,20 @@ func targetForSignal(input router.HookInput) string {
 // signal. The escalate field was removed alongside the in-gate LLM
 // advisor (audit Tier 6 cull, 2026-05-08); chain consumers stamp
 // any escalation intent themselves when they read the signals.
-func writeRouterTelemetry(errOut io.Writer, kind string, outcome router.HeuristicOutcome, kernelDeny bool) {
+func writeRouterTelemetry(errOut io.Writer, kind string, outcome router.HeuristicOutcome, kernel KernelVerdict) {
 	out := map[string]interface{}{
 		"ts":                time.Now().UTC().Format(time.RFC3339),
 		"level":             "info",
 		"component":         "router-hook",
 		"msg":               kind,
-		"kernel_denied":     kernelDeny,
+		"kernel_denied":     kernel.Denied,
 		"heuristic_outcome": outcome,
+	}
+	if kernel.RuleID != "" {
+		out["kernel_rule_id"] = kernel.RuleID
+	}
+	if kernel.Reason != "" {
+		out["kernel_reason"] = kernel.Reason
 	}
 	body, _ := json.Marshal(out)
 	_, _ = errOut.Write(body)

--- a/go/execution-kernel/cmd/chitin-kernel/router_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/router_hook_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/router"
 )
 
@@ -30,7 +31,7 @@ func TestWriteRouterTelemetry_StableSchema(t *testing.T) {
 	}
 	for _, tc := range cases {
 		var buf bytes.Buffer
-		writeRouterTelemetry(&buf, tc.kind, router.HeuristicOutcome{}, tc.kernelDeny)
+		writeRouterTelemetry(&buf, tc.kind, router.HeuristicOutcome{}, KernelVerdict{Denied: tc.kernelDeny})
 		var parsed map[string]interface{}
 		if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &parsed); err != nil {
 			t.Errorf("%s: telemetry not valid JSON: %v (raw: %q)", tc.name, err, buf.String())
@@ -51,6 +52,87 @@ func TestWriteRouterTelemetry_StableSchema(t *testing.T) {
 			t.Errorf("%s: escalate field present (should have been removed in audit Tier 6 cull); raw=%q",
 				tc.name, buf.String())
 		}
+	}
+}
+
+func TestWriteRouterTelemetry_IncludesKernelDenialDetails(t *testing.T) {
+	var buf bytes.Buffer
+	writeRouterTelemetry(&buf, "heuristic-fired", router.HeuristicOutcome{}, KernelVerdict{
+		Denied: true,
+		RuleID: "worktree-required",
+		Reason: "worktree-required: cwd is the primary checkout",
+	})
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &parsed); err != nil {
+		t.Fatalf("telemetry not valid JSON: %v (raw: %q)", err, buf.String())
+	}
+	if parsed["kernel_rule_id"] != "worktree-required" {
+		t.Fatalf("kernel_rule_id=%v want worktree-required", parsed["kernel_rule_id"])
+	}
+	if !strings.Contains(parsed["kernel_reason"].(string), "primary checkout") {
+		t.Fatalf("kernel_reason missing denial reason: %v", parsed["kernel_reason"])
+	}
+}
+
+func TestParseKernelVerdictFromBlockJSON(t *testing.T) {
+	got := parseKernelVerdict([]byte(`{"decision":"block","reason":"chitin: no-rm: no rm","rule_id":"no-rm"}`), claudecode.ExitBlock)
+	if !got.Denied {
+		t.Fatal("Denied=false want true")
+	}
+	if got.RuleID != "no-rm" {
+		t.Fatalf("RuleID=%q want no-rm", got.RuleID)
+	}
+	if !strings.Contains(got.Reason, "no rm") {
+		t.Fatalf("Reason=%q missing original reason", got.Reason)
+	}
+}
+
+func TestEvalRouterHookStdin_PreservesKernelDenyInStdoutAndTelemetry(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy+`
+router:
+  enabled: true
+  heuristics:
+    blast_radius:
+      enabled: true
+      threshold: 0.1
+    floundering:
+      enabled: false
+`)
+	body, _ := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "rm -rf go/"},
+		"cwd":        env.cwd,
+		"session_id": "router-deny-test",
+	})
+	var out, errOut bytes.Buffer
+	code := evalRouterHookStdin(bytes.NewReader(body), &out, &errOut, "claude-code", "", "", false, true)
+	if code != claudecode.ExitBlock {
+		t.Fatalf("code=%d want block; stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+
+	var blocked map[string]string
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &blocked); err != nil {
+		t.Fatalf("stdout not valid block JSON: %v\n%s", err, out.String())
+	}
+	if blocked["rule_id"] != "no-rm" {
+		t.Fatalf("stdout rule_id=%q want no-rm", blocked["rule_id"])
+	}
+	if !strings.Contains(blocked["reason"], "no-rm") || !strings.Contains(blocked["reason"], "no rm -rf") {
+		t.Fatalf("stdout reason should preserve kernel rule and reason, got %q", blocked["reason"])
+	}
+
+	var telemetry map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(errOut.Bytes()), &telemetry); err != nil {
+		t.Fatalf("stderr telemetry not valid JSON: %v\n%s", err, errOut.String())
+	}
+	if telemetry["kernel_denied"] != true {
+		t.Fatalf("kernel_denied=%v want true", telemetry["kernel_denied"])
+	}
+	if telemetry["kernel_rule_id"] != "no-rm" {
+		t.Fatalf("kernel_rule_id=%v want no-rm", telemetry["kernel_rule_id"])
+	}
+	if !strings.Contains(telemetry["kernel_reason"].(string), "no rm -rf") {
+		t.Fatalf("kernel_reason missing policy reason: %v", telemetry["kernel_reason"])
 	}
 }
 

--- a/go/execution-kernel/internal/driver/claudecode/format.go
+++ b/go/execution-kernel/internal/driver/claudecode/format.go
@@ -45,6 +45,9 @@ func Format(d gov.Decision) ([]byte, int) {
 		"decision": "block",
 		"reason":   formatReason(d),
 	}
+	if d.RuleID != "" {
+		out["rule_id"] = d.RuleID
+	}
 	if d.RuleID == "lockdown" {
 		out["continue"] = false
 		out["stopReason"] = formatLockdownStopReason(d)
@@ -69,7 +72,15 @@ func Format(d gov.Decision) ([]byte, int) {
 // Identical shape to the v1 SDK driver's formatGuideError so audit-log
 // analytics across both drivers can pattern-match the same way.
 func formatReason(d gov.Decision) string {
-	parts := []string{"chitin: " + d.Reason}
+	reason := d.Reason
+	if d.RuleID != "" && !strings.Contains(reason, d.RuleID) {
+		if reason == "" {
+			reason = d.RuleID
+		} else {
+			reason = d.RuleID + ": " + reason
+		}
+	}
+	parts := []string{"chitin: " + reason}
 	if d.Suggestion != "" {
 		parts = append(parts, "suggest: "+d.Suggestion)
 	}

--- a/go/execution-kernel/internal/driver/claudecode/format_test.go
+++ b/go/execution-kernel/internal/driver/claudecode/format_test.go
@@ -35,8 +35,14 @@ func TestFormat_DenyIsBlockExit2WithReason(t *testing.T) {
 	if parsed["decision"] != "block" {
 		t.Fatalf("decision=%q want block", parsed["decision"])
 	}
+	if parsed["rule_id"] != "no-rm" {
+		t.Fatalf("rule_id=%q want no-rm", parsed["rule_id"])
+	}
 	if !strings.Contains(parsed["reason"], "chitin:") {
 		t.Fatalf("reason missing chitin: prefix: %q", parsed["reason"])
+	}
+	if !strings.Contains(parsed["reason"], "no-rm") {
+		t.Fatalf("reason missing kernel rule id: %q", parsed["reason"])
 	}
 	if !strings.Contains(parsed["reason"], "no rm") {
 		t.Fatalf("reason missing the policy reason: %q", parsed["reason"])


### PR DESCRIPTION
## Summary

- Adds `rule_id` to Claude Code-style block responses.
- Prefixes model-visible denial reasons with the kernel rule id when available.
- Parses the authoritative kernel block JSON in the router hook and carries `kernel_rule_id` / `kernel_reason` into router telemetry.
- Adds formatter, router telemetry, parser, and end-to-end router hook regression tests.

## Why

After PR #414, governed agents saw router heuristic telemetry while the actual kernel denial reason was hard to recover. Router signals are advisory; the kernel verdict needs to remain visible to autonomous agents and operator tooling.

This is Phase 1 of the autonomous-governance re-approach spec in PR #416.

## Validation

- `go test ./internal/driver/claudecode ./cmd/chitin-kernel -run 'Format|Router|KernelVerdict' -count=1`
- `go test ./internal/driver/claudecode ./cmd/chitin-kernel`
- `go test ./...`
- `git diff --check`
