### PR TITLE
test: emit withinDedupWindow/spanIDFromHash/tsToUnixNano, router drift truncate

### DIFF
--- a/go/execution-kernel/internal/emit/dedup_test.go
+++ b/go/execution-kernel/internal/emit/dedup_test.go
@@ -1,0 +1,41 @@
+package emit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithinDedupWindow_EmptyString(t *testing.T) {
+	if withinDedupWindow("") {
+		t.Error("empty timestamp should not be in dedup window")
+	}
+}
+
+func TestWithinDedupWindow_InvalidTimestamp(t *testing.T) {
+	if withinDedupWindow("not-a-timestamp") {
+		t.Error("invalid timestamp should not be in dedup window")
+	}
+}
+
+func TestWithinDedupWindow_RecentTimestamp(t *testing.T) {
+	// A timestamp 1 second ago should be within the dedup window (which is minutes)
+	ts := time.Now().Add(-1 * time.Second).Format(time.RFC3339)
+	if !withinDedupWindow(ts) {
+		t.Error("recent timestamp should be in dedup window")
+	}
+}
+
+func TestWithinDedupWindow_OldTimestamp(t *testing.T) {
+	// A timestamp far in the past should not be in the dedup window
+	ts := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
+	if withinDedupWindow(ts) {
+		t.Error("24-hour-old timestamp should not be in dedup window")
+	}
+}
+
+func TestWithinDedupWindow_NanoFormat(t *testing.T) {
+	ts := time.Now().Add(-1 * time.Second).Format(time.RFC3339Nano)
+	if !withinDedupWindow(ts) {
+		t.Error("recent nano-format timestamp should be in dedup window")
+	}
+}

--- a/go/execution-kernel/internal/emit/otel_pure_test.go
+++ b/go/execution-kernel/internal/emit/otel_pure_test.go
@@ -1,0 +1,49 @@
+package emit
+
+import (
+	"testing"
+)
+
+func TestSpanIDFromHash(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"short", "short"},
+		{"exactly16charsxx", "exactly16charsxx"},
+		{"this-is-a-very-long-hash-string", "this-is-a-very-l"},
+		{"", ""},
+		{"1234567890123456extra", "1234567890123456"},
+	}
+	for _, tc := range tests {
+		got := spanIDFromHash(tc.input)
+		if got != tc.want {
+			t.Errorf("spanIDFromHash(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestTsToUnixNano(t *testing.T) {
+	ts := "2026-05-09T13:00:00Z"
+	nano, err := tsToUnixNano(ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nano <= 0 {
+		t.Errorf("expected positive nano timestamp, got %d", nano)
+	}
+}
+
+func TestTsToUnixNano_InvalidInput(t *testing.T) {
+	_, err := tsToUnixNano("not-a-timestamp")
+	if err == nil {
+		t.Error("expected error for invalid timestamp")
+	}
+}
+
+func TestEndpointFromEnv_Empty(t *testing.T) {
+	// When neither env var is set, should return empty
+	result := endpointFromEnv()
+	// Result depends on env — just verify it doesn't panic
+	_ = result
+}

--- a/go/execution-kernel/internal/router/drift_pure_test.go
+++ b/go/execution-kernel/internal/router/drift_pure_test.go
@@ -1,0 +1,24 @@
+package router
+
+import (
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input string
+		n     int
+		want  string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello world", 5, "hello…"},
+		{"", 3, ""},
+	}
+	for _, tc := range tests {
+		got := truncate(tc.input, tc.n)
+		if got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tc.input, tc.n, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Earlier version — superseded by a later branch on the same package.