### PR TITLE
[codex] add chitin inspect console

### DIFF
--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -1,0 +1,264 @@
+import type { Command } from 'commander';
+import { resolveChitinDir } from '@chitin/contracts';
+import {
+  getAgentSummary,
+  getSessionTimeline,
+  listDecisions,
+  listRuleSummaries,
+  type AgentSummary,
+  type DecisionFilters,
+  type DecisionRow,
+  type RuleHitSummary,
+  type SessionTimeline,
+} from '@chitin/telemetry';
+
+interface InspectOpts {
+  readonly chitinDir?: string;
+  readonly workspace?: string;
+  readonly limit?: number;
+  readonly driver?: string;
+  readonly agent?: string;
+  readonly decision?: 'allow' | 'deny';
+  readonly since?: string;
+}
+
+export function registerInspect(program: Command): void {
+  const inspect = program.command('inspect').description('Inspect Chitin governance telemetry');
+
+  inspect
+    .command('live')
+    .description('Show recent governance decisions')
+    .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
+    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--limit <n>', 'max rows', parseLimit, 50)
+    .option('--driver <name>', 'filter by driver')
+    .option('--agent <id>', 'filter by agent')
+    .option('--decision <allow|deny>', 'filter by decision')
+    .option('--since <duration>', 'relative window: Nm, Nh, or Nd')
+    .action((opts: InspectOpts) => {
+      const rows = listDecisions(resolveInspectDir(opts), toDecisionFilters(opts));
+      process.stdout.write(renderDecisionRows(rows));
+    });
+
+  inspect
+    .command('denials')
+    .description('Show recent denied governance decisions')
+    .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
+    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--limit <n>', 'max rows', parseLimit, 50)
+    .option('--driver <name>', 'filter by driver')
+    .option('--agent <id>', 'filter by agent')
+    .option('--since <duration>', 'relative window: Nm, Nh, or Nd')
+    .action((opts: InspectOpts) => {
+      const rows = listDecisions(resolveInspectDir(opts), {
+        ...toDecisionFilters(opts),
+        decision: 'deny',
+      });
+      process.stdout.write(renderDenialRows(rows));
+    });
+
+  inspect
+    .command('session')
+    .description('Show a chain/session timeline')
+    .argument('<chain-id>', 'chain id to inspect')
+    .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
+    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .action((chainId: string, opts: InspectOpts) => {
+      const timeline = getSessionTimeline(resolveInspectDir(opts), chainId);
+      process.stdout.write(renderSessionTimeline(timeline));
+    });
+
+  inspect
+    .command('agent')
+    .description('Show recent governance summary for one agent')
+    .argument('<agent-id>', 'agent id to inspect')
+    .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
+    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .action((agentId: string, opts: InspectOpts) => {
+      process.stdout.write(renderAgentSummary(getAgentSummary(resolveInspectDir(opts), agentId)));
+    });
+
+  inspect
+    .command('rules')
+    .description('Show most-hit governance rules')
+    .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
+    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--limit <n>', 'max rules', parseLimit, 20)
+    .option('--driver <name>', 'filter by driver')
+    .option('--agent <id>', 'filter by agent')
+    .option('--since <duration>', 'relative window: Nm, Nh, or Nd')
+    .action((opts: InspectOpts) => {
+      const summaries = listRuleSummaries(resolveInspectDir(opts), toDecisionFilters(opts, false));
+      process.stdout.write(renderRuleSummaries(summaries.slice(0, opts.limit)));
+    });
+}
+
+export function renderDecisionRows(rows: readonly DecisionRow[]): string {
+  if (rows.length === 0) return '(no decisions found)\n';
+  return rows.map((row) => {
+    const driver = row.driver ?? '-';
+    const agent = row.agent ?? '-';
+    const rule = row.ruleId ?? '-';
+    const signal = renderSignals(row);
+    return [
+      row.ts,
+      row.decision.padEnd(5),
+      driver.padEnd(12),
+      agent.padEnd(14),
+      row.actionType.padEnd(14),
+      rule,
+      signal,
+      row.actionTarget,
+    ].filter((part) => part !== '').join(' ') + '\n';
+  }).join('');
+}
+
+export function renderDenialRows(rows: readonly DecisionRow[]): string {
+  const denials = rows.filter((row) => row.decision === 'deny');
+  if (denials.length === 0) return '(no denials found)\n';
+  return denials.map((row) => {
+    const driver = row.driver ?? '-';
+    const agent = row.agent ?? '-';
+    const reason = row.reason ? ` reason=${row.reason}` : '';
+    const suggestion = row.suggestion ? ` suggestion=${row.suggestion}` : '';
+    return `${row.ts} ${driver}/${agent} ${row.ruleId ?? '-'} ${row.actionType} ${row.actionTarget}${reason}${suggestion}\n`;
+  }).join('');
+}
+
+export function renderSessionTimeline(timeline: SessionTimeline): string {
+  const lines = [
+    `chain ${timeline.chainId}`,
+    `health ${timeline.chainHealth.ok ? 'ok' : 'broken'}`,
+  ];
+  for (const event of timeline.events) {
+    const payload = renderTimelinePayload(event.payload);
+    lines.push(
+      [
+        event.ts,
+        `seq=${event.seq}`,
+        event.surface,
+        event.eventType,
+        `hash=${shortHash(event.thisHash)}`,
+        payload,
+      ].filter((part) => part !== '').join(' '),
+    );
+  }
+  for (const chainBreak of timeline.chainHealth.breaks) {
+    lines.push(
+      `break seq=${chainBreak.seq} expected=${shortHash(chainBreak.expectedPrevHash)} actual=${shortHash(chainBreak.actualPrevHash)}`,
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+export function renderAgentSummary(summary: AgentSummary): string {
+  const lines = [
+    `agent ${summary.agent}`,
+    `decisions=${summary.decisionCount} allow=${summary.allowCount} deny=${summary.denyCount}`,
+  ];
+  if (summary.state) {
+    lines.push(
+      `state=${summary.state.level} total_denials=${summary.state.totalDenials} locked=${summary.state.locked}`,
+    );
+  }
+  if (summary.rules.length === 0) {
+    lines.push('(no rule hits)');
+  } else {
+    lines.push(...summary.rules.map(renderRuleSummaryLine));
+  }
+  return lines.join('\n') + '\n';
+}
+
+export function renderRuleSummaries(summaries: readonly RuleHitSummary[]): string {
+  if (summaries.length === 0) return '(no rule hits found)\n';
+  const lines: string[] = [];
+  for (const summary of summaries) {
+    lines.push(renderRuleSummaryLine(summary));
+    for (const example of summary.examples.slice(0, 2)) {
+      lines.push(`  example ${example.agent ?? '-'} ${example.actionType} ${example.actionTarget}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+export function parseSince(value: string | undefined, now = new Date()): Date | undefined {
+  if (!value) return undefined;
+  const match = /^(\d+)([mhd])$/.exec(value);
+  if (!match) throw new Error(`invalid --since ${value}; use Nm, Nh, or Nd`);
+  const amount = Number.parseInt(match[1], 10);
+  const unit = match[2];
+  const millis = unit === 'm'
+    ? amount * 60_000
+    : unit === 'h'
+      ? amount * 60 * 60_000
+      : amount * 24 * 60 * 60_000;
+  return new Date(now.getTime() - millis);
+}
+
+function toDecisionFilters(opts: InspectOpts, includeLimit = true): DecisionFilters {
+  return {
+    driver: opts.driver,
+    agent: opts.agent,
+    decision: opts.decision,
+    since: parseSince(opts.since),
+    limit: includeLimit ? opts.limit : undefined,
+  };
+}
+
+function resolveInspectDir(opts: InspectOpts): string {
+  if (opts.chitinDir) return opts.chitinDir;
+  return resolveChitinDir(process.cwd(), opts.workspace ?? '');
+}
+
+function renderSignals(row: DecisionRow): string {
+  const signals = row.signals;
+  if (!signals) return '';
+  const parts: string[] = [];
+  if (signals.predictedBlast !== undefined) parts.push(`blast=${signals.predictedBlast}`);
+  if (signals.flounderingScore !== undefined) parts.push(`flounder=${signals.flounderingScore}`);
+  if (signals.driftScore !== undefined) parts.push(`drift=${signals.driftScore}`);
+  if (signals.routingDecision !== undefined) parts.push(`route=${signals.routingDecision}`);
+  return parts.join(' ');
+}
+
+function parseLimit(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`invalid --limit ${value}`);
+  }
+  return parsed;
+}
+
+function shortHash(value: string | null): string {
+  return value === null ? '<null>' : value.slice(0, 12);
+}
+
+function renderTimelinePayload(payload: Record<string, unknown>): string {
+  const decision = stringPayload(payload, 'decision');
+  const rule = stringPayload(payload, 'rule_id');
+  const actionType = stringPayload(payload, 'action_type');
+  const actionTarget = stringPayload(payload, 'action_target');
+  const signals = renderPayloadSignals(payload);
+  return [decision, rule, actionType, actionTarget, signals]
+    .filter((part) => part !== undefined && part !== '')
+    .join(' ');
+}
+
+function renderRuleSummaryLine(summary: RuleHitSummary): string {
+  return `${summary.ruleId} count=${summary.count} allow=${summary.allowCount} deny=${summary.denyCount}`;
+}
+
+function renderPayloadSignals(payload: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (typeof payload.predicted_blast === 'number') parts.push(`blast=${payload.predicted_blast}`);
+  if (typeof payload.floundering_score === 'number') parts.push(`flounder=${payload.floundering_score}`);
+  if (typeof payload.drift_score === 'number') parts.push(`drift=${payload.drift_score}`);
+  const routingDecision = stringPayload(payload, 'routing_decision');
+  if (routingDecision) parts.push(`route=${routingDecision}`);
+  return parts.join(' ');
+}
+
+function stringPayload(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -29,7 +29,7 @@ export function registerInspect(program: Command): void {
     .command('live')
     .description('Show recent governance decisions')
     .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
-    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--workspace <dir>', 'optional workspace boundary for .chitin resolution')
     .option('--limit <n>', 'max rows', parseLimit, 50)
     .option('--driver <name>', 'filter by driver')
     .option('--agent <id>', 'filter by agent')
@@ -44,7 +44,7 @@ export function registerInspect(program: Command): void {
     .command('denials')
     .description('Show recent denied governance decisions')
     .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
-    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--workspace <dir>', 'optional workspace boundary for .chitin resolution')
     .option('--limit <n>', 'max rows', parseLimit, 50)
     .option('--driver <name>', 'filter by driver')
     .option('--agent <id>', 'filter by agent')
@@ -62,7 +62,7 @@ export function registerInspect(program: Command): void {
     .description('Show a chain/session timeline')
     .argument('<chain-id>', 'chain id to inspect')
     .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
-    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--workspace <dir>', 'optional workspace boundary for .chitin resolution')
     .action((chainId: string, opts: InspectOpts) => {
       const timeline = getSessionTimeline(resolveInspectDir(opts), chainId);
       process.stdout.write(renderSessionTimeline(timeline));
@@ -73,7 +73,7 @@ export function registerInspect(program: Command): void {
     .description('Show recent governance summary for one agent')
     .argument('<agent-id>', 'agent id to inspect')
     .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
-    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--workspace <dir>', 'optional workspace boundary for .chitin resolution')
     .action((agentId: string, opts: InspectOpts) => {
       process.stdout.write(renderAgentSummary(getAgentSummary(resolveInspectDir(opts), agentId)));
     });
@@ -82,7 +82,7 @@ export function registerInspect(program: Command): void {
     .command('rules')
     .description('Show most-hit governance rules')
     .option('--chitin-dir <dir>', 'state dir to read (default: resolved .chitin)')
-    .option('--workspace <dir>', 'workspace dir for .chitin resolution (default: cwd)')
+    .option('--workspace <dir>', 'optional workspace boundary for .chitin resolution')
     .option('--limit <n>', 'max rules', parseLimit, 20)
     .option('--driver <name>', 'filter by driver')
     .option('--agent <id>', 'filter by agent')

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -10,6 +10,7 @@ import { registerInstall } from './commands/install.js';
 import { registerHealth } from './commands/health.js';
 import { registerLedger } from './commands/ledger.js';
 import { registerReview } from './commands/review.js';
+import { registerInspect } from './commands/inspect.js';
 
 const program = new Command();
 program.name('chitin').description('Observability-first substrate for AI coding agents');
@@ -43,6 +44,7 @@ registerInstall(program);
 registerHealth(program);
 registerLedger(program);
 registerReview(program);
+registerInspect(program);
 
 program.parseAsync(process.argv).catch((err) => {
   console.error(err);

--- a/apps/cli/tests/inspect.test.ts
+++ b/apps/cli/tests/inspect.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSince,
+  renderAgentSummary,
+  renderDecisionRows,
+  renderDenialRows,
+  renderRuleSummaries,
+  renderSessionTimeline,
+} from '../src/commands/inspect.js';
+
+describe('inspect renderers', () => {
+  const rows = [
+    {
+      ts: '2026-05-11T18:25:43Z',
+      allowed: false,
+      decision: 'deny' as const,
+      mode: 'enforce',
+      ruleId: 'governance-mutation-authority-required',
+      reason: 'blocked',
+      suggestion: 'Ask the operator.',
+      agent: 'codex',
+      driver: 'codex',
+      actionType: 'shell.exec',
+      actionTarget: 'chitin-kernel --help',
+    },
+    {
+      ts: '2026-05-11T18:25:44Z',
+      allowed: true,
+      decision: 'allow' as const,
+      mode: 'monitor',
+      ruleId: 'router-heuristic:allow',
+      agent: 'claude-code',
+      driver: 'claude-code',
+      actionType: 'router.signal',
+      actionTarget: 'Bash:git status',
+      signals: { predictedBlast: 0.275, flounderingScore: 0.85 },
+    },
+  ];
+
+  it('renders a compact live decision view', () => {
+    const out = renderDecisionRows(rows);
+    expect(out).toContain('2026-05-11T18:25:43Z deny  codex');
+    expect(out).toContain('governance-mutation-authority-required');
+    expect(out).toContain('blast=0.275 flounder=0.85');
+  });
+
+  it('renders denials with reason and suggestion', () => {
+    const out = renderDenialRows(rows);
+    expect(out).toContain('governance-mutation-authority-required');
+    expect(out).toContain('blocked');
+    expect(out).toContain('Ask the operator.');
+    expect(out).not.toContain('router-heuristic:allow');
+  });
+
+  it('parses relative since durations', () => {
+    const now = new Date('2026-05-11T18:30:00Z');
+    expect(parseSince('5m', now)?.toISOString()).toBe('2026-05-11T18:25:00.000Z');
+    expect(parseSince('2h', now)?.toISOString()).toBe('2026-05-11T16:30:00.000Z');
+    expect(parseSince('1d', now)?.toISOString()).toBe('2026-05-10T18:30:00.000Z');
+    expect(() => parseSince('soon', now)).toThrow(/invalid --since/);
+  });
+
+  it('renders session timeline and chain health', () => {
+    const out = renderSessionTimeline({
+      chainId: 'chain-1',
+      events: [
+        {
+          ts: '2026-05-11T18:25:42Z',
+          seq: 0,
+          eventType: 'session_start',
+          surface: 'codex',
+          sessionId: 'sess-1',
+          chainId: 'chain-1',
+          prevHash: null,
+          thisHash: 'a'.repeat(64),
+          labels: {},
+          payload: {
+            decision: 'allow',
+            rule_id: 'default-allow-shell',
+            action_type: 'shell.exec',
+            action_target: 'pwd',
+            predicted_blast: 0.275,
+          },
+        },
+      ],
+      chainHealth: {
+        ok: false,
+        breaks: [{ seq: 1, expectedPrevHash: 'a'.repeat(64), actualPrevHash: 'bad' }],
+      },
+    });
+    expect(out).toContain('chain chain-1');
+    expect(out).toContain('health broken');
+    expect(out).toContain('seq=0');
+    expect(out).toContain('allow default-allow-shell shell.exec pwd blast=0.275');
+    expect(out).toContain('break seq=1 expected=a'.repeat(1));
+  });
+
+  it('renders agent summary with sticky state and top rules', () => {
+    const out = renderAgentSummary({
+      agent: 'codex',
+      allowCount: 4,
+      decisionCount: 6,
+      denyCount: 2,
+      recentDecisions: rows,
+      rules: [
+        {
+          allowCount: 1,
+          count: 2,
+          denyCount: 1,
+          examples: rows,
+          ruleId: 'default-allow-shell',
+        },
+      ],
+      state: {
+        level: 'high',
+        locked: false,
+        totalDenials: 7,
+      },
+    });
+    expect(out).toContain('agent codex');
+    expect(out).toContain('decisions=6 allow=4 deny=2');
+    expect(out).toContain('state=high total_denials=7 locked=false');
+    expect(out).toContain('default-allow-shell count=2 allow=1 deny=1');
+  });
+
+  it('renders rule summaries with examples', () => {
+    const out = renderRuleSummaries([
+      {
+        allowCount: 1,
+        count: 2,
+        denyCount: 1,
+        examples: rows,
+        ruleId: 'default-allow-shell',
+      },
+    ]);
+    expect(out).toContain('default-allow-shell count=2 allow=1 deny=1');
+    expect(out).toContain('example codex shell.exec chitin-kernel --help');
+  });
+});

--- a/docs/design/2026-05-11-chitin-console-spec.md
+++ b/docs/design/2026-05-11-chitin-console-spec.md
@@ -1,0 +1,331 @@
+# Chitin Console Spec
+
+## Assumptions
+
+1. The first deliverable is local-only and reads the operator's existing
+   `.chitin` directory.
+2. Hermes remains the operational UI for tickets, dispatch, approvals,
+   clarification, and swarm coordination.
+3. OpenClaw and Lobster remain dispatch/execution substrates; Chitin only
+   observes their governed tool calls.
+4. The browser UI, if built, must sit on top of shared read APIs rather than
+   parsing JSONL independently.
+5. The first milestone is CLI-first. A browser dashboard can come later, built
+   on the same telemetry query layer and optional local read API.
+
+Correct these before implementation if any are wrong.
+
+## Objective
+
+Build a Chitin observability surface for heterogeneous agent swarms. The
+surface should answer what happened across drivers, agents, sessions, policy
+decisions, chain integrity, and routing signals.
+
+The primary user is the local operator running Hermes, OpenClaw, Lobster, and
+frontier CLI agents while dogfooding Chitin. Success means the operator can
+inspect live and historical governance data without leaving Chitin's boundary
+or duplicating Hermes' operational responsibilities.
+
+## Tech Stack
+
+- Go kernel remains the canonical write path for gate evaluation, chain
+  emission, governance DB writes, and policy enforcement.
+- `libs/contracts` remains the canonical TypeScript schema layer.
+- `libs/telemetry` owns low-latency read-side indexing and query APIs over
+  canonical JSONL and derived SQLite views.
+- `python/analysis` owns deeper batch/offline analysis such as decision
+  pattern mining, debt streams, skill mining, predictive scoring,
+  floundering calibration, routing ELO, and report generation.
+- `apps/cli` exposes the first console commands through Commander.
+- A future local browser UI may be added only after the shared read/query API
+  is stable enough for both CLI and browser consumers.
+
+## Commands
+
+- Install: `pnpm install`
+- CLI dev: `pnpm exec nx run @chitin/cli:run -- --help`
+- CLI tests: `pnpm exec nx run @chitin/cli:test`
+- Telemetry tests: `pnpm exec nx run @chitin/telemetry:test`
+- All TypeScript tests: `pnpm exec vitest run`
+- TypeScript lint: `pnpm exec oxlint .` and `pnpm exec eslint .`
+- Go kernel build: `pnpm exec nx run execution-kernel:build`
+- Go kernel tests: `(cd go/execution-kernel && go test ./...)`
+
+## Project Structure
+
+- `docs/design/2026-05-11-chitin-console-spec.md` documents the product and
+  technical boundary.
+- `libs/telemetry/src/` owns reusable query functions for decisions,
+  sessions, agents, signals, and chain status.
+- `libs/telemetry/tests/` covers query behavior using fixture `.chitin`
+  directories.
+- `python/analysis/` remains the batch/deeper-insight layer for report-style
+  analytics and model/calibration work.
+- `apps/cli/src/commands/` exposes `chitin inspect ...` commands backed by
+  `libs/telemetry`.
+- `apps/cli/tests/` covers command output, filters, and error handling.
+- Future browser code, if approved, should live under a new app only after
+  CLI/query APIs prove the shape.
+
+## Console Surface
+
+### Milestone 1: Source Map and Shared Telemetry Queries
+
+Move reusable reads into `libs/telemetry` before adding new console commands:
+
+- decisions query with filters and pagination
+- session timeline query with chain verification metadata
+- agent summary query
+- denial summary query
+- rule-hit summary query
+- signal extraction from `router.signal` rows
+- serializable response shapes that can later back a local API
+
+The CLI should use `libs/telemetry` for fast interactive inspection. It may
+surface artifacts produced by `python/analysis`, but it should not port
+analysis algorithms into TypeScript unless they are needed for interactive
+read latency or browser/API consumption.
+
+#### Source Map
+
+| Console concern | Primary source | Reader layer | Notes |
+|---|---|---|---|
+| Event/session timeline | `.chitin/events-*.jsonl` materialized to `.chitin/events.db` | `libs/telemetry` | JSONL is canonical; `events.db` is a rebuildable interactive index. |
+| Chain continuity | `.chitin/events-*.jsonl` plus event `seq`/`prev_hash`/`this_hash` fields | `libs/telemetry` | Verify from event rows for inspect output; `chain_index.sqlite` is kernel tail bookkeeping, not the audit source. |
+| Current chain tail | `.chitin/chain_index.sqlite` | Go kernel | Useful for emit-time invariants; avoid making it the console's historical source. |
+| Gate decisions | `.chitin/gov-decisions-YYYY-MM-DD.jsonl` | `libs/telemetry` for interactive reads; `python/analysis` for batch reads | Daily JSONL is the audit log for allow/deny/mode/rule/reason/escalation. |
+| Router signals | `router.signal` rows in `gov-decisions-YYYY-MM-DD.jsonl` and decision payloads in event chain | `libs/telemetry` | Prefer decision JSONL for inspect summaries because router scores are stamped there as `predicted_blast`, `floundering_score`, `drift_score`, and `routing_decision`. |
+| Agent denial totals and lockdown | `.chitin/gov.db` tables `denials` and `agent_state` | `libs/telemetry` read-only SQLite query | Kernel-owned state; console must never mutate it. |
+| Cost/envelope state | `.chitin/gov.db` envelope tables | `libs/telemetry` read-only SQLite query | Include only when an inspect view needs tier/cost context beyond decision rows. |
+| Decision pattern mining | `.chitin/gov-decisions-*.jsonl` plus `python/analysis/out/decisions-*` | `python/analysis` | Surface generated artifacts or summaries; do not port pattern detection into CLI by default. |
+| Skill/debt/prediction/routing reports | `python/analysis/out/*` and analysis-specific stores such as `fingerprint-outcomes.sqlite` | `python/analysis` | Batch/deeper insight layer; CLI can point at latest artifacts or render summaries. |
+
+### Milestone 2: CLI Inspect Commands
+
+Add CLI commands that read from local telemetry state:
+
+- `chitin inspect live`
+  - Shows recent decisions across all drivers.
+  - Supports `--limit <n>`, `--driver <name>`, `--agent <id>`,
+    `--decision <allow|deny>`, and `--since <duration>`.
+- `chitin inspect session <chain-id>`
+  - Shows an ordered session timeline with action, target summary, rule,
+    decision, escalation, signal rows, and hash continuity status.
+- `chitin inspect agent <agent-id>`
+  - Shows deny counts, most-hit rules, recent sessions, blast/floundering/drift
+    trends when present, and current lockdown/severity state when indexed.
+- `chitin inspect denials`
+  - Shows denied actions with rule, reason, suggestion, driver, agent,
+    session, and timestamp.
+- `chitin inspect rules`
+  - Shows most-hit rules and recent examples for each rule.
+
+CLI output is the first product surface. It should be good enough for dogfood
+operations before a browser dashboard exists.
+
+### Milestone 3: Optional Local Read API
+
+After the CLI proves the read model, expose the same telemetry queries through
+a local read-only API if the browser dashboard needs process separation.
+
+Candidate command:
+
+- `chitin inspect serve --host 127.0.0.1 --port <port>`
+
+Constraints:
+
+- Bind to loopback by default.
+- Read-only endpoints only.
+- No dispatch, ticket mutation, approval prompting, or policy mutation.
+- No background daemon unless explicitly approved.
+- Reuse `libs/telemetry` response types exactly.
+- Expose analysis artifacts as files or report summaries when useful; do not
+  make the API responsible for running long batch jobs by default.
+
+Decision for this implementation slice: defer `chitin inspect serve`. The CLI
+now exercises the shared telemetry read model directly; adding a local HTTP
+surface should wait until browser work begins or another consumer needs
+process-separated access.
+
+### Milestone 4: Local Browser Console
+
+Only after Milestones 1-3 are stable, consider a browser app that consumes the
+same query API through a local process. Candidate views:
+
+- live decision stream
+- session timeline
+- agent risk profile
+- policy explainability
+- swarm overview
+- replay and audit export
+
+## Code Style
+
+Prefer small query functions with explicit filter objects and serializable
+return values:
+
+```ts
+export interface DecisionFilters {
+  readonly driver?: string;
+  readonly agent?: string;
+  readonly decision?: 'allow' | 'deny' | 'monitor';
+  readonly since?: Date;
+  readonly limit?: number;
+}
+
+export async function listDecisions(
+  chitinDir: string,
+  filters: DecisionFilters = {},
+): Promise<DecisionRow[]> {
+  // Open derived indexes through telemetry helpers; do not parse from CLI.
+}
+```
+
+CLI commands should format results only. They should not own indexing,
+normalization, policy interpretation, analysis algorithms, or chain
+verification logic.
+
+## Testing Strategy
+
+- Unit-test telemetry queries against temporary `.chitin` fixtures.
+- Keep existing `python/analysis` tests authoritative for batch analysis
+  behavior.
+- CLI-test command behavior with fixture directories and deterministic output.
+- Include at least one fixture with:
+  - allowed and denied decisions
+  - multiple drivers
+  - a `router.signal` row
+  - linked chain hashes
+  - one intentionally broken chain for verification output
+- Browser UI tests are out of scope until the browser milestone is approved.
+
+## Boundaries
+
+Always:
+
+- Treat canonical JSONL and kernel-owned DB files as source data, not UI-owned
+  mutable state.
+- Keep write authority and policy evaluation in the Go kernel.
+- Keep shared read logic in `libs/telemetry`.
+- Keep deeper/batch analysis logic in `python/analysis`.
+- Make command output useful in plain terminals and logs.
+- Preserve local-only operation unless a future decision explicitly changes
+  the product boundary.
+- Keep any API endpoint read-only and loopback-bound by default.
+
+Ask first:
+
+- Adding a new app for browser UI.
+- Adding runtime dependencies beyond current CLI/telemetry needs.
+- Porting Python analysis algorithms into TypeScript.
+- Changing event, decision, or governance DB schemas.
+- Writing back to Hermes, OpenClaw, Lobster, GitHub, or Discord.
+- Adding long-running daemons or background services.
+- Binding any API to a non-loopback interface.
+
+Never:
+
+- Dispatch agents, schedule work, manage kanban, or mutate tickets.
+- Prompt for operator approvals or implement approval persistence.
+- Route models or select frontier agents.
+- Spawn or consult an LLM from the kernel hot path.
+- Run long batch analysis jobs implicitly from lightweight inspect commands.
+- Make Chitin the source of truth for Hermes/OpenClaw operational state.
+
+## Success Criteria
+
+- The operator can answer "what just happened?" from Chitin data with one
+  command.
+- The operator can inspect one session by chain id and see tool-call order,
+  decisions, rules, signals, and chain health.
+- The operator can identify noisy or risky agents from Chitin-derived data.
+- The CLI and any future browser UI use the same telemetry read model.
+- The console reuses `python/analysis` outputs for deeper insights instead of
+  duplicating that layer.
+- Any API surface is read-only and backed by the same telemetry read model.
+- No milestone duplicates Hermes dispatch, ticketing, approval, or
+  clarification flows.
+
+## Implementation Plan
+
+1. Inventory current read paths.
+   - Confirm how `events.db`, `gov-decisions-YYYY-MM-DD.jsonl`,
+     `gov.db`, `chain_index.sqlite`, and `python/analysis/out/*` overlap.
+   - Decide which source each console query should use for Milestone 1 without
+     changing kernel-owned schemas.
+   - Mark each view as interactive telemetry, batch analysis artifact, or a
+     composition of both.
+2. Add telemetry query primitives.
+   - Implement typed functions in `libs/telemetry` for decisions, sessions,
+     agents, denials, rules, and signals.
+   - Prefer existing derived SQLite indexes where sufficient; parse decision
+     JSONL only where no derived read model exists yet.
+3. Add focused fixtures and tests.
+   - Build temporary `.chitin` fixtures with mixed drivers, allow/deny rows,
+     router signals, and chain continuity cases.
+   - Test query filters and stable response shapes before wiring CLI output.
+4. Add `chitin inspect` CLI group.
+   - Register commands in `apps/cli/src/main.ts`.
+   - Keep command code limited to option parsing and formatting.
+   - Include a machine-readable output flag only if needed for Hermes/OpenClaw
+     handoff; otherwise keep initial output human-readable.
+5. Evaluate local API need.
+   - If browser work starts, add a read-only loopback API that calls the same
+     telemetry functions.
+   - Decide whether the API should expose generated analysis artifacts as
+     static/read-only resources.
+   - Do not add the API just to serve the CLI.
+6. Build browser dashboard later.
+   - Use the local API/read model after the CLI has proven the data shape.
+   - Keep browser scope observability-only.
+
+## Task Breakdown
+
+- [x] Task: map current telemetry sources and choose source-of-truth per
+      inspect view.
+  - Acceptance: spec has a short source map for events, decisions, signals,
+    chain health, agent state, and Python analysis artifacts.
+  - Verify: review against existing `libs/telemetry`, `python/analysis`, and
+    Go governance files.
+  - Files: `docs/design/2026-05-11-chitin-console-spec.md`.
+- [x] Task: add telemetry decision/session query types.
+  - Acceptance: `libs/telemetry` exports typed query functions with filters
+    and serializable rows.
+  - Verify: `pnpm exec nx run @chitin/telemetry:test`.
+  - Files: `libs/telemetry/src/*`, `libs/telemetry/tests/*`.
+- [x] Task: add `chitin inspect live` and `chitin inspect denials`.
+  - Acceptance: commands render deterministic recent decision output from
+    fixtures.
+  - Verify: `pnpm exec nx run @chitin/cli:test`.
+  - Files: `apps/cli/src/main.ts`, `apps/cli/src/commands/*`,
+    `apps/cli/tests/*`.
+- [x] Task: add `chitin inspect session`.
+  - Acceptance: command shows ordered events, governance decisions, signal
+    rows, and chain health for a chain id.
+  - Verify: telemetry and CLI tests pass.
+  - Files: `libs/telemetry/src/*`, `apps/cli/src/commands/*`,
+    relevant tests.
+- [x] Task: add `chitin inspect agent` and `chitin inspect rules`.
+  - Acceptance: commands summarize recent risk/rule patterns without mutating
+    governance state.
+  - Verify: telemetry and CLI tests pass.
+  - Files: `libs/telemetry/src/*`, `apps/cli/src/commands/*`,
+    relevant tests.
+- [x] Task: decide whether to add `chitin inspect serve`.
+  - Acceptance: decision is documented after CLI dogfood, including whether a
+    browser dashboard needs process-separated access.
+  - Verify: spec update reviewed before implementation.
+  - Files: this spec and, if approved later, API/browser files.
+
+## Open Questions
+
+1. Should `chitin inspect live` be a one-shot recent view first, with
+   streaming `--follow` deferred until the static output is useful?
+2. What identifier should be the primary join back to Hermes kanban work:
+   `workflow_id`, `chain_id`, `agent_instance_id`, or a separate ticket id
+   field?
+3. Should Chitin expose read-only Hermes/OpenClaw reference links when present,
+   or should cross-system navigation remain outside Chitin for now?
+4. Which Python analysis outputs are worth surfacing in `chitin inspect` first:
+   decisions, debt, skill mining, prediction, routing ELO, or floundering
+   calibration?

--- a/docs/design/2026-05-11-chitin-console-spec.md
+++ b/docs/design/2026-05-11-chitin-console-spec.md
@@ -168,7 +168,7 @@ return values:
 export interface DecisionFilters {
   readonly driver?: string;
   readonly agent?: string;
-  readonly decision?: 'allow' | 'deny' | 'monitor';
+  readonly decision?: 'allow' | 'deny';
   readonly since?: Date;
   readonly limit?: number;
 }
@@ -180,6 +180,9 @@ export async function listDecisions(
   // Open derived indexes through telemetry helpers; do not parse from CLI.
 }
 ```
+
+`monitor`, `enforce`, and `guide` are decision modes. They should be modeled
+as a separate `mode` filter if the console needs them later.
 
 CLI commands should format results only. They should not own indexing,
 normalization, policy interpretation, analysis algorithms, or chain

--- a/libs/telemetry/src/index.ts
+++ b/libs/telemetry/src/index.ts
@@ -2,6 +2,7 @@ export * from './sqlite-indexer.js';
 export * from './jsonl-tailer.js';
 export * from './replay.js';
 export * from './ensure-indexed.js';
+export * from './inspect-queries.js';
 
 import BetterSqlite3 from 'better-sqlite3';
 import { join } from 'node:path';

--- a/libs/telemetry/src/inspect-queries.ts
+++ b/libs/telemetry/src/inspect-queries.ts
@@ -136,7 +136,9 @@ export function listDecisions(chitinDir: string, filters: DecisionFilters = {}):
     .sort()
     .reverse();
   const sinceMillis = filters.since?.getTime();
+  const sinceDate = filters.since?.toISOString().slice(0, 10);
   for (const name of names) {
+    if (sinceDate && decisionLogDate(name) < sinceDate) break;
     const content = readFileSync(join(chitinDir, name), 'utf8');
     const lines = content.split('\n');
     for (let index = lines.length - 1; index >= 0; index -= 1) {
@@ -340,4 +342,8 @@ function escalationLevel(totalDenials: number, locked: boolean): AgentStateSumma
   if (totalDenials >= 7) return 'high';
   if (totalDenials >= 3) return 'elevated';
   return 'normal';
+}
+
+function decisionLogDate(name: string): string {
+  return name.slice('gov-decisions-'.length, 'gov-decisions-YYYY-MM-DD'.length);
 }

--- a/libs/telemetry/src/inspect-queries.ts
+++ b/libs/telemetry/src/inspect-queries.ts
@@ -1,0 +1,343 @@
+import BetterSqlite3 from 'better-sqlite3';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { ensureIndexed } from './ensure-indexed.js';
+
+export type DecisionKind = 'allow' | 'deny';
+
+export interface DecisionFilters {
+  readonly driver?: string;
+  readonly agent?: string;
+  readonly actionType?: string;
+  readonly decision?: DecisionKind;
+  readonly since?: Date;
+  readonly limit?: number;
+}
+
+export interface DecisionSignals {
+  readonly predictedBlast?: number;
+  readonly flounderingScore?: number;
+  readonly driftScore?: number;
+  readonly routingDecision?: string;
+}
+
+export interface DecisionRow {
+  readonly ts: string;
+  readonly allowed: boolean;
+  readonly decision: DecisionKind;
+  readonly mode?: string;
+  readonly ruleId?: string;
+  readonly reason?: string;
+  readonly suggestion?: string;
+  readonly escalation?: string;
+  readonly agent?: string;
+  readonly driver?: string;
+  readonly actionType: string;
+  readonly actionTarget: string;
+  readonly envelopeId?: string;
+  readonly tier?: string;
+  readonly workflowId?: string;
+  readonly signals?: DecisionSignals;
+}
+
+export interface TimelineEvent {
+  readonly ts: string;
+  readonly seq: number;
+  readonly eventType: string;
+  readonly surface: string;
+  readonly sessionId: string;
+  readonly chainId: string;
+  readonly prevHash: string | null;
+  readonly thisHash: string;
+  readonly labels: Record<string, unknown>;
+  readonly payload: Record<string, unknown>;
+}
+
+export interface ChainBreak {
+  readonly seq: number;
+  readonly expectedPrevHash: string | null;
+  readonly actualPrevHash: string | null;
+}
+
+export interface SessionTimeline {
+  readonly chainId: string;
+  readonly events: TimelineEvent[];
+  readonly chainHealth: {
+    readonly ok: boolean;
+    readonly breaks: ChainBreak[];
+  };
+}
+
+export interface RuleHitSummary {
+  readonly ruleId: string;
+  readonly count: number;
+  readonly allowCount: number;
+  readonly denyCount: number;
+  readonly examples: DecisionRow[];
+}
+
+export interface AgentStateSummary {
+  readonly totalDenials: number;
+  readonly locked: boolean;
+  readonly lockedTs?: string;
+  readonly level: 'normal' | 'elevated' | 'high' | 'lockdown';
+}
+
+export interface AgentSummary {
+  readonly agent: string;
+  readonly decisionCount: number;
+  readonly allowCount: number;
+  readonly denyCount: number;
+  readonly rules: RuleHitSummary[];
+  readonly recentDecisions: DecisionRow[];
+  readonly state?: AgentStateSummary;
+}
+
+interface RawDecision {
+  readonly allowed?: unknown;
+  readonly mode?: unknown;
+  readonly rule_id?: unknown;
+  readonly reason?: unknown;
+  readonly suggestion?: unknown;
+  readonly escalation?: unknown;
+  readonly agent?: unknown;
+  readonly driver?: unknown;
+  readonly action_type?: unknown;
+  readonly action_target?: unknown;
+  readonly ts?: unknown;
+  readonly envelope_id?: unknown;
+  readonly tier?: unknown;
+  readonly workflow_id?: unknown;
+  readonly predicted_blast?: unknown;
+  readonly floundering_score?: unknown;
+  readonly drift_score?: unknown;
+  readonly routing_decision?: unknown;
+}
+
+interface EventRow {
+  readonly ts: string;
+  readonly seq: number;
+  readonly event_type: string;
+  readonly surface: string;
+  readonly session_id: string;
+  readonly chain_id: string;
+  readonly prev_hash: string | null;
+  readonly this_hash: string;
+  readonly labels: string;
+  readonly payload: string;
+}
+
+export function listDecisions(chitinDir: string, filters: DecisionFilters = {}): DecisionRow[] {
+  if (!existsSync(chitinDir)) return [];
+
+  const rows: DecisionRow[] = [];
+  const names = readdirSync(chitinDir)
+    .filter((name) => /^gov-decisions-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name))
+    .sort()
+    .reverse();
+  const sinceMillis = filters.since?.getTime();
+  for (const name of names) {
+    const content = readFileSync(join(chitinDir, name), 'utf8');
+    const lines = content.split('\n');
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index];
+      const row = parseDecisionLine(line);
+      if (!row) continue;
+      if (sinceMillis !== undefined && Date.parse(row.ts) < sinceMillis) break;
+      if (!matchesDecisionFilters(row, filters)) continue;
+      rows.push(row);
+      if (typeof filters.limit === 'number' && rows.length >= filters.limit) return rows;
+    }
+  }
+
+  return rows;
+}
+
+export function getSessionTimeline(chitinDir: string, chainId: string): SessionTimeline {
+  ensureIndexed(chitinDir);
+  const dbPath = join(chitinDir, 'events.db');
+  if (!existsSync(dbPath)) {
+    return { chainId, events: [], chainHealth: { ok: true, breaks: [] } };
+  }
+
+  const db = new BetterSqlite3(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .prepare(
+        `SELECT ts, seq, event_type, surface, session_id, chain_id, prev_hash,
+                this_hash, labels, payload
+         FROM events
+         WHERE chain_id = ?
+         ORDER BY seq ASC, ts ASC`,
+      )
+      .all(chainId) as EventRow[];
+    const events = rows.map((row) => ({
+      ts: row.ts,
+      seq: row.seq,
+      eventType: row.event_type,
+      surface: row.surface,
+      sessionId: row.session_id,
+      chainId: row.chain_id,
+      prevHash: row.prev_hash,
+      thisHash: row.this_hash,
+      labels: parseJSONRecord(row.labels),
+      payload: parseJSONRecord(row.payload),
+    }));
+    const breaks = findChainBreaks(events);
+    return { chainId, events, chainHealth: { ok: breaks.length === 0, breaks } };
+  } finally {
+    db.close();
+  }
+}
+
+export function getAgentSummary(chitinDir: string, agent: string): AgentSummary {
+  const decisions = listDecisions(chitinDir, { agent });
+  const allowCount = decisions.filter((row) => row.decision === 'allow').length;
+  const denyCount = decisions.filter((row) => row.decision === 'deny').length;
+  return {
+    agent,
+    decisionCount: decisions.length,
+    allowCount,
+    denyCount,
+    rules: summarizeRules(decisions),
+    recentDecisions: decisions.slice(0, 10),
+    state: readAgentState(chitinDir, agent),
+  };
+}
+
+export function listRuleSummaries(chitinDir: string, filters: DecisionFilters = {}): RuleHitSummary[] {
+  return summarizeRules(listDecisions(chitinDir, filters));
+}
+
+function parseDecisionLine(line: string): DecisionRow | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  let raw: RawDecision;
+  try {
+    raw = JSON.parse(trimmed) as RawDecision;
+  } catch {
+    return null;
+  }
+
+  if (typeof raw.ts !== 'string' || typeof raw.action_type !== 'string') return null;
+  if (!Number.isFinite(Date.parse(raw.ts))) return null;
+  const allowed = raw.allowed === true;
+  const actionTarget = typeof raw.action_target === 'string' ? raw.action_target : '';
+  const signals = decisionSignals(raw);
+  return {
+    ts: raw.ts,
+    allowed,
+    decision: allowed ? 'allow' : 'deny',
+    mode: stringField(raw.mode),
+    ruleId: stringField(raw.rule_id),
+    reason: stringField(raw.reason),
+    suggestion: stringField(raw.suggestion),
+    escalation: stringField(raw.escalation),
+    agent: stringField(raw.agent),
+    driver: stringField(raw.driver),
+    actionType: raw.action_type,
+    actionTarget,
+    envelopeId: stringField(raw.envelope_id),
+    tier: stringField(raw.tier),
+    workflowId: stringField(raw.workflow_id),
+    signals: Object.keys(signals).length > 0 ? signals : undefined,
+  };
+}
+
+function matchesDecisionFilters(row: DecisionRow, filters: DecisionFilters): boolean {
+  if (filters.driver && row.driver !== filters.driver) return false;
+  if (filters.agent && row.agent !== filters.agent) return false;
+  if (filters.actionType && row.actionType !== filters.actionType) return false;
+  if (filters.decision && row.decision !== filters.decision) return false;
+  return true;
+}
+
+function decisionSignals(raw: RawDecision): DecisionSignals {
+  const signals: Record<string, number | string> = {};
+  if (typeof raw.predicted_blast === 'number') signals.predictedBlast = raw.predicted_blast;
+  if (typeof raw.floundering_score === 'number') signals.flounderingScore = raw.floundering_score;
+  if (typeof raw.drift_score === 'number') signals.driftScore = raw.drift_score;
+  if (typeof raw.routing_decision === 'string' && raw.routing_decision !== '') {
+    signals.routingDecision = raw.routing_decision;
+  }
+  return signals;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function parseJSONRecord(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function findChainBreaks(events: TimelineEvent[]): ChainBreak[] {
+  const breaks: ChainBreak[] = [];
+  let expectedPrevHash: string | null = null;
+  for (const event of events) {
+    if (event.prevHash !== expectedPrevHash) {
+      breaks.push({ seq: event.seq, expectedPrevHash, actualPrevHash: event.prevHash });
+    }
+    expectedPrevHash = event.thisHash;
+  }
+  return breaks;
+}
+
+function summarizeRules(decisions: readonly DecisionRow[]): RuleHitSummary[] {
+  const byRule = new Map<string, DecisionRow[]>();
+  for (const decision of decisions) {
+    const ruleId = decision.ruleId ?? '<unknown>';
+    const existing = byRule.get(ruleId) ?? [];
+    existing.push(decision);
+    byRule.set(ruleId, existing);
+  }
+  return [...byRule.entries()]
+    .map(([ruleId, rows]) => ({
+      ruleId,
+      count: rows.length,
+      allowCount: rows.filter((row) => row.decision === 'allow').length,
+      denyCount: rows.filter((row) => row.decision === 'deny').length,
+      examples: rows.slice(0, 3),
+    }))
+    .sort((left, right) => {
+      if (right.count !== left.count) return right.count - left.count;
+      return left.ruleId.localeCompare(right.ruleId);
+    });
+}
+
+function readAgentState(chitinDir: string, agent: string): AgentStateSummary | undefined {
+  const dbPath = join(chitinDir, 'gov.db');
+  if (!existsSync(dbPath)) return undefined;
+  const db = new BetterSqlite3(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare('SELECT total, locked, locked_ts FROM agent_state WHERE agent = ?')
+      .get(agent) as { total: number; locked: number; locked_ts: string | null } | undefined;
+    if (!row) return undefined;
+    return {
+      totalDenials: row.total,
+      locked: row.locked === 1,
+      lockedTs: row.locked_ts ?? undefined,
+      level: escalationLevel(row.total, row.locked === 1),
+    };
+  } catch {
+    return undefined;
+  } finally {
+    db.close();
+  }
+}
+
+function escalationLevel(totalDenials: number, locked: boolean): AgentStateSummary['level'] {
+  if (locked || totalDenials >= 10) return 'lockdown';
+  if (totalDenials >= 7) return 'high';
+  if (totalDenials >= 3) return 'elevated';
+  return 'normal';
+}

--- a/libs/telemetry/tests/inspect-queries.test.ts
+++ b/libs/telemetry/tests/inspect-queries.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import BetterSqlite3 from 'better-sqlite3';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getAgentSummary,
+  getSessionTimeline,
+  listDecisions,
+  listRuleSummaries,
+} from '../src/inspect-queries.js';
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+function tempDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+function writeDecisionLog(chitinDir: string): void {
+  const rows = [
+    {
+      allowed: true,
+      mode: 'enforce',
+      rule_id: 'default-allow-shell',
+      reason: 'allowed',
+      agent: 'codex',
+      driver: 'codex',
+      action_type: 'shell.exec',
+      action_target: 'pwd',
+      ts: '2026-05-11T18:25:42Z',
+    },
+    {
+      allowed: false,
+      mode: 'enforce',
+      rule_id: 'governance-mutation-authority-required',
+      reason: 'blocked',
+      suggestion: 'Ask the operator.',
+      agent: 'codex',
+      driver: 'codex',
+      action_type: 'shell.exec',
+      action_target: 'chitin-kernel --help',
+      ts: '2026-05-11T18:25:43Z',
+    },
+    {
+      allowed: true,
+      mode: 'monitor',
+      rule_id: 'router-heuristic:allow',
+      agent: 'claude-code',
+      driver: 'claude-code',
+      action_type: 'router.signal',
+      action_target: 'Bash:git status',
+      predicted_blast: 0.275,
+      floundering_score: 0.85,
+      ts: '2026-05-11T18:25:44Z',
+    },
+  ];
+  writeFileSync(
+    join(chitinDir, 'gov-decisions-2026-05-11.jsonl'),
+    rows.map((r) => JSON.stringify(r)).join('\n') + '\n',
+  );
+}
+
+function event(overrides: Record<string, unknown>) {
+  return {
+    schema_version: '2',
+    run_id: 'run-1',
+    session_id: 'sess-1',
+    surface: 'codex',
+    driver_identity: { user: 'u', machine_id: 'm', machine_fingerprint: 'a'.repeat(64) },
+    agent_instance_id: 'codex',
+    parent_agent_id: null,
+    agent_fingerprint: 'b'.repeat(64),
+    event_type: 'decision',
+    chain_id: 'chain-1',
+    chain_type: 'session',
+    parent_chain_id: null,
+    seq: 0,
+    prev_hash: null,
+    this_hash: '0'.repeat(64),
+    ts: '2026-05-11T18:25:42Z',
+    labels: {},
+    payload: {},
+    ...overrides,
+  };
+}
+
+describe('inspect queries', () => {
+  it('lists decisions with filters, newest first, and exposes router scores', () => {
+    const dir = tempDir('chitin-inspect-');
+    writeDecisionLog(dir);
+
+    const denied = listDecisions(dir, { decision: 'deny', agent: 'codex' });
+    expect(denied).toHaveLength(1);
+    expect(denied[0]).toMatchObject({
+      allowed: false,
+      decision: 'deny',
+      ruleId: 'governance-mutation-authority-required',
+      suggestion: 'Ask the operator.',
+      driver: 'codex',
+    });
+
+    const signals = listDecisions(dir, { actionType: 'router.signal' });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].signals).toEqual({
+      predictedBlast: 0.275,
+      flounderingScore: 0.85,
+    });
+  });
+
+  it('drops malformed timestamps and applies limits while scanning newest first', () => {
+    const dir = tempDir('chitin-inspect-');
+    writeDecisionLog(dir);
+    writeFileSync(
+      join(dir, 'gov-decisions-2026-05-12.jsonl'),
+      [
+        JSON.stringify({
+          allowed: true,
+          action_type: 'shell.exec',
+          action_target: 'bad timestamp',
+          ts: 'not-a-date',
+        }),
+        JSON.stringify({
+          allowed: true,
+          action_type: 'shell.exec',
+          action_target: 'newest',
+          ts: '2026-05-12T00:00:00Z',
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const decisions = listDecisions(dir, { limit: 2 });
+    expect(decisions.map((row) => row.actionTarget)).toEqual(['newest', 'Bash:git status']);
+  });
+
+  it('returns a session timeline with chain continuity status', () => {
+    const dir = tempDir('chitin-inspect-');
+    writeFileSync(
+      join(dir, 'events-run-1.jsonl'),
+      [
+        event({ seq: 0, prev_hash: null, this_hash: 'a'.repeat(64), event_type: 'session_start' }),
+        event({ seq: 1, prev_hash: 'a'.repeat(64), this_hash: 'b'.repeat(64), event_type: 'decision' }),
+        event({ seq: 2, prev_hash: 'not-the-tail', this_hash: 'c'.repeat(64), event_type: 'session_end' }),
+      ].map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+
+    const timeline = getSessionTimeline(dir, 'chain-1');
+    expect(timeline.chainId).toBe('chain-1');
+    expect(timeline.events.map((e) => e.eventType)).toEqual(['session_start', 'decision', 'session_end']);
+    expect(timeline.chainHealth.ok).toBe(false);
+    expect(timeline.chainHealth.breaks).toEqual([
+      {
+        seq: 2,
+        expectedPrevHash: 'b'.repeat(64),
+        actualPrevHash: 'not-the-tail',
+      },
+    ]);
+  });
+
+  it('summarizes an agent from decisions and read-only gov.db state', () => {
+    const dir = tempDir('chitin-inspect-');
+    writeDecisionLog(dir);
+    const db = new BetterSqlite3(join(dir, 'gov.db'));
+    db.exec(`
+      CREATE TABLE agent_state (
+        agent TEXT PRIMARY KEY,
+        total INTEGER NOT NULL DEFAULT 0,
+        locked INTEGER NOT NULL DEFAULT 0,
+        locked_ts TEXT
+      );
+      INSERT INTO agent_state (agent, total, locked, locked_ts)
+      VALUES ('codex', 7, 0, NULL);
+    `);
+    db.close();
+
+    const summary = getAgentSummary(dir, 'codex');
+    expect(summary).toMatchObject({
+      agent: 'codex',
+      allowCount: 1,
+      denyCount: 1,
+      decisionCount: 2,
+      state: { level: 'high', locked: false, totalDenials: 7 },
+    });
+    expect(summary.rules[0]).toMatchObject({
+      ruleId: 'default-allow-shell',
+      count: 1,
+    });
+  });
+
+  it('summarizes rule hits with examples', () => {
+    const dir = tempDir('chitin-inspect-');
+    writeDecisionLog(dir);
+
+    const summaries = listRuleSummaries(dir);
+    expect(summaries[0]).toMatchObject({
+      ruleId: 'default-allow-shell',
+      count: 1,
+      allowCount: 1,
+      denyCount: 0,
+    });
+    expect(summaries.map((summary) => summary.ruleId)).toContain('governance-mutation-authority-required');
+    expect(summaries[0].examples[0]).toMatchObject({
+      actionType: 'shell.exec',
+      agent: 'codex',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a CLI-first Chitin Console surface for local governance observability.

- Adds a design spec for Chitin Console boundaries and milestones.
- Adds shared telemetry queries for decisions, session timelines, agent summaries, and rule summaries.
- Adds `chitin inspect live`, `denials`, `session`, `agent`, and `rules` commands.
- Keeps browser/API work deferred until the CLI read model is dogfooded.

## Copilot review follow-up

This replacement PR is rebased onto `main` and contains only the inspect-console commit. It also addresses Copilot feedback from #507:

- Scans `gov-decisions` logs newest-first and stops early when `--limit`/`--since` permits.
- Drops malformed decision timestamps during parsing.
- Resolves `.chitin` from nested working directories correctly.
- Updates the spec to match the implemented `--decision <allow|deny>` flag.

## Validation

- `pnpm exec nx run @chitin/telemetry:test`
- `pnpm exec nx run @chitin/cli:test`
- `pnpm exec nx run @chitin/telemetry:typecheck`
- `pnpm exec nx run @chitin/cli:typecheck` completed, but the CLI typecheck target is currently disabled by repo config and prints the existing explanatory echo.
- Manual smoke against `~/.chitin` for `inspect live`, `inspect session`, `inspect agent`, and `inspect rules`.

## Notes

This stays inside Chitin read-side observability. It does not add dispatch, approvals, ticket mutation, model routing, or a background API server.