### PR TITLE
[codex] Summarize worktree diagnostics

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/decisions.go
+++ b/go/execution-kernel/cmd/chitin-kernel/decisions.go
@@ -12,10 +12,14 @@ import (
 // surface for reading the daily gov-decisions-*.jsonl audit log.
 //
 // Subcommands:
-//   recent [--dir <dir>] [--window-hours N] [--limit N]
-//     Returns up to <limit> most recent decisions (newest first) whose
-//     ts falls within the past <window-hours>. Defaults: dir=$CHITIN_HOME
-//     (or ~/.chitin), window-hours=24, limit=100.
+//
+//	recent [--dir <dir>] [--window-hours N] [--limit N]
+//	  Returns up to <limit> most recent decisions (newest first) whose
+//	  ts falls within the past <window-hours>. Defaults: dir=$CHITIN_HOME
+//	  (or ~/.chitin), window-hours=24, limit=100.
+//	worktree-diagnostics [--dir <dir>] [--window-hours N] [--limit N]
+//	  Returns aggregate counts + recent sample rows for audit-only
+//	  worktree diagnostics.
 //
 // This subcommand exists so substrate MCP servers (hermes mcp,
 // openclaw mcp set) can register chitin's decision-log query as an
@@ -24,20 +28,45 @@ import (
 // docs/decisions/2026-05-08-cull-mcp-server-tools-as-subcommands.md.
 func cmdDecisions(args []string) {
 	if len(args) < 1 {
-		exitErr("decisions_no_subcommand", "usage: chitin-kernel decisions {recent} [flags]")
+		exitErr("decisions_no_subcommand", "usage: chitin-kernel decisions {recent|worktree-diagnostics} [flags]")
 	}
 	op := args[0]
 	rest := args[1:]
 	switch op {
 	case "recent":
 		cmdDecisionsRecent(rest)
+	case "worktree-diagnostics":
+		cmdDecisionsWorktreeDiagnostics(rest)
 	default:
 		exitErr("decisions_unknown_subcommand", op)
 	}
 }
 
 func cmdDecisionsRecent(args []string) {
-	fs := flag.NewFlagSet("decisions recent", flag.ExitOnError)
+	readArgs := parseDecisionReadFlags("decisions recent", args)
+	decs, err := gov.ReadRecent(readArgs)
+	if err != nil {
+		exitErr("decisions_read", err.Error())
+	}
+	// Always emit a JSON array — never null — so MCP-bridge readers
+	// can rely on .length / iteration without an empty-result branch.
+	if decs == nil {
+		decs = []gov.Decision{}
+	}
+	printJSON("decisions_marshal", decs)
+}
+
+func cmdDecisionsWorktreeDiagnostics(args []string) {
+	readArgs := parseDecisionReadFlags("decisions worktree-diagnostics", args)
+	summary, err := gov.ReadWorktreeDiagnosticSummary(readArgs)
+	if err != nil {
+		exitErr("decisions_read", err.Error())
+	}
+	printJSON("decisions_marshal", summary)
+}
+
+func parseDecisionReadFlags(name string, args []string) gov.ReadRecentArgs {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
 	dir := fs.String("dir", "", "path to chitin state dir (default: $CHITIN_HOME or ~/.chitin)")
 	windowHours := fs.Int("window-hours", 24, "look-back window in hours (must be > 0)")
 	limit := fs.Int("limit", 100, "max decisions returned (must be > 0)")
@@ -57,23 +86,17 @@ func cmdDecisionsRecent(args []string) {
 		// chitinDir()), so the read path can never miss a writer's dir.
 		resolved = chitinDir()
 	}
-
-	decs, err := gov.ReadRecent(gov.ReadRecentArgs{
+	return gov.ReadRecentArgs{
 		Dir:         resolved,
 		WindowHours: *windowHours,
 		Limit:       *limit,
-	})
-	if err != nil {
-		exitErr("decisions_read", err.Error())
 	}
-	// Always emit a JSON array — never null — so MCP-bridge readers
-	// can rely on .length / iteration without an empty-result branch.
-	if decs == nil {
-		decs = []gov.Decision{}
-	}
-	b, err := json.Marshal(decs)
+}
+
+func printJSON(errorKind string, v any) {
+	b, err := json.Marshal(v)
 	if err != nil {
-		exitErr("decisions_marshal", err.Error())
+		exitErr(errorKind, err.Error())
 	}
 	fmt.Println(string(b))
 }

--- a/go/execution-kernel/cmd/chitin-kernel/decisions_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/decisions_test.go
@@ -96,6 +96,41 @@ func TestCLI_DecisionsRecent_RejectsBadFlags(t *testing.T) {
 	}
 }
 
+func TestCLI_DecisionsWorktreeDiagnostics(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now().UTC()
+	date := now.Format("2006-01-02")
+	lines := []string{
+		`{"allowed":true,"mode":"guide","rule_id":"allow-write","agent":"codex","driver":"codex","action_type":"file.write","action_target":"src/main.go","ts":"` + now.Add(-2*time.Minute).Format(time.RFC3339) + `","worktree_diagnostic_rule_id":"worktree-required-diagnostic","worktree_status":"primary","worktree_reason":"side-effect action evaluated from primary git checkout"}`,
+		`{"allowed":true,"mode":"guide","rule_id":"allow-read","agent":"codex","driver":"codex","action_type":"file.read","action_target":"README.md","ts":"` + now.Add(-time.Minute).Format(time.RFC3339) + `"}`,
+	}
+	if err := os.WriteFile(filepath.Join(home, "gov-decisions-"+date+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runCLIWithHome(t, home,
+		"decisions", "worktree-diagnostics", "--window-hours", "1", "--limit", "10")
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr)
+	}
+	var got struct {
+		Total  int `json:"total"`
+		Recent []struct {
+			ActionType   string `json:"action_type"`
+			ActionTarget string `json:"action_target"`
+		} `json:"recent"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("parse stdout: %v\nstdout=%s", err, stdout)
+	}
+	if got.Total != 1 {
+		t.Fatalf("Total=%d want 1", got.Total)
+	}
+	if len(got.Recent) != 1 || got.Recent[0].ActionType != "file.write" || got.Recent[0].ActionTarget != "src/main.go" {
+		t.Fatalf("unexpected recent diagnostics: %+v", got.Recent)
+	}
+}
+
 // TestCLI_DecisionsRecent_UnknownSubcommand: chitin-kernel surfaces a
 // distinct error kind for unknown subcommands so callers can branch.
 func TestCLI_DecisionsRecent_UnknownSubcommand(t *testing.T) {

--- a/go/execution-kernel/internal/gov/decision_read.go
+++ b/go/execution-kernel/internal/gov/decision_read.go
@@ -30,7 +30,8 @@ type ReadRecentArgs struct {
 // gov-decisions-*.jsonl files in dir, newest first.
 //
 // Invariant: returned decisions satisfy
-//   ts ∈ (now-windowHours·hour, now]   AND   len ≤ limit.
+//
+//	ts ∈ (now-windowHours·hour, now]   AND   len ≤ limit.
 //
 // Behavior:
 //   - Files matching `gov-decisions-*.jsonl` are sorted by name in
@@ -136,8 +137,8 @@ func readFileReverse(path string, cutoff time.Time, maxLines int) (decs []Decisi
 	out := make([]Decision, 0, maxLines)
 	firstSeen := false
 	for i := len(lines) - 1; i >= 0; i-- {
-		var d Decision
-		if err := json.Unmarshal([]byte(lines[i]), &d); err != nil {
+		d, err := unmarshalDecisionLine([]byte(lines[i]))
+		if err != nil {
 			continue
 		}
 		if d.Ts == "" {
@@ -166,4 +167,19 @@ func readFileReverse(path string, cutoff time.Time, maxLines int) (decs []Decisi
 		}
 	}
 	return out, false, nil
+}
+
+func unmarshalDecisionLine(line []byte) (Decision, error) {
+	type wire struct {
+		Decision
+		ActionType   string `json:"action_type"`
+		ActionTarget string `json:"action_target"`
+	}
+	var row wire
+	if err := json.Unmarshal(line, &row); err != nil {
+		return Decision{}, err
+	}
+	d := row.Decision
+	d.Action = Action{Type: ActionType(row.ActionType), Target: row.ActionTarget}
+	return d, nil
 }

--- a/go/execution-kernel/internal/gov/worktree_diagnostic_summary.go
+++ b/go/execution-kernel/internal/gov/worktree_diagnostic_summary.go
@@ -1,0 +1,88 @@
+package gov
+
+import "sort"
+
+type WorktreeDiagnosticSummary struct {
+	Total    int                     `json:"total"`
+	ByAgent  []WorktreeDiagnosticBin `json:"by_agent"`
+	ByDriver []WorktreeDiagnosticBin `json:"by_driver"`
+	ByAction []WorktreeDiagnosticBin `json:"by_action_type"`
+	Recent   []WorktreeDiagnosticRow `json:"recent"`
+}
+
+type WorktreeDiagnosticBin struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+type WorktreeDiagnosticRow struct {
+	Ts             string `json:"ts"`
+	Agent          string `json:"agent,omitempty"`
+	Driver         string `json:"driver,omitempty"`
+	ActionType     string `json:"action_type,omitempty"`
+	ActionTarget   string `json:"action_target,omitempty"`
+	RuleID         string `json:"rule_id,omitempty"`
+	WorktreeStatus string `json:"worktree_status,omitempty"`
+	WorktreeReason string `json:"worktree_reason,omitempty"`
+}
+
+func ReadWorktreeDiagnosticSummary(args ReadRecentArgs) (WorktreeDiagnosticSummary, error) {
+	decisions, err := ReadRecent(args)
+	if err != nil {
+		return WorktreeDiagnosticSummary{}, err
+	}
+	summary := WorktreeDiagnosticSummary{
+		ByAgent:  []WorktreeDiagnosticBin{},
+		ByDriver: []WorktreeDiagnosticBin{},
+		ByAction: []WorktreeDiagnosticBin{},
+		Recent:   []WorktreeDiagnosticRow{},
+	}
+	agentCounts := map[string]int{}
+	driverCounts := map[string]int{}
+	actionCounts := map[string]int{}
+
+	for _, d := range decisions {
+		if d.WorktreeDiagnosticRuleID == "" {
+			continue
+		}
+		summary.Total++
+		agentCounts[countKey(d.Agent)]++
+		driverCounts[countKey(d.Driver)]++
+		actionCounts[countKey(string(d.Action.Type))]++
+		summary.Recent = append(summary.Recent, WorktreeDiagnosticRow{
+			Ts:             d.Ts,
+			Agent:          d.Agent,
+			Driver:         d.Driver,
+			ActionType:     string(d.Action.Type),
+			ActionTarget:   d.Action.Target,
+			RuleID:         d.WorktreeDiagnosticRuleID,
+			WorktreeStatus: d.WorktreeStatus,
+			WorktreeReason: d.WorktreeReason,
+		})
+	}
+	summary.ByAgent = sortedDiagnosticBins(agentCounts)
+	summary.ByDriver = sortedDiagnosticBins(driverCounts)
+	summary.ByAction = sortedDiagnosticBins(actionCounts)
+	return summary, nil
+}
+
+func sortedDiagnosticBins(counts map[string]int) []WorktreeDiagnosticBin {
+	out := make([]WorktreeDiagnosticBin, 0, len(counts))
+	for key, count := range counts {
+		out = append(out, WorktreeDiagnosticBin{Key: key, Count: count})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+func countKey(v string) string {
+	if v == "" {
+		return "(unknown)"
+	}
+	return v
+}

--- a/go/execution-kernel/internal/gov/worktree_diagnostic_summary_test.go
+++ b/go/execution-kernel/internal/gov/worktree_diagnostic_summary_test.go
@@ -1,0 +1,90 @@
+package gov
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func mkWorktreeDiagnosticDecision(t *testing.T, ts time.Time, agent, driver string, actionType ActionType, target string) string {
+	t.Helper()
+	type wire struct {
+		Allowed                  bool   `json:"allowed"`
+		Mode                     string `json:"mode"`
+		RuleID                   string `json:"rule_id"`
+		Agent                    string `json:"agent,omitempty"`
+		Driver                   string `json:"driver,omitempty"`
+		ActionType               string `json:"action_type"`
+		ActionTarget             string `json:"action_target"`
+		Ts                       string `json:"ts"`
+		WorktreeDiagnosticRuleID string `json:"worktree_diagnostic_rule_id,omitempty"`
+		WorktreeStatus           string `json:"worktree_status,omitempty"`
+		WorktreeReason           string `json:"worktree_reason,omitempty"`
+	}
+	b, err := json.Marshal(wire{
+		Allowed:                  true,
+		Mode:                     "guide",
+		RuleID:                   "allow",
+		Agent:                    agent,
+		Driver:                   driver,
+		ActionType:               string(actionType),
+		ActionTarget:             target,
+		Ts:                       ts.UTC().Format(time.RFC3339),
+		WorktreeDiagnosticRuleID: "worktree-required-diagnostic",
+		WorktreeStatus:           "primary",
+		WorktreeReason:           "side-effect action evaluated from primary git checkout",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestReadRecent_RestoresActionFromWireFields(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	writeDecisionLines(t, dir, "2026-05-10", []string{
+		mkWorktreeDiagnosticDecision(t, now.Add(-time.Minute), "codex", "codex", ActFileWrite, "src/main.go"),
+	})
+
+	out, err := ReadRecent(ReadRecentArgs{Dir: dir, WindowHours: 1, Limit: 10, Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 decision, got %d", len(out))
+	}
+	if out[0].Action.Type != ActFileWrite || out[0].Action.Target != "src/main.go" {
+		t.Fatalf("Action not restored from wire fields: %+v", out[0].Action)
+	}
+}
+
+func TestReadWorktreeDiagnosticSummary(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	writeDecisionLines(t, dir, "2026-05-10", []string{
+		mkDecision(t, now.Add(-4*time.Minute), "normal-row"),
+		mkWorktreeDiagnosticDecision(t, now.Add(-3*time.Minute), "codex", "codex", ActFileWrite, "src/main.go"),
+		mkWorktreeDiagnosticDecision(t, now.Add(-2*time.Minute), "codex", "codex", ActGitCommit, "commit"),
+		mkWorktreeDiagnosticDecision(t, now.Add(-time.Minute), "hermes", "hermes", ActFileWrite, "README.md"),
+	})
+
+	summary, err := ReadWorktreeDiagnosticSummary(ReadRecentArgs{
+		Dir: dir, WindowHours: 1, Limit: 10, Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Total != 3 {
+		t.Fatalf("Total=%d want 3", summary.Total)
+	}
+	if len(summary.Recent) != 3 || summary.Recent[0].Agent != "hermes" || summary.Recent[0].ActionTarget != "README.md" {
+		t.Fatalf("recent rows should be diagnostic-only newest-first, got %+v", summary.Recent)
+	}
+	if len(summary.ByAgent) != 2 || summary.ByAgent[0].Key != "codex" || summary.ByAgent[0].Count != 2 {
+		t.Fatalf("ByAgent not sorted/counting correctly: %+v", summary.ByAgent)
+	}
+	if len(summary.ByAction) != 2 || summary.ByAction[0].Key != string(ActFileWrite) || summary.ByAction[0].Count != 2 {
+		t.Fatalf("ByAction not sorted/counting correctly: %+v", summary.ByAction)
+	}
+}


### PR DESCRIPTION
## Summary
- add `chitin-kernel decisions worktree-diagnostics` for aggregate counts and recent diagnostic samples
- restore `action_type` / `action_target` into `gov.Decision.Action` when reading decision JSONL rows
- cover the read-side summary with gov and CLI tests

## Why
PR #421 made primary-checkout side effects chain-visible as audit-only metadata. This PR adds the read-side operator query needed to review real diagnostic data before deciding whether to enforce the invariant.

## Validation
- `go test ./internal/gov ./cmd/chitin-kernel -run 'ReadRecent_RestoresAction|WorktreeDiagnosticSummary|DecisionsWorktree|DecisionsRecent' -count=1`
- `go test ./internal/gov ./cmd/chitin-kernel ./internal/driver/copilot`
- `go test ./...`
- `git diff --check`
