### PR TITLE
fix(swarm-sdlc): drop code_review status — invisible on Hermes UI

### DIFF
--- a/docs/runbooks/swarm-sdlc-hermes-grooming-prompt.md
+++ b/docs/runbooks/swarm-sdlc-hermes-grooming-prompt.md
@@ -62,8 +62,8 @@ DISPATCH_AND_TICKETING_GUIDANCE = (
     "\n"
     "## Rule 1 — answer 'what's next?' from the board\n"
     "Call `hermes kanban --board chitin list`. Summarize: triage items "
-    "you can groom now, in_progress count + code_review PRs, blocked "
-    "items needing operator decision.\n"
+    "you can groom now, in_progress count (those with open PRs vs. "
+    "actively coding), blocked items needing operator decision.\n"
     "\n"
     "## Rule 2 — file tickets on hermes kanban, never GitHub Issues\n"
     "    hermes kanban --board chitin create \"<title>\" --body \"<body>\" "
@@ -106,7 +106,7 @@ After restart, ask Hermes "what's next?" in Discord. Expected reply
 shape:
 
 > Board state: <triage count> in triage, <ready count> in ready,
-> <in_progress count> in_progress (PRs in code_review: <list>), 
+> <in_progress count> in_progress (with open PRs: <list>), 
 > <blocked count> blocked. Want me to groom any of the triage items?
 
 Anti-test: ask Hermes "dispatch t_e1d0e815 now". Expected reply:

--- a/docs/runbooks/swarm-sdlc-status-machine.md
+++ b/docs/runbooks/swarm-sdlc-status-machine.md
@@ -11,11 +11,23 @@ truth — if a state change isn't visible there, it didn't happen.
 |---------------|----------------------------------------------------------|
 | `triage`      | Raw idea or auto-filed ticket. Body is rough.            |
 | `ready`       | Groomed; clear acceptance criteria; awaiting dispatch.   |
-| `in_progress` | A worker has claimed the ticket and started.             |
-| `code_review` | PR is open. Awaiting review verdict.                     |
+| `in_progress` | A worker has claimed the ticket and is working OR a PR is open and awaiting merge. |
 | `blocked`     | Cannot progress (external dep, decision needed).         |
 | `done`        | Merged + result recorded.                                |
 | `archived`    | Hidden from default views (cancelled, superseded).       |
+
+### Why no `code_review` status
+
+Hermes' kanban UI renders only triage/todo/ready/in_progress/blocked/done
+columns (hardcoded in hermes-agent; the kanban config block exposes only
+`dispatch_in_gateway`, `dispatch_interval_seconds`, and `failure_limit`).
+A ticket flipped to `code_review` would vanish from the operator's
+board until merged, breaking kanban-as-source-of-truth.
+
+Tickets stay in `in_progress` from the moment a worker claims them
+through PR open, review, and merge. The PR's GitHub state is the
+review-phase truth. `kanban-flow pr <id> <url>` records the URL as a
+comment + `pr_opened` task event without moving the ticket.
 
 ## Transitions
 
@@ -34,15 +46,17 @@ truth — if a state change isn't visible there, it didn't happen.
               │                       │ in_progress│◀────┘
               │                       └─────┬──────┘
               │                             │ worker opens PR
+              │                             │ (stays in_progress;
+              │                             │  pr_opened event +
+              │                             │  PR-url comment)
+              │                             │
               │                             ▼
-              │                       ┌────────────┐
-              │                       │ code_review│
-              │                       └─────┬──────┘
-              │                             │ reviewer
-              │     ┌───────────────────────┴────────┐
-              │     │ changes                approved │
-              │     ▼                                ▼
-              │  in_progress                       done
+              │                       PR merged on GitHub
+              │                             │
+              │                             ▼
+              │                          ┌─────┐
+              │                          │ done│
+              │                          └─────┘
               │
               └──── (any → blocked → ready)
 ```
@@ -54,15 +68,14 @@ truth — if a state change isn't visible there, it didn't happen.
 | `triage → ready`              | Hermes / operator | `kanban-flow ready <id>` or hermes grooming reply |
 | `ready → in_progress`         | Clawta poller     | dispatch path; `kanban-flow start <id>` from lobster |
 | `ready → triage` (demote)     | Clawta poller     | when sequence-check flags "not actually ready" |
-| `in_progress → code_review`   | Worker            | `kanban-flow pr <id> <url>` on PR open     |
-| `code_review → in_progress`   | Reviewer / clawta | `kanban-flow review <id> changes`          |
-| `code_review → done`          | Reviewer / merge  | `kanban-flow review <id> approved` or merge bot |
+| `in_progress → in_progress` (PR open) | Worker            | `kanban-flow pr <id> <url>` — no status flip, audit only |
+| `in_progress → done`          | Operator / merge bot | `kanban-flow done <id> --result "<txt>"` after PR merge |
 | `* → blocked`                 | Worker / clawta   | `kanban-flow block <id> <reason>`          |
 | `blocked → ready`             | Operator / hermes | `kanban-flow unblock <id>`                 |
 
-Non-canonical: `kanban-flow done <id> --result "<txt>"` is the catch-all
-that bypasses code review (use only for tickets that don't produce a PR,
-e.g. user-local config tweaks, decisions, research-with-no-PR).
+Recovery: `kanban-flow done` is the universal completion verb — accepts
+any `from` status. Use it after PR merge, or for tickets that don't
+produce a PR (research notes, decisions, config tweaks).
 
 ## Audit invariant
 
@@ -72,7 +85,11 @@ For every status change, two records exist:
 2. A row in `task_events` with `kind='status_transition'` and payload
    `{"from":"<status>","to":"<status>","by":"<author>"}`
 
-The `kanban-flow` helper enforces both. Direct SQL `UPDATE tasks SET
+For PR open (which is not a status change), a single `task_events` row
+with `kind='pr_opened'` and payload `{"pr_url":"<url>","by":"<author>"}`
+plus the comment.
+
+The `kanban-flow` helper enforces these. Direct SQL `UPDATE tasks SET
 status=…` without the matching comment + event is a bug — fix it by
 backfilling, not by ignoring.
 
@@ -89,10 +106,11 @@ Symptoms:
 - Ticket sits in `ready` with assignee set, no `task_runs` row → poller
   isn't picking it up (see Slice C — clawta autonomous poller).
 - Ticket in `in_progress` but no recent comments and no worker process →
-  worker crashed silently; either `kanban-flow block` it or reset to
-  `ready` after investigation.
-- Ticket in `code_review` after PR was merged → merge bot didn't fire;
-  promote to `done` manually with `kanban-flow review <id> approved`.
+  worker crashed silently OR PR is open and awaiting review. Check
+  GitHub PR state first; if no PR, either `kanban-flow block` it or
+  reset to `ready` after investigation.
+- Ticket in `in_progress` long after the PR merged → merge-completion
+  step missed; promote to `done` manually with `kanban-flow done`.
 
 Recovery rule: never mutate `status` via raw SQL without also writing
 the matching event + comment. The CLI is the cheap path; backfilling

--- a/scripts/kanban-flow
+++ b/scripts/kanban-flow
@@ -2,19 +2,25 @@
 # kanban-flow — lifecycle helper for the swarm SDLC.
 #
 # The Hermes kanban CLI exposes assign/comment/complete but not the
-# in_progress / code_review / blocked transitions a real SDLC needs.
-# This wrapper fills the gap: every command does the status flip AND
-# the matching audit comment AND a task_events row.
+# in_progress / blocked transitions a real SDLC needs. This wrapper
+# fills the gap: every status command does the flip AND the matching
+# audit comment AND a task_events row.
+#
+# We deliberately do NOT use a `code_review` status. Hermes' kanban UI
+# renders only triage/todo/ready/in_progress/blocked/done columns
+# (hardcoded in hermes-agent; not configurable). A ticket flipped to
+# code_review would vanish from the operator's board until merged,
+# breaking kanban-as-source-of-truth. Tickets stay in in_progress
+# while the PR is open; the PR's GitHub state is the review-phase
+# truth. `kanban-flow pr` records the URL as a comment + event but
+# does not move the ticket.
 #
 # Usage:
 #   kanban-flow start <id> [--author NAME] [--worktree PATH]
 #       triage|ready → in_progress. Comments "picking up at <ts>".
 #
 #   kanban-flow pr <id> <pr-url> [--author NAME]
-#       in_progress → code_review. Comments with PR url.
-#
-#   kanban-flow review <id> <verdict> [--author NAME]
-#       code_review → in_progress (verdict=changes) or code_review → done (verdict=approved).
+#       in_progress stays. Comments with PR url + emits pr_opened event.
 #
 #   kanban-flow block <id> <reason...> [--author NAME]
 #       any → blocked. Comments with reason.
@@ -27,7 +33,7 @@
 #       ticket isn't actually ready to dispatch.
 #
 #   kanban-flow done <id> --result "<summary>" [--author NAME]
-#       code_review|in_progress → done. Comments with result.
+#       in_progress → done. Comments with result.
 #
 #   kanban-flow status <id>
 #       Print current status + last 5 transition comments.
@@ -133,28 +139,19 @@ case "$cmd" in
     [[ -n "$url" ]] || die "missing PR url"
     assert_status "$id" in_progress
     hermes kanban --board "$BOARD" comment "$id" --author "$author" "PR opened: $url" >/dev/null
-    flip_status "$id" code_review 0 0
-    emit_transition "$id" in_progress code_review "$author" "$(printf '{"pr_url":"%s"}' "$url")"
-    echo "$id: in_progress → code_review ($url)"
-    ;;
-  review)
-    parse_flags "$@"
-    id="${REST[0]:-}"; verdict="${REST[1]:-}"; require_id "$id"
-    [[ -n "$verdict" ]] || die "missing verdict (approved|changes)"
-    assert_status "$id" code_review
-    if [[ "$verdict" == approved ]]; then
-      hermes kanban --board "$BOARD" comment "$id" --author "$author" "Review: APPROVED" >/dev/null
-      flip_status "$id" done 0 1
-      emit_transition "$id" code_review done "$author"
-      echo "$id: code_review → done (approved)"
-    elif [[ "$verdict" == changes ]]; then
-      hermes kanban --board "$BOARD" comment "$id" --author "$author" "Review: changes requested — back to in_progress" >/dev/null
-      flip_status "$id" in_progress 0 0
-      emit_transition "$id" code_review in_progress "$author"
-      echo "$id: code_review → in_progress (changes requested)"
-    else
-      die "verdict must be 'approved' or 'changes', got: $verdict"
-    fi
+    # No status flip — Hermes UI has no code_review column, so we keep
+    # the ticket in in_progress and let the PR's GitHub state be the
+    # review-phase truth. Audit still records the PR via a pr_opened
+    # event for downstream tooling.
+    pr_now="$(date +%s)"
+    sqlite3 "$DB" \
+      -cmd ".parameter set :id '$id'" \
+      -cmd ".parameter set :by '$author'" \
+      -cmd ".parameter set :url '$url'" \
+      -cmd ".parameter set :now $pr_now" \
+      "INSERT INTO task_events (task_id, kind, payload, created_at) \
+       VALUES (:id, 'pr_opened', json_object('pr_url', :url, 'by', :by), :now);"
+    echo "$id: in_progress (PR opened: $url)"
     ;;
   block)
     parse_flags "$@"

--- a/swarm/prompts/hermes-grooming-guidance.md
+++ b/swarm/prompts/hermes-grooming-guidance.md
@@ -22,7 +22,8 @@ wasn't wired. The new path:
 - Clawta-poller picks it up within 2 minutes and runs the lobster
   workflow.
 - The worker self-reports through the kanban (in_progress comment,
-  PR url comment, code_review transition).
+  PR url comment). Tickets stay in `in_progress` through PR open and
+  review; they flip to `done` after the PR merges.
 - You watch and report — you do not act.
 
 ## Rule 1 — Answer "what's next?" from the board
@@ -34,10 +35,11 @@ my queue", do NOT narrate plans. Read the board:
 
 Then summarize, in this order:
 - Tickets you can act on right now (`triage` items that need grooming)
-- Active work (`in_progress` count, with PRs in `code_review`)
+- Active work (`in_progress` count; identify which have open PRs by
+  looking for a `pr_opened` event or "PR opened:" comment)
 - Blocked items (`blocked` — these are the ones that need operator decision)
-- Empty queue is a valid answer: "Nothing in ready; 3 in code_review
-  awaiting review; 1 blocked."
+- Empty queue is a valid answer: "Nothing in ready; 3 in_progress with
+  open PRs awaiting review; 1 blocked."
 
 ## Rule 2 — Groom tickets, don't do them
 
@@ -104,7 +106,7 @@ The swarm has the following separation of duties:
 
 - **You (Hermes)** — social: user voice, grooming, board reporting
 - **Clawta-poller** — autonomous: sequencing, dispatch, demotion
-- **Workers** — self-driving: claim, in_progress, PR, code_review
+- **Workers** — self-driving: claim, in_progress, open PR, stay in_progress until merge → done
 
 When you dispatch directly, you bypass clawta's frontier-LLM
 sequencing (which decides which of the N ready tickets goes first and

--- a/swarm/roles/README.md
+++ b/swarm/roles/README.md
@@ -37,9 +37,9 @@ or whether `claude-code/sonnet-4-6/researcher` outperforms
 
 | Role         | When                                | Output            | Lifecycle                  |
 |--------------|-------------------------------------|-------------------|----------------------------|
-| `programmer` | Code change tickets (feat/fix/refactor/test) | PR | ready → in_progress → code_review |
+| `programmer` | Code change tickets (feat/fix/refactor/test) | PR | ready → in_progress (through PR open + merge) → done |
 | `researcher` | Investigation tickets               | Findings comment  | ready → in_progress → done |
-| `reviewer`   | PR review tickets                   | PR review comment | ready → in_progress → done (their ticket); separately transitions the PR's ticket |
+| `reviewer`   | PR review tickets                   | PR review comment | ready → in_progress → done (the PR's own ticket stays in_progress regardless of verdict) |
 
 ## Deployment
 

--- a/swarm/roles/programmer/SKILL.md
+++ b/swarm/roles/programmer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: programmer
-description: "Default worker role for code-change tickets. Claims ticket, creates a worktree + branch, makes the change, runs tests, opens a PR, flips the kanban to code_review. Used by clawta dispatch when the ticket asks for an implementation, refactor, fix, or test."
+description: "Default worker role for code-change tickets. Claims ticket, creates a worktree + branch, makes the change, runs tests, opens a PR, records the PR url on the kanban ticket. Used by clawta dispatch when the ticket asks for an implementation, refactor, fix, or test."
 allowed_tools: [Read, Edit, Write, Bash, Grep, Glob]
 success_criteria:
   - PR opened against main with the change
   - CI green (or explicit "yellow CI, see comment" note if a flake is unrelated)
-  - Kanban ticket flipped to code_review with PR url comment
+  - Kanban ticket has a PR-url comment and a `pr_opened` task event (ticket stays in_progress; Hermes UI has no code_review column)
   - Every status transition has both a comment and a task_events row
 ---
 
@@ -13,7 +13,8 @@ success_criteria:
 
 The default worker role for tickets that ship code. You are dispatched
 by Clawta when a ticket is sequenced for implementation. You own the
-ticket end-to-end through the SDLC until the PR is in code_review.
+ticket end-to-end through the SDLC until the PR is open and the URL
+is recorded on the kanban ticket.
 
 ## When to apply
 
@@ -31,14 +32,15 @@ PR, use the **reviewer** role.
 ## Lifecycle you walk
 
 ```
-ready → in_progress → code_review (waiting for review)
-                     → done (after merge, fired by merge bot or reviewer)
+ready → in_progress (claim + work + PR open) → done (after merge)
 ```
 
-You never move a ticket directly to `done` from `in_progress` — code
-review is the gate. Exception: the rare ticket that doesn't produce a
-PR (e.g., a one-shot config change) uses `kanban-flow done <id>
---result "..."` and is documented as such in the ticket body.
+The ticket stays in `in_progress` through PR open, review, and merge.
+Hermes' kanban UI has no `code_review` column, so we deliberately do
+not flip the status — the PR's GitHub state is the review-phase truth.
+`kanban-flow pr <id> <url>` records the PR url as a comment and a
+`pr_opened` audit event without moving the ticket. After merge, the
+ticket is closed via `kanban-flow done <id> --result "..."`.
 
 ## The recipe
 
@@ -67,9 +69,9 @@ PR (e.g., a one-shot config change) uses `kanban-flow done <id>
    Title format: `<type>(<scope>): <short subject>`. Body links the
    kanban ticket id.
 
-7. **Transition** — `kanban-flow pr <id> <pr-url> --author <your-name>`.
-   Flips in_progress→code_review, comments the PR url, writes the audit
-   event.
+7. **Record the PR** — `kanban-flow pr <id> <pr-url> --author <your-name>`.
+   Comments the PR url + emits a `pr_opened` task event. Ticket stays
+   in `in_progress` (Hermes UI has no code_review column).
 
 8. **Hand off** — you're done. Reviewer (or clawta sequencing) will
    handle the merge.
@@ -83,9 +85,9 @@ PR (e.g., a one-shot config change) uses `kanban-flow done <id>
   global files that get swept up otherwise.
 - **Skipping `kanban-flow`.** Raw `UPDATE tasks SET status=…` breaks
   the audit invariant.
-- **Closing the loop early.** Don't `kanban-flow done <id>` from
-  in_progress unless the ticket was explicitly scoped as a PR-less
-  change. The default path is through `code_review`.
+- **Closing the loop before merge.** Don't `kanban-flow done <id>`
+  until the PR has actually merged. The PR's GitHub state is the
+  review-phase truth; closing the kanban early loses audit signal.
 - **Scope creep.** If you discover related work mid-change, file a
   separate ticket. Don't bundle.
 

--- a/swarm/roles/reviewer/SKILL.md
+++ b/swarm/roles/reviewer/SKILL.md
@@ -1,26 +1,25 @@
 ---
 name: reviewer
-description: "Worker role for reviewing an open PR. Reads the diff, checks the ticket's acceptance criteria, posts an adversarial review comment, then either approves (code_review→done) or requests changes (code_review→in_progress). Used by clawta dispatch when a ticket is a review ticket OR when a PR-bearing ticket is in code_review and needs a second pair of eyes."
+description: "Worker role for reviewing an open PR. Reads the diff, checks the ticket's acceptance criteria, posts an adversarial review comment on GitHub, then closes the review ticket. The PR's own ticket stays in_progress until merge (Hermes UI has no code_review column; the PR's GitHub state is the review-phase truth)."
 allowed_tools: [Read, Bash, Grep, Glob]
 success_criteria:
-  - PR review comment posted on GitHub
-  - Kanban ticket transitioned via kanban-flow review <id> approved|changes
+  - PR review comment posted on GitHub (APPROVE or REQUEST CHANGES)
+  - Reviewer's own ticket closed via `kanban-flow done` with verdict in the result
   - Verdict cites specific files / lines / commits — not vibes
-  - If approved, follow-up tickets filed for any non-blocking observations
+  - Follow-up tickets filed for any non-blocking observations
 ---
 
 # Reviewer role
 
 For tickets that explicitly ask for review, OR when clawta sequences
-a PR-bearing ticket in `code_review` and needs an adversarial second
-pair of eyes before approving the merge.
+an independent second pair of eyes on a PR-bearing ticket before merge.
 
 ## When to apply
 
 Use this role when:
 
 - Ticket title is "Review: <PR url or description>" — explicit review ticket
-- Clawta dispatches you to a ticket currently in `code_review` state
+- Clawta dispatches you to give a PR a second pair of eyes
 - An operator hands you a PR url and asks for an independent take
 
 If you'd be writing code, use **programmer** instead. If you'd be
@@ -28,18 +27,17 @@ investigating without a PR in scope, use **researcher**.
 
 ## Lifecycle you walk
 
-Two paths depending on verdict:
-
 ```
-ready → in_progress → code_review (the PR's ticket) → done    (approved)
-ready → in_progress → code_review (the PR's ticket) → in_progress  (changes)
+ready → in_progress (read PR, post review on GitHub) → done
 ```
 
-The first lifecycle column (`ready → in_progress`) is YOUR review
-ticket. The transition you make on the PR's ticket is in the third
-column. If you have your OWN review ticket (a ticket whose work IS the
-review), close it with `kanban-flow done` after posting the GitHub
-review.
+The PR's own ticket stays in `in_progress` regardless of your verdict.
+Hermes' kanban UI has no `code_review` column, so we do not move the
+PR's ticket on review — the PR's GitHub state is the review-phase
+truth. If you request changes, the programmer pushes more commits to
+the same PR; their ticket is still `in_progress`. If you approve, the
+PR merges and the merge-completion step (or operator) flips that
+ticket to `done`.
 
 ## The recipe
 
@@ -62,25 +60,20 @@ review.
    back. (Knuth heuristic.)
 
 6. **Post the review** — `gh pr review <num> --comment --body
-   "<review>"`. Structure:
+   "<review>"` (or `--approve` / `--request-changes` on the GitHub
+   side). Structure:
 
-   - **Verdict** — APPROVE or REQUEST CHANGES (the latter triggers
-     `kanban-flow review <id> changes`).
+   - **Verdict** — APPROVE or REQUEST CHANGES.
    - **Acceptance scorecard** — bullet per criterion, met/not.
    - **Boundary observations** — what edge cases are covered, which
      aren't.
    - **Non-blocking observations** — nits worth fixing later, but not
      blockers.
 
-7. **Transition** — for the PR's ticket:
-   `kanban-flow review <pr-ticket-id> approved` if APPROVE, else
-   `kanban-flow review <pr-ticket-id> changes`. The helper writes the
-   appropriate comment + audit event.
-
-8. **Close your own ticket if applicable** — if this work was a
-   dedicated review ticket (not the PR's own ticket),
-   `kanban-flow done <your-ticket> --result "Reviewed PR #<n>;
-   verdict: <approve|changes>"`.
+7. **Close your review ticket** — `kanban-flow done <your-ticket-id>
+   --result "Reviewed PR #<n>; verdict: <approve|changes>"`. The PR's
+   own ticket stays in `in_progress` either way — the PR's GitHub
+   state carries the review-phase truth.
 
 ## Anti-patterns
 

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -293,7 +293,9 @@ steps:
         kanban-flow block ${ticket_id} "branch $BRANCH pushed but gh pr create failed" --author clawta 2>/dev/null || true
       else
         MSG="🦞 ${ticket_id}: done. Branch: $BRANCH. PR: $PR_URL"
-        # Slice D: PR opened — flip to code_review with the PR url.
+        # PR opened — record the URL on the ticket. Ticket stays in
+        # in_progress (Hermes UI has no code_review column; the PR's
+        # GitHub state is the review-phase truth).
         kanban-flow pr ${ticket_id} "$PR_URL" --author clawta 2>/dev/null || true
       fi
       hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Hermes' kanban UI renders only triage/todo/ready/in_progress/blocked/done columns. \`code_review\` is invisible; the kanban config block exposes only \`dispatch_in_gateway\`, \`dispatch_interval_seconds\`, and \`failure_limit\` — no lane customization.
- Drop \`code_review\` from kanban-flow without forking hermes-agent. Tickets stay in \`in_progress\` from claim through PR open, review, and merge. The PR's GitHub state carries the review-phase truth.
- \`kanban-flow pr\` keeps the ticket in_progress, posts the URL as a comment, emits a \`pr_opened\` task event for audit.
- \`kanban-flow review\` subcommand removed (reviewers post on GitHub, close their own review ticket with \`kanban-flow done\`).

## Why option A (drop) over the alternatives

- **Patching hermes-agent UI** — declined, since the kanban config doesn't expose lane structure, this would be a fork. Not a forking-hermes problem.
- **Map code_review → blocked** — abuses the blocked semantics ("awaiting external decision") and would clutter the Blocked column with normal review traffic.
- **Keep code_review, accept invisibility** — operator can't see tickets, breaks kanban-as-source-of-truth.

## Test plan

- [x] Live smoke: created throwaway ticket, walked ready → in_progress → pr → done. \`pr\` left status in_progress, recorded \`pr_opened\` event with payload \`{\"pr_url\":\"...\",\"by\":\"...\"}\`, \`done\` flipped straight from in_progress.
- [x] Bash syntax check on updated kanban-flow.
- [x] No in-flight tickets currently in code_review state to migrate.
- [ ] After merge: monitor next worker-PR cycle (lobster \`finalize_dispatch\` → \`kanban-flow pr\` → comment + event, no flip).

Kanban: t_fb97e71d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)