### PR TITLE
test: router blast_radius stringField + floundering detectStall

### DIFF
--- a/go/execution-kernel/internal/router/blast_radius_pure_test.go
+++ b/go/execution-kernel/internal/router/blast_radius_pure_test.go
@@ -1,0 +1,27 @@
+package router
+
+import (
+	"testing"
+)
+
+func TestBlastRadiusStringField(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]interface{}
+		key  string
+		want string
+	}{
+		{"missing key", map[string]interface{}{"other": "val"}, "key", ""},
+		{"string value", map[string]interface{}{"key": "hello"}, "key", "hello"},
+		{"trimmed string", map[string]interface{}{"key": "  hello  "}, "key", "hello"},
+		{"non-string value", map[string]interface{}{"key": 42}, "key", ""},
+		{"empty string", map[string]interface{}{"key": ""}, "key", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stringField(tc.m, tc.key); got != tc.want {
+				t.Errorf("stringField(%v, %q) = %q, want %q", tc.m, tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/execution-kernel/internal/router/floundering_pure_test.go
+++ b/go/execution-kernel/internal/router/floundering_pure_test.go
@@ -1,0 +1,94 @@
+package router
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDetectStall_NoEvents(t *testing.T) {
+	stalled, reason := detectStall(nil, 60, time.Now())
+	if stalled {
+		t.Errorf("expected no stall with no events, got reason: %s", reason)
+	}
+}
+
+func TestDetectStall_RecentWrite(t *testing.T) {
+	now := time.Now()
+	events := []ChainEvent{
+		{
+			EventType: "decision",
+			Ts:        now.Add(-5 * time.Second).Format(time.RFC3339),
+			Payload:   map[string]any{"decision": "allow", "action_type": "file.write"},
+		},
+	}
+	stalled, _ := detectStall(events, 60, now)
+	if stalled {
+		t.Error("expected no stall with recent write")
+	}
+}
+
+func TestDetectStall_OldWrite(t *testing.T) {
+	now := time.Now()
+	events := []ChainEvent{
+		{
+			EventType: "decision",
+			Ts:        now.Add(-120 * time.Second).Format(time.RFC3339),
+			Payload:   map[string]any{"decision": "allow", "action_type": "file.write"},
+		},
+	}
+	stalled, reason := detectStall(events, 60, now)
+	if !stalled {
+		t.Error("expected stall with old write")
+	}
+	if reason == "" {
+		t.Error("expected non-empty stall reason")
+	}
+}
+
+func TestDetectStall_NoWrites_LongSession(t *testing.T) {
+	now := time.Now()
+	events := []ChainEvent{
+		{
+			EventType: "decision",
+			Ts:        now.Add(-120 * time.Second).Format(time.RFC3339),
+			Payload:   map[string]any{"decision": "allow", "action_type": "shell.exec"},
+		},
+	}
+	stalled, reason := detectStall(events, 60, now)
+	if !stalled {
+		t.Error("expected stall with long session and no writes")
+	}
+	if reason == "" {
+		t.Error("expected non-empty stall reason")
+	}
+}
+
+func TestDetectStall_DenyDoesNotCountAsWrite(t *testing.T) {
+	now := time.Now()
+	events := []ChainEvent{
+		{
+			EventType: "decision",
+			Ts:        now.Add(-120 * time.Second).Format(time.RFC3339),
+			Payload:   map[string]any{"decision": "deny", "action_type": "file.write"},
+		},
+	}
+	stalled, _ := detectStall(events, 60, now)
+	if !stalled {
+		t.Error("denied writes should not count, so long session should stall")
+	}
+}
+
+func TestDetectStall_NoWrites_ShortSession(t *testing.T) {
+	now := time.Now()
+	events := []ChainEvent{
+		{
+			EventType: "decision",
+			Ts:        now.Add(-5 * time.Second).Format(time.RFC3339),
+			Payload:   map[string]any{"decision": "allow", "action_type": "shell.exec"},
+		},
+	}
+	stalled, _ := detectStall(events, 60, now)
+	if stalled {
+		t.Error("short session with no writes should not stall")
+	}
+}


### PR DESCRIPTION
Earlier version — superseded by a later branch on the same package.