### PR TITLE
test: ingest getKwargInt/Float→100%, getResourceStringAttr→100%, sanitizeFilename→100%, 81.5→83.6%

### DIFF
--- a/go/execution-kernel/internal/ingest/helper_attr_test.go
+++ b/go/execution-kernel/internal/ingest/helper_attr_test.go
@@ -1,0 +1,48 @@
+package ingest
+
+import (
+	"testing"
+)
+
+func TestIsAllZero(t *testing.T) {
+	if !isAllZero(nil) {
+		t.Error("nil slice should be all-zero")
+	}
+	if !isAllZero([]byte{0, 0, 0}) {
+		t.Error("all-zero slice should return true")
+	}
+	if isAllZero([]byte{0, 1, 0}) {
+		t.Error("slice with non-zero should return false")
+	}
+	if isAllZero([]byte{255}) {
+		t.Error("non-zero byte should return false")
+	}
+}
+
+func TestGetResourceStringAttr_Nil(t *testing.T) {
+	// nil resource → empty string
+	got := getResourceStringAttr(nil, "service.name")
+	if got != "" {
+		t.Errorf("expected empty string for nil resource, got %q", got)
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"a/b/c", "a_b_c"},
+		{"file.txt", "file.txt"},
+		{"", ""},
+		{"path\\to\\file", "path_to_file"},
+		{"C:\\Users", "C__Users"},
+	}
+	for _, c := range cases {
+		got := sanitizeFilename(c.input)
+		if got != c.want {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}

--- a/go/execution-kernel/internal/ingest/kwargs_attr_test.go
+++ b/go/execution-kernel/internal/ingest/kwargs_attr_test.go
@@ -1,0 +1,83 @@
+package ingest
+
+import (
+	"testing"
+)
+
+func TestGetKwargInt(t *testing.T) {
+	m := map[string]interface{}{}
+
+	// Missing key
+	if v, ok := getKwargInt(m, "x"); ok || v != 0 {
+		t.Errorf("missing key: got (%d, %v), want (0, false)", v, ok)
+	}
+
+	// float64
+	m["a"] = float64(42)
+	if v, ok := getKwargInt(m, "a"); !ok || v != 42 {
+		t.Errorf("float64: got (%d, %v), want (42, true)", v, ok)
+	}
+
+	// float32
+	m["b"] = float32(10)
+	if v, ok := getKwargInt(m, "b"); !ok || v != 10 {
+		t.Errorf("float32: got (%d, %v), want (10, true)", v, ok)
+	}
+
+	// int
+	m["c"] = int(7)
+	if v, ok := getKwargInt(m, "c"); !ok || v != 7 {
+		t.Errorf("int: got (%d, %v), want (7, true)", v, ok)
+	}
+
+	// int64
+	m["d"] = int64(99)
+	if v, ok := getKwargInt(m, "d"); !ok || v != 99 {
+		t.Errorf("int64: got (%d, %v), want (99, true)", v, ok)
+	}
+
+	// Wrong type
+	m["e"] = "not a number"
+	if v, ok := getKwargInt(m, "e"); ok || v != 0 {
+		t.Errorf("string: got (%d, %v), want (0, false)", v, ok)
+	}
+}
+
+func TestGetKwargFloat(t *testing.T) {
+	m := map[string]interface{}{}
+
+	// Missing key
+	if v, ok := getKwargFloat(m, "x"); ok || v != 0 {
+		t.Errorf("missing key: got (%f, %v), want (0, false)", v, ok)
+	}
+
+	// float64
+	m["a"] = float64(3.14)
+	if v, ok := getKwargFloat(m, "a"); !ok || v != 3.14 {
+		t.Errorf("float64: got (%f, %v), want (3.14, true)", v, ok)
+	}
+
+	// float32
+	m["b"] = float32(2.5)
+	if v, ok := getKwargFloat(m, "b"); !ok {
+		t.Errorf("float32: got (%f, %v), want true", v, ok)
+	}
+
+	// int
+	m["c"] = int(42)
+	if v, ok := getKwargFloat(m, "c"); !ok || v != 42.0 {
+		t.Errorf("int: got (%f, %v), want (42.0, true)", v, ok)
+	}
+
+	// int64
+	m["d"] = int64(100)
+	if v, ok := getKwargFloat(m, "d"); !ok || v != 100.0 {
+		t.Errorf("int64: got (%f, %v), want (100.0, true)", v, ok)
+	}
+
+	// Wrong type
+	m["e"] = "not a number"
+	if v, ok := getKwargFloat(m, "e"); ok || v != 0 {
+		t.Errorf("string: got (%f, %v), want (0, false)", v, ok)
+	}
+}


### PR DESCRIPTION
Supersedes ingest-helpers-cov, ingest-kwarg-cov, ingest-pure-cov2.