### PR TITLE
hardening: execute_code bypass coverage + regression tests

### DIFF
--- a/chitin.yaml
+++ b/chitin.yaml
@@ -27,6 +27,8 @@ escalation:
   high_threshold: 7
   lockdown_threshold: 10
   max_retries_per_action: 3
+  deny_cascade_count: 4
+  deny_cascade_window_seconds: 300
 
 invariantModes:
   no-governance-self-modification: enforce

--- a/docs/driver-conformance.md
+++ b/docs/driver-conformance.md
@@ -25,6 +25,11 @@ in one of these outcomes:
 | OpenClaw | `before_tool_call` plugin via `apps/openclaw-plugin-governance` | Plugin bridge into `chitin-kernel gate evaluate` | Tool calls dispatched by OpenClaw's native pi-agent-core runtime | Does not gate standalone Claude/Codex/Gemini/Copilot processes; use their native driver integrations. |
 | VS Code Copilot | Repository instructions + `AGENTS.md` context | No execution normalizer | Uses repo guidance to steer agent behavior in the IDE | No pre-tool hook surface. Treat this as guidance only; route terminal-side agent execution through chitin-aware CLIs where enforcement is required. |
 
+Claude Code has no Hermes-style `execute_code` Python runner in the governed
+hook surface. Its host execution path is `Bash`, which routes through
+`gov.Normalize("terminal", ...)` and the existing shell/canonical command
+detectors.
+
 ## Near-term work
 
 1. Mine `default-deny` / `unknown` rows from `~/.chitin/gov-decisions-*.jsonl`

--- a/docs/governance-setup.md
+++ b/docs/governance-setup.md
@@ -230,6 +230,11 @@ Denials accumulate per-agent in `~/.chitin/gov.db`:
 | 7–9 | high | tighter restrictions (reserved for v2 policy features) |
 | 10+ | lockdown | agent-wide; all actions denied |
 
+The lifetime ladder is complemented by a short-window shell denial cascade:
+`escalation.deny_cascade_count` `shell.exec` denials inside
+`escalation.deny_cascade_window_seconds` seconds force the same sticky
+lockdown. The baseline policy uses 4 denials in 300 seconds.
+
 Lockdown is sticky across sessions. Only `gate reset` clears.
 
 ## CLI reference

--- a/docs/observations/2026-05-11-chattr-immutable-workspace-investigation.md
+++ b/docs/observations/2026-05-11-chattr-immutable-workspace-investigation.md
@@ -1,0 +1,32 @@
+# chattr +i workspace hardening investigation
+
+Date: 2026-05-11
+
+## Question
+
+Could agent workspaces use Linux `chattr +i` immutable bits as an extra
+guardrail against governance bypasses?
+
+## Finding
+
+`chattr +i` is not a good default for whole agent workspaces. It is
+filesystem-specific, generally requires elevated capability, breaks normal
+agent edits, and is invisible to non-Linux environments. It also does not
+replace chitin's kernel gate: an immutable-bit failure happens after the tool
+is already attempted, while chitin's value is the pre-tool decision and audit
+chain.
+
+## Where it may help
+
+Use it only as an operator-owned hardening layer for small, stable paths that
+agents should never mutate directly, such as a checked-out `chitin.yaml`,
+wrapper scripts, or hook installation directories. Do not apply it to task
+worktrees, source trees under active edit, build outputs, or caches.
+
+## Recommendation
+
+Keep `chattr +i` out of the kernel hot path and installer defaults. If the
+operator wants defense in depth on Linux, document an opt-in runbook that
+sets immutable bits on policy and hook files outside active worktrees, with
+explicit `chattr -i` rollback steps. The enforceable chitin-side control
+remains typed pre-tool governance plus the denial cascade lockdown.

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -34,6 +34,11 @@ func setupHookEnv(t *testing.T, policyYAML string) *hookTestEnv {
 
 func runHookCall(t *testing.T, env *hookTestEnv, payload map[string]any, envelopeFlag string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runHookCallAsAgent(t, env, "claude-code", payload, envelopeFlag)
+}
+
+func runHookCallAsAgent(t *testing.T, env *hookTestEnv, agent string, payload map[string]any, envelopeFlag string) (stdout, stderr string, exitCode int) {
+	t.Helper()
 	if _, ok := payload["cwd"]; !ok {
 		payload["cwd"] = env.cwd
 	}
@@ -43,7 +48,7 @@ func runHookCall(t *testing.T, env *hookTestEnv, payload map[string]any, envelop
 	}
 	in := bytes.NewReader(body)
 	var out, errOut bytes.Buffer
-	exitCode = evalHookStdin(in, &out, &errOut, "claude-code", envelopeFlag, "", false, false)
+	exitCode = evalHookStdin(in, &out, &errOut, agent, envelopeFlag, "", false, false)
 	return out.String(), errOut.String(), exitCode
 }
 
@@ -69,6 +74,10 @@ rules:
     action: shell.exec
     effect: allow
     reason: shell ok
+  - id: allow-git-status
+    action: git.status
+    effect: allow
+    reason: git status ok
   - id: allow-http
     action: http.request
     effect: allow
@@ -115,6 +124,71 @@ func TestEvalHookStdin_DenyRmRfIsExit2BlockJSON(t *testing.T) {
 	// Suggestion + corrected propagate to the model.
 	if !strings.Contains(parsed["reason"], "git rm") {
 		t.Fatalf("reason missing suggestion/corrected: %q", parsed["reason"])
+	}
+}
+
+func TestEvalHookStdin_HermesExecuteCodeSubprocessRmRfDenied(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	stdout, _, code := runHookCallAsAgent(t, env, "hermes", map[string]any{
+		"tool_name": "execute_code",
+		"tool_input": map[string]any{
+			"code": `import subprocess
+subprocess.run(["rm", "-rf", "go/"])`,
+		},
+	}, "")
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (block)", code)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	if parsed["decision"] != "block" {
+		t.Fatalf("decision=%q", parsed["decision"])
+	}
+	if !strings.Contains(parsed["reason"], "no rm -rf") {
+		t.Fatalf("reason missing rm-rf denial: %q", parsed["reason"])
+	}
+}
+
+func TestEvalHookStdin_HermesExecuteCodeShutilRmtreeDenied(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	stdout, _, code := runHookCallAsAgent(t, env, "hermes", map[string]any{
+		"tool_name": "execute_code",
+		"tool_input": map[string]any{
+			"code": `import shutil
+shutil.rmtree("go/")`,
+		},
+	}, "")
+	if code != 2 {
+		t.Fatalf("exit=%d want 2 (block)", code)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout)
+	}
+	if parsed["decision"] != "block" {
+		t.Fatalf("decision=%q", parsed["decision"])
+	}
+	if !strings.Contains(parsed["reason"], "no rm -rf") {
+		t.Fatalf("reason missing rm-rf denial: %q", parsed["reason"])
+	}
+}
+
+func TestEvalHookStdin_HermesExecuteCodeGitStatusAllowed(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+	stdout, _, code := runHookCallAsAgent(t, env, "hermes", map[string]any{
+		"tool_name": "execute_code",
+		"tool_input": map[string]any{
+			"code": `import subprocess
+subprocess.run(["git", "status"])`,
+		},
+	}, "")
+	if code != 0 {
+		t.Fatalf("exit=%d want 0 (allow), stdout=%q", code, stdout)
+	}
+	if stdout != "" {
+		t.Fatalf("allow stdout must be empty, got %q", stdout)
 	}
 }
 

--- a/go/execution-kernel/internal/driver/hermes/normalize.go
+++ b/go/execution-kernel/internal/driver/hermes/normalize.go
@@ -19,11 +19,11 @@
 //	write_file         → file.write, target = path.
 //	patch              → file.write, target = path (patch-style write).
 //	search_files       → file.read, target = pattern (grep-like).
-//	execute_code       → shell.exec via gov.Normalize on the code string
-//	                     under "command" — best-effort because hermes's
-//	                     execute_code is a sandbox runner, not a raw
-//	                     shell, but the deny-rules (rm-rf, etc.) still
-//	                     apply to anything it would attempt.
+//	execute_code       → gov.Normalize("execute_code", code) so Python
+//	                     subprocess/shutil patterns are extracted before
+//	                     shell classification. Best-effort because
+//	                     hermes's execute_code is a sandbox runner, not a
+//	                     raw shell.
 //	web_search         → http.request, target = query.
 //	web_extract        → http.request, target = first url (urls is array).
 //	browser_navigate   → http.request, target = url.
@@ -102,11 +102,11 @@ func Normalize(in HookInput) (gov.Action, error) {
 		return a, nil
 
 	case "execute_code":
-		// hermes's sandboxed code runner. Treat the code string as a
-		// shell command for gov.Normalize purposes — the deny rules
-		// (rm-rf, etc.) still apply to anything it would attempt.
+		// Hermes's sandboxed code runner. Route through gov.Normalize's
+		// execute_code branch so Python subprocess/shutil patterns are
+		// extracted before shell classification.
 		code := stringField(in.ToolInput, "code")
-		a, err := gov.Normalize("terminal", map[string]any{"command": code})
+		a, err := gov.Normalize("execute_code", map[string]any{"code": code})
 		if err != nil {
 			return gov.Action{}, fmt.Errorf("normalize execute_code: %w", err)
 		}

--- a/go/execution-kernel/internal/gov/escalation.go
+++ b/go/execution-kernel/internal/gov/escalation.go
@@ -126,6 +126,16 @@ func (c *Counter) RecordActionDenial(agent, actionType, fp string, weight int) e
 	return nil
 }
 
+// PruneActionDenialsBefore drops windowed denial events older than the
+// maximum cascade window. Aggregate denial counters remain lifetime-spanning;
+// only timestamped events used for recent-behavior detection are pruned.
+func (c *Counter) PruneActionDenialsBefore(beforeUnix int64) error {
+	if _, err := c.db.Exec(`DELETE FROM denial_events WHERE ts_unix < ?`, beforeUnix); err != nil {
+		return fmt.Errorf("prune denial events: %w", err)
+	}
+	return nil
+}
+
 // CountActionDenialsSince returns timestamped denials for an agent/action type
 // in the trailing window. It is intentionally separate from the aggregate
 // denials table: the ladder stays lifetime-spanning, while cascade detection
@@ -182,4 +192,5 @@ func (c *Counter) Lockdown(agent string) {
 func (c *Counter) Reset(agent string) {
 	_, _ = c.db.Exec(`DELETE FROM denials WHERE agent = ?`, agent)
 	_, _ = c.db.Exec(`DELETE FROM agent_state WHERE agent = ?`, agent)
+	_, _ = c.db.Exec(`DELETE FROM denial_events WHERE agent = ?`, agent)
 }

--- a/go/execution-kernel/internal/gov/escalation.go
+++ b/go/execution-kernel/internal/gov/escalation.go
@@ -42,6 +42,14 @@ func OpenCounter(dbPath string) (*Counter, error) {
 			locked INTEGER NOT NULL DEFAULT 0,
 			locked_ts TEXT
 		);
+		CREATE TABLE IF NOT EXISTS denial_events (
+			agent TEXT NOT NULL,
+			action_type TEXT NOT NULL,
+			action_fp TEXT NOT NULL,
+			ts_unix INTEGER NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_denial_events_agent_type_ts
+			ON denial_events(agent, action_type, ts_unix);
 	`); err != nil {
 		return nil, fmt.Errorf("create schema: %w", err)
 	}
@@ -60,10 +68,17 @@ func (c *Counter) Close() error {
 // silently dropping the escalation count — a silent drop would let an
 // agent past the lockdown threshold without ever locking.
 func (c *Counter) RecordDenial(agent, fp string, weight int) error {
+	return c.RecordActionDenial(agent, "", fp, weight)
+}
+
+// RecordActionDenial increments the aggregate escalation counters and records
+// one timestamped denial event for windowed cascade detection.
+func (c *Counter) RecordActionDenial(agent, actionType, fp string, weight int) error {
 	if weight <= 0 {
 		weight = 1
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC()
+	nowText := now.Format(time.RFC3339)
 
 	tx, err := c.db.Begin()
 	if err != nil {
@@ -77,7 +92,7 @@ func (c *Counter) RecordDenial(agent, fp string, weight int) error {
 		ON CONFLICT(agent, action_fp) DO UPDATE SET
 			count = count + excluded.count,
 			last_ts = excluded.last_ts
-	`, agent, fp, weight, now, now); err != nil {
+	`, agent, fp, weight, nowText, nowText); err != nil {
 		return fmt.Errorf("upsert denial: %w", err)
 	}
 
@@ -88,13 +103,19 @@ func (c *Counter) RecordDenial(agent, fp string, weight int) error {
 	`, agent, weight); err != nil {
 		return fmt.Errorf("upsert agent_state: %w", err)
 	}
+	if _, err := tx.Exec(`
+		INSERT INTO denial_events (agent, action_type, action_fp, ts_unix)
+		VALUES (?, ?, ?, ?)
+	`, agent, actionType, fp, now.Unix()); err != nil {
+		return fmt.Errorf("insert denial event: %w", err)
+	}
 
 	var total int
 	if err := tx.QueryRow(`SELECT total FROM agent_state WHERE agent = ?`, agent).Scan(&total); err != nil {
 		return fmt.Errorf("read agent_state.total: %w", err)
 	}
 	if total >= 10 {
-		if _, err := tx.Exec(`UPDATE agent_state SET locked = 1, locked_ts = ? WHERE agent = ?`, now, agent); err != nil {
+		if _, err := tx.Exec(`UPDATE agent_state SET locked = 1, locked_ts = ? WHERE agent = ?`, nowText, agent); err != nil {
 			return fmt.Errorf("set locked: %w", err)
 		}
 	}
@@ -103,6 +124,20 @@ func (c *Counter) RecordDenial(agent, fp string, weight int) error {
 		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
+}
+
+// CountActionDenialsSince returns timestamped denials for an agent/action type
+// in the trailing window. It is intentionally separate from the aggregate
+// denials table: the ladder stays lifetime-spanning, while cascade detection
+// is recent behavior.
+func (c *Counter) CountActionDenialsSince(agent, actionType string, sinceUnix int64) int {
+	var count int
+	_ = c.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM denial_events
+		WHERE agent = ? AND action_type = ? AND ts_unix >= ?
+	`, agent, actionType, sinceUnix).Scan(&count)
+	return count
 }
 
 // Level returns the escalation level for an agent: normal | elevated |

--- a/go/execution-kernel/internal/gov/escalation_test.go
+++ b/go/execution-kernel/internal/gov/escalation_test.go
@@ -108,6 +108,31 @@ func TestCounter_Reset(t *testing.T) {
 	if lv := c.Level("agent1"); lv != "normal" {
 		t.Errorf("after Reset, level=%q want normal", lv)
 	}
+	if got := c.CountActionDenialsSince("agent1", string(ActShellExec), 0); got != 0 {
+		t.Errorf("Reset should clear denial events, got %d", got)
+	}
+}
+
+func TestCounter_PruneActionDenialsBefore(t *testing.T) {
+	c := newTestCounter(t)
+	for _, ts := range []int64{100, 200, 300} {
+		if _, err := c.db.Exec(`
+			INSERT INTO denial_events (agent, action_type, action_fp, ts_unix)
+			VALUES (?, ?, ?, ?)
+		`, "agent1", string(ActShellExec), "fp", ts); err != nil {
+			t.Fatalf("insert denial event: %v", err)
+		}
+	}
+
+	if err := c.PruneActionDenialsBefore(200); err != nil {
+		t.Fatalf("PruneActionDenialsBefore: %v", err)
+	}
+	if got := c.CountActionDenialsSince("agent1", string(ActShellExec), 0); got != 2 {
+		t.Fatalf("prune should retain events at/after cutoff, got %d", got)
+	}
+	if got := c.CountActionDenialsSince("agent1", string(ActShellExec), 250); got != 1 {
+		t.Fatalf("recent count after prune: got %d want 1", got)
+	}
 }
 
 func TestCounter_ManualLockdown(t *testing.T) {

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -342,6 +342,12 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 			if err := g.Counter.RecordActionDenial(agent, string(a.Type), a.Fingerprint(), weight); err != nil {
 				fmt.Fprintf(os.Stderr, "gov: RecordDenial failed agent=%s rule=%s: %v\n", agent, d.RuleID, err)
 			}
+			pruneBefore := denyCascadeSince(g.Policy.Escalation)
+			if pruneBefore > 0 {
+				if err := g.Counter.PruneActionDenialsBefore(pruneBefore); err != nil {
+					fmt.Fprintf(os.Stderr, "gov: PruneActionDenials failed agent=%s rule=%s: %v\n", agent, d.RuleID, err)
+				}
+			}
 			if a.Type == ActShellExec && denyCascadeFired(g.Counter, agent, g.Policy.Escalation) {
 				g.Counter.Lockdown(agent)
 			}
@@ -385,8 +391,15 @@ func denyCascadeFired(counter *Counter, agent string, cfg EscalationConfig) bool
 	if counter == nil || cfg.DenyCascadeCount <= 0 || cfg.DenyCascadeWindowSeconds <= 0 {
 		return false
 	}
-	since := time.Now().UTC().Add(-time.Duration(cfg.DenyCascadeWindowSeconds) * time.Second).Unix()
+	since := denyCascadeSince(cfg)
 	return counter.CountActionDenialsSince(agent, string(ActShellExec), since) >= cfg.DenyCascadeCount
+}
+
+func denyCascadeSince(cfg EscalationConfig) int64 {
+	if cfg.DenyCascadeWindowSeconds <= 0 {
+		return 0
+	}
+	return time.Now().UTC().Add(-time.Duration(cfg.DenyCascadeWindowSeconds) * time.Second).Unix()
 }
 
 // stampEnvelope is the lockdown-path helper: it does its own classify +

--- a/go/execution-kernel/internal/gov/gate.go
+++ b/go/execution-kernel/internal/gov/gate.go
@@ -339,8 +339,11 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 			// from the DB, so the row may be stale) so the caller gets a
 			// Decision; the operator sees the error on stderr and can
 			// repair the DB before the next call.
-			if err := g.Counter.RecordDenial(agent, a.Fingerprint(), weight); err != nil {
+			if err := g.Counter.RecordActionDenial(agent, string(a.Type), a.Fingerprint(), weight); err != nil {
 				fmt.Fprintf(os.Stderr, "gov: RecordDenial failed agent=%s rule=%s: %v\n", agent, d.RuleID, err)
+			}
+			if a.Type == ActShellExec && denyCascadeFired(g.Counter, agent, g.Policy.Escalation) {
+				g.Counter.Lockdown(agent)
 			}
 		}
 		d.Escalation = g.Counter.Level(agent)
@@ -376,6 +379,14 @@ func (g *Gate) Evaluate(a Action, agent string, envelope *BudgetEnvelope) (final
 	// AFTER the function returns.
 	final = d
 	return
+}
+
+func denyCascadeFired(counter *Counter, agent string, cfg EscalationConfig) bool {
+	if counter == nil || cfg.DenyCascadeCount <= 0 || cfg.DenyCascadeWindowSeconds <= 0 {
+		return false
+	}
+	since := time.Now().UTC().Add(-time.Duration(cfg.DenyCascadeWindowSeconds) * time.Second).Unix()
+	return counter.CountActionDenialsSince(agent, string(ActShellExec), since) >= cfg.DenyCascadeCount
 }
 
 // stampEnvelope is the lockdown-path helper: it does its own classify +

--- a/go/execution-kernel/internal/gov/gate_test.go
+++ b/go/execution-kernel/internal/gov/gate_test.go
@@ -80,6 +80,35 @@ func TestGate_EscalationRecorded(t *testing.T) {
 	}
 }
 
+func TestGate_DenyCascadeLocksShellExecWithinWindow(t *testing.T) {
+	g, _ := newTestGate(t)
+	g.Policy.Escalation.DenyCascadeCount = 3
+	g.Policy.Escalation.DenyCascadeWindowSeconds = 60
+
+	for i := 0; i < 2; i++ {
+		d := g.Evaluate(Action{Type: ActShellExec, Target: "rm -rf go/"}, "agent1", nil)
+		if d.RuleID != "no-rm" {
+			t.Fatalf("iter %d: RuleID=%q want no-rm", i, d.RuleID)
+		}
+		if d.Escalation == "lockdown" {
+			t.Fatalf("iter %d: lockdown triggered before cascade threshold", i)
+		}
+	}
+
+	d := g.Evaluate(Action{Type: ActShellExec, Target: "rm -rf go/"}, "agent1", nil)
+	if d.RuleID != "no-rm" {
+		t.Fatalf("third deny RuleID=%q want no-rm", d.RuleID)
+	}
+	if d.Escalation != "lockdown" {
+		t.Fatalf("third shell.exec deny should trigger cascade lockdown, escalation=%q", d.Escalation)
+	}
+
+	read := g.Evaluate(Action{Type: ActFileRead, Target: "/tmp/x"}, "agent1", nil)
+	if read.RuleID != "lockdown" {
+		t.Fatalf("post-cascade read RuleID=%q want lockdown", read.RuleID)
+	}
+}
+
 func TestGate_LockdownDeniesEverything(t *testing.T) {
 	g, _ := newTestGate(t)
 	g.Counter.Lockdown("agent1")

--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -144,10 +144,12 @@ func (b Bounds) effectiveBounds(actionType string) ActionBounds {
 
 // EscalationConfig overrides the default escalation thresholds.
 type EscalationConfig struct {
-	ElevatedThreshold int `yaml:"elevated_threshold"`     // default 3
-	HighThreshold     int `yaml:"high_threshold"`         // default 7
-	LockdownThreshold int `yaml:"lockdown_threshold"`     // default 10
-	MaxRetriesPerFp   int `yaml:"max_retries_per_action"` // default 3
+	ElevatedThreshold        int `yaml:"elevated_threshold"`          // default 3
+	HighThreshold            int `yaml:"high_threshold"`              // default 7
+	LockdownThreshold        int `yaml:"lockdown_threshold"`          // default 10
+	MaxRetriesPerFp          int `yaml:"max_retries_per_action"`      // default 3
+	DenyCascadeCount         int `yaml:"deny_cascade_count"`          // default 4
+	DenyCascadeWindowSeconds int `yaml:"deny_cascade_window_seconds"` // default 300
 }
 
 // Decision is the result of evaluating an Action against a Policy.
@@ -367,6 +369,12 @@ func (p *Policy) ApplyDefaults() error {
 	}
 	if p.Escalation.MaxRetriesPerFp == 0 {
 		p.Escalation.MaxRetriesPerFp = 3
+	}
+	if p.Escalation.DenyCascadeCount == 0 {
+		p.Escalation.DenyCascadeCount = 4
+	}
+	if p.Escalation.DenyCascadeWindowSeconds == 0 {
+		p.Escalation.DenyCascadeWindowSeconds = 300
 	}
 	for i, grant := range p.Authority.Trusted {
 		if grant.Authority == "" {

--- a/go/execution-kernel/internal/gov/policy_test.go
+++ b/go/execution-kernel/internal/gov/policy_test.go
@@ -27,6 +27,12 @@ func TestPolicy_LoadBaseline(t *testing.T) {
 	if p.Bounds.MaxFilesChanged != 25 {
 		t.Errorf("Bounds.MaxFilesChanged: got %d", p.Bounds.MaxFilesChanged)
 	}
+	if p.Escalation.DenyCascadeCount != 4 {
+		t.Errorf("Escalation.DenyCascadeCount: got %d want 4", p.Escalation.DenyCascadeCount)
+	}
+	if p.Escalation.DenyCascadeWindowSeconds != 300 {
+		t.Errorf("Escalation.DenyCascadeWindowSeconds: got %d want 300", p.Escalation.DenyCascadeWindowSeconds)
+	}
 	if len(p.Rules) != 5 {
 		t.Errorf("Rules count: got %d want 5", len(p.Rules))
 	}

--- a/go/execution-kernel/internal/gov/testdata/policy-baseline.yaml
+++ b/go/execution-kernel/internal/gov/testdata/policy-baseline.yaml
@@ -11,6 +11,8 @@ escalation:
   elevated_threshold: 3
   high_threshold: 7
   lockdown_threshold: 10
+  deny_cascade_count: 4
+  deny_cascade_window_seconds: 300
 
 rules:
   - id: no-destructive-rm

--- a/go/execution-kernel/internal/gov/unknown_rate_alarm_test.go
+++ b/go/execution-kernel/internal/gov/unknown_rate_alarm_test.go
@@ -176,6 +176,22 @@ func TestUnknownRateAlarmFailureMessageIncludesTopToolsAndSamples(t *testing.T) 
 	}
 }
 
+func TestUnknownRateAlarmRejectsMalformedJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gov-decisions-2026-05-11.jsonl")
+	if err := os.WriteFile(path, []byte("{not-json}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := analyzeUnknownRateDir(dir, 3)
+	if err == nil {
+		t.Fatal("expected malformed JSONL to fail closed")
+	}
+	if !strings.Contains(err.Error(), "malformed JSON") || !strings.Contains(err.Error(), ":1:") {
+		t.Fatalf("error should identify malformed JSON line, got %v", err)
+	}
+}
+
 func TestUnknownRateAlarmCurrentChainOptIn(t *testing.T) {
 	dir := os.Getenv("CHITIN_UNKNOWN_RATE_DIR")
 	if dir == "" {
@@ -292,7 +308,7 @@ func scanUnknownRateFile(path, filename string, topN int, buckets map[string]*un
 		}
 		var row unknownDecisionWire
 		if err := json.Unmarshal([]byte(line), &row); err != nil {
-			continue
+			return fmt.Errorf("malformed JSON in %s:%d: %w", path, lineNo, err)
 		}
 		if row.ActionType == "" {
 			continue


### PR DESCRIPTION
## Summary
- Fix execute_code normalization: route through `gov.Normalize('execute_code')` instead of `'terminal'` so Python subprocess/shutil patterns are extracted before shell classification.
- Add 4 regression tests for hermes execute_code paths (subprocess recursive-delete, shutil rmtree, git status allow).
- Add deny-cascade escalation: N shell.exec denials in M-second window triggers lockdown. New `EscalationConfig.deny_cascade_count` (4) + `deny_cascade_window_seconds` (300) fields.

Closes kanban ticket t_00306ffc.

## Test plan
- [x] go test ./... clean
- [x] 4 new regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Clawta follow-up:
- addressed automated review finding by making unknown-rate JSONL parsing fail closed on malformed rows
- added malformed JSONL regression coverage

Additional validation:
- /usr/local/go/bin/gofmt on touched file
- git diff --check
- /usr/local/go/bin/go test ./internal/gov
- /usr/local/go/bin/go test ./...

Clawta follow-up 2:
- addressed reviewer retention finding by pruning timestamped denial cascade events outside the configured cascade window
- Reset now clears timestamped denial events too
- added pruning/reset regression coverage

Additional validation after retention fix:
- /usr/local/go/bin/gofmt on touched files
- git diff --check
- /usr/local/go/bin/go test ./internal/gov
- /usr/local/go/bin/go test ./...

