### PR TITLE
test: canon walkStmt/binOpToChainOp/isOutputRedirOp→100%, 92.1→95.1%

### DIFF
--- a/go/execution-kernel/internal/canon/ast_pure_test.go
+++ b/go/execution-kernel/internal/canon/ast_pure_test.go
@@ -1,0 +1,102 @@
+package canon
+
+import (
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestBinOpToChainOp(t *testing.T) {
+	tests := []struct {
+		op   syntax.BinCmdOperator
+		want ChainOp
+	}{
+		{syntax.AndStmt, OpAnd},
+		{syntax.OrStmt, OpOr},
+		{syntax.Pipe, OpPipe},
+		{syntax.PipeAll, OpPipe},
+	}
+	for _, tt := range tests {
+		got := binOpToChainOp(tt.op)
+		if got != tt.want {
+			t.Errorf("binOpToChainOp(%v) = %v, want %v", tt.op, got, tt.want)
+		}
+	}
+	// Unknown/zero operator returns OpSeq
+	got := binOpToChainOp(syntax.BinCmdOperator(0))
+	if got != OpSeq {
+		t.Errorf("binOpToChainOp(0) = %v, want OpSeq", got)
+	}
+}
+
+func TestIsOutputRedirOp(t *testing.T) {
+	outputOps := []syntax.RedirOperator{
+		syntax.RdrOut,
+		syntax.AppOut,
+		syntax.RdrClob,
+		syntax.AppClob,
+		syntax.Hdoc,
+		syntax.DashHdoc,
+		syntax.WordHdoc,
+		syntax.RdrAll,
+		syntax.AppAll,
+	}
+	for _, op := range outputOps {
+		if !isOutputRedirOp(op) {
+			t.Errorf("isOutputRedirOp(%v) = false, want true", op)
+		}
+	}
+
+	// Input redirections should be false
+	inputOps := []syntax.RedirOperator{
+		syntax.RdrIn,
+		syntax.RdrInOut,
+	}
+	for _, op := range inputOps {
+		if isOutputRedirOp(op) {
+			t.Errorf("isOutputRedirOp(%v) = true, want false", op)
+		}
+	}
+}
+
+func TestWalkStmtNilCmd(t *testing.T) {
+	// nil stmt should not panic, just return
+	p := Pipeline{}
+	walkStmt(nil, OpNone, &p)
+	if len(p.Segments) != 0 {
+		t.Errorf("walkStmt(nil) should produce 0 segments, got %d", len(p.Segments))
+	}
+}
+
+func TestWalkStmtNilCmdField(t *testing.T) {
+	// syntax.Stmt with nil Cmd — should not produce segments
+	p := Pipeline{}
+	stmt := &syntax.Stmt{Cmd: nil}
+	walkStmt(stmt, OpNone, &p)
+	if len(p.Segments) != 0 {
+		t.Errorf("walkStmt(stmt with nil Cmd) should produce 0 segments, got %d", len(p.Segments))
+	}
+}
+
+func TestWordLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		word *syntax.Word
+		want string
+	}{
+		{"lit", &syntax.Word{Parts: []syntax.WordPart{&syntax.Lit{Value: "hello"}}}, "hello"},
+		{"empty", &syntax.Word{Parts: nil}, ""},
+		{"concat", &syntax.Word{Parts: []syntax.WordPart{
+			&syntax.Lit{Value: "a"},
+			&syntax.Lit{Value: "b"},
+		}}, "ab"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wordLiteral(tt.word)
+			if got != tt.want {
+				t.Errorf("wordLiteral() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/execution-kernel/internal/canon/ast_walk_test.go
+++ b/go/execution-kernel/internal/canon/ast_walk_test.go
@@ -1,0 +1,69 @@
+package canon
+
+import "testing"
+
+// TestWalkStmt_Block verifies that { stmt1; stmt2 } flattens into
+// sequential segments (OpSeq between inner statements).
+func TestWalkStmt_Block(t *testing.T) {
+	p := ParseAST("{ echo a; echo b; }")
+	if len(p.Segments) != 2 {
+		t.Fatalf("expected 2 segments from block, got %d", len(p.Segments))
+	}
+	if p.Segments[0].Op != OpNone {
+		t.Errorf("segments[0].Op = %v, want OpNone", p.Segments[0].Op)
+	}
+	if p.Segments[1].Op != OpSeq {
+		t.Errorf("segments[1].Op = %v, want OpSeq", p.Segments[1].Op)
+	}
+}
+
+// TestWalkStmt_Subshell verifies that (cmd1; cmd2) produces separate
+// segments with OpSeq between them.
+func TestWalkStmt_Subshell(t *testing.T) {
+	p := ParseAST("(echo a; echo b)")
+	if len(p.Segments) != 2 {
+		t.Fatalf("expected 2 segments from subshell, got %d", len(p.Segments))
+	}
+}
+
+// TestWalkStmt_BinaryOr verifies that cmd1 || cmd2 produces OpOr.
+func TestWalkStmt_BinaryOr(t *testing.T) {
+	p := ParseAST("echo a || echo b")
+	if len(p.Segments) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(p.Segments))
+	}
+	if p.Segments[1].Op != OpOr {
+		t.Errorf("segments[1].Op = %v, want OpOr", p.Segments[1].Op)
+	}
+}
+
+// TestWalkStmt_BinaryPipe verifies that cmd1 | cmd2 produces OpPipe.
+func TestWalkStmt_BinaryPipe(t *testing.T) {
+	p := ParseAST("echo a | grep b")
+	if len(p.Segments) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(p.Segments))
+	}
+	if p.Segments[1].Op != OpPipe {
+		t.Errorf("segments[1].Op = %v, want OpPipe", p.Segments[1].Op)
+	}
+}
+
+// TestWalkStmt_BinaryPipeAll verifies that cmd1 |& cmd2 produces OpPipe.
+func TestWalkStmt_BinaryPipeAll(t *testing.T) {
+	p := ParseAST("echo a |& grep b")
+	if len(p.Segments) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(p.Segments))
+	}
+	if p.Segments[1].Op != OpPipe {
+		t.Errorf("segments[1].Op = %v, want OpPipe (PipeAll maps to OpPipe)", p.Segments[1].Op)
+	}
+}
+
+// TestEmitCallExpr_EnvPrefixAssign verifies that VAR=$(cmd) produces a descent
+// into the inner command.
+func TestEmitCallExpr_EnvPrefixAssign(t *testing.T) {
+	p := ParseAST("x=$(rm -rf /tmp)")
+	if !pipelineHasRecursiveDelete(p) {
+		t.Errorf("env-prefix command substitution must detect rm -rf; segments=%+v", summarizeSegments(p))
+	}
+}


### PR DESCRIPTION
AST pure function coverage.