### PR TITLE
feat(swarm-sdlc): Slice A — kanban-flow lifecycle helper + state machine runbook

### DIFF
--- a/docs/runbooks/swarm-sdlc-status-machine.md
+++ b/docs/runbooks/swarm-sdlc-status-machine.md
@@ -1,0 +1,99 @@
+# Swarm SDLC status machine
+
+The chitin swarm runs a real SDLC on the Hermes kanban board. Every
+ticket walks a deterministic state machine; every transition emits a
+comment AND a `task_events` row. The kanban is the single source of
+truth — if a state change isn't visible there, it didn't happen.
+
+## States
+
+| Status        | Meaning                                                  |
+|---------------|----------------------------------------------------------|
+| `triage`      | Raw idea or auto-filed ticket. Body is rough.            |
+| `ready`       | Groomed; clear acceptance criteria; awaiting dispatch.   |
+| `in_progress` | A worker has claimed the ticket and started.             |
+| `code_review` | PR is open. Awaiting review verdict.                     |
+| `blocked`     | Cannot progress (external dep, decision needed).         |
+| `done`        | Merged + result recorded.                                |
+| `archived`    | Hidden from default views (cancelled, superseded).       |
+
+## Transitions
+
+```
+                                 (grooming)
+              ┌──────────────────────────────────────────┐
+              ▼                                          │
+        ┌──────────┐  hermes/operator   ┌────────┐       │
+   ────▶│  triage  │ ─────────────────▶ │ ready  │       │
+        └──────────┘                    └────┬───┘       │
+              ▲                              │           │
+              │ clawta demote                │ clawta    │
+              │ ("not actually ready")       │ dispatch  │
+              │                              ▼           │
+              │                       ┌────────────┐     │
+              │                       │ in_progress│◀────┘
+              │                       └─────┬──────┘
+              │                             │ worker opens PR
+              │                             ▼
+              │                       ┌────────────┐
+              │                       │ code_review│
+              │                       └─────┬──────┘
+              │                             │ reviewer
+              │     ┌───────────────────────┴────────┐
+              │     │ changes                approved │
+              │     ▼                                ▼
+              │  in_progress                       done
+              │
+              └──── (any → blocked → ready)
+```
+
+## Who can fire which transition
+
+| Transition                    | Owner       | Mechanism                                  |
+|-------------------------------|-------------|--------------------------------------------|
+| `triage → ready`              | Hermes / operator | `kanban-flow ready <id>` or hermes grooming reply |
+| `ready → in_progress`         | Clawta poller     | dispatch path; `kanban-flow start <id>` from lobster |
+| `ready → triage` (demote)     | Clawta poller     | when sequence-check flags "not actually ready" |
+| `in_progress → code_review`   | Worker            | `kanban-flow pr <id> <url>` on PR open     |
+| `code_review → in_progress`   | Reviewer / clawta | `kanban-flow review <id> changes`          |
+| `code_review → done`          | Reviewer / merge  | `kanban-flow review <id> approved` or merge bot |
+| `* → blocked`                 | Worker / clawta   | `kanban-flow block <id> <reason>`          |
+| `blocked → ready`             | Operator / hermes | `kanban-flow unblock <id>`                 |
+
+Non-canonical: `kanban-flow done <id> --result "<txt>"` is the catch-all
+that bypasses code review (use only for tickets that don't produce a PR,
+e.g. user-local config tweaks, decisions, research-with-no-PR).
+
+## Audit invariant
+
+For every status change, two records exist:
+
+1. A row in `task_comments` (human-readable, surfaced by `hermes kanban show`)
+2. A row in `task_events` with `kind='status_transition'` and payload
+   `{"from":"<status>","to":"<status>","by":"<author>"}`
+
+The `kanban-flow` helper enforces both. Direct SQL `UPDATE tasks SET
+status=…` without the matching comment + event is a bug — fix it by
+backfilling, not by ignoring.
+
+## Tooling
+
+- `scripts/kanban-flow` — lifecycle helper, source of truth for transitions
+- `hermes kanban` — display, comments, assign, complete (legacy paths)
+- `swarm-elo` — post-merge judge ratings (separate; doesn't drive lifecycle)
+
+## When the state machine drifts
+
+Symptoms:
+
+- Ticket sits in `ready` with assignee set, no `task_runs` row → poller
+  isn't picking it up (see Slice C — clawta autonomous poller).
+- Ticket in `in_progress` but no recent comments and no worker process →
+  worker crashed silently; either `kanban-flow block` it or reset to
+  `ready` after investigation.
+- Ticket in `code_review` after PR was merged → merge bot didn't fire;
+  promote to `done` manually with `kanban-flow review <id> approved`.
+
+Recovery rule: never mutate `status` via raw SQL without also writing
+the matching event + comment. The CLI is the cheap path; backfilling
+audit later is the expensive path.

--- a/scripts/kanban-flow
+++ b/scripts/kanban-flow
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# kanban-flow — lifecycle helper for the swarm SDLC.
+#
+# The Hermes kanban CLI exposes assign/comment/complete but not the
+# in_progress / code_review / blocked transitions a real SDLC needs.
+# This wrapper fills the gap: every command does the status flip AND
+# the matching audit comment AND a task_events row.
+#
+# Usage:
+#   kanban-flow start <id> [--author NAME] [--worktree PATH]
+#       triage|ready → in_progress. Comments "picking up at <ts>".
+#
+#   kanban-flow pr <id> <pr-url> [--author NAME]
+#       in_progress → code_review. Comments with PR url.
+#
+#   kanban-flow review <id> <verdict> [--author NAME]
+#       code_review → in_progress (verdict=changes) or code_review → done (verdict=approved).
+#
+#   kanban-flow block <id> <reason...> [--author NAME]
+#       any → blocked. Comments with reason.
+#
+#   kanban-flow unblock <id> [--author NAME]
+#       blocked → ready.
+#
+#   kanban-flow demote <id> <reason...> [--author NAME]
+#       ready → triage. Comments with reason. Used by clawta when a
+#       ticket isn't actually ready to dispatch.
+#
+#   kanban-flow done <id> --result "<summary>" [--author NAME]
+#       code_review|in_progress → done. Comments with result.
+#
+#   kanban-flow status <id>
+#       Print current status + last 5 transition comments.
+#
+# Audit invariant: every status change emits both a task_comment AND a
+# task_events row. Read either to reconstruct the lifecycle.
+
+set -euo pipefail
+
+DB="${KANBAN_DB:-$HOME/.hermes/kanban/boards/chitin/kanban.db}"
+BOARD="${KANBAN_BOARD:-chitin}"
+AUTHOR_DEFAULT="${HERMES_PROFILE:-${USER:-user}}"
+
+die() { echo "kanban-flow: $*" >&2; exit 2; }
+
+usage() {
+  sed -n '2,/^set -euo/p' "$0" | sed 's/^# \?//; /^set -euo/d'
+}
+
+require_id() {
+  [[ "${1:-}" =~ ^t_[a-f0-9]+$ ]] || die "expected ticket id (t_XXXXXXXX), got: ${1:-<empty>}"
+}
+
+ticket_status() {
+  local id="$1"
+  sqlite3 "$DB" "SELECT status FROM tasks WHERE id='$id'"
+}
+
+assert_status() {
+  local id="$1"; shift
+  local cur; cur="$(ticket_status "$id")"
+  for s in "$@"; do
+    [[ "$cur" == "$s" ]] && return 0
+  done
+  die "$id status is '$cur'; expected one of: $*"
+}
+
+emit_transition() {
+  # Args: id from to author [extra_json]
+  # Uses parameterized SQL via sqlite3's -cmd .parameter to avoid
+  # quoting issues with the JSON extra payload.
+  local id="$1" from="$2" to="$3" author="$4" payload_extra="${5:-{\}}"
+  local now; now="$(date +%s)"
+  sqlite3 "$DB" \
+    -cmd ".parameter set :id '$id'" \
+    -cmd ".parameter set :from '$from'" \
+    -cmd ".parameter set :to '$to'" \
+    -cmd ".parameter set :by '$author'" \
+    -cmd ".parameter set :extra '$payload_extra'" \
+    -cmd ".parameter set :now $now" \
+    "INSERT INTO task_events (task_id, kind, payload, created_at) \
+     VALUES (:id, 'status_transition', \
+             json_object('from', :from, 'to', :to, 'by', :by, 'extra', json(:extra)), \
+             :now);"
+}
+
+flip_status() {
+  local id="$1" to="$2" set_started="${3:-0}" set_completed="${4:-0}"
+  local now; now="$(date +%s)"
+  local fields="status='$to'"
+  [[ "$set_started" -eq 1 ]] && fields="$fields, started_at=COALESCE(started_at, $now)"
+  [[ "$set_completed" -eq 1 ]] && fields="$fields, completed_at=$now"
+  sqlite3 "$DB" "UPDATE tasks SET $fields WHERE id='$id'"
+}
+
+cmd=${1:-}; shift || die "missing command (see kanban-flow --help)"
+case "$cmd" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+# Parse common flags
+author="$AUTHOR_DEFAULT"
+worktree=""
+parse_flags() {
+  local rest=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --author) author="$2"; shift 2 ;;
+      --worktree) worktree="$2"; shift 2 ;;
+      --result) result="$2"; shift 2 ;;
+      *) rest+=("$1"); shift ;;
+    esac
+  done
+  REST=("${rest[@]+"${rest[@]}"}")
+}
+
+case "$cmd" in
+  start)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    assert_status "$id" triage ready in_progress
+    from="$(ticket_status "$id")"
+    body="Picking up at $(date -Iseconds)"
+    [[ -n "$worktree" ]] && body="$body — worktree: $worktree"
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "$body" >/dev/null
+    flip_status "$id" in_progress 1 0
+    emit_transition "$id" "$from" in_progress "$author"
+    echo "$id: $from → in_progress"
+    ;;
+  pr)
+    parse_flags "$@"
+    id="${REST[0]:-}"; url="${REST[1]:-}"; require_id "$id"
+    [[ -n "$url" ]] || die "missing PR url"
+    assert_status "$id" in_progress
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "PR opened: $url" >/dev/null
+    flip_status "$id" code_review 0 0
+    emit_transition "$id" in_progress code_review "$author" "$(printf '{"pr_url":"%s"}' "$url")"
+    echo "$id: in_progress → code_review ($url)"
+    ;;
+  review)
+    parse_flags "$@"
+    id="${REST[0]:-}"; verdict="${REST[1]:-}"; require_id "$id"
+    [[ -n "$verdict" ]] || die "missing verdict (approved|changes)"
+    assert_status "$id" code_review
+    if [[ "$verdict" == approved ]]; then
+      hermes kanban --board "$BOARD" comment "$id" --author "$author" "Review: APPROVED" >/dev/null
+      flip_status "$id" done 0 1
+      emit_transition "$id" code_review done "$author"
+      echo "$id: code_review → done (approved)"
+    elif [[ "$verdict" == changes ]]; then
+      hermes kanban --board "$BOARD" comment "$id" --author "$author" "Review: changes requested — back to in_progress" >/dev/null
+      flip_status "$id" in_progress 0 0
+      emit_transition "$id" code_review in_progress "$author"
+      echo "$id: code_review → in_progress (changes requested)"
+    else
+      die "verdict must be 'approved' or 'changes', got: $verdict"
+    fi
+    ;;
+  block)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    reason="${REST[*]:1}"
+    [[ -n "$reason" ]] || die "missing reason"
+    from="$(ticket_status "$id")"
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Blocked: $reason" >/dev/null
+    flip_status "$id" blocked 0 0
+    emit_transition "$id" "$from" blocked "$author"
+    echo "$id: $from → blocked ($reason)"
+    ;;
+  unblock)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    assert_status "$id" blocked
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Unblocked at $(date -Iseconds)" >/dev/null
+    flip_status "$id" ready 0 0
+    emit_transition "$id" blocked ready "$author"
+    echo "$id: blocked → ready"
+    ;;
+  demote)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    reason="${REST[*]:1}"
+    [[ -n "$reason" ]] || die "missing reason"
+    assert_status "$id" ready
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Demoted ready→triage: $reason" >/dev/null
+    flip_status "$id" triage 0 0
+    emit_transition "$id" ready triage "$author"
+    echo "$id: ready → triage ($reason)"
+    ;;
+  ready)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    from="$(ticket_status "$id")"
+    [[ "$from" == triage || "$from" == blocked ]] || die "$id is in '$from'; can only mark ready from triage|blocked"
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Marked ready by $author at $(date -Iseconds)" >/dev/null
+    flip_status "$id" ready 0 0
+    emit_transition "$id" "$from" ready "$author"
+    echo "$id: $from → ready"
+    ;;
+  done)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    [[ -n "${result:-}" ]] || die "missing --result"
+    from="$(ticket_status "$id")"
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Done: $result" >/dev/null
+    flip_status "$id" done 0 1
+    sqlite3 "$DB" "UPDATE tasks SET result='$(echo "$result" | sed "s/'/''/g")' WHERE id='$id'"
+    emit_transition "$id" "$from" done "$author"
+    echo "$id: $from → done"
+    ;;
+  status)
+    id="${1:-}"; require_id "$id"
+    cur="$(ticket_status "$id")"
+    echo "$id: $cur"
+    echo "Last 5 transitions:"
+    sqlite3 "$DB" "SELECT datetime(created_at,'unixepoch','localtime'), kind, payload FROM task_events WHERE task_id='$id' AND kind='status_transition' ORDER BY id DESC LIMIT 5"
+    ;;
+  *)
+    die "unknown command: $cmd (try kanban-flow --help)"
+    ;;
+esac


### PR DESCRIPTION
## Summary
Slice A of the Swarm SDLC v1 epic ([kanban t_26b840d1](https://hermes/board/chitin/t_26b840d1)).

Adds:
- **`scripts/kanban-flow`** — lifecycle helper for the swarm SDLC. Fills the gap between the hermes kanban CLI (assign/comment/complete) and the `in_progress` / `code_review` / `blocked` / demote transitions a real SDLC needs.
- **`docs/runbooks/swarm-sdlc-status-machine.md`** — the durable contract for what Hermes / Clawta / workers are each allowed to do, with the transition ownership table.

## Why
This morning's missing-poller bug surfaced that the swarm has no SDLC discipline — 6 research tickets sat in \`ready\` overnight with assignees set, nothing polling. This is the first slice toward fixing that: lay the lifecycle tooling before building the poller (Slice C) that will use it.

## State machine
\`triage → ready → in_progress → code_review → done\`, with \`blocked\` as a side state and \`triage\` as the demotion target when clawta sequence-check rejects a ticket.

## Tested
- Live smoke on throwaway tickets (\`t_1fef63e8\`, \`t_fb5dea62\`) — all 8 commands fire transition + comment + audit event cleanly.
- Caught + fixed a JSON-escape bug in \`emit_transition\` during smoke (parameterized SQL via sqlite3 \`.parameter set\` instead of inline quoting).

## Audit invariant
Every status change writes BOTH a \`task_comment\` (human-readable) AND a \`task_events\` row (structured). Direct \`UPDATE tasks SET status=…\` without both is a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)