### PR TITLE
[codex] allow identity-aware policy rules

### DIFF
--- a/docs/design/2026-05-10-agent-fingerprinting-v2.md
+++ b/docs/design/2026-05-10-agent-fingerprinting-v2.md
@@ -43,8 +43,8 @@ bucket for ad-hoc hooks and operator CLI calls.
 Always:
 
 - Keep allow/deny authority in the Go kernel.
-- Treat identity fields as audit metadata unless policy grants explicitly
-  trust a stable selector.
+- Treat raw identity fields as untrusted metadata unless policy grants
+  explicitly trust a stable selector.
 - Preserve the legacy `agent` display field and `fingerprint` alias.
 
 Never:
@@ -52,6 +52,26 @@ Never:
 - Let a claimed env authority become effective authority by itself.
 - Spawn or consult an LLM from the kernel.
 - Write lab/research state into the Chitin repo.
+
+## Policy Selectors
+
+Rules may constrain matches by exact identity selectors in addition to action
+shape:
+
+- `agent_instance_id`
+- `agent_fingerprint`
+- `driver`
+- `model`
+- `role`
+- `station_prompt_hash`
+- `skills_tools_hash`
+- `soul_lens`
+- `authority`
+- `workflow_id`
+
+Each selector accepts either a scalar or a list. Empty entries are rejected at
+policy load time. `authority` matches the effective authority resolved by the
+kernel from `authority.trusted`, not the caller's raw `claimed_authority`.
 
 ## Success Criteria
 

--- a/docs/governance-setup.md
+++ b/docs/governance-setup.md
@@ -176,6 +176,26 @@ Env claims such as `CHITIN_AUTHORITY=supervisor` are recorded as
 `authority.trusted` policy grant anchored by `agent_fingerprint`,
 `agent_instance_id`, or `workflow_id`.
 
+Rules can also constrain actions by identity dimensions. These are exact-match
+selectors and accept either a scalar or list value:
+
+```yaml
+rules:
+  - id: reviewers-read-only
+    action: shell.exec
+    effect: deny
+    role: reviewer
+    reason: reviewers cannot run shell commands
+
+  - id: supervisor-can-merge-prs
+    action: github.pr.merge
+    effect: allow
+    authority: supervisor
+```
+
+The `authority` selector uses the effective kernel-resolved authority, not a
+raw env claim.
+
 ## Escalation ladder
 
 Denials accumulate per-agent in `~/.chitin/gov.db`:

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -249,7 +249,7 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 	}
 
 	// 2. Policy evaluate.
-	d := g.Policy.Evaluate(a)
+	d := g.Policy.EvaluateWithFingerprint(a, g.Fingerprint)
 	d.Ts = now
 	d.Agent = agent
 	d.CallerOrigin = callerOrigin

--- a/go/execution-kernel/internal/gov/gate_test.go
+++ b/go/execution-kernel/internal/gov/gate_test.go
@@ -416,6 +416,32 @@ func TestGate_TypedAgentIdentityStampedOnDeny(t *testing.T) {
 	}
 }
 
+func TestGate_IdentityPolicyRuleParticipatesInDecision(t *testing.T) {
+	g, _ := newTestGate(t)
+	g.Policy.Rules = append([]Rule{{
+		ID:     "reviewer-read-restricted",
+		Action: ActionMatcher{string(ActFileRead)},
+		Effect: "deny",
+		Role:   IdentityMatcher{"reviewer"},
+		Reason: "reviewers must not read this surface",
+	}}, g.Policy.Rules...)
+	if err := g.Policy.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+
+	g.Fingerprint = FingerprintContext{Role: "reviewer"}
+	d := g.Evaluate(Action{Type: ActFileRead, Target: "/tmp/x"}, "codex-cli", nil)
+	if d.Allowed || d.RuleID != "reviewer-read-restricted" {
+		t.Fatalf("identity deny rule should participate in gate decision, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+
+	g.Fingerprint = FingerprintContext{Role: "worker"}
+	d = g.Evaluate(Action{Type: ActFileRead, Target: "/tmp/x"}, "codex-cli", nil)
+	if !d.Allowed || d.RuleID != "allow-read" {
+		t.Fatalf("non-matching identity should fall through to existing rule, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+}
+
 func TestGate_TrustedAuthorityGrantStampsSupervisor(t *testing.T) {
 	g, _ := newTestGate(t)
 	g.Policy.Authority.Trusted = []TrustedAuthority{

--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -26,17 +26,27 @@ type Policy struct {
 
 // Rule is one entry in the policy. Evaluated top-to-bottom; first match wins.
 type Rule struct {
-	ID               string        `yaml:"id"`
-	Action           ActionMatcher `yaml:"action"`                 // single type OR list of types
-	Effect           string        `yaml:"effect"`                 // allow | deny | guide | monitor
-	Target           string        `yaml:"target,omitempty"`       // substring match on Action.Target
-	TargetRegex      string        `yaml:"target_regex,omitempty"` // regex match on Action.Target
-	Branches         []string      `yaml:"branches,omitempty"`     // for git.push — match if Action.Target ∈ list
-	PathUnder        []string      `yaml:"path_under,omitempty"`   // for file.* — match if Action.Target begins with any
-	Reason           string        `yaml:"reason,omitempty"`
-	Suggestion       string        `yaml:"suggestion,omitempty"`
-	CorrectedCommand string        `yaml:"correctedCommand,omitempty"`
-	EscalationWeight int           `yaml:"escalation_weight,omitempty"` // default 1
+	ID                string          `yaml:"id"`
+	Action            ActionMatcher   `yaml:"action"`                 // single type OR list of types
+	Effect            string          `yaml:"effect"`                 // allow | deny | guide | monitor
+	Target            string          `yaml:"target,omitempty"`       // substring match on Action.Target
+	TargetRegex       string          `yaml:"target_regex,omitempty"` // regex match on Action.Target
+	Branches          []string        `yaml:"branches,omitempty"`     // for git.push — match if Action.Target ∈ list
+	PathUnder         []string        `yaml:"path_under,omitempty"`   // for file.* — match if Action.Target begins with any
+	AgentInstanceID   IdentityMatcher `yaml:"agent_instance_id,omitempty"`
+	AgentFingerprint  IdentityMatcher `yaml:"agent_fingerprint,omitempty"`
+	Driver            IdentityMatcher `yaml:"driver,omitempty"`
+	Model             IdentityMatcher `yaml:"model,omitempty"`
+	Role              IdentityMatcher `yaml:"role,omitempty"`
+	StationPromptHash IdentityMatcher `yaml:"station_prompt_hash,omitempty"`
+	SkillsToolsHash   IdentityMatcher `yaml:"skills_tools_hash,omitempty"`
+	SoulLens          IdentityMatcher `yaml:"soul_lens,omitempty"`
+	Authority         IdentityMatcher `yaml:"authority,omitempty"`
+	WorkflowID        IdentityMatcher `yaml:"workflow_id,omitempty"`
+	Reason            string          `yaml:"reason,omitempty"`
+	Suggestion        string          `yaml:"suggestion,omitempty"`
+	CorrectedCommand  string          `yaml:"correctedCommand,omitempty"`
+	EscalationWeight  int             `yaml:"escalation_weight,omitempty"` // default 1
 
 	// compiledRegex is populated by ApplyDefaults from TargetRegex so we
 	// validate patterns at load time (fail-closed on bad regex) rather than
@@ -262,6 +272,41 @@ func (a ActionMatcher) Matches(t ActionType) bool {
 	return false
 }
 
+// IdentityMatcher accepts either a scalar string or a list of exact string
+// values. Empty matcher means "no identity constraint" for that rule.
+type IdentityMatcher []string
+
+func (m *IdentityMatcher) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		*m = []string{node.Value}
+		return nil
+	}
+	if node.Kind == yaml.SequenceNode {
+		var list []string
+		if err := node.Decode(&list); err != nil {
+			return err
+		}
+		if len(list) == 0 {
+			return fmt.Errorf("identity matcher list must not be empty")
+		}
+		*m = list
+		return nil
+	}
+	return fmt.Errorf("identity matcher must be string or list of strings, got %v", node.Kind)
+}
+
+func (m IdentityMatcher) Matches(value string) bool {
+	if len(m) == 0 {
+		return true
+	}
+	for _, candidate := range m {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
 // LoadPolicyFile reads and parses a single chitin.yaml. Returns an error
 // on malformed YAML or any rule with a regex that fails to compile —
 // fail-closed at load time rather than silently-false at eval time.
@@ -368,6 +413,45 @@ func (p *Policy) ApplyDefaults() error {
 				return fmt.Errorf("rule %q: action[%d] is empty; remove the entry or fill it in", p.Rules[i].ID, j)
 			}
 		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "agent_instance_id", p.Rules[i].AgentInstanceID); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "agent_fingerprint", p.Rules[i].AgentFingerprint); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "driver", p.Rules[i].Driver); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "model", p.Rules[i].Model); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "role", p.Rules[i].Role); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "station_prompt_hash", p.Rules[i].StationPromptHash); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "skills_tools_hash", p.Rules[i].SkillsToolsHash); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "soul_lens", p.Rules[i].SoulLens); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "authority", p.Rules[i].Authority); err != nil {
+			return err
+		}
+		if err := validateIdentityMatcher(p.Rules[i].ID, "workflow_id", p.Rules[i].WorkflowID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateIdentityMatcher(ruleID, field string, matcher IdentityMatcher) error {
+	for i, v := range matcher {
+		if v == "" {
+			return fmt.Errorf("rule %q: %s[%d] is empty; remove the entry or fill it in", ruleID, field, i)
+		}
 	}
 	return nil
 }
@@ -386,14 +470,28 @@ func (p *Policy) ApplyDefaults() error {
 // commit log. Hermes' tools/approval.py handles operator-prompted
 // approvals natively.)
 func (p Policy) Evaluate(a Action) Decision {
+	return p.evaluate(a, FingerprintContext{})
+}
+
+// EvaluateWithFingerprint evaluates a policy with typed identity context.
+// The legacy Evaluate method remains action-only for callers that have not
+// wired CHITIN_* identity yet; identity-constrained rules simply do not match
+// there. Gate.Evaluate uses this path so policy can constrain autonomous
+// agents by stable fingerprint dimensions without trusting claimed authority.
+func (p Policy) EvaluateWithFingerprint(a Action, ctx FingerprintContext) Decision {
+	ctx.Authority = ResolveTrustedAuthority(ctx, p.Authority)
+	return p.evaluate(a, ctx)
+}
+
+func (p Policy) evaluate(a Action, ctx FingerprintContext) Decision {
 	for _, r := range p.Rules {
-		if r.Effect != "deny" || !r.matches(a) {
+		if r.Effect != "deny" || !r.matchesWithFingerprint(a, ctx) {
 			continue
 		}
 		return p.decisionFromRule(r, false, a)
 	}
 	for _, r := range p.Rules {
-		if r.Effect != "allow" || !r.matches(a) {
+		if r.Effect != "allow" || !r.matchesWithFingerprint(a, ctx) {
 			continue
 		}
 		return p.decisionFromRule(r, true, a)
@@ -426,7 +524,14 @@ func (p Policy) decisionFromRule(r Rule, allowed bool, a Action) Decision {
 }
 
 func (r Rule) matches(a Action) bool {
+	return r.matchesWithFingerprint(a, FingerprintContext{})
+}
+
+func (r Rule) matchesWithFingerprint(a Action, ctx FingerprintContext) bool {
 	if !r.Action.Matches(a.Type) {
+		return false
+	}
+	if !r.identityMatches(ctx) {
 		return false
 	}
 	// Branch condition: Action.Target must be in the list
@@ -474,4 +579,18 @@ func (r Rule) matches(a Action) bool {
 		}
 	}
 	return true
+}
+
+func (r Rule) identityMatches(ctx FingerprintContext) bool {
+	agentFingerprint := firstNonEmpty(ctx.AgentFingerprint, ctx.Fingerprint)
+	return r.AgentInstanceID.Matches(ctx.AgentInstanceID) &&
+		r.AgentFingerprint.Matches(agentFingerprint) &&
+		r.Driver.Matches(ctx.Driver) &&
+		r.Model.Matches(ctx.Model) &&
+		r.Role.Matches(ctx.Role) &&
+		r.StationPromptHash.Matches(ctx.StationPromptHash) &&
+		r.SkillsToolsHash.Matches(ctx.SkillsToolsHash) &&
+		r.SoulLens.Matches(ctx.SoulLens) &&
+		r.Authority.Matches(ctx.Authority) &&
+		r.WorkflowID.Matches(ctx.WorkflowID)
 }

--- a/go/execution-kernel/internal/gov/policy_test.go
+++ b/go/execution-kernel/internal/gov/policy_test.go
@@ -152,6 +152,100 @@ func TestPolicy_Evaluate_DenyWinsOverEarlierAllow(t *testing.T) {
 	}
 }
 
+func TestPolicy_EvaluateWithFingerprint_IdentityRuleMatches(t *testing.T) {
+	p := Policy{
+		Mode: "enforce",
+		Rules: []Rule{
+			{
+				ID:     "reviewers-read-only",
+				Action: ActionMatcher{string(ActShellExec)},
+				Effect: "deny",
+				Role:   IdentityMatcher{"reviewer"},
+				Reason: "reviewers cannot run shell commands",
+			},
+			{ID: "allow-shell", Action: ActionMatcher{string(ActShellExec)}, Effect: "allow"},
+		},
+	}
+	if err := p.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+
+	d := p.EvaluateWithFingerprint(
+		Action{Type: ActShellExec, Target: "go test ./..."},
+		FingerprintContext{Role: "reviewer"},
+	)
+	if d.Allowed || d.RuleID != "reviewers-read-only" {
+		t.Fatalf("reviewer shell should be denied by identity rule, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+
+	d = p.EvaluateWithFingerprint(
+		Action{Type: ActShellExec, Target: "go test ./..."},
+		FingerprintContext{Role: "worker"},
+	)
+	if !d.Allowed || d.RuleID != "allow-shell" {
+		t.Fatalf("worker shell should fall through to allow rule, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+}
+
+func TestPolicy_Evaluate_IgnoresIdentityRulesWithoutContext(t *testing.T) {
+	p := Policy{
+		Mode: "enforce",
+		Rules: []Rule{
+			{
+				ID:     "reviewers-read-only",
+				Action: ActionMatcher{string(ActShellExec)},
+				Effect: "deny",
+				Role:   IdentityMatcher{"reviewer"},
+			},
+			{ID: "allow-shell", Action: ActionMatcher{string(ActShellExec)}, Effect: "allow"},
+		},
+	}
+	if err := p.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+
+	d := p.Evaluate(Action{Type: ActShellExec, Target: "go test ./..."})
+	if !d.Allowed || d.RuleID != "allow-shell" {
+		t.Fatalf("legacy action-only evaluation should ignore identity rule, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+}
+
+func TestPolicy_EvaluateWithFingerprint_UsesEffectiveAuthority(t *testing.T) {
+	p := Policy{
+		Mode: "enforce",
+		Authority: AuthorityConfig{Trusted: []TrustedAuthority{
+			{Authority: "supervisor", AgentFingerprint: "fp-supervisor"},
+		}},
+		Rules: []Rule{
+			{
+				ID:        "supervisor-pr-merge",
+				Action:    ActionMatcher{string(ActGithubPRMerge)},
+				Effect:    "allow",
+				Authority: IdentityMatcher{"supervisor"},
+			},
+		},
+	}
+	if err := p.ApplyDefaults(); err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+
+	d := p.EvaluateWithFingerprint(
+		Action{Type: ActGithubPRMerge, Target: "423"},
+		FingerprintContext{AgentFingerprint: "fp-supervisor", ClaimedAuthority: "worker"},
+	)
+	if !d.Allowed || d.RuleID != "supervisor-pr-merge" {
+		t.Fatalf("trusted supervisor should match authority rule, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+
+	d = p.EvaluateWithFingerprint(
+		Action{Type: ActGithubPRMerge, Target: "423"},
+		FingerprintContext{AgentFingerprint: "fp-worker", ClaimedAuthority: "supervisor"},
+	)
+	if d.Allowed || d.RuleID != "default-deny" {
+		t.Fatalf("claimed authority must not match authority rule, got allowed=%v rule=%q", d.Allowed, d.RuleID)
+	}
+}
+
 func TestPolicy_RegexCompiledAtLoad(t *testing.T) {
 	// Invalid target_regex must fail at LoadPolicyFile, not silently at eval.
 	dir := t.TempDir()
@@ -505,6 +599,34 @@ rules:
     reason: "x"
 `,
 			wantSub: "bad-action",
+		},
+		{
+			name: "empty identity matcher entry",
+			yaml: `
+id: t
+mode: enforce
+rules:
+  - id: bad-identity
+    action: shell.exec
+    effect: deny
+    role: ["reviewer", ""]
+    reason: "x"
+`,
+			wantSub: "bad-identity",
+		},
+		{
+			name: "empty identity matcher list",
+			yaml: `
+id: t
+mode: enforce
+rules:
+  - id: bad-empty-identity-list
+    action: shell.exec
+    effect: deny
+    role: []
+    reason: "x"
+`,
+			wantSub: "identity matcher list must not be empty",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Add identity-aware policy selectors for agent instance, fingerprint, driver, model, role, prompt hash, tools hash, soul lens, effective authority, and workflow id.
- Wire `Gate.Evaluate` through identity-aware policy evaluation so CHITIN_* context can participate in allow/deny decisions.
- Preserve legacy action-only `Policy.Evaluate` behavior for callers without identity context.
- Document the selector contract and effective-authority semantics.

## Validation

- go test ./internal/gov
- go test ./... from go/execution-kernel
- pnpm exec nx run execution-kernel:build
- git diff --check

## Notes

The `authority` selector matches kernel-resolved effective authority. Raw `CHITIN_AUTHORITY` claims remain audit-only as `claimed_authority` unless trusted by `authority.trusted`.