### PR TITLE
fix(lobster): classify bypasses clawta wrapper — breaks recursive-dispatch trap

### DIFF
--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -76,14 +76,26 @@ steps:
   # (which it always does). Read via stdin + variable assignment inside
   # a bash heredoc so the JSON never touches the shell parser as a
   # literal. Same pattern as spawn_worker.
+  #
+  # Why this calls `openclaw agent` directly instead of `clawta --text`:
+  # the `clawta` wrapper has unanchored pattern detection for dispatch
+  # intent — it matches any `t_xxxxxxxx` id and any dispatch-verb word
+  # anywhere in the prompt. The classify prompt embeds the full ticket
+  # JSON, which always contains a ticket id and frequently contains
+  # dispatch-verb words in the body. That misfires as a recursive
+  # dispatch call, runs the workflow on itself, and returns a failure
+  # envelope instead of classification JSON. Every dispatch on
+  # 2026-05-12 failed for this reason. The classify step is a pure
+  # LLM call and has no business going through the wrapper.
   - id: classify
-    description: Classify ticket via clawta (glm-agent on glm-5.1:cloud)
+    description: Classify ticket via glm-agent on glm-5.1:cloud (direct, no wrapper)
     run: |
       bash -c "$(cat <<'BASH_SCRIPT'
       set -euo pipefail
       TICKET=$(cat)
       PROMPT="Classify this ticket and reply with ONLY a JSON object (no prose, no markdown fences): {\"complexity\": \"low\" | \"med\" | \"high\", \"capabilities\": [\"go\" | \"ts\" | \"python\" | \"refactor\" | \"debug\" | \"review\"], \"estimated_loc\": <integer>, \"needs_frontier\": <true|false>}. Ticket JSON: $TICKET"
-      clawta --text "$PROMPT"
+      OPENCLAW_BIN="${OPENCLAW_BIN:-/home/red/.vite-plus/bin/openclaw}"
+      "$OPENCLAW_BIN" agent --agent glm-agent --message "$PROMPT"
       BASH_SCRIPT
       )"
     stdin: $fetch_ticket.stdout


### PR DESCRIPTION
## Summary

- Replace the classify step's `clawta --text` call with a direct `openclaw agent --agent glm-agent --message` call.
- The `clawta` wrapper's unanchored regex (`(t_[a-z0-9]+)` + dispatch-verb anywhere) was mistaking the classify prompt — which embeds the full ticket JSON — for a recursive dispatch request, running lobster on itself, and returning a failure envelope instead of classification JSON.
- Every dispatch on 2026-05-12 failed identically with `classify produced no JSON object`. All 6 logs in `~/.openclaw/logs/dispatch-*.log` confirm.

## Reproduce + verify

\`bash -x clawta --text \"Classify ticket t_xxx: dispatch matters\"\` shows the wrapper matching its dispatch regex and recursively invoking lobster.

After applying this fix to `~/.openclaw/workflows/kanban-dispatch.lobster` (mirror sync), \`pnpm exec lobster run\` on a fresh ticket (`t_3d819a17`) now progresses past classify and pick_driver to the approval gate.

\`\`\`
{
  \"ok\": true,
  \"status\": \"needs_approval\",
  \"requiresApproval\": { \"prompt\": \"Dispatch ... to ... ?\" }
}
\`\`\`

## Why bypass the wrapper instead of fixing the regex

The wrapper's regex CAN be fixed (anchor to message start, require exact pattern), but the classify step is a pure LLM call that has no business going through dispatch-detection at all. Bypass is the smaller surface area and makes the classify step's intent obvious to a future reader.

## Followup (separate PR)

The clawta-poller flips status→in_progress *before* dispatch and never sees Popen failures, so when dispatch fails (as it has been for 6 tickets today), the ticket sits in_progress forever with no comment and no worktree. This is the silent-stasis pattern Clawta surfaced in Discord. Needs a block-on-failure path. Tracking ticket TBD.

Kanban: t_3d819a17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)