### PR TITLE
fix(chitin-kernel): classify --version/--help as read; fix pipe mutation classification (#t_41b18659)

### DIFF
--- a/docs/architecture/2026-05-10-nx-inventory.md
+++ b/docs/architecture/2026-05-10-nx-inventory.md
@@ -1,0 +1,266 @@
+# Nx Workspace Inventory - 2026-05-10
+
+Status: restored and revalidated for kanban task `t_7c01b5e4`.
+
+This document records the current Nx and filesystem shape before the
+monorepo restructuring spec. It intentionally does not choose a target
+layout.
+
+## Commands Run
+
+```bash
+pnpm exec nx show projects --json
+pnpm exec nx graph --print
+pnpm exec nx show project <name> --json
+pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage
+pnpm install
+cat pnpm-workspace.yaml
+git ls-files apps libs tools go python
+test ! -d apps/mcp-server
+test ! -d apps/runner
+test ! -d apps/slack-app
+test ! -d libs/governance
+test ! -d libs/scheduler
+```
+
+## Resolved Nx Projects
+
+`pnpm exec nx show projects --json` reports 11 projects:
+
+```json
+[
+  "@chitin/router-plugin-api",
+  "@chitinhq/openclaw-plugin-governance",
+  "@chitin/adapter-ollama-local",
+  "@chitin/adapter-claude-code",
+  "@chitin/adapter-openclaw",
+  "execution-kernel",
+  "@chitin/generators",
+  "@chitin/contracts",
+  "@chitin/telemetry",
+  "@chitin/tooling-lint",
+  "@chitin/cli"
+]
+```
+
+| Project | Root | Project Type | Source Root | Tags | Targets |
+|---|---|---:|---|---|---|
+| `@chitin/router-plugin-api` | `libs/router-plugin-api/typescript` | null | null | `npm:private` | none |
+| `@chitinhq/openclaw-plugin-governance` | `apps/openclaw-plugin-governance` | null | null | `npm:public`, `layer:app` | `test`, `nx-release-publish` |
+| `@chitin/adapter-ollama-local` | `libs/adapters/ollama-local` | `library` | `libs/adapters/ollama-local/src` | `npm:private`, `layer:adapter` | `typecheck` |
+| `@chitin/adapter-claude-code` | `libs/adapters/claude-code` | null | null | `npm:private`, `layer:adapter` | `typecheck` |
+| `@chitin/adapter-openclaw` | `libs/adapters/openclaw` | `library` | `libs/adapters/openclaw/src` | `npm:private`, `layer:adapter` | `typecheck` |
+| `execution-kernel` | `go/execution-kernel` | `application` | `go/execution-kernel` | `npm:private`, `layer:kernel` | `build`, `test`, `lint`, `run` |
+| `@chitin/generators` | `tools/generators` | null | null | `npm:private`, `layer:tooling` | none |
+| `@chitin/contracts` | `libs/contracts` | null | null | `npm:private`, `layer:contracts` | `typecheck`, `test`, `generate-go-types` |
+| `@chitin/telemetry` | `libs/telemetry` | null | null | `npm:private`, `layer:telemetry` | `typecheck`, `test` |
+| `@chitin/tooling-lint` | `tools/lint` | null | null | `npm:private`, `layer:tooling` | `typecheck`, `test`, `lint:layer-tag-coverage` |
+| `@chitin/cli` | `apps/cli` | null | null | `npm:private`, `layer:cli` | `typecheck`, `test`, `run` |
+
+## Target Commands
+
+The resolved project target commands are:
+
+| Project | Target | Executor | Command / Notes |
+|---|---|---|---|
+| `@chitinhq/openclaw-plugin-governance` | `test` | `nx:run-commands` | `pnpm exec vitest run apps/openclaw-plugin-governance/test` |
+| `@chitinhq/openclaw-plugin-governance` | `nx-release-publish` | `@nx/js:release-publish` | Nx release publish target |
+| `@chitin/adapter-ollama-local` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/adapters/ollama-local` |
+| `@chitin/adapter-claude-code` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/adapters/claude-code` |
+| `@chitin/adapter-openclaw` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/adapters/openclaw` |
+| `execution-kernel` | `build` | `nx:run-commands` | `go build -o ../../dist/go/execution-kernel/chitin-kernel ./cmd/chitin-kernel` in `go/execution-kernel` |
+| `execution-kernel` | `test` | `nx:run-commands` | `go test ./...` in `go/execution-kernel` |
+| `execution-kernel` | `lint` | `nx:run-commands` | `go vet ./...` in `go/execution-kernel` |
+| `execution-kernel` | `run` | `nx:run-commands` | `go run ./cmd/chitin-kernel` in `go/execution-kernel` |
+| `@chitin/contracts` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/contracts` |
+| `@chitin/contracts` | `test` | `nx:run-commands` | `pnpm exec vitest run libs/contracts/tests` |
+| `@chitin/contracts` | `generate-go-types` | `nx:run-commands` | `pnpm exec tsx libs/contracts/tools/generate-go-types.ts`; output `go/execution-kernel/internal/event/event.go` |
+| `@chitin/telemetry` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/telemetry` |
+| `@chitin/telemetry` | `test` | `nx:run-commands` | `pnpm exec vitest run libs/telemetry/tests` |
+| `@chitin/tooling-lint` | `typecheck` | `nx:run-commands` | disabled echo target because project references set `noEmit: true` |
+| `@chitin/tooling-lint` | `test` | `nx:run-commands` | `pnpm exec vitest run --config tools/lint/vitest.config.ts` |
+| `@chitin/tooling-lint` | `lint:layer-tag-coverage` | `nx:run-commands` | `pnpm exec tsx tools/lint/layer-tag-coverage.ts` |
+| `@chitin/cli` | `typecheck` | `nx:run-commands` | disabled echo target because project references set `noEmit: true` |
+| `@chitin/cli` | `test` | `nx:run-commands` | `pnpm exec vitest run apps/cli/tests` |
+| `@chitin/cli` | `run` | `nx:run-commands` | `pnpm exec tsx apps/cli/src/main.ts` |
+
+`@chitin/router-plugin-api` and `@chitin/generators` currently resolve
+with no targets.
+
+## Project Graph Edges
+
+`pnpm exec nx graph --print` reports these project-to-project edges:
+
+| Source | Target | Type |
+|---|---|---|
+| `@chitin/adapter-ollama-local` | `@chitin/contracts` | static |
+| `@chitin/adapter-claude-code` | `@chitin/contracts` | static |
+| `@chitin/telemetry` | `@chitin/contracts` | static |
+| `@chitin/tooling-lint` | `@chitin/contracts` | static |
+| `@chitin/cli` | `@chitin/contracts` | static |
+| `@chitin/cli` | `@chitin/telemetry` | static |
+| `@chitin/cli` | `@chitin/telemetry` | dynamic |
+
+The following resolved projects currently have no graph dependencies:
+
+- `@chitin/router-plugin-api`
+- `@chitinhq/openclaw-plugin-governance`
+- `@chitin/adapter-openclaw`
+- `execution-kernel`
+- `@chitin/generators`
+- `@chitin/contracts`
+
+## Workspace Package Globs
+
+`pnpm-workspace.yaml` currently declares:
+
+```yaml
+packages:
+  - 'libs/*'
+  - 'libs/adapters/*'
+  - 'libs/router-plugin-api/typescript'
+  - 'apps/*'
+  - 'go/*'
+  - 'tools/*'
+```
+
+Notably, `python/analysis` is not included in the pnpm workspace globs.
+
+## Module Boundary Constraints
+
+`eslint.config.mjs` contains the active `@nx/enforce-module-boundaries`
+rule. Current `layer:*` depConstraints are:
+
+| Source Tag | May Depend On |
+|---|---|
+| `layer:contracts` | none |
+| `layer:telemetry` | `layer:contracts` |
+| `layer:scheduler` | `layer:contracts`, `layer:telemetry` |
+| `layer:slack` | `layer:contracts`, `layer:telemetry` |
+| `layer:adapter` | `layer:contracts`, `layer:telemetry` |
+| `layer:mcp` | `layer:contracts`, `layer:telemetry` |
+| `layer:cli` | `layer:contracts`, `layer:telemetry`, `layer:scheduler` |
+| `layer:app` | `layer:contracts`, `layer:telemetry` |
+| `layer:tooling` | `layer:contracts` |
+| `layer:kernel` | none |
+
+`pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage`
+completed successfully with 0 errors and 3 orphan warnings:
+
+```text
+layer-tag-coverage: warning - depConstraints with no matching package:
+  layer:mcp (defined but no package carries this tag yet)
+  layer:scheduler (defined but no package carries this tag yet)
+  layer:slack (defined but no package carries this tag yet)
+layer-tag-coverage: ok (0 errors, 3 orphan warnings)
+
+NX   Successfully ran target lint:layer-tag-coverage for project @chitin/tooling-lint
+```
+
+Nx also printed:
+
+```text
+Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.
+```
+
+## Tracked Paths By Surface
+
+Tracked source paths under the workspace roots reduce to:
+
+```text
+apps/cli
+apps/openclaw-plugin-governance
+go/execution-kernel
+libs/adapters/claude-code
+libs/adapters/ollama-local
+libs/adapters/openclaw
+libs/contracts
+libs/router-plugin-api
+libs/telemetry
+python/analysis
+tools/generators
+tools/lint
+```
+
+## Removed Historical Ghost Directories
+
+The following historical ghost directories do not exist in the current
+worktree:
+
+- `apps/mcp-server`
+- `apps/runner`
+- `apps/slack-app`
+- `libs/governance`
+- `libs/scheduler`
+
+Scope guards with `test ! -d` passed for all five paths during
+revalidation.
+
+## Tracked Code Outside Resolved Nx Projects
+
+Two tracked surfaces are outside, or only partially inside, resolved Nx
+project coverage.
+
+### `python/analysis`
+
+`python/analysis` has 47 tracked files and is not represented in the Nx
+project list. It is also not included in `pnpm-workspace.yaml`.
+
+Tracked examples include:
+
+```text
+python/analysis/__init__.py
+python/analysis/__main__.py
+python/analysis/codex_mine.py
+python/analysis/debt.py
+python/analysis/decisions.py
+python/analysis/detect.py
+python/analysis/draft.py
+python/analysis/floundering_calibration.py
+python/analysis/llm_draft.py
+python/analysis/loaders.py
+python/analysis/models.py
+python/analysis/predict.py
+```
+
+Ignored local Python artifacts also exist under `python/analysis`, such as
+`.venv`, `.pytest_cache`, `__pycache__`, `*.egg-info`, and `out/`.
+
+### `libs/router-plugin-api/python`
+
+`libs/router-plugin-api/python` has 2 tracked files:
+
+```text
+libs/router-plugin-api/python/chitin_governance.py
+libs/router-plugin-api/python/setup.py
+```
+
+The resolved Nx project for router plugin API is only
+`libs/router-plugin-api/typescript`.
+
+## Observed Metadata Gaps
+
+These are factual gaps in the current resolved workspace metadata, not
+target-architecture decisions:
+
+- 7 of 11 resolved projects have `projectType: null`.
+- 8 of 11 resolved projects have `sourceRoot: null`.
+- `@chitin/router-plugin-api` has no `layer:*` tag.
+- `@chitin/router-plugin-api` and `@chitin/generators` have no targets.
+- `@chitin/tooling-lint:typecheck` and `@chitin/cli:typecheck` are disabled
+  echo targets because project references set `noEmit: true`.
+- Boundary constraints still include orphaned historical layers:
+  `layer:mcp`, `layer:scheduler`, and `layer:slack`.
+- `@chitin/contracts:generate-go-types` writes into
+  `go/execution-kernel/internal/event/event.go`, which is outside the
+  contracts project root.
+
+## Verification Status
+
+- `pnpm install`: passed; lockfile was up to date.
+- `pnpm exec nx show projects --json`: passed.
+- `pnpm exec nx graph --print`: passed.
+- `pnpm exec nx show project <name> --json`: passed for all 11 projects.
+- Scope guards for removed ghost directories: passed.
+- `pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage`: passed
+  with 3 orphan warnings.

--- a/docs/runbooks/unknown-rate-alarm.md
+++ b/docs/runbooks/unknown-rate-alarm.md
@@ -1,0 +1,78 @@
+# Unknown-Rate Alarm Runbook
+
+Chitin's `unknown` action type is the fail-closed bucket for tool calls that
+the driver normalizers do not understand. A sustained unknown rate means a
+driver surface changed or a dispatcher routed the wrong tool shape into a
+normalizer.
+
+## Alarm
+
+Run the guardrail against the local chain:
+
+```sh
+cd go/execution-kernel
+CHITIN_UNKNOWN_RATE_DIR="$HOME/.chitin" \
+CHITIN_UNKNOWN_RATE_DAY="$(date -u +%F)" \
+go test ./internal/gov -run TestUnknownRateAlarmCurrentChainOptIn -count=1
+```
+
+The test fails when any `(agent, UTC day)` bucket has an unexpected unknown
+rate of at least `1%`.
+
+Omit `CHITIN_UNKNOWN_RATE_DAY` for forensics across every
+`gov-decisions-*.jsonl` file in the state directory. Historical bad days, such
+as `2026-05-07`, will still fail by design.
+
+The alarm excludes the documented Hermes intentional-unknown tools:
+
+- `clarify`
+- `image_generate`
+- `text_to_speech`
+- `vision_analyze`
+- `cronjob`
+
+These are chat/modality/scheduling surfaces that intentionally still map to
+`unknown` until chitin has a stable canonical action for them.
+
+## Triage
+
+1. Read the failing test output. It includes:
+   - `(agent, day)`
+   - unknown count, total count, and rate
+   - top unknown tool names with counts
+   - sample locations as `chain_id:seq` when present, otherwise
+     `gov-decisions-YYYY-MM-DD.jsonl:line`
+2. Inspect the raw daily log:
+
+```sh
+jq -c 'select(.agent=="AGENT" and .action_type=="unknown") |
+  {ts, agent, action_target, rule_id, chain_id, seq}' \
+  "$HOME/.chitin/gov-decisions-YYYY-MM-DD.jsonl" | head -50
+```
+
+3. Decide whether each top tool is:
+   - a real new tool that needs a canonical mapping in the relevant
+     `internal/driver/<driver>/normalize.go`
+   - a cross-driver leak that should be normalized through the correct driver
+     or fixed in the upstream dispatcher
+   - an intentional unknown that belongs in the documented whitelist
+
+## Known Reference Points
+
+- `2026-05-07`: Hermes hit roughly `67%` unknowns because runtime plumbing such
+  as `kanban_show`, `kanban_block`, and `process` was unmapped.
+- `2026-05-09`: after the Hermes fixes, the remaining unknowns were much lower
+  and concentrated in specific unmapped tools such as `skills_list`, `memory`,
+  and `skill_manage`, plus intentional `clarify` calls.
+
+## Fix
+
+Add or repair the driver normalizer mapping, then add focused tests near that
+driver. For Hermes, start with:
+
+- `go/execution-kernel/internal/driver/hermes/normalize.go`
+- `go/execution-kernel/internal/gov/action.go`
+
+Do not route approvals, orchestration, or LLM consultation into chitin. The
+kernel should only normalize, govern, record the chain, and stamp pure-Go
+signals.

--- a/docs/superpowers/specs/2026-05-10-nx-restructure.md
+++ b/docs/superpowers/specs/2026-05-10-nx-restructure.md
@@ -1,0 +1,332 @@
+# Nx-Native Monorepo Restructuring Spec
+
+Date: 2026-05-10
+
+Status: Proposed
+
+Task: `t_8bda2f95` / P100 kickoff
+
+## Inputs
+
+This spec is grounded in `AGENTS.md`, `.github/copilot-instructions.md`, current package manifests, current `nx.json`, and the post-cull decision docs named in `AGENTS.md`.
+
+The requested inventory artifact, `docs/architecture/2026-05-10-nx-inventory.md`, is not present in this checkout at spec time. Before executing migration changes, recreate or restore that inventory and compare it against this spec. The validation commands below include a path check for that artifact.
+
+## Goal
+
+Make the repository Nx-native without broadening Chitin's product scope. The restructuring is allowed to change project metadata, tags, target names, and directory placement. It must not add orchestration, approvals, LLM consultation, MCP hosting, model routing, SaaS surfaces, or feature behavior.
+
+## Allowed Buckets as Nx Projects
+
+| Chitin bucket | Nx project type | Required tags | Current examples | Rule |
+| --- | --- | --- | --- | --- |
+| Kernel | `application` | `type:app`, `scope:kernel`, `layer:kernel`, `lang:go`, `runtime:local` | `execution-kernel` | Canonical write path and gate runtime only. |
+| Analytics libs | `library` | `type:lib`, `scope:analytics`, layer tag by role, language tag | `@chitin/contracts`, `@chitin/telemetry`, `chitin-analysis` | Read-side schemas, replay, indexing, analysis, and contracts. |
+| Plugins | `library` for reusable adapters/API packages, `application` only for runnable downstream plugin packages | `type:plugin` or `type:adapter`, `scope:plugin`, layer tag by role | `@chitin/adapter-claude-code`, `@chitin/router-plugin-api`, `@chitinhq/openclaw-plugin-governance` | Operator-installed driver adapters and downstream substrate plugins only. |
+| Apps built off kernel | `application` | `type:app`, `scope:app`, specific layer tag | `@chitin/cli` | Must non-trivially consume kernel state in a way no substrate already does. |
+
+Projects outside these buckets must be deleted, moved to `scratch/`, or kept outside Nx. They must not be tagged into the production project graph.
+
+## Canonical Top-Level Layout
+
+The canonical layout is:
+
+```text
+apps/
+  cli/
+  openclaw-plugin-governance/
+go/
+  execution-kernel/
+libs/
+  adapters/
+    claude-code/
+    ollama-local/
+    openclaw/
+  contracts/
+  router-plugin-api/
+    typescript/
+    python/
+  telemetry/
+python/
+  analysis/
+tools/
+  generators/
+  lint/
+docs/
+  architecture/
+  decisions/
+  superpowers/
+examples/
+  router-plugins/
+scratch/
+scripts/
+```
+
+Directory rules:
+
+- `go/execution-kernel` remains the kernel root. Do not split kernel internals into separate Nx projects unless Go module boundaries are also split.
+- `python/analysis` remains under `python/` because it is an analytics read-side package, not a TS workspace package.
+- `libs/router-plugin-api` may contain language-specific packages. `libs/router-plugin-api/typescript` is an Nx package; `libs/router-plugin-api/python` is either added as a Python Nx project later or left as source-only until Python targets are wired.
+- `tools/*` are Nx tooling projects only when they enforce or generate repository structure. They are not Chitin runtime features.
+- `examples/*` are non-production examples and should use `type:example` if added to Nx; otherwise keep them outside the project graph.
+- `scratch/*` is excluded from production Nx boundaries and validation except basic repository hygiene.
+
+## Project Naming
+
+Nx project names must be stable and command-friendly.
+
+| Area | Directory | Nx project name |
+| --- | --- | --- |
+| Go kernel | `go/execution-kernel` | `execution-kernel` |
+| CLI app | `apps/cli` | `@chitin/cli` |
+| OpenClaw governance plugin app | `apps/openclaw-plugin-governance` | `@chitinhq/openclaw-plugin-governance` |
+| Contracts | `libs/contracts` | `@chitin/contracts` |
+| Telemetry | `libs/telemetry` | `@chitin/telemetry` |
+| Claude Code adapter | `libs/adapters/claude-code` | `@chitin/adapter-claude-code` |
+| OpenClaw adapter | `libs/adapters/openclaw` | `@chitin/adapter-openclaw` |
+| Ollama local adapter | `libs/adapters/ollama-local` | `@chitin/adapter-ollama-local` |
+| Router plugin API TS | `libs/router-plugin-api/typescript` | `@chitin/router-plugin-api` |
+| Python analysis | `python/analysis` | `analysis` or `chitin-analysis` |
+| Generators | `tools/generators` | `@chitin/generators` |
+| Lint tooling | `tools/lint` | `@chitin/tooling-lint` |
+
+Rules:
+
+- Published or potentially published TS packages use npm package names as Nx names.
+- Non-TS projects use short kebab-case names unless a package manager already owns the name.
+- Do not use bucket names alone as project names. `kernel`, `contracts`, `telemetry`, `adapter`, and `plugin` are roles, not project identities.
+
+## Tag Taxonomy
+
+Every production Nx project must have one tag from each applicable axis:
+
+- `type:app`, `type:lib`, `type:adapter`, `type:plugin`, `type:tooling`, or `type:example`
+- `scope:kernel`, `scope:analytics`, `scope:plugin`, `scope:app`, `scope:tooling`, or `scope:example`
+- `layer:kernel`, `layer:contracts`, `layer:telemetry`, `layer:analysis`, `layer:adapter`, `layer:plugin-api`, `layer:plugin`, `layer:cli`, or `layer:tooling`
+- `lang:go`, `lang:ts`, `lang:python`, or `lang:mixed`
+- Optional runtime tags: `runtime:local`, `runtime:driver`, `runtime:openclaw`, `runtime:cli`, `runtime:tooling`
+
+Legacy culled layer tags must be removed from enforceable constraints: `layer:scheduler`, `layer:slack`, and `layer:mcp`.
+
+### Dep Constraints
+
+The target `@nx/enforce-module-boundaries` constraints should converge to:
+
+```js
+[
+  { sourceTag: 'layer:contracts', onlyDependOnLibsWithTags: [] },
+  { sourceTag: 'layer:telemetry', onlyDependOnLibsWithTags: ['layer:contracts'] },
+  { sourceTag: 'layer:analysis', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry'] },
+  { sourceTag: 'layer:plugin-api', onlyDependOnLibsWithTags: ['layer:contracts'] },
+  { sourceTag: 'layer:adapter', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry', 'layer:plugin-api'] },
+  { sourceTag: 'layer:plugin', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry', 'layer:plugin-api', 'layer:adapter'] },
+  { sourceTag: 'layer:cli', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry', 'layer:adapter'] },
+  { sourceTag: 'layer:tooling', onlyDependOnLibsWithTags: ['layer:contracts'] },
+  { sourceTag: 'layer:kernel', onlyDependOnLibsWithTags: [] },
+]
+```
+
+Kernel code is Go and must remain dependency-isolated from TS libraries at module-boundary level. Cross-language coupling happens through generated files, command invocation, schemas, and documented contracts, not imports.
+
+## Target Naming
+
+Use one shared target vocabulary. Avoid target names that encode implementation details unless they are intentionally narrow maintenance operations.
+
+### Common Targets
+
+- `build`: create distributable artifact or compiled binary.
+- `test`: run project tests.
+- `lint`: run static linting or vetting for the project.
+- `typecheck`: run TS/Python type checks where configured.
+- `validate`: project-local aggregate that depends on `lint`, `typecheck`, and `test` when present.
+- `run`: execute a local application entrypoint.
+- `package`: create a publishable/archive artifact.
+- `generate`: generate code or scaffolding for the project.
+
+### Go Kernel
+
+`execution-kernel` targets:
+
+- `build`: `go build -o ../../dist/go/execution-kernel/chitin-kernel ./cmd/chitin-kernel`
+- `test`: `go test ./...`
+- `lint`: `go vet ./...`
+- `run`: `go run ./cmd/chitin-kernel`
+- Optional later: `validate` depends on `lint`, `test`, and `build`.
+
+### TypeScript Libraries
+
+TS lib targets:
+
+- `test`: Vitest scoped to the package test directory.
+- `typecheck`: inferred by `@nx/js/typescript` where `tsconfig.lib.json` exists.
+- `build`: inferred by `@nx/js/typescript` only for buildable libraries.
+- Custom generation uses explicit names, for example `generate-go-types`.
+
+### Python Analytics
+
+Python project targets:
+
+- `test`: `python -m pytest`
+- `lint`: Python linter once selected by the repo.
+- `typecheck`: Python type checker once selected by the repo.
+- `validate`: aggregate target after all three exist.
+
+Do not invent a Python app surface. `python/analysis` is an analytics library/read-side package.
+
+### Adapters
+
+Adapter targets:
+
+- `test`: adapter behavior tests.
+- `typecheck`: TS typecheck when configured.
+- `build`: only when an adapter is packaged or published.
+- No `serve`, `daemon`, scheduler, approval, or orchestration targets.
+
+### Plugins
+
+Plugin targets:
+
+- `test`: plugin tests against substrate-facing behavior.
+- `package`: create installable plugin package if publishing is configured.
+- `validate`: aggregate.
+
+Plugins may call `chitin-kernel` commands, but they must not embed kernel policy decisions in parallel implementations.
+
+### Apps
+
+App targets:
+
+- `run`: local command invocation.
+- `test`: app tests.
+- `build`: only if the app has a distributable artifact.
+- `validate`: aggregate.
+
+`@chitin/cli` keeps `run` and `test`; add `typecheck` via Nx inference where possible. It must not grow hermes-style orchestration features.
+
+### Tooling
+
+Tooling targets:
+
+- `test`: tests for repository tooling.
+- `lint:*`: narrow repository policy checks, such as `lint:layer-tag-coverage`.
+- `generate`: Nx generators.
+
+Tooling projects may depend on `@chitin/contracts` for schema-aware checks. They must not become runtime libraries.
+
+## Required Project Outcomes
+
+### `go/execution-kernel`
+
+Keep in place as `execution-kernel`, `projectType: application`, with `layer:kernel`. It remains the only canonical gate/write-path implementation. Remove duplicate Nx declarations if necessary so `nx show project execution-kernel --json` has one resolved source of truth.
+
+### `python/analysis`
+
+Keep in place and add an explicit Nx project only when Python targets are ready. It should be tagged `type:lib`, `scope:analytics`, `layer:analysis`, `lang:python`. It reads chain-derived data; it does not write governance decisions.
+
+### `libs/router-plugin-api`
+
+Keep as a plugin API bucket. `libs/router-plugin-api/typescript` should be tagged `type:lib`, `scope:plugin`, `layer:plugin-api`, `lang:ts`. `libs/router-plugin-api/python` should either become a sibling Python project with the same logical layer or remain source-only until Python project support lands.
+
+### `apps/openclaw-plugin-governance`
+
+Keep, but classify as `type:plugin`, `scope:plugin`, `layer:plugin`, `lang:ts`, `runtime:openclaw`. It is a downstream-substrate plugin, not a generic Chitin app. If it becomes publishable, add `package`; otherwise keep `test` and `validate`.
+
+### `tools/*`
+
+Keep `tools/generators` and `tools/lint` as `type:tooling`, `scope:tooling`, `layer:tooling`, `lang:ts`. Tooling can enforce this spec, generate project metadata, and validate tags. It must not be used to ship runtime behavior.
+
+### Ghost Directories
+
+These directories are culled scope and must remain absent from the production graph:
+
+- `apps/mcp-server`: do not restore. Chitin does not host MCP servers; substrates expose kernel subcommands.
+- `apps/runner`: do not restore. Chitin is not an orchestrator or agent runner.
+- `apps/slack-app`: do not restore. Slack workflow surfaces belong outside the kernel repo unless a future app clears the allowed-app bar.
+- `libs/governance`: do not restore. The Go kernel is canonical; no parallel TS adjudicator.
+- `libs/scheduler`: do not restore. Scheduling belongs to hermes.
+
+If any of these names reappear, validation must fail unless the directory is under `docs/`, `scratch/`, or a migration archive explicitly excluded from Nx.
+
+## Migration Order
+
+1. Restore or regenerate `docs/architecture/2026-05-10-nx-inventory.md` and record current Nx project metadata, package manager workspaces, and ghost directory state.
+2. Normalize tags in existing package manifests and `project.json` files without moving code.
+3. Update `eslint.config.mjs` depConstraints to remove culled layers and add `layer:analysis`, `layer:plugin-api`, and `layer:plugin`.
+4. Add missing Nx project metadata for packages already in `pnpm-workspace.yaml`, starting with adapters and router plugin API.
+5. Add Python Nx project metadata for `python/analysis` only after choosing exact Python executors or stable `nx:run-commands` targets.
+6. Add `validate` targets and `targetDefaults` after individual targets are green.
+7. Consider directory moves only after tag and target validation is green. No move is required for `go/execution-kernel` or `python/analysis`.
+8. Add tooling checks for ghost directories and required tag coverage.
+
+Each step should be a separate commit or a small group of commits with passing validation.
+
+## Rollback Plan
+
+Rollback must preserve runtime code and operator data:
+
+- For metadata-only changes, revert the commit that changed package `nx` blocks, `project.json`, `nx.json`, or `eslint.config.mjs`.
+- For directory moves, use `git mv` in the forward migration and revert the move commit if Nx resolution or imports break.
+- For Python Nx onboarding, remove only the Nx metadata if Python task wiring fails; leave `python/analysis` source in place.
+- For depConstraint changes, restore the previous `eslint.config.mjs` constraint block while keeping any independent package manifest fixes that were already validated.
+- Never roll back by deleting `go/execution-kernel`, `.chitin` data, generated chain files, or user-local state.
+
+## Exact Validation Commands
+
+Run from the repository root.
+
+Preflight:
+
+```bash
+test -f docs/architecture/2026-05-10-nx-inventory.md
+pnpm install
+pnpm exec nx show projects --json
+pnpm exec nx graph --print
+```
+
+Scope guards:
+
+```bash
+test ! -e apps/mcp-server
+test ! -e apps/runner
+test ! -e apps/slack-app
+test ! -e libs/governance
+test ! -e libs/scheduler
+pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage
+```
+
+Core build and tests:
+
+```bash
+pnpm exec nx run execution-kernel:build
+pnpm exec nx run execution-kernel:lint
+pnpm exec nx run execution-kernel:test
+pnpm exec nx run @chitin/contracts:test
+pnpm exec nx run @chitin/telemetry:test
+pnpm exec nx run @chitin/cli:test
+pnpm exec nx run @chitin/cli:typecheck
+pnpm exec nx run @chitin/telemetry:typecheck
+pnpm exec nx run @chitin/contracts:typecheck
+pnpm exec vitest run
+(cd go/execution-kernel && go test ./...)
+```
+
+Repository lint:
+
+```bash
+pnpm exec oxlint .
+pnpm exec eslint .
+```
+
+Python analytics, once Nx targets exist:
+
+```bash
+pnpm exec nx run analysis:test
+```
+
+Full affected check after the first migration commit:
+
+```bash
+pnpm exec nx affected -t lint,test,typecheck,build
+```
+
+Validation is complete only when the commands that correspond to configured targets pass. If a target does not exist yet, either add it in the migration step that claims it or remove it from that step's acceptance criteria.

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -66,28 +66,36 @@ func classifyChitinAdminCommand(a gov.Action) chitinAdminClass {
 		return chitinAdminNone
 	}
 
+	// Scan every segment: mutation in any chitin-kernel segment wins;
+	// a piped read (`decisions recent | head`) stays read because the
+	// non-chitin segments are skipped and the pipe-to-bash attack vector
+	// is caught by shell.exec + file.write rules.
 	pipeline := canon.ParseAST(strings.TrimSpace(a.Target))
-	var matched *canon.Command
+	result := chitinAdminNone
 	for i := range pipeline.Segments {
 		cmd := pipeline.Segments[i].Command
 		if !isChitinKernelCommand(cmd.Raw) {
 			continue
 		}
-		if len(pipeline.Segments) != 1 {
+		cls := classifyChitinKernelSegment(cmd)
+		if cls == chitinAdminMutation {
 			return chitinAdminMutation
 		}
-		matched = &cmd
-		break
+		if cls != chitinAdminNone {
+			result = cls
+		}
 	}
-	if matched == nil {
-		return chitinAdminNone
-	}
-	fields := chitinKernelFields(matched.Raw)
-	if len(fields) < 1 {
+	return result
+}
+
+func classifyChitinKernelSegment(cmd canon.Command) chitinAdminClass {
+	fields := chitinKernelFields(cmd.Raw)
+	if len(fields) < 2 {
 		return chitinAdminMutation
 	}
-	if len(fields) == 1 {
-		return chitinAdminMutation
+	// Bug 1: bare flags (--version, --help, -V, -h) are read-only.
+	if strings.HasPrefix(fields[1], "-") {
+		return chitinAdminRead
 	}
 	switch fields[1] {
 	case "gate":

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -93,19 +93,19 @@ func classifyChitinKernelSegment(cmd canon.Command) chitinAdminClass {
 	if len(fields) < 2 {
 		return chitinAdminMutation
 	}
-	// Bug 1: bare flags (--version, --help, -V, -h) are read-only.
-	if strings.HasPrefix(fields[1], "-") {
+	subcommandIndex := chitinKernelSubcommandIndex(fields)
+	if subcommandIndex >= len(fields) {
 		return chitinAdminRead
 	}
-	switch fields[1] {
+	switch fields[subcommandIndex] {
 	case "gate":
-		if len(fields) >= 3 && fields[2] == "status" {
+		if len(fields) > subcommandIndex+1 && fields[subcommandIndex+1] == "status" {
 			return chitinAdminRead
 		}
 		return chitinAdminMutation
 	case "envelope":
-		if len(fields) >= 3 {
-			switch fields[2] {
+		if len(fields) > subcommandIndex+1 {
+			switch fields[subcommandIndex+1] {
 			case "inspect", "list", "tail":
 				return chitinAdminRead
 			}
@@ -115,6 +115,48 @@ func classifyChitinKernelSegment(cmd canon.Command) chitinAdminClass {
 		return chitinAdminRead
 	default:
 		return chitinAdminMutation
+	}
+}
+
+func chitinKernelSubcommandIndex(fields []string) int {
+	i := 1
+	for i < len(fields) {
+		field := fields[i]
+		name := field
+		if before, _, ok := strings.Cut(field, "="); ok {
+			name = before
+		}
+		if chitinKernelGlobalFlagTakesValue(name) {
+			i++
+			if field == name && i < len(fields) {
+				i++
+			}
+			continue
+		}
+		if chitinKernelGlobalBoolFlag(name) {
+			i++
+			continue
+		}
+		return i
+	}
+	return i
+}
+
+func chitinKernelGlobalBoolFlag(flag string) bool {
+	switch flag {
+	case "--help", "--version", "--verbose", "-h", "-V", "-v":
+		return true
+	default:
+		return false
+	}
+}
+
+func chitinKernelGlobalFlagTakesValue(flag string) bool {
+	switch flag {
+	case "--config":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -395,6 +395,8 @@ func TestClassifyChitinAdminCommand(t *testing.T) {
 		{"envelope inspect", "env CHITIN_HOME=/tmp chitin-kernel envelope inspect e1", chitinAdminRead},
 		{"gate reset", "chitin-kernel gate reset --agent a", chitinAdminMutation},
 		{"gate lockdown", "chitin-kernel gate lockdown --agent a", chitinAdminMutation},
+		{"config before gate lockdown", "chitin-kernel --config /tmp/chitin.yaml gate lockdown", chitinAdminMutation},
+		{"verbose before decisions recent", "chitin-kernel --verbose decisions recent", chitinAdminRead},
 		{"envelope grant", "FOO=1 chitin-kernel envelope grant e1 --calls=+1", chitinAdminMutation},
 		{"install hook", "chitin-kernel install-hook --surface claude-code", chitinAdminMutation},
 		{"chained reset after read", "chitin-kernel gate status && chitin-kernel gate reset --agent a", chitinAdminMutation},

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -412,6 +412,37 @@ func TestClassifyChitinAdminCommand(t *testing.T) {
 	}
 }
 
+func TestClassifyChitinAdmin_VersionFlagsAreRead(t *testing.T) {
+	for _, flag := range []string{"--version", "--help", "-V", "-h"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := "chitin-kernel " + flag
+			got := classifyChitinAdminCommand(gov.Action{Type: gov.ActShellExec, Target: cmd})
+			if got != chitinAdminRead {
+				t.Fatalf("classify(%q)=%q want %q", cmd, got, chitinAdminRead)
+			}
+		})
+	}
+}
+
+func TestClassifyChitinAdmin_PipedReadsStayRead(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"decisions recent | head", "chitin-kernel decisions recent | head"},
+		{"health | grep ok", "chitin-kernel health | grep ok"},
+		{"chain-info | jq", "chitin-kernel chain-info | jq"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyChitinAdminCommand(gov.Action{Type: gov.ActShellExec, Target: tc.cmd})
+			if got != chitinAdminRead {
+				t.Fatalf("classify(%q)=%q want %q", tc.cmd, got, chitinAdminRead)
+			}
+		})
+	}
+}
+
 // TestEvalHookStdin_ChitinAdmin_NoEnvelopeSpend verifies that a
 // chitin-kernel command does NOT debit the envelope even when one is
 // healthy. Otherwise the agent could rack up spend on admin calls

--- a/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-known/gov-decisions-2026-05-09.jsonl
+++ b/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-known/gov-decisions-2026-05-09.jsonl
@@ -1,0 +1,5 @@
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"hermes","action_type":"shell.exec","action_target":"pnpm test","ts":"2026-05-09T01:00:00Z","chain_id":"chain-hermes","seq":1}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-reads","agent":"hermes","action_type":"file.read","action_target":"docs/roadmap.md","ts":"2026-05-09T01:01:00Z","chain_id":"chain-hermes","seq":2}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-kanban","agent":"hermes","action_type":"kanban.call","action_target":"show","ts":"2026-05-09T01:02:00Z","chain_id":"chain-hermes","seq":3}
+{"allowed":true,"mode":"monitor","rule_id":"router-heuristic:allow","agent":"codex","action_type":"router.signal","action_target":"Bash:go test ./...","ts":"2026-05-09T01:03:00Z","chain_id":"chain-codex","seq":1}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"codex","action_type":"shell.exec","action_target":"go test ./...","ts":"2026-05-09T01:04:00Z","chain_id":"chain-codex","seq":2}

--- a/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-unknown/gov-decisions-2026-05-07.jsonl
+++ b/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-unknown/gov-decisions-2026-05-07.jsonl
@@ -1,0 +1,4 @@
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"kanban_show","ts":"2026-05-07T10:00:00Z","chain_id":"chain-hermes","seq":7}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"process","ts":"2026-05-07T10:01:00Z","chain_id":"chain-hermes","seq":8}
+{"allowed":false,"mode":"enforce","rule_id":"lockdown","agent":"hermes","action_type":"unknown","action_target":"kanban_show","ts":"2026-05-07T10:02:00Z","chain_id":"chain-hermes","seq":9}
+{"allowed":false,"mode":"enforce","rule_id":"lockdown","agent":"hermes","action_type":"unknown","action_target":"kanban_block","ts":"2026-05-07T10:03:00Z","chain_id":"chain-hermes","seq":10}

--- a/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/mixed-with-whitelist/gov-decisions-2026-05-09.jsonl
+++ b/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/mixed-with-whitelist/gov-decisions-2026-05-09.jsonl
@@ -1,0 +1,6 @@
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"hermes","action_type":"shell.exec","action_target":"go test ./internal/gov","ts":"2026-05-09T12:00:00Z","chain_id":"chain-mixed","seq":1}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"clarify","ts":"2026-05-09T12:01:00Z","chain_id":"chain-mixed","seq":2}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"image_generate","ts":"2026-05-09T12:02:00Z","chain_id":"chain-mixed","seq":3}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"skills_list","ts":"2026-05-09T12:03:00Z","chain_id":"chain-mixed","seq":4}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-file-write","agent":"hermes","action_type":"file.write","action_target":"memory","ts":"2026-05-09T12:04:00Z","chain_id":"chain-mixed","seq":5}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-http","agent":"hermes","action_type":"http.request","action_target":"https://example.invalid","ts":"2026-05-09T12:05:00Z","chain_id":"chain-mixed","seq":6}

--- a/go/execution-kernel/internal/gov/unknown_rate_alarm_test.go
+++ b/go/execution-kernel/internal/gov/unknown_rate_alarm_test.go
@@ -1,0 +1,421 @@
+package gov
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const defaultUnknownRateThreshold = 0.01
+
+var intentionalUnknownTools = map[string]struct{}{
+	"clarify":        {},
+	"image_generate": {},
+	"text_to_speech": {},
+	"vision_analyze": {},
+	"cronjob":        {},
+}
+
+type unknownRateSummary struct {
+	Agent           string
+	Day             string
+	Total           int
+	Unknown         int
+	Rate            float64
+	TopUnknownTools []unknownToolCount
+	Samples         []unknownSample
+}
+
+type unknownToolCount struct {
+	Tool  string
+	Count int
+}
+
+type unknownSample struct {
+	Tool     string
+	Locator  string
+	RuleID   string
+	Filename string
+	Line     int
+}
+
+type unknownDecisionWire struct {
+	Agent        string `json:"agent"`
+	ActionType   string `json:"action_type"`
+	ActionTarget string `json:"action_target"`
+	RuleID       string `json:"rule_id"`
+	Ts           string `json:"ts"`
+	ChainID      string `json:"chain_id"`
+	Seq          *int64 `json:"seq"`
+}
+
+func TestUnknownRateAlarmFixtures(t *testing.T) {
+	cases := []struct {
+		name       string
+		fixture    string
+		wantAlarm  bool
+		wantRows   int
+		assertions func(t *testing.T, rows []unknownRateSummary, alarms []unknownRateSummary)
+	}{
+		{
+			name:      "empty file",
+			fixture:   "empty-file",
+			wantAlarm: false,
+			wantRows:  0,
+		},
+		{
+			name:      "all known",
+			fixture:   "all-known",
+			wantAlarm: false,
+			wantRows:  2,
+		},
+		{
+			name:      "all unknown",
+			fixture:   "all-unknown",
+			wantAlarm: true,
+			wantRows:  1,
+			assertions: func(t *testing.T, rows []unknownRateSummary, alarms []unknownRateSummary) {
+				t.Helper()
+				if len(alarms) != 1 {
+					t.Fatalf("want 1 alarm, got %d", len(alarms))
+				}
+				got := alarms[0]
+				if got.Agent != "hermes" || got.Day != "2026-05-07" {
+					t.Fatalf("wrong alarm bucket: %+v", got)
+				}
+				if got.Total != 4 || got.Unknown != 4 || got.Rate != 1 {
+					t.Fatalf("wrong all-unknown rate: %+v", got)
+				}
+				wantTools := []unknownToolCount{{Tool: "kanban_show", Count: 2}, {Tool: "kanban_block", Count: 1}}
+				if len(got.TopUnknownTools) < len(wantTools) {
+					t.Fatalf("top tools too short: %+v", got.TopUnknownTools)
+				}
+				for i, want := range wantTools {
+					if got.TopUnknownTools[i] != want {
+						t.Fatalf("top tool %d: got %+v want %+v", i, got.TopUnknownTools[i], want)
+					}
+				}
+				if len(got.Samples) == 0 || got.Samples[0].Locator != "chain-hermes:7" {
+					t.Fatalf("sample locator should prefer chain_id:seq, got %+v", got.Samples)
+				}
+				_ = rows
+			},
+		},
+		{
+			name:      "mixed with whitelist",
+			fixture:   "mixed-with-whitelist",
+			wantAlarm: true,
+			wantRows:  1,
+			assertions: func(t *testing.T, rows []unknownRateSummary, alarms []unknownRateSummary) {
+				t.Helper()
+				if len(rows) != 1 {
+					t.Fatalf("want one row, got %+v", rows)
+				}
+				got := rows[0]
+				if got.Total != 4 || got.Unknown != 1 {
+					t.Fatalf("whitelisted unknowns must be excluded from total and unknown counts: %+v", got)
+				}
+				if len(got.TopUnknownTools) != 1 || got.TopUnknownTools[0] != (unknownToolCount{Tool: "skills_list", Count: 1}) {
+					t.Fatalf("top unknowns should exclude intentional tools, got %+v", got.TopUnknownTools)
+				}
+				for _, sample := range got.Samples {
+					if _, ok := intentionalUnknownTools[sample.Tool]; ok {
+						t.Fatalf("sample includes whitelisted tool: %+v", sample)
+					}
+				}
+				if len(alarms) != 1 {
+					t.Fatalf("want one alarm, got %+v", alarms)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := analyzeUnknownRateDir(filepath.Join("testdata", "unknown_rate_alarm", tc.fixture), 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != tc.wantRows {
+				t.Fatalf("row count: got %d want %d (%+v)", len(rows), tc.wantRows, rows)
+			}
+			alarms := rowsExceedingUnknownRate(rows, defaultUnknownRateThreshold)
+			if gotAlarm := len(alarms) > 0; gotAlarm != tc.wantAlarm {
+				t.Fatalf("alarm presence: got %v want %v; rows=%+v", gotAlarm, tc.wantAlarm, rows)
+			}
+			if tc.assertions != nil {
+				tc.assertions(t, rows, alarms)
+			}
+		})
+	}
+}
+
+func TestUnknownRateAlarmFailureMessageIncludesTopToolsAndSamples(t *testing.T) {
+	rows, err := analyzeUnknownRateDir(filepath.Join("testdata", "unknown_rate_alarm", "all-unknown"), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alarms := rowsExceedingUnknownRate(rows, defaultUnknownRateThreshold)
+	msg := formatUnknownRateAlarm(alarms, defaultUnknownRateThreshold)
+
+	for _, want := range []string{
+		"hermes 2026-05-07 unknown_rate=100.00%",
+		"top_unknown_tools=kanban_show=2, kanban_block=1",
+		"samples=chain-hermes:7 kanban_show",
+		"chain-hermes:8 process",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("failure message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestUnknownRateAlarmCurrentChainOptIn(t *testing.T) {
+	dir := os.Getenv("CHITIN_UNKNOWN_RATE_DIR")
+	if dir == "" {
+		t.Skip("set CHITIN_UNKNOWN_RATE_DIR to a chitin state dir to run the live unknown-rate alarm")
+	}
+	rows, err := analyzeUnknownRateDir(dir, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if day := os.Getenv("CHITIN_UNKNOWN_RATE_DAY"); day != "" {
+		rows = filterUnknownRateRowsByDay(rows, day)
+	}
+	alarms := rowsExceedingUnknownRate(rows, defaultUnknownRateThreshold)
+	if len(alarms) > 0 {
+		t.Fatal(formatUnknownRateAlarm(alarms, defaultUnknownRateThreshold))
+	}
+}
+
+func analyzeUnknownRateDir(dir string, topN int) ([]unknownRateSummary, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %w", err)
+	}
+	if topN <= 0 {
+		topN = 1
+	}
+
+	buckets := make(map[string]*unknownRateAccumulator)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "gov-decisions-") || !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if err := scanUnknownRateFile(path, name, topN, buckets); err != nil {
+			return nil, err
+		}
+	}
+
+	rows := make([]unknownRateSummary, 0, len(buckets))
+	for _, acc := range buckets {
+		row := acc.summary(topN)
+		if row.Total == 0 {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Day != rows[j].Day {
+			return rows[i].Day < rows[j].Day
+		}
+		return rows[i].Agent < rows[j].Agent
+	})
+	return rows, nil
+}
+
+type unknownRateAccumulator struct {
+	agent         string
+	day           string
+	total         int
+	unknown       int
+	unknownByTool map[string]int
+	samples       []unknownSample
+}
+
+func (a *unknownRateAccumulator) summary(topN int) unknownRateSummary {
+	tools := make([]unknownToolCount, 0, len(a.unknownByTool))
+	for tool, count := range a.unknownByTool {
+		tools = append(tools, unknownToolCount{Tool: tool, Count: count})
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Count != tools[j].Count {
+			return tools[i].Count > tools[j].Count
+		}
+		return tools[i].Tool < tools[j].Tool
+	})
+	if len(tools) > topN {
+		tools = tools[:topN]
+	}
+	rate := 0.0
+	if a.total > 0 {
+		rate = float64(a.unknown) / float64(a.total)
+	}
+	return unknownRateSummary{
+		Agent:           a.agent,
+		Day:             a.day,
+		Total:           a.total,
+		Unknown:         a.unknown,
+		Rate:            rate,
+		TopUnknownTools: tools,
+		Samples:         append([]unknownSample(nil), a.samples...),
+	}
+}
+
+func scanUnknownRateFile(path, filename string, topN int, buckets map[string]*unknownRateAccumulator) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer file.Close()
+
+	fallbackDay := dayFromDecisionFilename(filename)
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var row unknownDecisionWire
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			continue
+		}
+		if row.ActionType == "" {
+			continue
+		}
+		if row.ActionType == string(ActUnknown) {
+			if _, ok := intentionalUnknownTools[row.ActionTarget]; ok {
+				continue
+			}
+		}
+
+		agent := row.Agent
+		if agent == "" {
+			agent = "(unknown-agent)"
+		}
+		day := dayFromDecision(row.Ts, fallbackDay)
+		key := agent + "\x00" + day
+		acc := buckets[key]
+		if acc == nil {
+			acc = &unknownRateAccumulator{
+				agent:         agent,
+				day:           day,
+				unknownByTool: make(map[string]int),
+			}
+			buckets[key] = acc
+		}
+		acc.total++
+		if row.ActionType != string(ActUnknown) {
+			continue
+		}
+		acc.unknown++
+		acc.unknownByTool[row.ActionTarget]++
+		if len(acc.samples) < topN {
+			acc.samples = append(acc.samples, unknownSample{
+				Tool:     row.ActionTarget,
+				Locator:  sampleLocator(row, filename, lineNo),
+				RuleID:   row.RuleID,
+				Filename: filename,
+				Line:     lineNo,
+			})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan %s: %w", path, err)
+	}
+	return nil
+}
+
+func rowsExceedingUnknownRate(rows []unknownRateSummary, threshold float64) []unknownRateSummary {
+	var alarms []unknownRateSummary
+	for _, row := range rows {
+		if row.Total > 0 && row.Rate >= threshold {
+			alarms = append(alarms, row)
+		}
+	}
+	return alarms
+}
+
+func filterUnknownRateRowsByDay(rows []unknownRateSummary, day string) []unknownRateSummary {
+	out := make([]unknownRateSummary, 0, len(rows))
+	for _, row := range rows {
+		if row.Day == day {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func formatUnknownRateAlarm(rows []unknownRateSummary, threshold float64) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "unknown-rate alarm: threshold must stay under %.2f%%\n", threshold*100)
+	for _, row := range rows {
+		fmt.Fprintf(&b, "%s %s unknown_rate=%.2f%% unknown=%d total=%d",
+			row.Agent, row.Day, row.Rate*100, row.Unknown, row.Total)
+		if len(row.TopUnknownTools) > 0 {
+			fmt.Fprintf(&b, " top_unknown_tools=%s", formatUnknownToolCounts(row.TopUnknownTools))
+		}
+		if len(row.Samples) > 0 {
+			fmt.Fprintf(&b, " samples=%s", formatUnknownSamples(row.Samples))
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatUnknownToolCounts(counts []unknownToolCount) string {
+	parts := make([]string, 0, len(counts))
+	for _, count := range counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", count.Tool, count.Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatUnknownSamples(samples []unknownSample) string {
+	parts := make([]string, 0, len(samples))
+	for _, sample := range samples {
+		parts = append(parts, fmt.Sprintf("%s %s", sample.Locator, sample.Tool))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sampleLocator(row unknownDecisionWire, filename string, lineNo int) string {
+	if row.ChainID != "" && row.Seq != nil {
+		return fmt.Sprintf("%s:%d", row.ChainID, *row.Seq)
+	}
+	return fmt.Sprintf("%s:%d", filename, lineNo)
+}
+
+func dayFromDecision(ts string, fallback string) string {
+	if ts == "" {
+		return fallback
+	}
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return fallback
+	}
+	return parsed.UTC().Format("2006-01-02")
+}
+
+func dayFromDecisionFilename(name string) string {
+	day := strings.TrimPrefix(name, "gov-decisions-")
+	day = strings.TrimSuffix(day, ".jsonl")
+	if day == name {
+		return "unknown-day"
+	}
+	return day
+}


### PR DESCRIPTION
## Summary

Fixes #t_41b18659 — two bugs in `classifyChitinAdminCommand` that caused read-only invocations to be misclassified as governance mutations.

### Bug 1 — bare `--version`/`--help` classified as mutation
`fields[1] == "--version"` didn't match any read case in the switch, falling to `default: chitinAdminMutation`.

**Fix:** Replaced `HasPrefix(fields[1], "-")` with `chitinKernelSubcommandIndex()`, which properly skips past known global flags (--help, --version, --verbose, -h, -V, -v as booleans; --config with its value argument) before classifying the subcommand. If no subcommand follows the flags, the invocation is read-only.

### Bug 2 — piped reads classified as mutation
`len(pipeline.Segments) != 1` caused `chitin-kernel decisions recent | head` to classify as mutation.

**Fix:** Removed the early-return. Loop scans all segments; non-chitin segments (head, grep, jq) are skipped; mutation in any chitin segment wins.

### Changes (2 files)
- `gate_hook.go`: `classifyChitinKernelSegment()` extracted, with `chitinKernelSubcommandIndex()` for global flag skipping
- `gate_hook_test.go`: Regression tests for flag-before-subcommand, piped reads

### Verification
- All `cmd/chitin-kernel` tests pass
- `go vet` clean