### PR TITLE
[codex] Stamp worktree diagnostics

### DIFF
--- a/go/execution-kernel/internal/gov/decision.go
+++ b/go/execution-kernel/internal/gov/decision.go
@@ -75,6 +75,11 @@ func WriteLog(d Decision, dir string) error {
 		FlounderingScore float64 `json:"floundering_score,omitempty"`
 		DriftScore       float64 `json:"drift_score,omitempty"`
 		RoutingDecision  string  `json:"routing_decision,omitempty"`
+		// Audit-only worktree diagnostic. This is metadata on the existing
+		// decision row, not an enforcement rule result.
+		WorktreeDiagnosticRuleID string `json:"worktree_diagnostic_rule_id,omitempty"`
+		WorktreeStatus           string `json:"worktree_status,omitempty"`
+		WorktreeReason           string `json:"worktree_reason,omitempty"`
 	}{
 		Allowed: d.Allowed, Mode: d.Mode, RuleID: d.RuleID,
 		Reason: d.Reason, Suggestion: d.Suggestion,
@@ -83,20 +88,23 @@ func WriteLog(d Decision, dir string) error {
 		Ts:         d.Ts,
 		EnvelopeID: d.EnvelopeID, Tier: d.Tier, CostUSD: d.CostUSD,
 		InputBytes: d.InputBytes, OutputBytes: d.OutputBytes, ToolCalls: d.ToolCalls,
-		CallerOrigin:     d.CallerOrigin,
-		AgentInstanceID:  d.AgentInstanceID,
-		AgentFingerprint: d.AgentFingerprint,
-		Driver:           d.Driver,
-		Model:            d.Model,
-		Role:             d.Role,
-		ClaimedAuthority: d.ClaimedAuthority,
-		Authority:        d.Authority,
-		WorkflowID:       d.WorkflowID,
-		Fingerprint:      d.Fingerprint,
-		PredictedBlast:   d.PredictedBlast,
-		FlounderingScore: d.FlounderingScore,
-		DriftScore:       d.DriftScore,
-		RoutingDecision:  d.RoutingDecision,
+		CallerOrigin:             d.CallerOrigin,
+		AgentInstanceID:          d.AgentInstanceID,
+		AgentFingerprint:         d.AgentFingerprint,
+		Driver:                   d.Driver,
+		Model:                    d.Model,
+		Role:                     d.Role,
+		ClaimedAuthority:         d.ClaimedAuthority,
+		Authority:                d.Authority,
+		WorkflowID:               d.WorkflowID,
+		Fingerprint:              d.Fingerprint,
+		PredictedBlast:           d.PredictedBlast,
+		FlounderingScore:         d.FlounderingScore,
+		DriftScore:               d.DriftScore,
+		RoutingDecision:          d.RoutingDecision,
+		WorktreeDiagnosticRuleID: d.WorktreeDiagnosticRuleID,
+		WorktreeStatus:           d.WorktreeStatus,
+		WorktreeReason:           d.WorktreeReason,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal decision: %w", err)

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -224,6 +224,7 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 		}
 		stampEnvelope(&d, envelope, g, a, agent)
 		stampFingerprint(&d, g.Fingerprint, g.Policy.Authority)
+		stampWorktreeDiagnostic(&d, a, g.Cwd)
 		if !g.NoRecord {
 			_ = WriteLog(d, g.LogDir)
 		}
@@ -339,6 +340,10 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 	// row carries (model, role, workflow_id, fingerprint) for joining
 	// against PR/review outcomes downstream.
 	stampFingerprint(&d, g.Fingerprint, g.Policy.Authority)
+	// 7b. Stamp audit-only worktree posture. This deliberately does not
+	// alter d.Allowed or the policy RuleID; it gives downstream readers
+	// chain evidence before the worktree requirement graduates to enforce.
+	stampWorktreeDiagnostic(&d, a, g.Cwd)
 
 	// 8. Log. Suppressed by NoRecord so smoke evaluations don't pollute
 	// daily chain rollups (fingerprint_outcomes, swarm_health) with

--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -211,6 +211,15 @@ type Decision struct {
 	DriftScore       float64 `json:"drift_score,omitempty"`
 	RoutingDecision  string  `json:"routing_decision,omitempty"`
 
+	// Worktree diagnostic metadata is stamped when a side-effect action is
+	// evaluated from the primary git checkout instead of a linked worktree.
+	// This is intentionally audit-only for now: it does not change Allowed,
+	// Mode, escalation counters, or envelope spend. The chain needs operator
+	// data before this becomes an enforceable invariant.
+	WorktreeDiagnosticRuleID string `json:"worktree_diagnostic_rule_id,omitempty"`
+	WorktreeStatus           string `json:"worktree_status,omitempty"` // primary
+	WorktreeReason           string `json:"worktree_reason,omitempty"`
+
 	// Effect is the rule's effect value as parsed from chitin.yaml
 	// (allow|deny|guide|monitor). Internal to the gate's flow control;
 	// not serialized to the chain (the chain only cares about the

--- a/go/execution-kernel/internal/gov/worktree_diagnostic.go
+++ b/go/execution-kernel/internal/gov/worktree_diagnostic.go
@@ -1,0 +1,108 @@
+package gov
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const worktreeDiagnosticRuleID = "worktree-required-diagnostic"
+
+func stampWorktreeDiagnostic(d *Decision, a Action, cwd string) {
+	cwd = firstNonEmpty(cwd, a.Path)
+	if !isSideEffectAction(a) || cwd == "" {
+		return
+	}
+	status := detectGitWorktreeStatus(cwd)
+	if status != "primary" {
+		return
+	}
+	d.WorktreeDiagnosticRuleID = worktreeDiagnosticRuleID
+	d.WorktreeStatus = status
+	d.WorktreeReason = "side-effect action evaluated from primary git checkout; use a linked worktree for autonomous agent changes"
+}
+
+func isSideEffectAction(a Action) bool {
+	return !isReadOnlyAction(a)
+}
+
+func isReadOnlyAction(a Action) bool {
+	switch a.Type {
+	case ActFileRead,
+		ActGitDiff,
+		ActGitLog,
+		ActGitStatus,
+		ActGitWorktreeList,
+		ActGithubPRView,
+		ActGithubPRList,
+		ActGithubIssueView,
+		ActGithubIssueList,
+		ActHTTPRequest:
+		return true
+	case ActShellExec:
+		subAction, _ := a.Params["sub_action"].(string)
+		return subAction == "shell.cat"
+	default:
+		return false
+	}
+}
+
+func detectGitWorktreeStatus(cwd string) string {
+	list, err := gitOutput(cwd, "worktree", "list", "--porcelain")
+	if err != nil || list == "" {
+		return ""
+	}
+	worktrees := parseWorktreePorcelain(list)
+	if len(worktrees) == 0 {
+		return ""
+	}
+	if pathUnderOrEqual(cwd, worktrees[0]) {
+		return "primary"
+	}
+	for _, wt := range worktrees[1:] {
+		if pathUnderOrEqual(cwd, wt) {
+			return "linked"
+		}
+	}
+	return ""
+}
+
+func pathUnderOrEqual(path, root string) bool {
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		pathAbs = path
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		rootAbs = root
+	}
+	pathClean := filepath.Clean(pathAbs)
+	rootClean := filepath.Clean(rootAbs)
+	if pathClean == rootClean {
+		return true
+	}
+	rel, err := filepath.Rel(rootClean, pathClean)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func gitOutput(cwd string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func parseWorktreePorcelain(out string) []string {
+	var worktrees []string
+	for _, line := range strings.Split(out, "\n") {
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			worktrees = append(worktrees, path)
+		}
+	}
+	return worktrees
+}

--- a/go/execution-kernel/internal/gov/worktree_diagnostic_test.go
+++ b/go/execution-kernel/internal/gov/worktree_diagnostic_test.go
@@ -1,0 +1,208 @@
+package gov
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGate_StampsWorktreeDiagnosticForPrimarySideEffect(t *testing.T) {
+	repo, _ := tempGitRepoWithLinkedWorktree(t)
+	g, _ := newTestGate(t)
+	g.Cwd = repo
+	g.Policy.Rules = append(g.Policy.Rules, Rule{
+		ID:     "allow-write",
+		Action: ActionMatcher{string(ActFileWrite)},
+		Effect: "allow",
+		Reason: "writes ok",
+	})
+
+	d := g.Evaluate(Action{Type: ActFileWrite, Target: "src/main.go"}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("diagnostic must not deny primary-checkout side effects: %+v", d)
+	}
+	if d.RuleID != "allow-write" {
+		t.Fatalf("RuleID=%q want allow-write", d.RuleID)
+	}
+	if d.WorktreeDiagnosticRuleID != worktreeDiagnosticRuleID {
+		t.Fatalf("WorktreeDiagnosticRuleID=%q want %s", d.WorktreeDiagnosticRuleID, worktreeDiagnosticRuleID)
+	}
+	if d.WorktreeStatus != "primary" {
+		t.Fatalf("WorktreeStatus=%q want primary", d.WorktreeStatus)
+	}
+	if !strings.Contains(d.WorktreeReason, "primary git checkout") {
+		t.Fatalf("WorktreeReason=%q should explain primary checkout", d.WorktreeReason)
+	}
+}
+
+func TestGate_DoesNotStampWorktreeDiagnosticForLinkedWorktree(t *testing.T) {
+	_, linked := tempGitRepoWithLinkedWorktree(t)
+	g, _ := newTestGate(t)
+	g.Cwd = linked
+	g.Policy.Rules = append(g.Policy.Rules, Rule{
+		ID:     "allow-write",
+		Action: ActionMatcher{string(ActFileWrite)},
+		Effect: "allow",
+		Reason: "writes ok",
+	})
+
+	d := g.Evaluate(Action{Type: ActFileWrite, Target: "src/main.go"}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("linked worktree write should remain allowed: %+v", d)
+	}
+	if d.WorktreeDiagnosticRuleID != "" || d.WorktreeStatus != "" || d.WorktreeReason != "" {
+		t.Fatalf("linked worktree should not carry worktree diagnostic fields: %+v", d)
+	}
+}
+
+func TestGate_DoesNotStampWorktreeDiagnosticForReadOnlyAction(t *testing.T) {
+	repo, _ := tempGitRepoWithLinkedWorktree(t)
+	g, _ := newTestGate(t)
+	g.Cwd = repo
+
+	d := g.Evaluate(Action{Type: ActFileRead, Target: "README.md"}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("read should remain allowed: %+v", d)
+	}
+	if d.WorktreeDiagnosticRuleID != "" || d.WorktreeStatus != "" || d.WorktreeReason != "" {
+		t.Fatalf("read-only action should not carry worktree diagnostic fields: %+v", d)
+	}
+}
+
+func TestGate_DoesNotStampWorktreeDiagnosticForT0ShellCat(t *testing.T) {
+	repo, _ := tempGitRepoWithLinkedWorktree(t)
+	g, _ := newTestGate(t)
+	g.Cwd = repo
+	g.Policy.Rules = append(g.Policy.Rules, Rule{
+		ID:     "allow-shell",
+		Action: ActionMatcher{string(ActShellExec)},
+		Effect: "allow",
+		Reason: "shell ok",
+	})
+
+	d := g.Evaluate(Action{
+		Type:   ActShellExec,
+		Target: "cat README.md",
+		Params: map[string]any{"sub_action": "shell.cat"},
+	}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("shell.cat should remain allowed: %+v", d)
+	}
+	if d.WorktreeDiagnosticRuleID != "" || d.WorktreeStatus != "" || d.WorktreeReason != "" {
+		t.Fatalf("shell.cat should not carry worktree diagnostic fields: %+v", d)
+	}
+}
+
+func TestGate_DoesNotStampWorktreeDiagnosticForHTTPRequest(t *testing.T) {
+	repo, _ := tempGitRepoWithLinkedWorktree(t)
+	g, _ := newTestGate(t)
+	g.Cwd = repo
+	g.Policy.Rules = append(g.Policy.Rules, Rule{
+		ID:     "allow-http",
+		Action: ActionMatcher{string(ActHTTPRequest)},
+		Effect: "allow",
+		Reason: "http ok",
+	})
+
+	d := g.Evaluate(Action{Type: ActHTTPRequest, Target: "https://example.test"}, "agent1", nil)
+	if !d.Allowed {
+		t.Fatalf("http.request should remain allowed: %+v", d)
+	}
+	if d.WorktreeDiagnosticRuleID != "" || d.WorktreeStatus != "" || d.WorktreeReason != "" {
+		t.Fatalf("http.request should not carry worktree diagnostic fields: %+v", d)
+	}
+}
+
+func TestDetectGitWorktreeStatusHandlesNestedCwd(t *testing.T) {
+	repo, linked := tempGitRepoWithLinkedWorktree(t)
+	repoNested := filepath.Join(repo, "src", "pkg")
+	linkedNested := filepath.Join(linked, "src", "pkg")
+	if err := os.MkdirAll(repoNested, 0o755); err != nil {
+		t.Fatalf("mkdir repo nested: %v", err)
+	}
+	if err := os.MkdirAll(linkedNested, 0o755); err != nil {
+		t.Fatalf("mkdir linked nested: %v", err)
+	}
+
+	if got := detectGitWorktreeStatus(repoNested); got != "primary" {
+		t.Fatalf("primary nested status=%q want primary", got)
+	}
+	if got := detectGitWorktreeStatus(linkedNested); got != "linked" {
+		t.Fatalf("linked nested status=%q want linked", got)
+	}
+}
+
+func TestWriteLog_PersistsWorktreeDiagnosticFields(t *testing.T) {
+	dir := t.TempDir()
+	d := Decision{
+		Allowed:                  true,
+		Mode:                     "guide",
+		RuleID:                   "allow-write",
+		Reason:                   "writes ok",
+		Action:                   Action{Type: ActFileWrite, Target: "src/main.go"},
+		Ts:                       "2026-05-10T00:00:00Z",
+		WorktreeDiagnosticRuleID: worktreeDiagnosticRuleID,
+		WorktreeStatus:           "primary",
+		WorktreeReason:           "side-effect action evaluated from primary git checkout",
+	}
+
+	if err := WriteLog(d, dir); err != nil {
+		t.Fatalf("WriteLog: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "gov-decisions-2026-05-10.jsonl"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	var row map[string]any
+	if err := json.Unmarshal(bytesTrimSpace(data), &row); err != nil {
+		t.Fatalf("unmarshal log row: %v", err)
+	}
+	if row["worktree_diagnostic_rule_id"] != worktreeDiagnosticRuleID {
+		t.Fatalf("worktree_diagnostic_rule_id=%v", row["worktree_diagnostic_rule_id"])
+	}
+	if row["worktree_status"] != "primary" {
+		t.Fatalf("worktree_status=%v", row["worktree_status"])
+	}
+	if row["worktree_reason"] == "" {
+		t.Fatalf("worktree_reason should be persisted")
+	}
+}
+
+func tempGitRepoWithLinkedWorktree(t *testing.T) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	linked := filepath.Join(dir, "linked")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+	runGit(t, repo, "worktree", "add", "-b", "linked-test", linked)
+	return repo, linked
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+func bytesTrimSpace(b []byte) []byte {
+	return []byte(strings.TrimSpace(string(b)))
+}


### PR DESCRIPTION
## Summary
- stamp audit-only worktree diagnostic metadata on side-effect gate decisions from the primary git checkout
- detect primary vs linked worktree using `git worktree list --porcelain`
- persist the diagnostic fields through `WriteLog`

## Why
Autonomous agents should have chain-visible evidence when they are operating from the primary checkout instead of an isolated worktree, without turning that into enforcement before we review real chain data.

## Validation
- `go test ./internal/gov -run 'WorktreeDiagnostic' -count=1`
- `go test ./internal/gov ./cmd/chitin-kernel ./internal/driver/copilot`
- `go test ./...`
- `git diff --check`
