### PR TITLE
docs(spec): Hermes + Clawta two-agent architecture (5 slices)

### DIFF
--- a/docs/architecture/2026-05-10-nx-inventory.md
+++ b/docs/architecture/2026-05-10-nx-inventory.md
@@ -1,0 +1,266 @@
+# Nx Workspace Inventory - 2026-05-10
+
+Status: restored and revalidated for kanban task `t_7c01b5e4`.
+
+This document records the current Nx and filesystem shape before the
+monorepo restructuring spec. It intentionally does not choose a target
+layout.
+
+## Commands Run
+
+```bash
+pnpm exec nx show projects --json
+pnpm exec nx graph --print
+pnpm exec nx show project <name> --json
+pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage
+pnpm install
+cat pnpm-workspace.yaml
+git ls-files apps libs tools go python
+test ! -d apps/mcp-server
+test ! -d apps/runner
+test ! -d apps/slack-app
+test ! -d libs/governance
+test ! -d libs/scheduler
+```
+
+## Resolved Nx Projects
+
+`pnpm exec nx show projects --json` reports 11 projects:
+
+```json
+[
+  "@chitin/router-plugin-api",
+  "@chitinhq/openclaw-plugin-governance",
+  "@chitin/adapter-ollama-local",
+  "@chitin/adapter-claude-code",
+  "@chitin/adapter-openclaw",
+  "execution-kernel",
+  "@chitin/generators",
+  "@chitin/contracts",
+  "@chitin/telemetry",
+  "@chitin/tooling-lint",
+  "@chitin/cli"
+]
+```
+
+| Project | Root | Project Type | Source Root | Tags | Targets |
+|---|---|---:|---|---|---|
+| `@chitin/router-plugin-api` | `libs/router-plugin-api/typescript` | null | null | `npm:private` | none |
+| `@chitinhq/openclaw-plugin-governance` | `apps/openclaw-plugin-governance` | null | null | `npm:public`, `layer:app` | `test`, `nx-release-publish` |
+| `@chitin/adapter-ollama-local` | `libs/adapters/ollama-local` | `library` | `libs/adapters/ollama-local/src` | `npm:private`, `layer:adapter` | `typecheck` |
+| `@chitin/adapter-claude-code` | `libs/adapters/claude-code` | null | null | `npm:private`, `layer:adapter` | `typecheck` |
+| `@chitin/adapter-openclaw` | `libs/adapters/openclaw` | `library` | `libs/adapters/openclaw/src` | `npm:private`, `layer:adapter` | `typecheck` |
+| `execution-kernel` | `go/execution-kernel` | `application` | `go/execution-kernel` | `npm:private`, `layer:kernel` | `build`, `test`, `lint`, `run` |
+| `@chitin/generators` | `tools/generators` | null | null | `npm:private`, `layer:tooling` | none |
+| `@chitin/contracts` | `libs/contracts` | null | null | `npm:private`, `layer:contracts` | `typecheck`, `test`, `generate-go-types` |
+| `@chitin/telemetry` | `libs/telemetry` | null | null | `npm:private`, `layer:telemetry` | `typecheck`, `test` |
+| `@chitin/tooling-lint` | `tools/lint` | null | null | `npm:private`, `layer:tooling` | `typecheck`, `test`, `lint:layer-tag-coverage` |
+| `@chitin/cli` | `apps/cli` | null | null | `npm:private`, `layer:cli` | `typecheck`, `test`, `run` |
+
+## Target Commands
+
+The resolved project target commands are:
+
+| Project | Target | Executor | Command / Notes |
+|---|---|---|---|
+| `@chitinhq/openclaw-plugin-governance` | `test` | `nx:run-commands` | `pnpm exec vitest run apps/openclaw-plugin-governance/test` |
+| `@chitinhq/openclaw-plugin-governance` | `nx-release-publish` | `@nx/js:release-publish` | Nx release publish target |
+| `@chitin/adapter-ollama-local` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/adapters/ollama-local` |
+| `@chitin/adapter-claude-code` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/adapters/claude-code` |
+| `@chitin/adapter-openclaw` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/adapters/openclaw` |
+| `execution-kernel` | `build` | `nx:run-commands` | `go build -o ../../dist/go/execution-kernel/chitin-kernel ./cmd/chitin-kernel` in `go/execution-kernel` |
+| `execution-kernel` | `test` | `nx:run-commands` | `go test ./...` in `go/execution-kernel` |
+| `execution-kernel` | `lint` | `nx:run-commands` | `go vet ./...` in `go/execution-kernel` |
+| `execution-kernel` | `run` | `nx:run-commands` | `go run ./cmd/chitin-kernel` in `go/execution-kernel` |
+| `@chitin/contracts` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/contracts` |
+| `@chitin/contracts` | `test` | `nx:run-commands` | `pnpm exec vitest run libs/contracts/tests` |
+| `@chitin/contracts` | `generate-go-types` | `nx:run-commands` | `pnpm exec tsx libs/contracts/tools/generate-go-types.ts`; output `go/execution-kernel/internal/event/event.go` |
+| `@chitin/telemetry` | `typecheck` | `nx:run-commands` | `tsc --build tsconfig.json --emitDeclarationOnly` in `libs/telemetry` |
+| `@chitin/telemetry` | `test` | `nx:run-commands` | `pnpm exec vitest run libs/telemetry/tests` |
+| `@chitin/tooling-lint` | `typecheck` | `nx:run-commands` | disabled echo target because project references set `noEmit: true` |
+| `@chitin/tooling-lint` | `test` | `nx:run-commands` | `pnpm exec vitest run --config tools/lint/vitest.config.ts` |
+| `@chitin/tooling-lint` | `lint:layer-tag-coverage` | `nx:run-commands` | `pnpm exec tsx tools/lint/layer-tag-coverage.ts` |
+| `@chitin/cli` | `typecheck` | `nx:run-commands` | disabled echo target because project references set `noEmit: true` |
+| `@chitin/cli` | `test` | `nx:run-commands` | `pnpm exec vitest run apps/cli/tests` |
+| `@chitin/cli` | `run` | `nx:run-commands` | `pnpm exec tsx apps/cli/src/main.ts` |
+
+`@chitin/router-plugin-api` and `@chitin/generators` currently resolve
+with no targets.
+
+## Project Graph Edges
+
+`pnpm exec nx graph --print` reports these project-to-project edges:
+
+| Source | Target | Type |
+|---|---|---|
+| `@chitin/adapter-ollama-local` | `@chitin/contracts` | static |
+| `@chitin/adapter-claude-code` | `@chitin/contracts` | static |
+| `@chitin/telemetry` | `@chitin/contracts` | static |
+| `@chitin/tooling-lint` | `@chitin/contracts` | static |
+| `@chitin/cli` | `@chitin/contracts` | static |
+| `@chitin/cli` | `@chitin/telemetry` | static |
+| `@chitin/cli` | `@chitin/telemetry` | dynamic |
+
+The following resolved projects currently have no graph dependencies:
+
+- `@chitin/router-plugin-api`
+- `@chitinhq/openclaw-plugin-governance`
+- `@chitin/adapter-openclaw`
+- `execution-kernel`
+- `@chitin/generators`
+- `@chitin/contracts`
+
+## Workspace Package Globs
+
+`pnpm-workspace.yaml` currently declares:
+
+```yaml
+packages:
+  - 'libs/*'
+  - 'libs/adapters/*'
+  - 'libs/router-plugin-api/typescript'
+  - 'apps/*'
+  - 'go/*'
+  - 'tools/*'
+```
+
+Notably, `python/analysis` is not included in the pnpm workspace globs.
+
+## Module Boundary Constraints
+
+`eslint.config.mjs` contains the active `@nx/enforce-module-boundaries`
+rule. Current `layer:*` depConstraints are:
+
+| Source Tag | May Depend On |
+|---|---|
+| `layer:contracts` | none |
+| `layer:telemetry` | `layer:contracts` |
+| `layer:scheduler` | `layer:contracts`, `layer:telemetry` |
+| `layer:slack` | `layer:contracts`, `layer:telemetry` |
+| `layer:adapter` | `layer:contracts`, `layer:telemetry` |
+| `layer:mcp` | `layer:contracts`, `layer:telemetry` |
+| `layer:cli` | `layer:contracts`, `layer:telemetry`, `layer:scheduler` |
+| `layer:app` | `layer:contracts`, `layer:telemetry` |
+| `layer:tooling` | `layer:contracts` |
+| `layer:kernel` | none |
+
+`pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage`
+completed successfully with 0 errors and 3 orphan warnings:
+
+```text
+layer-tag-coverage: warning - depConstraints with no matching package:
+  layer:mcp (defined but no package carries this tag yet)
+  layer:scheduler (defined but no package carries this tag yet)
+  layer:slack (defined but no package carries this tag yet)
+layer-tag-coverage: ok (0 errors, 3 orphan warnings)
+
+NX   Successfully ran target lint:layer-tag-coverage for project @chitin/tooling-lint
+```
+
+Nx also printed:
+
+```text
+Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.
+```
+
+## Tracked Paths By Surface
+
+Tracked source paths under the workspace roots reduce to:
+
+```text
+apps/cli
+apps/openclaw-plugin-governance
+go/execution-kernel
+libs/adapters/claude-code
+libs/adapters/ollama-local
+libs/adapters/openclaw
+libs/contracts
+libs/router-plugin-api
+libs/telemetry
+python/analysis
+tools/generators
+tools/lint
+```
+
+## Removed Historical Ghost Directories
+
+The following historical ghost directories do not exist in the current
+worktree:
+
+- `apps/mcp-server`
+- `apps/runner`
+- `apps/slack-app`
+- `libs/governance`
+- `libs/scheduler`
+
+Scope guards with `test ! -d` passed for all five paths during
+revalidation.
+
+## Tracked Code Outside Resolved Nx Projects
+
+Two tracked surfaces are outside, or only partially inside, resolved Nx
+project coverage.
+
+### `python/analysis`
+
+`python/analysis` has 47 tracked files and is not represented in the Nx
+project list. It is also not included in `pnpm-workspace.yaml`.
+
+Tracked examples include:
+
+```text
+python/analysis/__init__.py
+python/analysis/__main__.py
+python/analysis/codex_mine.py
+python/analysis/debt.py
+python/analysis/decisions.py
+python/analysis/detect.py
+python/analysis/draft.py
+python/analysis/floundering_calibration.py
+python/analysis/llm_draft.py
+python/analysis/loaders.py
+python/analysis/models.py
+python/analysis/predict.py
+```
+
+Ignored local Python artifacts also exist under `python/analysis`, such as
+`.venv`, `.pytest_cache`, `__pycache__`, `*.egg-info`, and `out/`.
+
+### `libs/router-plugin-api/python`
+
+`libs/router-plugin-api/python` has 2 tracked files:
+
+```text
+libs/router-plugin-api/python/chitin_governance.py
+libs/router-plugin-api/python/setup.py
+```
+
+The resolved Nx project for router plugin API is only
+`libs/router-plugin-api/typescript`.
+
+## Observed Metadata Gaps
+
+These are factual gaps in the current resolved workspace metadata, not
+target-architecture decisions:
+
+- 7 of 11 resolved projects have `projectType: null`.
+- 8 of 11 resolved projects have `sourceRoot: null`.
+- `@chitin/router-plugin-api` has no `layer:*` tag.
+- `@chitin/router-plugin-api` and `@chitin/generators` have no targets.
+- `@chitin/tooling-lint:typecheck` and `@chitin/cli:typecheck` are disabled
+  echo targets because project references set `noEmit: true`.
+- Boundary constraints still include orphaned historical layers:
+  `layer:mcp`, `layer:scheduler`, and `layer:slack`.
+- `@chitin/contracts:generate-go-types` writes into
+  `go/execution-kernel/internal/event/event.go`, which is outside the
+  contracts project root.
+
+## Verification Status
+
+- `pnpm install`: passed; lockfile was up to date.
+- `pnpm exec nx show projects --json`: passed.
+- `pnpm exec nx graph --print`: passed.
+- `pnpm exec nx show project <name> --json`: passed for all 11 projects.
+- Scope guards for removed ghost directories: passed.
+- `pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage`: passed
+  with 3 orphan warnings.

--- a/docs/runbooks/unknown-rate-alarm.md
+++ b/docs/runbooks/unknown-rate-alarm.md
@@ -1,0 +1,78 @@
+# Unknown-Rate Alarm Runbook
+
+Chitin's `unknown` action type is the fail-closed bucket for tool calls that
+the driver normalizers do not understand. A sustained unknown rate means a
+driver surface changed or a dispatcher routed the wrong tool shape into a
+normalizer.
+
+## Alarm
+
+Run the guardrail against the local chain:
+
+```sh
+cd go/execution-kernel
+CHITIN_UNKNOWN_RATE_DIR="$HOME/.chitin" \
+CHITIN_UNKNOWN_RATE_DAY="$(date -u +%F)" \
+go test ./internal/gov -run TestUnknownRateAlarmCurrentChainOptIn -count=1
+```
+
+The test fails when any `(agent, UTC day)` bucket has an unexpected unknown
+rate of at least `1%`.
+
+Omit `CHITIN_UNKNOWN_RATE_DAY` for forensics across every
+`gov-decisions-*.jsonl` file in the state directory. Historical bad days, such
+as `2026-05-07`, will still fail by design.
+
+The alarm excludes the documented Hermes intentional-unknown tools:
+
+- `clarify`
+- `image_generate`
+- `text_to_speech`
+- `vision_analyze`
+- `cronjob`
+
+These are chat/modality/scheduling surfaces that intentionally still map to
+`unknown` until chitin has a stable canonical action for them.
+
+## Triage
+
+1. Read the failing test output. It includes:
+   - `(agent, day)`
+   - unknown count, total count, and rate
+   - top unknown tool names with counts
+   - sample locations as `chain_id:seq` when present, otherwise
+     `gov-decisions-YYYY-MM-DD.jsonl:line`
+2. Inspect the raw daily log:
+
+```sh
+jq -c 'select(.agent=="AGENT" and .action_type=="unknown") |
+  {ts, agent, action_target, rule_id, chain_id, seq}' \
+  "$HOME/.chitin/gov-decisions-YYYY-MM-DD.jsonl" | head -50
+```
+
+3. Decide whether each top tool is:
+   - a real new tool that needs a canonical mapping in the relevant
+     `internal/driver/<driver>/normalize.go`
+   - a cross-driver leak that should be normalized through the correct driver
+     or fixed in the upstream dispatcher
+   - an intentional unknown that belongs in the documented whitelist
+
+## Known Reference Points
+
+- `2026-05-07`: Hermes hit roughly `67%` unknowns because runtime plumbing such
+  as `kanban_show`, `kanban_block`, and `process` was unmapped.
+- `2026-05-09`: after the Hermes fixes, the remaining unknowns were much lower
+  and concentrated in specific unmapped tools such as `skills_list`, `memory`,
+  and `skill_manage`, plus intentional `clarify` calls.
+
+## Fix
+
+Add or repair the driver normalizer mapping, then add focused tests near that
+driver. For Hermes, start with:
+
+- `go/execution-kernel/internal/driver/hermes/normalize.go`
+- `go/execution-kernel/internal/gov/action.go`
+
+Do not route approvals, orchestration, or LLM consultation into chitin. The
+kernel should only normalize, govern, record the chain, and stamp pure-Go
+signals.

--- a/docs/superpowers/specs/2026-05-10-nx-restructure.md
+++ b/docs/superpowers/specs/2026-05-10-nx-restructure.md
@@ -1,0 +1,332 @@
+# Nx-Native Monorepo Restructuring Spec
+
+Date: 2026-05-10
+
+Status: Proposed
+
+Task: `t_8bda2f95` / P100 kickoff
+
+## Inputs
+
+This spec is grounded in `AGENTS.md`, `.github/copilot-instructions.md`, current package manifests, current `nx.json`, and the post-cull decision docs named in `AGENTS.md`.
+
+The requested inventory artifact, `docs/architecture/2026-05-10-nx-inventory.md`, is not present in this checkout at spec time. Before executing migration changes, recreate or restore that inventory and compare it against this spec. The validation commands below include a path check for that artifact.
+
+## Goal
+
+Make the repository Nx-native without broadening Chitin's product scope. The restructuring is allowed to change project metadata, tags, target names, and directory placement. It must not add orchestration, approvals, LLM consultation, MCP hosting, model routing, SaaS surfaces, or feature behavior.
+
+## Allowed Buckets as Nx Projects
+
+| Chitin bucket | Nx project type | Required tags | Current examples | Rule |
+| --- | --- | --- | --- | --- |
+| Kernel | `application` | `type:app`, `scope:kernel`, `layer:kernel`, `lang:go`, `runtime:local` | `execution-kernel` | Canonical write path and gate runtime only. |
+| Analytics libs | `library` | `type:lib`, `scope:analytics`, layer tag by role, language tag | `@chitin/contracts`, `@chitin/telemetry`, `chitin-analysis` | Read-side schemas, replay, indexing, analysis, and contracts. |
+| Plugins | `library` for reusable adapters/API packages, `application` only for runnable downstream plugin packages | `type:plugin` or `type:adapter`, `scope:plugin`, layer tag by role | `@chitin/adapter-claude-code`, `@chitin/router-plugin-api`, `@chitinhq/openclaw-plugin-governance` | Operator-installed driver adapters and downstream substrate plugins only. |
+| Apps built off kernel | `application` | `type:app`, `scope:app`, specific layer tag | `@chitin/cli` | Must non-trivially consume kernel state in a way no substrate already does. |
+
+Projects outside these buckets must be deleted, moved to `scratch/`, or kept outside Nx. They must not be tagged into the production project graph.
+
+## Canonical Top-Level Layout
+
+The canonical layout is:
+
+```text
+apps/
+  cli/
+  openclaw-plugin-governance/
+go/
+  execution-kernel/
+libs/
+  adapters/
+    claude-code/
+    ollama-local/
+    openclaw/
+  contracts/
+  router-plugin-api/
+    typescript/
+    python/
+  telemetry/
+python/
+  analysis/
+tools/
+  generators/
+  lint/
+docs/
+  architecture/
+  decisions/
+  superpowers/
+examples/
+  router-plugins/
+scratch/
+scripts/
+```
+
+Directory rules:
+
+- `go/execution-kernel` remains the kernel root. Do not split kernel internals into separate Nx projects unless Go module boundaries are also split.
+- `python/analysis` remains under `python/` because it is an analytics read-side package, not a TS workspace package.
+- `libs/router-plugin-api` may contain language-specific packages. `libs/router-plugin-api/typescript` is an Nx package; `libs/router-plugin-api/python` is either added as a Python Nx project later or left as source-only until Python targets are wired.
+- `tools/*` are Nx tooling projects only when they enforce or generate repository structure. They are not Chitin runtime features.
+- `examples/*` are non-production examples and should use `type:example` if added to Nx; otherwise keep them outside the project graph.
+- `scratch/*` is excluded from production Nx boundaries and validation except basic repository hygiene.
+
+## Project Naming
+
+Nx project names must be stable and command-friendly.
+
+| Area | Directory | Nx project name |
+| --- | --- | --- |
+| Go kernel | `go/execution-kernel` | `execution-kernel` |
+| CLI app | `apps/cli` | `@chitin/cli` |
+| OpenClaw governance plugin app | `apps/openclaw-plugin-governance` | `@chitinhq/openclaw-plugin-governance` |
+| Contracts | `libs/contracts` | `@chitin/contracts` |
+| Telemetry | `libs/telemetry` | `@chitin/telemetry` |
+| Claude Code adapter | `libs/adapters/claude-code` | `@chitin/adapter-claude-code` |
+| OpenClaw adapter | `libs/adapters/openclaw` | `@chitin/adapter-openclaw` |
+| Ollama local adapter | `libs/adapters/ollama-local` | `@chitin/adapter-ollama-local` |
+| Router plugin API TS | `libs/router-plugin-api/typescript` | `@chitin/router-plugin-api` |
+| Python analysis | `python/analysis` | `analysis` or `chitin-analysis` |
+| Generators | `tools/generators` | `@chitin/generators` |
+| Lint tooling | `tools/lint` | `@chitin/tooling-lint` |
+
+Rules:
+
+- Published or potentially published TS packages use npm package names as Nx names.
+- Non-TS projects use short kebab-case names unless a package manager already owns the name.
+- Do not use bucket names alone as project names. `kernel`, `contracts`, `telemetry`, `adapter`, and `plugin` are roles, not project identities.
+
+## Tag Taxonomy
+
+Every production Nx project must have one tag from each applicable axis:
+
+- `type:app`, `type:lib`, `type:adapter`, `type:plugin`, `type:tooling`, or `type:example`
+- `scope:kernel`, `scope:analytics`, `scope:plugin`, `scope:app`, `scope:tooling`, or `scope:example`
+- `layer:kernel`, `layer:contracts`, `layer:telemetry`, `layer:analysis`, `layer:adapter`, `layer:plugin-api`, `layer:plugin`, `layer:cli`, or `layer:tooling`
+- `lang:go`, `lang:ts`, `lang:python`, or `lang:mixed`
+- Optional runtime tags: `runtime:local`, `runtime:driver`, `runtime:openclaw`, `runtime:cli`, `runtime:tooling`
+
+Legacy culled layer tags must be removed from enforceable constraints: `layer:scheduler`, `layer:slack`, and `layer:mcp`.
+
+### Dep Constraints
+
+The target `@nx/enforce-module-boundaries` constraints should converge to:
+
+```js
+[
+  { sourceTag: 'layer:contracts', onlyDependOnLibsWithTags: [] },
+  { sourceTag: 'layer:telemetry', onlyDependOnLibsWithTags: ['layer:contracts'] },
+  { sourceTag: 'layer:analysis', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry'] },
+  { sourceTag: 'layer:plugin-api', onlyDependOnLibsWithTags: ['layer:contracts'] },
+  { sourceTag: 'layer:adapter', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry', 'layer:plugin-api'] },
+  { sourceTag: 'layer:plugin', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry', 'layer:plugin-api', 'layer:adapter'] },
+  { sourceTag: 'layer:cli', onlyDependOnLibsWithTags: ['layer:contracts', 'layer:telemetry', 'layer:adapter'] },
+  { sourceTag: 'layer:tooling', onlyDependOnLibsWithTags: ['layer:contracts'] },
+  { sourceTag: 'layer:kernel', onlyDependOnLibsWithTags: [] },
+]
+```
+
+Kernel code is Go and must remain dependency-isolated from TS libraries at module-boundary level. Cross-language coupling happens through generated files, command invocation, schemas, and documented contracts, not imports.
+
+## Target Naming
+
+Use one shared target vocabulary. Avoid target names that encode implementation details unless they are intentionally narrow maintenance operations.
+
+### Common Targets
+
+- `build`: create distributable artifact or compiled binary.
+- `test`: run project tests.
+- `lint`: run static linting or vetting for the project.
+- `typecheck`: run TS/Python type checks where configured.
+- `validate`: project-local aggregate that depends on `lint`, `typecheck`, and `test` when present.
+- `run`: execute a local application entrypoint.
+- `package`: create a publishable/archive artifact.
+- `generate`: generate code or scaffolding for the project.
+
+### Go Kernel
+
+`execution-kernel` targets:
+
+- `build`: `go build -o ../../dist/go/execution-kernel/chitin-kernel ./cmd/chitin-kernel`
+- `test`: `go test ./...`
+- `lint`: `go vet ./...`
+- `run`: `go run ./cmd/chitin-kernel`
+- Optional later: `validate` depends on `lint`, `test`, and `build`.
+
+### TypeScript Libraries
+
+TS lib targets:
+
+- `test`: Vitest scoped to the package test directory.
+- `typecheck`: inferred by `@nx/js/typescript` where `tsconfig.lib.json` exists.
+- `build`: inferred by `@nx/js/typescript` only for buildable libraries.
+- Custom generation uses explicit names, for example `generate-go-types`.
+
+### Python Analytics
+
+Python project targets:
+
+- `test`: `python -m pytest`
+- `lint`: Python linter once selected by the repo.
+- `typecheck`: Python type checker once selected by the repo.
+- `validate`: aggregate target after all three exist.
+
+Do not invent a Python app surface. `python/analysis` is an analytics library/read-side package.
+
+### Adapters
+
+Adapter targets:
+
+- `test`: adapter behavior tests.
+- `typecheck`: TS typecheck when configured.
+- `build`: only when an adapter is packaged or published.
+- No `serve`, `daemon`, scheduler, approval, or orchestration targets.
+
+### Plugins
+
+Plugin targets:
+
+- `test`: plugin tests against substrate-facing behavior.
+- `package`: create installable plugin package if publishing is configured.
+- `validate`: aggregate.
+
+Plugins may call `chitin-kernel` commands, but they must not embed kernel policy decisions in parallel implementations.
+
+### Apps
+
+App targets:
+
+- `run`: local command invocation.
+- `test`: app tests.
+- `build`: only if the app has a distributable artifact.
+- `validate`: aggregate.
+
+`@chitin/cli` keeps `run` and `test`; add `typecheck` via Nx inference where possible. It must not grow hermes-style orchestration features.
+
+### Tooling
+
+Tooling targets:
+
+- `test`: tests for repository tooling.
+- `lint:*`: narrow repository policy checks, such as `lint:layer-tag-coverage`.
+- `generate`: Nx generators.
+
+Tooling projects may depend on `@chitin/contracts` for schema-aware checks. They must not become runtime libraries.
+
+## Required Project Outcomes
+
+### `go/execution-kernel`
+
+Keep in place as `execution-kernel`, `projectType: application`, with `layer:kernel`. It remains the only canonical gate/write-path implementation. Remove duplicate Nx declarations if necessary so `nx show project execution-kernel --json` has one resolved source of truth.
+
+### `python/analysis`
+
+Keep in place and add an explicit Nx project only when Python targets are ready. It should be tagged `type:lib`, `scope:analytics`, `layer:analysis`, `lang:python`. It reads chain-derived data; it does not write governance decisions.
+
+### `libs/router-plugin-api`
+
+Keep as a plugin API bucket. `libs/router-plugin-api/typescript` should be tagged `type:lib`, `scope:plugin`, `layer:plugin-api`, `lang:ts`. `libs/router-plugin-api/python` should either become a sibling Python project with the same logical layer or remain source-only until Python project support lands.
+
+### `apps/openclaw-plugin-governance`
+
+Keep, but classify as `type:plugin`, `scope:plugin`, `layer:plugin`, `lang:ts`, `runtime:openclaw`. It is a downstream-substrate plugin, not a generic Chitin app. If it becomes publishable, add `package`; otherwise keep `test` and `validate`.
+
+### `tools/*`
+
+Keep `tools/generators` and `tools/lint` as `type:tooling`, `scope:tooling`, `layer:tooling`, `lang:ts`. Tooling can enforce this spec, generate project metadata, and validate tags. It must not be used to ship runtime behavior.
+
+### Ghost Directories
+
+These directories are culled scope and must remain absent from the production graph:
+
+- `apps/mcp-server`: do not restore. Chitin does not host MCP servers; substrates expose kernel subcommands.
+- `apps/runner`: do not restore. Chitin is not an orchestrator or agent runner.
+- `apps/slack-app`: do not restore. Slack workflow surfaces belong outside the kernel repo unless a future app clears the allowed-app bar.
+- `libs/governance`: do not restore. The Go kernel is canonical; no parallel TS adjudicator.
+- `libs/scheduler`: do not restore. Scheduling belongs to hermes.
+
+If any of these names reappear, validation must fail unless the directory is under `docs/`, `scratch/`, or a migration archive explicitly excluded from Nx.
+
+## Migration Order
+
+1. Restore or regenerate `docs/architecture/2026-05-10-nx-inventory.md` and record current Nx project metadata, package manager workspaces, and ghost directory state.
+2. Normalize tags in existing package manifests and `project.json` files without moving code.
+3. Update `eslint.config.mjs` depConstraints to remove culled layers and add `layer:analysis`, `layer:plugin-api`, and `layer:plugin`.
+4. Add missing Nx project metadata for packages already in `pnpm-workspace.yaml`, starting with adapters and router plugin API.
+5. Add Python Nx project metadata for `python/analysis` only after choosing exact Python executors or stable `nx:run-commands` targets.
+6. Add `validate` targets and `targetDefaults` after individual targets are green.
+7. Consider directory moves only after tag and target validation is green. No move is required for `go/execution-kernel` or `python/analysis`.
+8. Add tooling checks for ghost directories and required tag coverage.
+
+Each step should be a separate commit or a small group of commits with passing validation.
+
+## Rollback Plan
+
+Rollback must preserve runtime code and operator data:
+
+- For metadata-only changes, revert the commit that changed package `nx` blocks, `project.json`, `nx.json`, or `eslint.config.mjs`.
+- For directory moves, use `git mv` in the forward migration and revert the move commit if Nx resolution or imports break.
+- For Python Nx onboarding, remove only the Nx metadata if Python task wiring fails; leave `python/analysis` source in place.
+- For depConstraint changes, restore the previous `eslint.config.mjs` constraint block while keeping any independent package manifest fixes that were already validated.
+- Never roll back by deleting `go/execution-kernel`, `.chitin` data, generated chain files, or user-local state.
+
+## Exact Validation Commands
+
+Run from the repository root.
+
+Preflight:
+
+```bash
+test -f docs/architecture/2026-05-10-nx-inventory.md
+pnpm install
+pnpm exec nx show projects --json
+pnpm exec nx graph --print
+```
+
+Scope guards:
+
+```bash
+test ! -e apps/mcp-server
+test ! -e apps/runner
+test ! -e apps/slack-app
+test ! -e libs/governance
+test ! -e libs/scheduler
+pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage
+```
+
+Core build and tests:
+
+```bash
+pnpm exec nx run execution-kernel:build
+pnpm exec nx run execution-kernel:lint
+pnpm exec nx run execution-kernel:test
+pnpm exec nx run @chitin/contracts:test
+pnpm exec nx run @chitin/telemetry:test
+pnpm exec nx run @chitin/cli:test
+pnpm exec nx run @chitin/cli:typecheck
+pnpm exec nx run @chitin/telemetry:typecheck
+pnpm exec nx run @chitin/contracts:typecheck
+pnpm exec vitest run
+(cd go/execution-kernel && go test ./...)
+```
+
+Repository lint:
+
+```bash
+pnpm exec oxlint .
+pnpm exec eslint .
+```
+
+Python analytics, once Nx targets exist:
+
+```bash
+pnpm exec nx run analysis:test
+```
+
+Full affected check after the first migration commit:
+
+```bash
+pnpm exec nx affected -t lint,test,typecheck,build
+```
+
+Validation is complete only when the commands that correspond to configured targets pass. If a target does not exist yet, either add it in the migration step that claims it or remove it from that step's acceptance criteria.

--- a/docs/superpowers/specs/2026-05-12-clawta-hermes-architecture.md
+++ b/docs/superpowers/specs/2026-05-12-clawta-hermes-architecture.md
@@ -1,0 +1,377 @@
+# Hermes + Clawta Architecture — 5-slice spec
+
+Date: 2026-05-12
+Status: spec — under discussion
+Author: Jared + Claude (collaborative)
+
+## Goal
+
+Two-agent operator architecture with a clean separation of concerns:
+
+- **Hermes** (Ares bot) — personal assistant, kanban orchestrator, talks to the user
+- **Clawta** (Clawta bot) — swarm manager, dispatch executor, manages leaf-CLI workers
+- **Workers** — claude-code / codex / gemini / copilot CLIs, pure executors with no decision authority
+
+The two agents communicate peer-to-peer via Discord DM. The user talks to Hermes primarily; talks to Clawta only when asking questions ("why did you dispatch X to codex?", "show swarm health"). Chitin gates every hop, so the chain ledger is the canonical telemetry plane.
+
+## Target architecture
+
+```
+                              USER
+                               │
+       primary chat ───────────┤────────── questions only
+                               ▼                    ▼
+       ┌─────────────────── HERMES ◄──── DM ────► CLAWTA ───────────────┐
+       │  orchestrator                            swarm manager          │
+       │  • owns kanban + grooming                • owns dispatch        │
+       │  • prioritization                        • picks agent + model  │
+       │  • research + ingestion                  • explains routing     │
+       │  • watches GitHub                        • short + long memory  │
+       │  • cron: highest-leverage-next           • ELO leaderboard      │
+       │  • escalates to operator                 • escalates to Hermes  │
+       └──────────────────┬───────────────────────────┬─────────────────┘
+                                                      │
+                                                      ▼
+                                                 LOBSTER WORKFLOW
+                                                      │
+                                                      ▼
+                                      LEAF CLIs (pure executors)
+                                      claude-code · codex · gemini · copilot
+                                                      │
+                                                      ▼
+                                                 WORK PRODUCT (PR)
+                                                      │
+                                                      ▼
+                                                 JUDGE LLM (frontier)
+                                                      │
+                                                      ▼
+                                                 ELO LEDGER ──► routing feedback
+```
+
+Telemetry plane = chitin (chain ledger across every hop, every Discord post, every tool call).
+
+## Responsibility split
+
+| Capability | Owner | Notes |
+|---|---|---|
+| Talk to user | Hermes | Primary surface |
+| Answer user questions about swarm | Clawta | Q&A only, user-initiated |
+| Own the kanban (create, groom, prioritize) | Hermes | Including stale-ticket detection |
+| Watch GitHub (PRs, CI, reviews) | Hermes | Notifies user about new PRs |
+| Decide what to do next (highest-leverage) | Hermes | Runs cron; surfaces to user |
+| Decide *which agent + model* to dispatch | Clawta | Reads ticket, picks driver, justifies |
+| Run the lobster workflow | Clawta | spawn_worker → leaf CLI |
+| Escalate dispatch errors | Clawta → Hermes via DM | Hermes translates to user |
+| Score work product (ELO judge) | Clawta | Frontier-model judge per PR |
+| Persist long-term memory | Both | Hermes for board state; Clawta for routing decisions |
+
+## Hard rules (invariants)
+
+1. **No subprocess invocation between agents.** Hermes does not exec `clawta`. Clawta does not exec `hermes`. They speak via Discord. The `clawta` CLI wrapper stays for operator manual use.
+2. **Workers never decide.** Leaf CLIs (claude-code, codex, gemini, copilot) execute. They never pick the next ticket, never re-dispatch, never escalate to user.
+3. **One operator thread.** User, Hermes, and Clawta all post in the same Discord thread/channel. No fragmented narration across channels.
+4. **Chitin telemetry covers every hop.** Every shell exec, every Discord post (via openclaw plugin), every tool call routes through the chain ledger with `driver` + `agent` stamps.
+5. **Clawta never DMs the user unsolicited.** User initiates Q&A; Clawta replies. Hermes is the only agent that can DM the user proactively.
+6. **Failures escalate up the chain.** Worker fails → Clawta sees it → Clawta DMs Hermes → Hermes decides whether to re-dispatch, ask user, or close.
+
+## Phase ordering + dependencies
+
+```
+Slice 1 (Smoke current path) — no deps
+  │
+  ▼
+Slice 2 (Discord DM peer comm) — needs Slice 1
+  │
+  ├─► Slice 3 (Routing reasoning log) — needs Slice 1
+  ├─► Slice 4 (Hermes board-audit cron) — needs Slice 2
+  └─► Slice 5 (PR judge + ELO) — needs Slice 1; benefits from Slice 3
+```
+
+Slices 3, 4, 5 can run in parallel after Slice 2 lands. Slice 1 is the gating verification.
+
+---
+
+## Slice 1 — Smoke the current dispatch path
+
+**Goal:** prove the rewired `clawta` CLI + `kanban-dispatch.lobster` (with `audit_comment` broadcast + new `finalize_dispatch` step) actually works end-to-end on one substantive ticket. NO new code; this is verification of changes already made today.
+
+**Components in scope:**
+- `/home/red/.local/bin/clawta` (rewired today: pattern detection → lobster invocation with auto-approve)
+- `~/.openclaw/workflows/kanban-dispatch.lobster` + repo mirror at `docs/governance-setup-extras/kanban-dispatch.lobster`
+- Chitin chain ledger (read-only inspection)
+- One substantive kanban ticket assigned to a frontier coder
+
+**Tasks:**
+1. Pick a ready ticket with substantive code work (not a "print OK" smoke). Candidates: `t_cb0311ab` (codex, Nx step 2), `t_41b18659` (claude-code, classifier bug), or a freshly filed one.
+2. Invoke `clawta "dispatch ticket t_X to <driver>"` directly from a shell to confirm the wrapper detects the dispatch pattern.
+3. Observe the workflow steps fire: `fetch_ticket → classify → pick_driver → confirm (auto-approve) → reassign → audit_comment → spawn_worker → finalize_dispatch`.
+4. Verify the four observable beats:
+   - Start: kanban comment `🦞 Starting dispatch to <driver> ...` from author `clawta`
+   - Start broadcast: Discord message in Clawta's channel (best-effort)
+   - Spawn: leaf CLI runs, chain ledger shows driver=clawta + agent=<driver>
+   - Finalize: branch pushed; PR opened; final kanban comment `🦞 Done. PR: <url>`; final Discord broadcast
+5. Inspect ledger: `~/.chitin/gov-decisions-<date>.jsonl` — confirm every action has non-empty driver and agent.
+
+**Acceptance:**
+- One real ticket dispatched via the new wrapper, completes with a PR on origin
+- Kanban has both start and final comments authored by `clawta`
+- Chain ledger shows expected driver/agent attribution across the workflow
+- No silent step failures (look for `|| true` paths that swallowed an error)
+
+**Dependencies:** none
+
+**Open questions:** none
+
+---
+
+## Slice 2 — Hermes ↔ Clawta Discord DM peer comm
+
+**Goal:** Hermes and Clawta communicate via Discord DM instead of CLI subprocess. Both bots post in the same operator thread; user sees the full conversation under each bot's identity.
+
+**Components in scope:**
+- Hermes-side tool: `dispatch_via_clawta` (or extend an existing send_message tool) that DMs Clawta on Discord
+- Clawta-side trigger: detect dispatch-shaped DMs and run the lobster workflow
+- Operator-thread routing: confirm both bots are active in the same Discord channel/thread
+- `clawta` CLI wrapper stays as-is (still works for operator manual invocation)
+
+**Sub-problems:**
+- **Clawta-side trigger.** Openclaw's glm-agent currently responds to @-mentions with text. We need a programmatic intercept: when an incoming Discord message matches `/dispatch (ticket )?(t_[a-z0-9]+)/i`, route directly to lobster (not to glm-agent's LLM). Two paths:
+  - (a) Add a Clawta-specific skill that pattern-matches and shells out to `clawta` (the CLI wrapper) — reuses Slice 1's plumbing
+  - (b) Build an openclaw plugin that intercepts before glm-agent — cleaner but more code
+  - Recommend (a) for minimum surface area.
+- **Hermes-side send.** Hermes already has terminal tool, so `openclaw message send --channel discord --account default --to <clawta-handle> --text "dispatch ticket t_X to codex"` works today. Need to know Clawta's user/handle and confirm the message reaches Clawta's listener.
+- **Reply path.** When Clawta finishes, it DMs Hermes back: `🦞 t_X done. PR: <url>`. Hermes detects the DM, summarizes to user. Need Hermes's user/handle for the reply target.
+- **Identity discovery.** Use `openclaw directory self` or `openclaw channels list` to get bot handles. Document in the operator-runbook.
+
+**Tasks:**
+1. Discover Clawta's and Hermes's Discord user ids / handles via `openclaw directory`.
+2. Update `DISPATCH_AND_TICKETING_GUIDANCE` in `agent/prompt_builder.py`: replace "use `clawta` CLI" with "send a Discord DM to @Clawta". Include the exact handle.
+3. Add a Clawta-side trigger skill or plugin that pattern-matches incoming Discord DMs and runs `clawta "dispatch ticket t_X to <driver>"` (the wrapper handles auto-approve from Slice 1).
+4. Add Clawta-side reply: at the end of the workflow (or in finalize_dispatch), post a Discord DM to Hermes with the result.
+5. Smoke: user @Hermes ("dispatch t_X") → Hermes DMs @Clawta → Clawta runs lobster → Clawta DMs @Hermes ("done, PR <url>") → Hermes summarizes to user.
+
+**Acceptance:**
+- User dispatches by messaging Hermes; Hermes does NOT exec clawta CLI; Hermes DMs Clawta on Discord
+- Clawta receives the DM, runs lobster, narrates progress on Discord
+- Clawta DMs Hermes when done; Hermes relays to user
+- No CLI subprocess between Hermes and Clawta during dispatch
+- Full conversation visible in the operator Discord thread under three identities (user, Hermes/Ares, Clawta)
+
+**Dependencies:** Slice 1 (dispatch path must work first)
+
+**Open questions:**
+- DMs vs single channel: if both bots have a shared channel they post in (vs each pair DMing), the user sees one threaded conversation. Recommend shared operator channel.
+- Does openclaw glm-agent's Discord listener forward all incoming messages to the LLM, or can a plugin intercept? Need to verify before picking the trigger approach.
+- Hermes already uses Discord — how does it currently differentiate between user messages and bot-DM messages? May need a sender-filter in Hermes's inbound handler.
+
+---
+
+## Slice 3 — Clawta routing-reasoning log
+
+**Goal:** every dispatch includes a 2-3 sentence natural-language justification from glm-agent explaining why it chose that driver + model. Recorded in kanban, chain, and Clawta's memory so the user can later ask "why did you dispatch t_X to codex?" and get the original reasoning.
+
+**Components in scope:**
+- New step in `kanban-dispatch.lobster`: `router_explanation` (between `pick_driver` and `confirm`)
+- Decision storage: a new SQLite table `clawta_decisions` (or chain-event metadata) recording (ticket_id, driver, model, reasoning, ts)
+- Clawta's openclaw skill/identity: teach it to look up past explanations when asked "why?"
+
+**Tasks:**
+1. Add `router_explanation` step to lobster workflow. Calls glm-agent with a prompt like: *"Ticket: {{fetch_ticket.stdout}}. You picked {{pick_driver.json.driver}} ({{model}}). In 2 sentences, explain why that's the right pick for this ticket. Reference: code complexity, language, ticket type, capabilities, cost tradeoff."*
+2. Capture the reasoning. Post it to kanban as a clawta comment: `🦞 Routing: {{driver}}/{{model}} chosen because <reasoning>`.
+3. Persist for later lookup. Pick one:
+   - (a) Store in chain-event metadata on the dispatch event (lightweight, reuses existing ledger)
+   - (b) New SQLite table at `~/.openclaw/data/clawta_decisions.db` with full schema
+   - Recommend (b) for query speed and structured access.
+4. Update Clawta's persona: add a skill or system-prompt section that says "when asked 'why did you dispatch X to Y?', look up the decision record at <db>/<api> and quote the reasoning verbatim."
+5. Smoke: dispatch a ticket; check kanban comment + Discord broadcast; ask `@Clawta why did you dispatch t_X to <driver>?` and verify it returns the recorded reasoning.
+
+**Acceptance:**
+- Each dispatch has a recorded reasoning string visible in kanban + chain
+- User can ask Clawta "why did you dispatch X to Y?" via Discord DM and get the original justification
+- Reasoning is grounded in ticket content, not generic
+
+**Dependencies:** Slice 1 (workflow path); ideally Slice 2 (Clawta on Discord for Q&A)
+
+**Open questions:**
+- Use glm-agent (cheap) for reasoning, or a frontier model (better quality, more $$$)? Recommend glm-agent for now — Clawta's persona is glm-5.1; using the same model preserves voice consistency. Upgrade to opus/gpt-5.5 if reasoning quality is consistently weak.
+- Storage: chain-event metadata (no new infrastructure) vs new SQLite table (queryable). The user wants Clawta to maintain a "swarm health" view — that suggests a real table.
+- Retention: keep forever? Bound to last 90 days?
+- Reasoning length: 2 sentences is tight; 1 paragraph might be more useful for low-context tickets. Make it configurable.
+
+---
+
+## Slice 4 — Hermes board-audit cron
+
+**Goal:** Hermes proactively reviews the board every N minutes and DMs the user when there's a highest-leverage next action. No more "user has to remember to ask Hermes about the board".
+
+**Components in scope:**
+- New `hermes cron` job (Hermes has cron via `hermes cron` subcommand)
+- Audit ruleset (what's stale, what's blocked, what's missing context)
+- Leverage scoring (effort vs impact heuristic)
+- DM templates (what Hermes says to the user)
+
+**Audit rules (initial):**
+1. **Stale ready tickets:** ready state, no activity > 7 days → "deferred?"
+2. **Missing-context tickets:** body length < 100 chars + no parent task → "needs grooming?"
+3. **PRs without reviews:** open > 24h, no review comments → "want a code-review dispatch?"
+4. **PRs with failing CI:** open + failing checks → "needs attention?"
+5. **Stuck dispatches:** running > 2h, no kanban heartbeat → "kill or escalate?"
+6. **Duplicate tickets:** title similarity > 0.85 → "merge or close one?"
+7. **Operator-only tickets:** explicitly tagged `operator-job` → "ready for you when you have time"
+
+**Tasks:**
+1. Spec the audit rules formally (`docs/runbooks/hermes-board-audit.md`)
+2. Build a `board_audit` Python tool/skill that returns a structured candidate list
+3. Add leverage scoring: each candidate gets a score (effort × impact); top 3 surface to user
+4. Wire to `hermes cron` with default 30min interval; configurable in `~/.hermes/config.yaml`
+5. DM template: bullet list of candidates with `[dispatch] [defer] [snooze] [dismiss]` action buttons (or text prompts)
+6. Smoke: let cron fire on schedule; verify a real audit message lands; respond → Hermes acts
+
+**Acceptance:**
+- Cron fires on schedule (configurable interval)
+- Identifies real, actionable candidates from the board (low false-positive rate)
+- User receives structured DM with 1-3 top candidates and clear options
+- User's response routes to the right action (dispatch, defer, file, dismiss)
+- Quiet on quiet boards (no message if nothing actionable)
+
+**Dependencies:** Slice 2 (Hermes can DM user without prompt — currently works for replies, may need verification for cron-driven sends)
+
+**Open questions:**
+- Leverage scoring: hard-coded heuristic vs LLM-judged ranking? Start with hard-coded; can upgrade later.
+- Chattiness: 30min interval might be too frequent. Make it user-tunable. Default to "once an hour, only if something is actionable".
+- Should the cron also DM Clawta to dispatch autonomously when no operator decision is needed (e.g., a clear-cut "this ticket is ready, no ambiguity, dispatch to X")? Recommend: no for v1; user-in-loop. Reconsider after observing usage.
+- Quiet hours: don't ping at night unless critical?
+
+---
+
+## Slice 5 — Post-PR judge LLM + ELO leaderboard
+
+**Goal:** every PR (or completed dispatch with a PR) gets reviewed by a frontier judge LLM. Judge scores on multiple dimensions. Scores feed an ELO leaderboard for (driver, model, task-class) tuples. Eventually, Clawta uses ELO when picking driver.
+
+**Components in scope:**
+- New workflow: `pr-judge.lobster` (separate from kanban-dispatch.lobster)
+- Trigger: PR open event (GitHub webhook OR polling) OR `kanban_complete` with `pr_url` in metadata
+- Judge model: frontier (opus-4-7 or gpt-5.5) reads ticket + final code + tests + commit messages + chain telemetry from the dispatch run
+- ELO storage: SQLite table `swarm_elo`
+- Surface: `clawta status leaderboard` returns current rankings; queryable via Discord DM
+
+**Judge rubric (initial — 5 dimensions, each 1-5):**
+1. **Code quality:** clarity, idioms, no dead code, sensible structure
+2. **Test coverage:** new tests added, exercises the change, edge cases
+3. **Scope adherence:** matches ticket; no scope creep
+4. **Efficiency:** time-to-PR, number of iterations, no thrashing
+5. **Review-friendliness:** small diff, good commit messages, well-bounded
+
+Total score: sum of 5 dimensions (range 5-25). Mapped to ELO delta via expected-vs-actual.
+
+**ELO storage schema:**
+```sql
+CREATE TABLE swarm_elo (
+  id INTEGER PRIMARY KEY,
+  driver TEXT NOT NULL,
+  model TEXT NOT NULL,
+  task_class TEXT,           -- 'refactor' | 'feature' | 'bugfix' | 'research' | 'docs' | 'unknown'
+  elo_score REAL NOT NULL,   -- starts at 1500; updates per dispatch
+  dispatches_count INTEGER NOT NULL DEFAULT 0,
+  last_dispatch_id TEXT,
+  last_updated INTEGER NOT NULL,
+  UNIQUE(driver, model, task_class)
+);
+
+CREATE TABLE swarm_dispatch_scores (
+  id INTEGER PRIMARY KEY,
+  ticket_id TEXT NOT NULL,
+  pr_url TEXT,
+  driver TEXT NOT NULL,
+  model TEXT NOT NULL,
+  task_class TEXT,
+  code_quality INTEGER,
+  test_coverage INTEGER,
+  scope_adherence INTEGER,
+  efficiency INTEGER,
+  review_friendliness INTEGER,
+  total_score INTEGER,
+  judge_model TEXT NOT NULL,
+  judge_reasoning TEXT,
+  scored_at INTEGER NOT NULL
+);
+```
+
+**Tasks:**
+1. Design the judge prompt with the 5-dimension rubric. Iterate on a few historical PRs to calibrate.
+2. Build `pr-judge.lobster` workflow. Inputs: ticket id + PR url. Steps: fetch ticket → fetch PR diff → fetch worker chain events → call judge LLM → parse scores → update ELO table → comment on PR + kanban.
+3. Trigger: poll new PRs every N minutes (simpler than webhook for v1). Alternative: hook into `kanban_complete` to fire immediately.
+4. Implement ELO update with K-factor tuned for low-volume comparisons (start K=32; reduce as `dispatches_count` grows).
+5. Build `clawta status leaderboard [--task-class X]` command. Returns rankings.
+6. Surface on Discord: `@Clawta show leaderboard` returns top 5 (driver, model) pairs.
+7. Wire to `pick_driver`: as a SECONDARY signal (not primary) until ELO has 50+ dispatches per pair. Initially logs the ELO-suggested choice alongside the existing pick.
+
+**Acceptance:**
+- After a PR opens, the judge run fires within N minutes (poll interval)
+- Judge produces structured scores stored in `swarm_dispatch_scores` + ELO update in `swarm_elo`
+- Leaderboard queryable via Discord under Clawta's identity
+- `pick_driver` step logs the ELO-suggested choice alongside its actual choice (observable, not yet authoritative)
+- After 50+ dispatches per (driver, model, task-class), routing decisions show measurable improvement (track over time)
+
+**Dependencies:** Slice 1 (dispatch must produce PRs), ideally Slice 3 (routing reasoning recorded — useful context for judge)
+
+**Open questions:**
+- Judge model: opus is best but $$$ per PR. Sonnet might be enough. Could also use a cheap fast pass + escalate to opus for high-disagreement scores.
+- Trigger: PR open (early signal) vs PR merge (final signal). Recommend score both — they measure different things (worker quality vs final review-adjusted quality).
+- Task class detection: how do we tag tickets with task_class for ELO bucketing? Heuristic from ticket title/body, or explicit field? Recommend heuristic v1.
+- ELO maturity threshold: how many dispatches before ELO is trustworthy enough to drive routing decisions? Convention: 50 (chess uses ~30 for provisional rating). Make configurable.
+- Bias: the judge might consistently favor certain styles (e.g., Go-idiomatic over Python-ish in mixed codebases). Counter-measure: judge separate models in head-to-head occasionally (route the same ticket to two drivers and compare).
+- Cost ceiling: each judge call costs $0.05-$0.50 depending on model. At 20 dispatches/day, that's $30/month for opus or $3/month for sonnet. Budget-bound the workflow.
+
+---
+
+## What's NOT in this spec (out of scope)
+
+- **Auto-merge.** Every public 2026 swarm system keeps human-in-loop on merge (per `project_self_improving_swarm_landscape_2026.md`). We follow that convention.
+- **Live tool synthesis.** Live-SWE-agent pattern (workers generating their own tools) is deferred (memory: widens blast radius too much for v1).
+- **Replacing OpenClaw's workflow engine.** We sit above as policy + orchestration; we don't rebuild Lobster.
+- **Replacing chitin's gate.** The gate stays the authoritative side-effect adjudicator. New flows route through it; they don't bypass it.
+
+## Where things live (file paths + conventions)
+
+| Component | Path | Owner |
+|---|---|---|
+| Hermes operator code | `/home/red/.hermes/hermes-agent/` | hermes-agent repo |
+| Hermes system prompt | `agent/prompt_builder.py` | KANBAN_GUIDANCE, DISPATCH_AND_TICKETING_GUIDANCE |
+| Hermes skills | `skills/devops/{kanban-worker,kanban-orchestrator}/SKILL.md` | hermes-agent repo |
+| Clawta CLI wrapper | `/home/red/.local/bin/clawta` | operator-local |
+| Clawta agent config | `~/.openclaw/agents/glm-agent/` | openclaw operator state |
+| Dispatch workflow | `~/.openclaw/workflows/kanban-dispatch.lobster` | operator-local; mirror in chitin repo |
+| Dispatch workflow mirror | `docs/governance-setup-extras/kanban-dispatch.lobster` | chitin repo, audit trail |
+| Agent cards | `~/.openclaw/data/agent-cards/*.json` | operator-local; mirror in chitin repo |
+| Chitin gate code | `go/execution-kernel/internal/gov/` | chitin repo |
+| Chain ledger | `~/.chitin/gov-decisions-<date>.jsonl` | operator-local persistent |
+| ELO + decision storage (new) | `~/.openclaw/data/clawta.db` | operator-local; SQLite |
+| pr-judge workflow (new) | `~/.openclaw/workflows/pr-judge.lobster` | mirrored to repo |
+| Hermes cron jobs (new) | `~/.hermes/cron.yaml` or `hermes cron add` | operator-local |
+| Audit ruleset (new) | `docs/runbooks/hermes-board-audit.md` | chitin repo |
+
+## Plugin recommendations
+
+**Openclaw plugins for Clawta:**
+- Memory: openclaw has built-in memory primitives (`openclaw memory` subcommand exists). Audit whether it persists across sessions; add a vector-recall plugin if not (Cipher / Mem0 via MCP).
+- Discord: openclaw's Discord adapter already exists; we just need to use it for Clawta-side broadcasts (Slices 2, 3).
+
+**Hermes plugins:**
+- Memory: `agent/memory_manager.py` exists. Verify it's wired to persistent storage.
+- Cron: `hermes cron` subcommand exists. Use for Slice 4.
+- GitHub watch: use `gh` via terminal + cron polling.
+
+**Cross-cutting:**
+- Chitin extension: a chain-ledger consumer that records (driver, model, ticket_class, success) for ELO feeding.
+- Discord adapter shared between bots: confirm both Ares and Clawta can post in the same channel under separate identities.
+
+## Phase rollout
+
+Recommended cadence:
+
+- **Week 1:** Slice 1 (smoke), Slice 2 (Discord DM)
+- **Week 2:** Slice 3 (routing reasoning), Slice 4 (board-audit cron)
+- **Week 3:** Slice 5 (PR judge + ELO)
+
+Each slice ends with a kanban ticket marked complete + a PR merged. After all 5, the architecture is operational and self-improving.

--- a/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-known/gov-decisions-2026-05-09.jsonl
+++ b/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-known/gov-decisions-2026-05-09.jsonl
@@ -1,0 +1,5 @@
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"hermes","action_type":"shell.exec","action_target":"pnpm test","ts":"2026-05-09T01:00:00Z","chain_id":"chain-hermes","seq":1}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-reads","agent":"hermes","action_type":"file.read","action_target":"docs/roadmap.md","ts":"2026-05-09T01:01:00Z","chain_id":"chain-hermes","seq":2}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-kanban","agent":"hermes","action_type":"kanban.call","action_target":"show","ts":"2026-05-09T01:02:00Z","chain_id":"chain-hermes","seq":3}
+{"allowed":true,"mode":"monitor","rule_id":"router-heuristic:allow","agent":"codex","action_type":"router.signal","action_target":"Bash:go test ./...","ts":"2026-05-09T01:03:00Z","chain_id":"chain-codex","seq":1}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"codex","action_type":"shell.exec","action_target":"go test ./...","ts":"2026-05-09T01:04:00Z","chain_id":"chain-codex","seq":2}

--- a/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-unknown/gov-decisions-2026-05-07.jsonl
+++ b/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/all-unknown/gov-decisions-2026-05-07.jsonl
@@ -1,0 +1,4 @@
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"kanban_show","ts":"2026-05-07T10:00:00Z","chain_id":"chain-hermes","seq":7}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"process","ts":"2026-05-07T10:01:00Z","chain_id":"chain-hermes","seq":8}
+{"allowed":false,"mode":"enforce","rule_id":"lockdown","agent":"hermes","action_type":"unknown","action_target":"kanban_show","ts":"2026-05-07T10:02:00Z","chain_id":"chain-hermes","seq":9}
+{"allowed":false,"mode":"enforce","rule_id":"lockdown","agent":"hermes","action_type":"unknown","action_target":"kanban_block","ts":"2026-05-07T10:03:00Z","chain_id":"chain-hermes","seq":10}

--- a/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/mixed-with-whitelist/gov-decisions-2026-05-09.jsonl
+++ b/go/execution-kernel/internal/gov/testdata/unknown_rate_alarm/mixed-with-whitelist/gov-decisions-2026-05-09.jsonl
@@ -1,0 +1,6 @@
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-shell","agent":"hermes","action_type":"shell.exec","action_target":"go test ./internal/gov","ts":"2026-05-09T12:00:00Z","chain_id":"chain-mixed","seq":1}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"clarify","ts":"2026-05-09T12:01:00Z","chain_id":"chain-mixed","seq":2}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"image_generate","ts":"2026-05-09T12:02:00Z","chain_id":"chain-mixed","seq":3}
+{"allowed":false,"mode":"enforce","rule_id":"default-deny-unknown","agent":"hermes","action_type":"unknown","action_target":"skills_list","ts":"2026-05-09T12:03:00Z","chain_id":"chain-mixed","seq":4}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-file-write","agent":"hermes","action_type":"file.write","action_target":"memory","ts":"2026-05-09T12:04:00Z","chain_id":"chain-mixed","seq":5}
+{"allowed":true,"mode":"enforce","rule_id":"default-allow-http","agent":"hermes","action_type":"http.request","action_target":"https://example.invalid","ts":"2026-05-09T12:05:00Z","chain_id":"chain-mixed","seq":6}

--- a/go/execution-kernel/internal/gov/unknown_rate_alarm_test.go
+++ b/go/execution-kernel/internal/gov/unknown_rate_alarm_test.go
@@ -1,0 +1,421 @@
+package gov
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const defaultUnknownRateThreshold = 0.01
+
+var intentionalUnknownTools = map[string]struct{}{
+	"clarify":        {},
+	"image_generate": {},
+	"text_to_speech": {},
+	"vision_analyze": {},
+	"cronjob":        {},
+}
+
+type unknownRateSummary struct {
+	Agent           string
+	Day             string
+	Total           int
+	Unknown         int
+	Rate            float64
+	TopUnknownTools []unknownToolCount
+	Samples         []unknownSample
+}
+
+type unknownToolCount struct {
+	Tool  string
+	Count int
+}
+
+type unknownSample struct {
+	Tool     string
+	Locator  string
+	RuleID   string
+	Filename string
+	Line     int
+}
+
+type unknownDecisionWire struct {
+	Agent        string `json:"agent"`
+	ActionType   string `json:"action_type"`
+	ActionTarget string `json:"action_target"`
+	RuleID       string `json:"rule_id"`
+	Ts           string `json:"ts"`
+	ChainID      string `json:"chain_id"`
+	Seq          *int64 `json:"seq"`
+}
+
+func TestUnknownRateAlarmFixtures(t *testing.T) {
+	cases := []struct {
+		name       string
+		fixture    string
+		wantAlarm  bool
+		wantRows   int
+		assertions func(t *testing.T, rows []unknownRateSummary, alarms []unknownRateSummary)
+	}{
+		{
+			name:      "empty file",
+			fixture:   "empty-file",
+			wantAlarm: false,
+			wantRows:  0,
+		},
+		{
+			name:      "all known",
+			fixture:   "all-known",
+			wantAlarm: false,
+			wantRows:  2,
+		},
+		{
+			name:      "all unknown",
+			fixture:   "all-unknown",
+			wantAlarm: true,
+			wantRows:  1,
+			assertions: func(t *testing.T, rows []unknownRateSummary, alarms []unknownRateSummary) {
+				t.Helper()
+				if len(alarms) != 1 {
+					t.Fatalf("want 1 alarm, got %d", len(alarms))
+				}
+				got := alarms[0]
+				if got.Agent != "hermes" || got.Day != "2026-05-07" {
+					t.Fatalf("wrong alarm bucket: %+v", got)
+				}
+				if got.Total != 4 || got.Unknown != 4 || got.Rate != 1 {
+					t.Fatalf("wrong all-unknown rate: %+v", got)
+				}
+				wantTools := []unknownToolCount{{Tool: "kanban_show", Count: 2}, {Tool: "kanban_block", Count: 1}}
+				if len(got.TopUnknownTools) < len(wantTools) {
+					t.Fatalf("top tools too short: %+v", got.TopUnknownTools)
+				}
+				for i, want := range wantTools {
+					if got.TopUnknownTools[i] != want {
+						t.Fatalf("top tool %d: got %+v want %+v", i, got.TopUnknownTools[i], want)
+					}
+				}
+				if len(got.Samples) == 0 || got.Samples[0].Locator != "chain-hermes:7" {
+					t.Fatalf("sample locator should prefer chain_id:seq, got %+v", got.Samples)
+				}
+				_ = rows
+			},
+		},
+		{
+			name:      "mixed with whitelist",
+			fixture:   "mixed-with-whitelist",
+			wantAlarm: true,
+			wantRows:  1,
+			assertions: func(t *testing.T, rows []unknownRateSummary, alarms []unknownRateSummary) {
+				t.Helper()
+				if len(rows) != 1 {
+					t.Fatalf("want one row, got %+v", rows)
+				}
+				got := rows[0]
+				if got.Total != 4 || got.Unknown != 1 {
+					t.Fatalf("whitelisted unknowns must be excluded from total and unknown counts: %+v", got)
+				}
+				if len(got.TopUnknownTools) != 1 || got.TopUnknownTools[0] != (unknownToolCount{Tool: "skills_list", Count: 1}) {
+					t.Fatalf("top unknowns should exclude intentional tools, got %+v", got.TopUnknownTools)
+				}
+				for _, sample := range got.Samples {
+					if _, ok := intentionalUnknownTools[sample.Tool]; ok {
+						t.Fatalf("sample includes whitelisted tool: %+v", sample)
+					}
+				}
+				if len(alarms) != 1 {
+					t.Fatalf("want one alarm, got %+v", alarms)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := analyzeUnknownRateDir(filepath.Join("testdata", "unknown_rate_alarm", tc.fixture), 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != tc.wantRows {
+				t.Fatalf("row count: got %d want %d (%+v)", len(rows), tc.wantRows, rows)
+			}
+			alarms := rowsExceedingUnknownRate(rows, defaultUnknownRateThreshold)
+			if gotAlarm := len(alarms) > 0; gotAlarm != tc.wantAlarm {
+				t.Fatalf("alarm presence: got %v want %v; rows=%+v", gotAlarm, tc.wantAlarm, rows)
+			}
+			if tc.assertions != nil {
+				tc.assertions(t, rows, alarms)
+			}
+		})
+	}
+}
+
+func TestUnknownRateAlarmFailureMessageIncludesTopToolsAndSamples(t *testing.T) {
+	rows, err := analyzeUnknownRateDir(filepath.Join("testdata", "unknown_rate_alarm", "all-unknown"), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alarms := rowsExceedingUnknownRate(rows, defaultUnknownRateThreshold)
+	msg := formatUnknownRateAlarm(alarms, defaultUnknownRateThreshold)
+
+	for _, want := range []string{
+		"hermes 2026-05-07 unknown_rate=100.00%",
+		"top_unknown_tools=kanban_show=2, kanban_block=1",
+		"samples=chain-hermes:7 kanban_show",
+		"chain-hermes:8 process",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("failure message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestUnknownRateAlarmCurrentChainOptIn(t *testing.T) {
+	dir := os.Getenv("CHITIN_UNKNOWN_RATE_DIR")
+	if dir == "" {
+		t.Skip("set CHITIN_UNKNOWN_RATE_DIR to a chitin state dir to run the live unknown-rate alarm")
+	}
+	rows, err := analyzeUnknownRateDir(dir, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if day := os.Getenv("CHITIN_UNKNOWN_RATE_DAY"); day != "" {
+		rows = filterUnknownRateRowsByDay(rows, day)
+	}
+	alarms := rowsExceedingUnknownRate(rows, defaultUnknownRateThreshold)
+	if len(alarms) > 0 {
+		t.Fatal(formatUnknownRateAlarm(alarms, defaultUnknownRateThreshold))
+	}
+}
+
+func analyzeUnknownRateDir(dir string, topN int) ([]unknownRateSummary, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %w", err)
+	}
+	if topN <= 0 {
+		topN = 1
+	}
+
+	buckets := make(map[string]*unknownRateAccumulator)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "gov-decisions-") || !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if err := scanUnknownRateFile(path, name, topN, buckets); err != nil {
+			return nil, err
+		}
+	}
+
+	rows := make([]unknownRateSummary, 0, len(buckets))
+	for _, acc := range buckets {
+		row := acc.summary(topN)
+		if row.Total == 0 {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Day != rows[j].Day {
+			return rows[i].Day < rows[j].Day
+		}
+		return rows[i].Agent < rows[j].Agent
+	})
+	return rows, nil
+}
+
+type unknownRateAccumulator struct {
+	agent         string
+	day           string
+	total         int
+	unknown       int
+	unknownByTool map[string]int
+	samples       []unknownSample
+}
+
+func (a *unknownRateAccumulator) summary(topN int) unknownRateSummary {
+	tools := make([]unknownToolCount, 0, len(a.unknownByTool))
+	for tool, count := range a.unknownByTool {
+		tools = append(tools, unknownToolCount{Tool: tool, Count: count})
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Count != tools[j].Count {
+			return tools[i].Count > tools[j].Count
+		}
+		return tools[i].Tool < tools[j].Tool
+	})
+	if len(tools) > topN {
+		tools = tools[:topN]
+	}
+	rate := 0.0
+	if a.total > 0 {
+		rate = float64(a.unknown) / float64(a.total)
+	}
+	return unknownRateSummary{
+		Agent:           a.agent,
+		Day:             a.day,
+		Total:           a.total,
+		Unknown:         a.unknown,
+		Rate:            rate,
+		TopUnknownTools: tools,
+		Samples:         append([]unknownSample(nil), a.samples...),
+	}
+}
+
+func scanUnknownRateFile(path, filename string, topN int, buckets map[string]*unknownRateAccumulator) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer file.Close()
+
+	fallbackDay := dayFromDecisionFilename(filename)
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var row unknownDecisionWire
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			continue
+		}
+		if row.ActionType == "" {
+			continue
+		}
+		if row.ActionType == string(ActUnknown) {
+			if _, ok := intentionalUnknownTools[row.ActionTarget]; ok {
+				continue
+			}
+		}
+
+		agent := row.Agent
+		if agent == "" {
+			agent = "(unknown-agent)"
+		}
+		day := dayFromDecision(row.Ts, fallbackDay)
+		key := agent + "\x00" + day
+		acc := buckets[key]
+		if acc == nil {
+			acc = &unknownRateAccumulator{
+				agent:         agent,
+				day:           day,
+				unknownByTool: make(map[string]int),
+			}
+			buckets[key] = acc
+		}
+		acc.total++
+		if row.ActionType != string(ActUnknown) {
+			continue
+		}
+		acc.unknown++
+		acc.unknownByTool[row.ActionTarget]++
+		if len(acc.samples) < topN {
+			acc.samples = append(acc.samples, unknownSample{
+				Tool:     row.ActionTarget,
+				Locator:  sampleLocator(row, filename, lineNo),
+				RuleID:   row.RuleID,
+				Filename: filename,
+				Line:     lineNo,
+			})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan %s: %w", path, err)
+	}
+	return nil
+}
+
+func rowsExceedingUnknownRate(rows []unknownRateSummary, threshold float64) []unknownRateSummary {
+	var alarms []unknownRateSummary
+	for _, row := range rows {
+		if row.Total > 0 && row.Rate >= threshold {
+			alarms = append(alarms, row)
+		}
+	}
+	return alarms
+}
+
+func filterUnknownRateRowsByDay(rows []unknownRateSummary, day string) []unknownRateSummary {
+	out := make([]unknownRateSummary, 0, len(rows))
+	for _, row := range rows {
+		if row.Day == day {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func formatUnknownRateAlarm(rows []unknownRateSummary, threshold float64) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "unknown-rate alarm: threshold must stay under %.2f%%\n", threshold*100)
+	for _, row := range rows {
+		fmt.Fprintf(&b, "%s %s unknown_rate=%.2f%% unknown=%d total=%d",
+			row.Agent, row.Day, row.Rate*100, row.Unknown, row.Total)
+		if len(row.TopUnknownTools) > 0 {
+			fmt.Fprintf(&b, " top_unknown_tools=%s", formatUnknownToolCounts(row.TopUnknownTools))
+		}
+		if len(row.Samples) > 0 {
+			fmt.Fprintf(&b, " samples=%s", formatUnknownSamples(row.Samples))
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatUnknownToolCounts(counts []unknownToolCount) string {
+	parts := make([]string, 0, len(counts))
+	for _, count := range counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", count.Tool, count.Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatUnknownSamples(samples []unknownSample) string {
+	parts := make([]string, 0, len(samples))
+	for _, sample := range samples {
+		parts = append(parts, fmt.Sprintf("%s %s", sample.Locator, sample.Tool))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sampleLocator(row unknownDecisionWire, filename string, lineNo int) string {
+	if row.ChainID != "" && row.Seq != nil {
+		return fmt.Sprintf("%s:%d", row.ChainID, *row.Seq)
+	}
+	return fmt.Sprintf("%s:%d", filename, lineNo)
+}
+
+func dayFromDecision(ts string, fallback string) string {
+	if ts == "" {
+		return fallback
+	}
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return fallback
+	}
+	return parsed.UTC().Format("2006-01-02")
+}
+
+func dayFromDecisionFilename(name string) string {
+	day := strings.TrimPrefix(name, "gov-decisions-")
+	day = strings.TrimSuffix(day, ".jsonl")
+	if day == name {
+		return "unknown-day"
+	}
+	return day
+}


### PR DESCRIPTION
## Summary
Captures the operator-architecture conversation from 2026-05-12: two-agent design.

- **Hermes** = orchestrator (user-facing, owns kanban, watches GitHub, runs grooming cron)
- **Clawta** = swarm manager (dispatch executor, picks driver+model, escalates errors to Hermes, manages ELO leaderboard)
- **Workers** (claude-code/codex/gemini/copilot) = pure executors

## Five slices (dependency order)
1. Smoke current dispatch path  — landed via #515
2. Hermes ↔ Clawta peer comm + hybrid LLM router — landed via #516 + Discord channel @-mentions
3. Clawta routing-reasoning log (pending)
4. Hermes board-audit cron (pending)
5. Post-PR judge LLM + ELO leaderboard — implemented in ~/.openclaw; 8 dispatches scored; `swarm-elo leaderboard` live

## Epic
Kanban: t_b7af50db on chitin board. This spec file is the durable record; kanban tickets cross-reference back here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)