### PR TITLE
docs: update Go version in toolchain.md

### DIFF
--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -26,7 +26,7 @@ Two-pass lint:
 
 ## Go
 
-Real Nx project with `project.json` and named targets driven by `nx:run-commands`. Go 1.22+; no custom Nx executors in Phase 1.
+Real Nx project with `project.json` and named targets driven by `nx:run-commands`. Go 1.25+; no custom Nx executors in Phase 1.
 
 ## Python
 


### PR DESCRIPTION
Documents the Go 1.25 toolchain requirement.