### PR TITLE
fix(swarm-sdlc): poller sequencer bypasses clawta wrapper (companion to #529)

### DIFF
--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -68,6 +68,19 @@ TERMINAL_LANES = tuple(
     ).split(",") if s.strip()
 )
 CLAWTA_BIN = os.environ.get("CLAWTA_BIN", "clawta")
+# Direct openclaw client for the sequencer LLM call. The `clawta` wrapper
+# has unanchored regex pattern detection — any prompt containing a
+# `t_xxxxxxxx` id and a dispatch-verb word is treated as a dispatch
+# request and recursively invokes lobster. The sequencer prompt embeds
+# all queued ticket ids and the word "dispatch", so calling `clawta` here
+# triggers an unintended dispatch of whichever ticket id appears first.
+# Fix #529 covered the lobster classify step; this covers the poller's
+# own LLM call. The sequencer is a pure-classification ask — there's no
+# reason for it to go through the dispatch-detection layer.
+OPENCLAW_BIN = os.environ.get(
+    "OPENCLAW_BIN", str(Path.home() / ".vite-plus/bin/openclaw")
+)
+SEQUENCER_AGENT = os.environ.get("SEQUENCER_AGENT", "glm-agent")
 KANBAN_FLOW_BIN = os.environ.get("KANBAN_FLOW_BIN", "kanban-flow")
 LOG_DIR = Path.home() / ".openclaw" / "logs"
 LOG_FILE = LOG_DIR / "clawta-poller.log"
@@ -177,17 +190,17 @@ Rules:
 
     try:
         result = subprocess.run(
-            [CLAWTA_BIN, "--text", prompt],
+            [OPENCLAW_BIN, "agent", "--agent", SEQUENCER_AGENT, "--message", prompt],
             capture_output=True,
             text=True,
             timeout=240,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        log(f"sequence_with_llm: clawta call failed ({e}); falling back to FIFO")
+        log(f"sequence_with_llm: openclaw call failed ({e}); falling back to FIFO")
         return fallback
 
     if result.returncode != 0:
-        log(f"sequence_with_llm: clawta rc={result.returncode}; falling back to FIFO")
+        log(f"sequence_with_llm: openclaw rc={result.returncode}; falling back to FIFO")
         return fallback
 
     body = result.stdout or ""


### PR DESCRIPTION
## Summary

- clawta-poller's \`sequence_with_llm\` called \`clawta --text\` with a prompt that embeds every queued ticket id and the word \"dispatch\". The clawta wrapper's unanchored regex misreads this as a recursive dispatch request and runs lobster on whichever ticket id appears first.
- #529 fixed the same trap in the lobster classify step. This PR is the companion fix for the poller side.
- Direct \`openclaw agent --agent glm-agent\` call; same LLM, no wrapper.

## Live evidence

Running cron ticks at 12:07 and 12:10 saw all 5 ready tickets but produced no \`dispatched\` log line — sequencer hung in the recursion path while a spurious lobster dispatch fired in the background.

After this fix, dry-run returns a coherent plan:

\`\`\`
[dry-run] would dispatch t_710e0d1b to codex: Highest priority...
[dry-run] would dispatch t_652e9b88 to codex: Well-scoped research...
tick: cap reached (2); deferring t_2f7fffab
tick: cap reached (2); deferring t_33dd70f7
[dry-run] would demote t_b0472d23: Body is truncated and vague...
{\"dispatched\":[\"t_710e0d1b\",\"t_652e9b88\"],\"demoted\":[\"t_b0472d23\"],\"queue_size\":5}
\`\`\`

## Followup

Per #529 body: the poller flips status→in_progress *before* dispatch and Popen's fire-and-forget. Failed dispatches still produce silent stasis. Block-on-failure path is the next thing.

Kanban: t_89127b25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)