### PR TITLE
[codex] Add typed agent identity to decisions

### DIFF
--- a/go/execution-kernel/internal/gov/decision.go
+++ b/go/execution-kernel/internal/gov/decision.go
@@ -51,13 +51,18 @@ func WriteLog(d Decision, dir string) error {
 		OutputBytes      int64   `json:"output_bytes,omitempty"`
 		ToolCalls        int64   `json:"tool_calls,omitempty"`
 		CallerOrigin     string  `json:"caller_origin,omitempty"`
-		// P2 routing-as-learning-system fingerprint dimensions.
-		// All four are optional with omitempty so older readers and
-		// non-fingerprint dispatches keep working.
-		Model       string `json:"model,omitempty"`
-		Role        string `json:"role,omitempty"`
-		WorkflowID  string `json:"workflow_id,omitempty"`
-		Fingerprint string `json:"fingerprint,omitempty"`
+		// Typed agent identity dimensions. All are optional with
+		// omitempty so older readers and non-identity dispatches keep
+		// working. Fingerprint is retained as the legacy alias for
+		// AgentFingerprint.
+		AgentInstanceID  string `json:"agent_instance_id,omitempty"`
+		AgentFingerprint string `json:"agent_fingerprint,omitempty"`
+		Driver           string `json:"driver,omitempty"`
+		Model            string `json:"model,omitempty"`
+		Role             string `json:"role,omitempty"`
+		Authority        string `json:"authority,omitempty"`
+		WorkflowID       string `json:"workflow_id,omitempty"`
+		Fingerprint      string `json:"fingerprint,omitempty"`
 		// Router-heuristic signal metadata (audit Tier 6 cull,
 		// 2026-05-08). Stamped by router-hook when its policy is
 		// enabled and at least one signal is non-zero; absent on
@@ -77,11 +82,15 @@ func WriteLog(d Decision, dir string) error {
 		Ts:         d.Ts,
 		EnvelopeID: d.EnvelopeID, Tier: d.Tier, CostUSD: d.CostUSD,
 		InputBytes: d.InputBytes, OutputBytes: d.OutputBytes, ToolCalls: d.ToolCalls,
-		CallerOrigin: d.CallerOrigin,
-		Model:       d.Model,
-		Role:        d.Role,
-		WorkflowID:  d.WorkflowID,
-		Fingerprint: d.Fingerprint,
+		CallerOrigin:     d.CallerOrigin,
+		AgentInstanceID:  d.AgentInstanceID,
+		AgentFingerprint: d.AgentFingerprint,
+		Driver:           d.Driver,
+		Model:            d.Model,
+		Role:             d.Role,
+		Authority:        d.Authority,
+		WorkflowID:       d.WorkflowID,
+		Fingerprint:      d.Fingerprint,
 		PredictedBlast:   d.PredictedBlast,
 		FlounderingScore: d.FlounderingScore,
 		DriftScore:       d.DriftScore,

--- a/go/execution-kernel/internal/gov/decision_test.go
+++ b/go/execution-kernel/internal/gov/decision_test.go
@@ -19,7 +19,7 @@ func TestWriteLog_PersistsCallerOrigin(t *testing.T) {
 	dir := t.TempDir()
 	d := Decision{
 		Allowed: true, Mode: "enforce", RuleID: "default-allow-reads",
-		Ts: "2026-04-30T12:00:00Z",
+		Ts:           "2026-04-30T12:00:00Z",
 		CallerOrigin: "main.go:42",
 	}
 	if err := WriteLog(d, dir); err != nil {
@@ -44,7 +44,7 @@ func TestWriteLog_PersistsFingerprintDims(t *testing.T) {
 	dir := t.TempDir()
 	d := Decision{
 		Allowed: true, Mode: "enforce", RuleID: "default-allow-shell",
-		Ts: "2026-05-04T17:30:00Z",
+		Ts:    "2026-05-04T17:30:00Z",
 		Agent: "claude-code", Action: Action{Type: ActShellExec, Target: "ls"},
 		Model:       "claude-haiku-4-5",
 		Role:        "reviewer",
@@ -71,6 +71,43 @@ func TestWriteLog_PersistsFingerprintDims(t *testing.T) {
 	}
 }
 
+func TestWriteLog_PersistsTypedAgentIdentity(t *testing.T) {
+	dir := t.TempDir()
+	d := Decision{
+		Allowed: true, Mode: "enforce", RuleID: "default-allow-shell",
+		Ts:    "2026-05-09T13:45:00Z",
+		Agent: "codex-cli", Action: Action{Type: ActShellExec, Target: "ls"},
+		AgentInstanceID:  "codex-session-42",
+		AgentFingerprint: "agentfp123456",
+		Driver:           "codex",
+		Model:            "gpt-5.5",
+		Role:             "reviewer",
+		Authority:        "worker",
+		WorkflowID:       "wf-agent-identity",
+		Fingerprint:      "agentfp123456",
+	}
+	if err := WriteLog(d, dir); err != nil {
+		t.Fatalf("WriteLog: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	data, _ := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	for _, want := range []string{
+		`"agent":"codex-cli"`,
+		`"agent_instance_id":"codex-session-42"`,
+		`"agent_fingerprint":"agentfp123456"`,
+		`"driver":"codex"`,
+		`"model":"gpt-5.5"`,
+		`"role":"reviewer"`,
+		`"authority":"worker"`,
+		`"workflow_id":"wf-agent-identity"`,
+		`"fingerprint":"agentfp123456"`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("missing %q in JSONL; got: %s", want, string(data))
+		}
+	}
+}
+
 func TestWriteLog_OmitsEmptyFingerprintDims(t *testing.T) {
 	// Backwards compatibility: pre-fingerprint dispatches (operator
 	// manual runs, older swarm builds, ad-hoc CLI invocations) write
@@ -88,8 +125,12 @@ func TestWriteLog_OmitsEmptyFingerprintDims(t *testing.T) {
 	entries, _ := os.ReadDir(dir)
 	data, _ := os.ReadFile(filepath.Join(dir, entries[0].Name()))
 	for _, unwant := range []string{
+		`"agent_instance_id":`,
+		`"agent_fingerprint":`,
+		`"driver":`,
 		`"model":`,
 		`"role":`,
+		`"authority":`,
 		`"workflow_id":`,
 		`"fingerprint":`,
 	} {

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -47,13 +47,11 @@ type Gate struct {
 	EstimateCost func(a Action, agent string) CostDelta
 	ClassifyTier func(a Action) Tier
 	OnDecision   func(d *Decision)
-	// Fingerprint dimensions for the routing-as-learning-system (P2).
-	// Stamped onto every Decision this Gate writes when populated. The
-	// CLI hook layer reads these from CHITIN_MODEL / CHITIN_ROLE /
-	// CHITIN_WORKFLOW_ID / CHITIN_FINGERPRINT and sets them on the Gate
-	// at construction. Empty values omit the JSON field (omitempty on
-	// Decision); pre-fingerprint dispatches (manual operator runs, older
-	// swarm builds) keep writing the smaller schema with no breakage.
+	// Agent identity dimensions stamped onto every Decision this Gate
+	// writes when populated. The CLI hook layer reads these from CHITIN_*
+	// env vars and sets them on the Gate at construction. Empty values
+	// omit the JSON field (omitempty on Decision); pre-identity dispatches
+	// keep writing the smaller schema with no breakage.
 	Fingerprint FingerprintContext
 
 	// NoRecord, when true, suppresses persistent side effects: no
@@ -76,15 +74,19 @@ type Gate struct {
 	// no longer maintains its own pending_approvals + bridge POST.
 }
 
-// FingerprintContext carries the four routing dimensions the kernel
+// FingerprintContext carries the typed identity dimensions the kernel
 // stamps on every Decision it writes. All optional — when missing the
 // Decision row omits the corresponding JSON field. See
 // libs/contracts/src/fingerprint.ts for the canonical-hash side.
 type FingerprintContext struct {
-	Model       string
-	Role        string
-	WorkflowID  string
-	Fingerprint string
+	AgentInstanceID  string
+	AgentFingerprint string
+	Driver           string
+	Model            string
+	Role             string
+	Authority        string
+	WorkflowID       string
+	Fingerprint      string
 }
 
 // FingerprintContextFromEnv reads the CHITIN_* env vars that the
@@ -97,7 +99,7 @@ type FingerprintContext struct {
 //
 // Read precedence per dimension is:
 //
-//  1. CHITIN_<DIM> — the legacy name read by the kernel since P2.
+//  1. CHITIN_<DIM> — the direct name read by the kernel.
 //  2. CHITIN_DISPATCH_<DIM> — the dispatch_meta-shaped name introduced
 //     by PR #344 so the dispatcher's (role, model, tier, driver) tuple
 //     can flow into the kernel without re-stamping the legacy vars.
@@ -122,11 +124,26 @@ func FingerprintContextFromEnv() FingerprintContext {
 	if role == "" {
 		role = "external"
 	}
+	agentFingerprint := firstNonEmpty(
+		os.Getenv("CHITIN_AGENT_FINGERPRINT"),
+		os.Getenv("CHITIN_FINGERPRINT"),
+		os.Getenv("CHITIN_DISPATCH_AGENT_FINGERPRINT"),
+	)
 	return FingerprintContext{
-		Model:       firstNonEmpty(os.Getenv("CHITIN_MODEL"), os.Getenv("CHITIN_DISPATCH_MODEL")),
-		Role:        role,
-		WorkflowID:  os.Getenv("CHITIN_WORKFLOW_ID"),
-		Fingerprint: os.Getenv("CHITIN_FINGERPRINT"),
+		AgentInstanceID: firstNonEmpty(
+			os.Getenv("CHITIN_AGENT_INSTANCE_ID"),
+			os.Getenv("CHITIN_DISPATCH_AGENT_INSTANCE_ID"),
+		),
+		AgentFingerprint: agentFingerprint,
+		Driver:           firstNonEmpty(os.Getenv("CHITIN_DRIVER"), os.Getenv("CHITIN_DISPATCH_DRIVER")),
+		Model:            firstNonEmpty(os.Getenv("CHITIN_MODEL"), os.Getenv("CHITIN_DISPATCH_MODEL")),
+		Role:             role,
+		Authority:        firstNonEmpty(os.Getenv("CHITIN_AUTHORITY"), os.Getenv("CHITIN_DISPATCH_AUTHORITY")),
+		WorkflowID: firstNonEmpty(
+			os.Getenv("CHITIN_WORKFLOW_ID"),
+			os.Getenv("CHITIN_DISPATCH_WORKFLOW_ID"),
+		),
+		Fingerprint: agentFingerprint,
 	}
 }
 
@@ -378,16 +395,21 @@ func stampEnvelopeWith(d *Decision, envelope *BudgetEnvelope, tier Tier, delta C
 	d.ToolCalls = delta.ToolCalls
 }
 
-// stampFingerprint writes the routing-as-learning-system dims onto d.
+// stampFingerprint writes the typed identity dims onto d.
 // Empty-string values are pass-through — Decision's omitempty JSON tags
-// drop them on serialization, so pre-fingerprint dispatches still emit
-// the smaller schema with no breakage. Single call site (lockdown path
-// + main flow) prevents drift if the field set grows.
+// drop them on serialization, so pre-identity dispatches still emit the
+// smaller schema with no breakage. Single call site (lockdown path +
+// main flow) prevents drift if the field set grows.
 func stampFingerprint(d *Decision, ctx FingerprintContext) {
+	agentFingerprint := firstNonEmpty(ctx.AgentFingerprint, ctx.Fingerprint)
+	d.AgentInstanceID = ctx.AgentInstanceID
+	d.AgentFingerprint = agentFingerprint
+	d.Driver = ctx.Driver
 	d.Model = ctx.Model
 	d.Role = ctx.Role
+	d.Authority = ctx.Authority
 	d.WorkflowID = ctx.WorkflowID
-	d.Fingerprint = ctx.Fingerprint
+	d.Fingerprint = agentFingerprint
 }
 
 // findRuleEscalation removed in cull Phase 3 (2026-05-08).

--- a/go/execution-kernel/internal/gov/gate_test.go
+++ b/go/execution-kernel/internal/gov/gate_test.go
@@ -372,6 +372,40 @@ func TestGate_FingerprintStampedOnAllow(t *testing.T) {
 	}
 }
 
+func TestGate_TypedAgentIdentityStampedOnDeny(t *testing.T) {
+	g, _ := newTestGate(t)
+	g.Fingerprint = FingerprintContext{
+		AgentInstanceID:  "codex-session-42",
+		AgentFingerprint: "agentfp123456",
+		Driver:           "codex",
+		Model:            "gpt-5.5",
+		Role:             "reviewer",
+		Authority:        "worker",
+		WorkflowID:       "wf-agent-identity",
+	}
+
+	d := g.Evaluate(Action{Type: ActShellExec, Target: "rm -rf go/"}, "codex-cli", nil)
+	if d.Allowed {
+		t.Fatalf("expected deny")
+	}
+	if d.Agent != "codex-cli" {
+		t.Errorf("legacy Agent display field changed: got %q want codex-cli", d.Agent)
+	}
+	if d.AgentInstanceID != "codex-session-42" {
+		t.Errorf("AgentInstanceID: got %q want codex-session-42", d.AgentInstanceID)
+	}
+	if d.AgentFingerprint != "agentfp123456" {
+		t.Errorf("AgentFingerprint: got %q want agentfp123456", d.AgentFingerprint)
+	}
+	if d.Fingerprint != "agentfp123456" {
+		t.Errorf("legacy Fingerprint alias: got %q want agentfp123456", d.Fingerprint)
+	}
+	if d.Driver != "codex" || d.Model != "gpt-5.5" || d.Role != "reviewer" ||
+		d.Authority != "worker" || d.WorkflowID != "wf-agent-identity" {
+		t.Errorf("typed identity dims not stamped: %+v", d)
+	}
+}
+
 func TestGate_FingerprintStampedOnLockdown(t *testing.T) {
 	// Lockdown short-circuit must also stamp fingerprint dims so the
 	// audit row stays consistent regardless of which branch produced
@@ -412,9 +446,14 @@ func TestGate_FingerprintEmptyByDefault(t *testing.T) {
 // Centralized so the cleanup helper below can never drift from the
 // reader and leak a leftover value into adjacent tests.
 var fingerprintEnvKeys = []string{
+	"CHITIN_AGENT_INSTANCE_ID", "CHITIN_DISPATCH_AGENT_INSTANCE_ID",
+	"CHITIN_AGENT_FINGERPRINT", "CHITIN_DISPATCH_AGENT_FINGERPRINT",
+	"CHITIN_DRIVER", "CHITIN_DISPATCH_DRIVER",
 	"CHITIN_MODEL", "CHITIN_DISPATCH_MODEL",
 	"CHITIN_ROLE", "CHITIN_DISPATCH_ROLE",
-	"CHITIN_WORKFLOW_ID", "CHITIN_FINGERPRINT",
+	"CHITIN_AUTHORITY", "CHITIN_DISPATCH_AUTHORITY",
+	"CHITIN_WORKFLOW_ID", "CHITIN_DISPATCH_WORKFLOW_ID",
+	"CHITIN_FINGERPRINT",
 }
 
 // withCleanFingerprintEnv saves+clears every fingerprint-related env
@@ -458,6 +497,9 @@ func TestFingerprintContextFromEnv_LegacyVarsRead(t *testing.T) {
 		got.WorkflowID != "wf-123" || got.Fingerprint != "fp-abc" {
 		t.Errorf("legacy CHITIN_* vars not read correctly: %+v", got)
 	}
+	if got.AgentFingerprint != "fp-abc" {
+		t.Errorf("legacy CHITIN_FINGERPRINT must mirror AgentFingerprint: got %q want fp-abc", got.AgentFingerprint)
+	}
 }
 
 func TestFingerprintContextFromEnv_DispatchVarsFallback(t *testing.T) {
@@ -476,6 +518,44 @@ func TestFingerprintContextFromEnv_DispatchVarsFallback(t *testing.T) {
 	}
 }
 
+func TestFingerprintContextFromEnv_TypedIdentityVarsRead(t *testing.T) {
+	withCleanFingerprintEnv(t)
+	_ = os.Setenv("CHITIN_AGENT_INSTANCE_ID", "inst-123")
+	_ = os.Setenv("CHITIN_AGENT_FINGERPRINT", "agentfp-primary")
+	_ = os.Setenv("CHITIN_DRIVER", "hermes")
+	_ = os.Setenv("CHITIN_AUTHORITY", "supervisor")
+
+	got := FingerprintContextFromEnv()
+	if got.AgentInstanceID != "inst-123" {
+		t.Errorf("AgentInstanceID: got %q want inst-123", got.AgentInstanceID)
+	}
+	if got.AgentFingerprint != "agentfp-primary" || got.Fingerprint != "agentfp-primary" {
+		t.Errorf("agent fingerprint and legacy alias not mirrored: %+v", got)
+	}
+	if got.Driver != "hermes" {
+		t.Errorf("Driver: got %q want hermes", got.Driver)
+	}
+	if got.Authority != "supervisor" {
+		t.Errorf("Authority: got %q want supervisor", got.Authority)
+	}
+}
+
+func TestFingerprintContextFromEnv_TypedDispatchVarsFallback(t *testing.T) {
+	withCleanFingerprintEnv(t)
+	_ = os.Setenv("CHITIN_DISPATCH_AGENT_INSTANCE_ID", "inst-dispatch")
+	_ = os.Setenv("CHITIN_DISPATCH_AGENT_FINGERPRINT", "agentfp-dispatch")
+	_ = os.Setenv("CHITIN_DISPATCH_DRIVER", "copilot")
+	_ = os.Setenv("CHITIN_DISPATCH_AUTHORITY", "worker")
+	_ = os.Setenv("CHITIN_DISPATCH_WORKFLOW_ID", "wf-dispatch")
+
+	got := FingerprintContextFromEnv()
+	if got.AgentInstanceID != "inst-dispatch" || got.AgentFingerprint != "agentfp-dispatch" ||
+		got.Fingerprint != "agentfp-dispatch" || got.Driver != "copilot" ||
+		got.Authority != "worker" || got.WorkflowID != "wf-dispatch" {
+		t.Errorf("typed dispatch vars not read correctly: %+v", got)
+	}
+}
+
 func TestFingerprintContextFromEnv_LegacyWinsOverDispatch(t *testing.T) {
 	// Precedence: CHITIN_<DIM> beats CHITIN_DISPATCH_<DIM>. The legacy
 	// names are what existing dispatchers stamp; a stray DISPATCH-
@@ -486,12 +566,17 @@ func TestFingerprintContextFromEnv_LegacyWinsOverDispatch(t *testing.T) {
 	_ = os.Setenv("CHITIN_DISPATCH_ROLE", "programmer")
 	_ = os.Setenv("CHITIN_MODEL", "claude-opus-4-7")
 	_ = os.Setenv("CHITIN_DISPATCH_MODEL", "qwen3-coder")
+	_ = os.Setenv("CHITIN_FINGERPRINT", "fp-legacy-direct")
+	_ = os.Setenv("CHITIN_DISPATCH_AGENT_FINGERPRINT", "fp-dispatch")
 	got := FingerprintContextFromEnv()
 	if got.Role != "reviewer" {
 		t.Errorf("legacy CHITIN_ROLE must win: got %q want reviewer", got.Role)
 	}
 	if got.Model != "claude-opus-4-7" {
 		t.Errorf("legacy CHITIN_MODEL must win: got %q want claude-opus-4-7", got.Model)
+	}
+	if got.AgentFingerprint != "fp-legacy-direct" || got.Fingerprint != "fp-legacy-direct" {
+		t.Errorf("legacy CHITIN_FINGERPRINT must win over dispatch agent fingerprint: %+v", got)
 	}
 }
 

--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -139,26 +139,26 @@ type Decision struct {
 	// Surfaced for the analysis layer's `decisions_missing_envelope_id` finding.
 	CallerOrigin string `json:"caller_origin,omitempty"`
 
-	// Routing-as-learning-system fingerprint dimensions (P2 of the
-	// project_routing_as_learning_system phase ladder). Stamped on every
-	// decision the kernel writes when the dispatching agent supplies them
-	// via the env vars CHITIN_MODEL / CHITIN_ROLE / CHITIN_WORKFLOW_ID /
-	// CHITIN_FINGERPRINT (or the equivalent fields on a hook payload).
-	// All four are optional + omitempty for backwards compatibility:
-	// pre-fingerprint dispatches (operator manual runs, older swarm
-	// builds, ad-hoc CLI invocations) write rows without these fields
-	// and existing readers tolerate the omission.
+	// Typed agent identity dimensions. Stamped on every decision the
+	// kernel writes when the dispatching agent supplies them via the
+	// CHITIN_* env vars (or equivalent hook payload fields). All are
+	// optional + omitempty for backwards compatibility: pre-identity
+	// dispatches write rows without these fields and existing readers
+	// tolerate the omission.
 	//
-	// Why these four: (driver, model, role) define WHAT the agent was;
-	// workflow_id joins to Temporal/swarm-runs for outcome attribution;
-	// fingerprint is the pre-computed canonical hash from
-	// libs/contracts/src/fingerprint.ts so the analysis lib can group
-	// decisions by configuration without re-deriving the hash here.
-	// Driver is captured implicitly via the Agent field already.
-	Model       string `json:"model,omitempty"`
-	Role        string `json:"role,omitempty"`
-	WorkflowID  string `json:"workflow_id,omitempty"`
-	Fingerprint string `json:"fingerprint,omitempty"`
+	// Agent remains the legacy display/source field. AgentInstanceID
+	// identifies one running instance/session; AgentFingerprint is the
+	// canonical config hash from libs/contracts/src/fingerprint.ts;
+	// Fingerprint is retained as its legacy JSON alias for analytics
+	// already reading that field.
+	AgentInstanceID  string `json:"agent_instance_id,omitempty"`
+	AgentFingerprint string `json:"agent_fingerprint,omitempty"`
+	Driver           string `json:"driver,omitempty"`
+	Model            string `json:"model,omitempty"`
+	Role             string `json:"role,omitempty"`
+	Authority        string `json:"authority,omitempty"`
+	WorkflowID       string `json:"workflow_id,omitempty"`
+	Fingerprint      string `json:"fingerprint,omitempty"`
 
 	// EscalationID was removed in cull Phase 3 (2026-05-08). The
 	// pending_approvals table that this referenced is gone; any


### PR DESCRIPTION
## Summary

Adds typed agent identity fields to kernel decision rows without changing enforcement behavior:

- keeps the legacy `agent` display/source field intact
- adds `agent_instance_id`, `agent_fingerprint`, `driver`, and `authority`
- keeps `fingerprint` as a backwards-compatible alias for `agent_fingerprint`
- reads direct `CHITIN_*` vars first, then `CHITIN_DISPATCH_*` fallbacks where applicable

This is Phase 2 identity plumbing from the autonomous governance re-approach spec. Authority is recorded only when supplied; this PR does not grant supervisor behavior or alter policy decisions.

## Validation

- `go test ./internal/gov -run 'Fingerprint|TypedAgentIdentity|PersistsTypedAgentIdentity' -count=1`
- `go test ./internal/gov ./cmd/chitin-kernel ./internal/driver/copilot`
- `go test ./...`
- `git diff --check`