### PR TITLE
[codex] Gate governance mutations by authority

### DIFF
--- a/docs/governance-setup.md
+++ b/docs/governance-setup.md
@@ -160,6 +160,22 @@ The envelope is the live cost view; gov-decisions JSONL is the audit log.
 - **Hard** — `chitin-kernel gate lockdown --agent=<agent-name>`. That agent is denied all actions until reset.
 - **Clear** — `chitin-kernel gate reset --agent=<agent-name>`.
 
+When these commands are attempted from inside a governed hook session,
+Chitin classifies `chitin-kernel` commands before envelope spend:
+
+- **Worker-safe reads:** `gate status`, `envelope inspect/list/tail`,
+  `decisions`, `chain`, `health`, `chain-info`, `chain-verify`, `router`,
+  and `simulate`.
+- **Supervisor/operator/system mutations:** `gate reset`, `gate lockdown`,
+  envelope mutation (`create/use/grant/close`), install/uninstall, ingest,
+  emit, init, drive, and unknown `chitin-kernel` subcommands.
+
+Env claims such as `CHITIN_AUTHORITY=supervisor` are recorded as
+`claimed_authority`, but do not grant mutation rights. The effective
+`authority` must resolve through trusted identity metadata, such as an
+`authority.trusted` policy grant anchored by `agent_fingerprint`,
+`agent_instance_id`, or `workflow_id`.
+
 ## Escalation ladder
 
 Denials accumulate per-agent in `~/.chitin/gov.db`:

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/canon"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/cost"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/claudecode"
 	"github.com/chitinhq/chitin/go/execution-kernel/internal/driver/codex"
@@ -48,6 +49,97 @@ func isChitinAdminCommand(a gov.Action) bool {
 		return reChitinAdminCmd.MatchString(strings.TrimSpace(a.Target))
 	}
 	return false
+}
+
+type chitinAdminClass string
+
+const (
+	chitinAdminNone     chitinAdminClass = ""
+	chitinAdminRead     chitinAdminClass = "read"
+	chitinAdminMutation chitinAdminClass = "mutation"
+)
+
+func classifyChitinAdminCommand(a gov.Action) chitinAdminClass {
+	switch a.Type {
+	case gov.ActShellExec, gov.ActFileRecursiveDelete:
+	default:
+		return chitinAdminNone
+	}
+
+	pipeline := canon.ParseAST(strings.TrimSpace(a.Target))
+	var matched *canon.Command
+	for i := range pipeline.Segments {
+		cmd := pipeline.Segments[i].Command
+		if !isChitinKernelCommand(cmd.Raw) {
+			continue
+		}
+		if len(pipeline.Segments) != 1 {
+			return chitinAdminMutation
+		}
+		matched = &cmd
+		break
+	}
+	if matched == nil {
+		return chitinAdminNone
+	}
+	fields := chitinKernelFields(matched.Raw)
+	if len(fields) < 1 {
+		return chitinAdminMutation
+	}
+	if len(fields) == 1 {
+		return chitinAdminMutation
+	}
+	switch fields[1] {
+	case "gate":
+		if len(fields) >= 3 && fields[2] == "status" {
+			return chitinAdminRead
+		}
+		return chitinAdminMutation
+	case "envelope":
+		if len(fields) >= 3 {
+			switch fields[2] {
+			case "inspect", "list", "tail":
+				return chitinAdminRead
+			}
+		}
+		return chitinAdminMutation
+	case "decisions", "chain", "health", "chain-info", "chain-verify", "router", "simulate":
+		return chitinAdminRead
+	default:
+		return chitinAdminMutation
+	}
+}
+
+func isChitinKernelCommand(raw string) bool {
+	return len(chitinKernelFields(raw)) > 0
+}
+
+func chitinKernelFields(raw string) []string {
+	fields := strings.Fields(strings.TrimSpace(raw))
+	for len(fields) > 0 {
+		if fields[0] == "env" || strings.Contains(fields[0], "=") {
+			fields = fields[1:]
+			continue
+		}
+		break
+	}
+	if len(fields) > 0 && fields[0] == "command" {
+		fields = fields[1:]
+	}
+	if len(fields) == 0 || filepath.Base(fields[0]) != "chitin-kernel" {
+		return nil
+	}
+	fields[0] = "chitin-kernel"
+	return fields
+}
+
+func authorityCanMutateGovernance(authority string) bool {
+	switch authority {
+	case "supervisor", "operator", "system":
+		return true
+	default:
+		return false
+	}
 }
 
 // runHookStdin is the production entry point for the Claude Code
@@ -220,6 +312,7 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag, poli
 	}
 
 	rates := loadRates(absCwd, errOut)
+	identity := gov.FingerprintContextFromEnv()
 
 	gate := &gov.Gate{
 		Policy: policy, Counter: counter,
@@ -232,12 +325,30 @@ func evalHookStdin(r io.Reader, out, errOut io.Writer, agent, envelopeFlag, poli
 		// Decision the gate writes when the dispatching agent supplies
 		// them via env. FingerprintContextFromEnv centralizes the env
 		// read so all Gate constructors stay in sync.
-		Fingerprint: gov.FingerprintContextFromEnv(),
+		Fingerprint: identity,
 		// noRecord=true suppresses Counter.RecordDenial + WriteLog inside
 		// gov.Gate. We additionally skip OnDecision wiring + envelope
 		// spend below so a smoke evaluation has zero persistent side
 		// effects regardless of which path it traverses.
 		NoRecord: noRecord,
+	}
+	if classifyChitinAdminCommand(action) == chitinAdminMutation {
+		effectiveAuthority := gov.ResolveTrustedAuthority(identity, policy.Authority)
+		if !authorityCanMutateGovernance(effectiveAuthority) {
+			policy.Rules = append(policy.Rules, gov.Rule{
+				ID:         "governance-mutation-authority-required",
+				Action:     gov.ActionMatcher{string(gov.ActShellExec), string(gov.ActFileRecursiveDelete)},
+				Effect:     "deny",
+				Target:     action.Target,
+				Reason:     "governance mutation requires trusted supervisor/operator/system authority; self-reset is not permitted",
+				Suggestion: "Ask the operator or a trusted supervisor to perform the governance mutation.",
+			})
+			if policy.InvariantModes == nil {
+				policy.InvariantModes = map[string]string{}
+			}
+			policy.InvariantModes["governance-mutation-authority-required"] = "enforce"
+			gate.Policy = policy
+		}
 	}
 	// Operator-approval escalation wiring removed in cull Phase 3
 	// (2026-05-08). Hermes' tools/approval.py provides operator-prompt

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/gov"
 )
 
 // hookTestEnv stages a CHITIN_HOME + chitin.yaml in cwd so evalHookStdin
@@ -341,12 +343,11 @@ rules:
     reason: read ok
 `
 
-// TestEvalHookStdin_ChitinAdmin_AllowedOnExhaustedEnvelope verifies the
-// recovery path: with a 1-call envelope already exhausted by a prior
-// Read, a chitin-kernel admin command still passes the gate. Without
-// the exemption, the hook would deny on envelope-closed and the
-// operator would have to leave the gated session to recover.
-func TestEvalHookStdin_ChitinAdmin_AllowedOnExhaustedEnvelope(t *testing.T) {
+// TestEvalHookStdin_ChitinAdmin_ReadAllowedOnExhaustedEnvelope verifies
+// the recovery-adjacent read path: with an exhausted envelope, read-only
+// governance introspection still passes the gate without spend. Mutating
+// recovery commands such as envelope grant are supervisor/operator-only.
+func TestEvalHookStdin_ChitinAdmin_ReadAllowedOnExhaustedEnvelope(t *testing.T) {
 	env := setupHookEnv(t, baselinePolicy)
 	dbPath := filepath.Join(env.chitin, "gov.db")
 	store, _ := openBudgetStoreForTest(t, dbPath)
@@ -371,15 +372,43 @@ func TestEvalHookStdin_ChitinAdmin_AllowedOnExhaustedEnvelope(t *testing.T) {
 		t.Fatalf("non-admin call exit=%d want 2 (envelope blocked); stdout=%q", codeDeny, stdoutDeny)
 	}
 
-	// chitin-kernel envelope grant should pass — exempt from spend.
+	// chitin-kernel envelope inspect should pass — exempt from spend.
 	stdoutAdmin, _, codeAdmin := runHookCall(t, env, map[string]any{
 		"tool_name": "Bash",
 		"tool_input": map[string]any{
-			"command": "chitin-kernel envelope grant " + envelope.ID + " --calls=+10",
+			"command": "chitin-kernel envelope inspect " + envelope.ID,
 		},
 	}, envelope.ID)
 	if codeAdmin != 0 {
-		t.Fatalf("chitin-admin call exit=%d want 0 (exempt); stdout=%q", codeAdmin, stdoutAdmin)
+		t.Fatalf("chitin-admin read exit=%d want 0 (exempt); stdout=%q", codeAdmin, stdoutAdmin)
+	}
+}
+
+func TestClassifyChitinAdminCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want chitinAdminClass
+	}{
+		{"gate status", "chitin-kernel gate status --agent a", chitinAdminRead},
+		{"decisions recent", "chitin-kernel decisions recent --json", chitinAdminRead},
+		{"envelope inspect", "env CHITIN_HOME=/tmp chitin-kernel envelope inspect e1", chitinAdminRead},
+		{"gate reset", "chitin-kernel gate reset --agent a", chitinAdminMutation},
+		{"gate lockdown", "chitin-kernel gate lockdown --agent a", chitinAdminMutation},
+		{"envelope grant", "FOO=1 chitin-kernel envelope grant e1 --calls=+1", chitinAdminMutation},
+		{"install hook", "chitin-kernel install-hook --surface claude-code", chitinAdminMutation},
+		{"chained reset after read", "chitin-kernel gate status && chitin-kernel gate reset --agent a", chitinAdminMutation},
+		{"command wrapper", "command chitin-kernel gate reset --agent a", chitinAdminMutation},
+		{"path prefixed", "/usr/local/bin/chitin-kernel gate reset --agent a", chitinAdminMutation},
+		{"lookalike", "echo chitin-kernel gate reset --agent a", chitinAdminNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyChitinAdminCommand(gov.Action{Type: gov.ActShellExec, Target: tc.cmd})
+			if got != tc.want {
+				t.Fatalf("classify=%q want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -415,6 +444,116 @@ func TestEvalHookStdin_ChitinAdmin_NoEnvelopeSpend(t *testing.T) {
 	st, _ := e2.Inspect()
 	if st.SpentCalls != 0 {
 		t.Fatalf("SpentCalls=%d want 0 — admin commands debited envelope", st.SpentCalls)
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_WorkerCanReadStatus(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	dbPath := filepath.Join(env.chitin, "gov.db")
+	store, _ := openBudgetStoreForTest(t, dbPath)
+	envelope, _ := store.Create(budgetLimits(t, 10, 0))
+	store.Close()
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "chitin-kernel gate status --agent claude-code"},
+	}, envelope.ID)
+	if code != 0 {
+		t.Fatalf("gate status exit=%d want 0; stdout=%q", code, stdout)
+	}
+
+	store2, _ := openBudgetStoreForTest(t, dbPath)
+	defer store2.Close()
+	e2, _ := store2.Load(envelope.ID)
+	st, _ := e2.Inspect()
+	if st.SpentCalls != 0 {
+		t.Fatalf("SpentCalls=%d want 0 — read-only governance command debited envelope", st.SpentCalls)
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_WorkerCannotResetSelf(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "chitin-kernel gate reset --agent claude-code"},
+	}, "")
+	if code != 2 {
+		t.Fatalf("gate reset exit=%d want 2; stdout=%q", code, stdout)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	if parsed["rule_id"] != "governance-mutation-authority-required" {
+		t.Fatalf("rule_id=%q want governance-mutation-authority-required; parsed=%v", parsed["rule_id"], parsed)
+	}
+	if !strings.Contains(parsed["reason"], "self-reset is not permitted") {
+		t.Fatalf("reason should explain self-reset denial, got %q", parsed["reason"])
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_SpoofedSupervisorCannotReset(t *testing.T) {
+	t.Setenv("CHITIN_AUTHORITY", "supervisor")
+	env := setupHookEnv(t, baselinePolicy)
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "chitin-kernel gate reset --agent other-agent"},
+	}, "")
+	if code != 2 {
+		t.Fatalf("spoofed supervisor reset exit=%d want 2; stdout=%q", code, stdout)
+	}
+	if !strings.Contains(stdout, "trusted supervisor/operator/system authority") {
+		t.Fatalf("denial should explain trusted authority requirement: %q", stdout)
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_MutationDeniedInMonitorMode(t *testing.T) {
+	env := setupHookEnv(t, `
+id: hook-test-monitor-admin
+mode: monitor
+rules:
+  - id: allow-shell
+    action: shell.exec
+    effect: allow
+    reason: shell ok
+`)
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "chitin-kernel gate reset --agent claude-code"},
+	}, "")
+	if code != 2 {
+		t.Fatalf("monitor-mode governance mutation exit=%d want 2; stdout=%q", code, stdout)
+	}
+	if !strings.Contains(stdout, "governance-mutation-authority-required") {
+		t.Fatalf("stdout missing authority rule id: %q", stdout)
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_TrustedSupervisorCanReset(t *testing.T) {
+	t.Setenv("CHITIN_AGENT_FINGERPRINT", "agentfp-supervisor")
+	env := setupHookEnv(t, `
+id: hook-test-supervisor
+mode: enforce
+authority:
+  trusted:
+    - authority: supervisor
+      agent_fingerprint: agentfp-supervisor
+rules:
+  - id: allow-shell
+    action: shell.exec
+    effect: allow
+    reason: shell ok
+`)
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "chitin-kernel gate reset --agent other-agent"},
+	}, "")
+	if code != 0 {
+		t.Fatalf("trusted supervisor reset exit=%d want 0; stdout=%q", code, stdout)
 	}
 }
 

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -409,12 +409,12 @@ func stampFingerprint(d *Decision, ctx FingerprintContext, authority AuthorityCo
 	d.Model = ctx.Model
 	d.Role = ctx.Role
 	d.ClaimedAuthority = ctx.ClaimedAuthority
-	d.Authority = resolveTrustedAuthority(ctx, authority)
+	d.Authority = ResolveTrustedAuthority(ctx, authority)
 	d.WorkflowID = ctx.WorkflowID
 	d.Fingerprint = agentFingerprint
 }
 
-func resolveTrustedAuthority(ctx FingerprintContext, authority AuthorityConfig) string {
+func ResolveTrustedAuthority(ctx FingerprintContext, authority AuthorityConfig) string {
 	if ctx.Authority != "" {
 		return ctx.Authority
 	}


### PR DESCRIPTION
## Summary

Adds the Phase 3b command-class enforcement slice:

- classifies hook-side `chitin-kernel` commands as worker-safe reads vs governance mutations
- keeps read-only governance introspection envelope-exempt for workers
- blocks governance mutations from workers and spoofed `claimed_authority=supervisor`
- allows mutations only for effective `supervisor`, `operator`, or `system` authority
- documents the command classes in `docs/governance-setup.md`

This does not add worktree enforcement. It only uses the trusted authority resolver from #419 for the governance command surface.

## Validation

- `go test ./cmd/chitin-kernel -run 'ChitinAdmin|ClassifyChitinAdminCommand' -count=1`
- `go test ./internal/gov ./cmd/chitin-kernel ./internal/driver/copilot`
- `go test ./...`
- `git diff --check`