### PR TITLE
fix(swarm-sdlc): spawn_worker owns the worktree contract — workers can finally produce PRs

### DIFF
--- a/swarm/roles/programmer/SKILL.md
+++ b/swarm/roles/programmer/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: programmer
-description: "Default worker role for code-change tickets. Claims ticket, creates a worktree + branch, makes the change, runs tests, opens a PR, records the PR url on the kanban ticket. Used by clawta dispatch when the ticket asks for an implementation, refactor, fix, or test."
+description: "Default worker role for code-change tickets. Edits code on a feature branch in a pre-prepared worktree, runs tests, commits. Lobster orchestrates the worktree creation, push, and PR open — the worker just makes the change."
 allowed_tools: [Read, Edit, Write, Bash, Grep, Glob]
 success_criteria:
-  - PR opened against main with the change
-  - CI green (or explicit "yellow CI, see comment" note if a flake is unrelated)
-  - Kanban ticket has a PR-url comment and a `pr_opened` task event (ticket stays in_progress; Hermes UI has no code_review column)
-  - Every status transition has both a comment and a task_events row
+  - Code change committed on the feature branch lobster prepared
+  - Tests run (or an explicit note in the commit message if untested)
+  - Commit message references the ticket id
+  - No `git push` or `gh pr create` calls — lobster does those after exit
 ---
 
 # Programmer role
 
-The default worker role for tickets that ship code. You are dispatched
-by Clawta when a ticket is sequenced for implementation. You own the
-ticket end-to-end through the SDLC until the PR is open and the URL
-is recorded on the kanban ticket.
+The default worker role for tickets that ship code. Clawta dispatches
+you to a ticket; lobster prepares a clean worktree on a feature branch
+and exec's you in it. **Your job: make the change, run tests, commit.
+Then exit.** Lobster handles everything else.
 
 ## When to apply
 
@@ -29,80 +29,70 @@ If the ticket is pure investigation with no PR expected, use the
 **researcher** role instead. If the ticket is reviewing someone else's
 PR, use the **reviewer** role.
 
-## Lifecycle you walk
+## What lobster did before exec'ing you
 
-```
-ready → in_progress (claim + work + PR open) → done (after merge)
-```
+By the time your prompt runs, lobster has:
 
-The ticket stays in `in_progress` through PR open, review, and merge.
-Hermes' kanban UI has no `code_review` column, so we deliberately do
-not flip the status — the PR's GitHub state is the review-phase truth.
-`kanban-flow pr <id> <url>` records the PR url as a comment and a
-`pr_opened` audit event without moving the ticket. After merge, the
-ticket is closed via `kanban-flow done <id> --result "..."`.
+- Created a worktree at `~/.cache/chitin/swarm-worktrees/swarm-<driver>-<ticket_id>/`
+- Branched it as `swarm/<driver>-<ticket-short>` off `origin/main`
+- `cd`'d into the worktree before exec'ing you
+- Flipped the kanban ticket to `in_progress`
+- Comment-stamped the dispatch on the board
+
+You do not need to repeat any of these steps.
 
 ## The recipe
 
-1. **Claim** — `hermes kanban --board chitin assign <id> <your-name>`.
-   If the ticket already has another assignee, abort: someone is already
-   on it.
+1. **Make the change.** Edit files. Use Read/Edit/Write/Bash/Grep/Glob.
+   Stay inside the worktree (`pwd` already places you there).
 
-2. **Worktree** — `scripts/create-worktree.sh --agent <your-name> --task
-   <slug>`. The branch is `<your-name>/<slug>`. Always work in a
-   worktree; never on main. Never use `git add -A` (operator-local skill
-   files leak).
+2. **Run tests** if the change touches code with tests. If untested,
+   note it in the commit message rather than skipping silently.
 
-3. **Start** — `kanban-flow start <id> --author <your-name> --worktree
-   <path>`. Flips ready→in_progress, comments "picking up at <ts>",
-   writes the audit event.
+3. **Commit.** Stage by name (`git add <files>`), not `git add -A`.
+   Commit message format: `<type>(<scope>): <short subject>`. The body
+   should reference the ticket id explicitly. Author identity is
+   inherited from chitin's git config (project-local).
 
-4. **Work** — make the change. Run tests. If you find that the ticket
-   isn't actually doable (missing dependency, broken assumption, etc.),
-   call `kanban-flow block <id> "<reason>"` and stop. Don't ship a half
-   implementation.
-
-5. **Commit** — author email is project-specific. For chitin, that's
-   `jpleva91@gmail.com`. Sign your name in `Co-Authored-By`.
-
-6. **Push + PR** — `git push -u origin <branch>` then `gh pr create`.
-   Title format: `<type>(<scope>): <short subject>`. Body links the
-   kanban ticket id.
-
-7. **Record the PR** — `kanban-flow pr <id> <pr-url> --author <your-name>`.
-   Comments the PR url + emits a `pr_opened` task event. Ticket stays
-   in `in_progress` (Hermes UI has no code_review column).
-
-8. **Hand off** — you're done. Reviewer (or clawta sequencing) will
-   handle the merge.
+4. **Exit.** Lobster's `finalize_dispatch` step takes over — it pushes
+   the branch, opens a PR with the commit's subject as title, and
+   records the PR url back on the kanban ticket via a `pr_opened`
+   event. No action needed from you.
 
 ## Anti-patterns
 
-- **Editing on main.** Hard rule: every code change starts with `git
-  checkout -b` BEFORE the first edit. If you find yourself on main,
-  stash, branch, then pop.
-- **`git add -A`.** Always stage by name. The operator's home dir has
-  global files that get swept up otherwise.
-- **Skipping `kanban-flow`.** Raw `UPDATE tasks SET status=…` breaks
-  the audit invariant.
-- **Closing the loop before merge.** Don't `kanban-flow done <id>`
-  until the PR has actually merged. The PR's GitHub state is the
-  review-phase truth; closing the kanban early loses audit signal.
+- **Running `git push` or `gh pr create`.** Lobster does these. If you
+  push, you'll race the finalize step; if you open a PR yourself, the
+  finalize step will try and find an existing PR for the branch and
+  re-use it — better than racing, but you've duplicated work.
+- **Creating another worktree.** You're already in one. The path is
+  `~/.cache/chitin/swarm-worktrees/swarm-<driver>-<ticket_id>/`.
+- **`git add -A`.** Stage by name. The chitin checkout has operator-
+  local files (`.claude/scheduled_tasks.lock`, `chitin.yaml.bak.*`, etc.)
+  that would leak.
+- **Calling `kanban-flow start` / `kanban-flow pr`.** Lobster does
+  these too. The worker is past the `start` point already and never
+  records its own `pr_opened` event.
 - **Scope creep.** If you discover related work mid-change, file a
-  separate ticket. Don't bundle.
+  separate ticket (`hermes kanban --board chitin create ... --triage`).
+  Don't bundle.
 
 ## When you fail
 
-If the work blocks on something outside your control:
+If the work blocks on something outside your control (missing
+dependency, broken assumption in the ticket, etc.):
 
 ```
-kanban-flow block <id> "<one-sentence reason>" --author <your-name>
+kanban-flow block <ticket-id> "<one-sentence reason>" --author <your-name>
 ```
 
 The blocker should be specific enough that whoever unblocks knows what
 to do. "external dep" is not enough; "waiting on PR #519 to merge so
 spec lands on main" is.
 
-If you crash mid-work or hit an unrecoverable error, leave the ticket
-in `in_progress` and post a comment explaining. The poller or operator
-will reset it to `ready` after triage.
+Then exit without committing. Lobster will see no commits and post the
+"no feature branch checked out" path on the audit trail.
+
+If you crash mid-work or hit an unrecoverable error, exit and let the
+finalize step report. The poller or operator will reset the ticket to
+`ready` after triage.

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -76,14 +76,24 @@ steps:
   # (which it always does). Read via stdin + variable assignment inside
   # a bash heredoc so the JSON never touches the shell parser as a
   # literal. Same pattern as spawn_worker.
+  # Why this calls `openclaw agent` directly instead of `clawta --text`:
+  # the `clawta` wrapper has unanchored pattern detection for dispatch
+  # intent — it matches any `t_xxxxxxxx` id and any dispatch-verb word
+  # anywhere in the prompt. The classify prompt embeds the full ticket
+  # JSON, which always contains a ticket id and frequently contains
+  # dispatch-verb words in the body. That misfires as a recursive
+  # dispatch call, runs the workflow on itself, and returns a failure
+  # envelope instead of classification JSON. Every dispatch on
+  # 2026-05-12 failed for this reason until the bypass landed (#529).
   - id: classify
-    description: Classify ticket via clawta (glm-agent on glm-5.1:cloud)
+    description: Classify ticket via glm-agent on glm-5.1:cloud (direct, no wrapper)
     run: |
       bash -c "$(cat <<'BASH_SCRIPT'
       set -euo pipefail
       TICKET=$(cat)
       PROMPT="Classify this ticket and reply with ONLY a JSON object (no prose, no markdown fences): {\"complexity\": \"low\" | \"med\" | \"high\", \"capabilities\": [\"go\" | \"ts\" | \"python\" | \"refactor\" | \"debug\" | \"review\"], \"estimated_loc\": <integer>, \"needs_frontier\": <true|false>}. Ticket JSON: $TICKET"
-      clawta --text "$PROMPT"
+      OPENCLAW_BIN="${OPENCLAW_BIN:-/home/red/.vite-plus/bin/openclaw}"
+      "$OPENCLAW_BIN" agent --agent glm-agent --message "$PROMPT"
       BASH_SCRIPT
       )"
     stdin: $fetch_ticket.stdout
@@ -194,18 +204,59 @@ steps:
       if [[ -z "$TICKET_BODY" ]]; then
         TICKET_BODY="$TICKET_JSON"
       fi
-      # Slice D: inline role SKILL.md into the worker's system prompt.
-      # Role is set via ROLE env var (clawta-poller passes it; default
-      # 'programmer'). Falls back to no-prefix if the role file is missing.
-      # printf %s avoids the YAML-scanner-breaking multi-line bash string.
+      # Extract ticket id from the JSON rather than depending on
+      # lobster's ${ticket_id} substitution. Lobster substitutes
+      # unbraced step refs inside this single-quoted heredoc (the
+      # DRIVER='$pick_driver.json.driver' pattern works), but braced
+      # arg refs (${ticket_id}) don't — they survive as literal text
+      # and bash errors with `unbound variable` under set -u.
+      TICKET_ID=$(printf '%s' "$TICKET_JSON" | jq -r '.task.id // .id // empty')
+      if [[ -z "$TICKET_ID" ]]; then
+        echo "spawn_worker: could not extract ticket id from JSON" >&2
+        exit 1
+      fi
+      # Pre-create the swarm worktree at the path finalize_dispatch
+      # expects. Without this, workers either (a) commit on whatever
+      # branch they happened to be on in the chitin primary checkout,
+      # leaving nothing for finalize to find, or (b) call
+      # scripts/create-worktree.sh which defaults to ../chitin-<branch>/
+      # — a path finalize doesn't search. Lobster owns the worktree
+      # contract end-to-end now; the leaf CLI just edits and commits.
+      WORKTREE_DIR="$HOME/.cache/chitin/swarm-worktrees/swarm-${DRIVER}-${TICKET_ID}"
+      TICKET_ID_SHORT="${TICKET_ID#t_}"
+      BRANCH="swarm/${DRIVER}-${TICKET_ID_SHORT}"
+      CHITIN_REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+      mkdir -p "$(dirname "$WORKTREE_DIR")"
+      if [[ ! -d "$WORKTREE_DIR" ]]; then
+        # Use git worktree add directly — scripts/create-worktree.sh
+        # has extra bootstrap logic we don't need here. If the branch
+        # already exists (re-dispatch case), check it out instead of
+        # erroring on duplicate.
+        git -C "$CHITIN_REPO" worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main 2>&1 \
+          || git -C "$CHITIN_REPO" worktree add "$WORKTREE_DIR" "$BRANCH" 2>&1
+      fi
+      cd "$WORKTREE_DIR"
+      # Inline role SKILL.md into the worker's system prompt. Role is
+      # set via ROLE env var (default 'programmer'). Falls back to
+      # no-prefix if the role file is missing. printf %s avoids the
+      # YAML-scanner-breaking multi-line bash string.
       ROLE="${ROLE:-programmer}"
       ROLE_SKILL="$HOME/.openclaw/roles/$ROLE/SKILL.md"
       if [[ -f "$ROLE_SKILL" ]]; then
-        ROLE_HEADER=$(printf '# Worker role: %s\n\n%s\n\n# Ticket\n\n' "$ROLE" "$(cat "$ROLE_SKILL")")
+        ROLE_HEADER=$(printf '# Worker role: %s\n\n%s\n\n' "$ROLE" "$(cat "$ROLE_SKILL")")
       else
         ROLE_HEADER=""
       fi
-      PROMPT="${ROLE_HEADER}Implement the ticket: $TICKET_BODY"
+      # The working-environment header makes the contract concrete:
+      # the worker is already in a worktree on a feature branch; it
+      # must NOT try to create another, push, or open a PR — lobster's
+      # finalize_dispatch step does those. Without these explicit DO
+      # NOTs, frontier LLMs read the role SKILL.md, attempt the full
+      # SDLC, and fail at the create-worktree step (path mismatch) or
+      # the push step (the worker has no GH_TOKEN).
+      ENV_HEADER=$(printf '# Working environment\n\nYou are already in a fresh git worktree at %s on branch %s (based on origin/main).\n\nDO NOT create another worktree or branch — you are in one.\nDO NOT run `git push` or `gh pr create` — lobster handles those after you exit.\n\nYour job: make the code change for the ticket, run any relevant tests, then commit with a clear message referencing %s. Then exit. That is it.\n\n# Ticket %s\n\n' \
+        "$WORKTREE_DIR" "$BRANCH" "$TICKET_ID" "$TICKET_ID")
+      PROMPT="${ROLE_HEADER}${ENV_HEADER}${TICKET_BODY}"
       MODEL=$(jq -r '[.models[]] | sort_by(.premium_cost) | .[0].id' "$CARD_PATH")
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
       ARGS_JSON=$(jq -c --arg model "$MODEL" --arg prompt "$PROMPT" \


### PR DESCRIPTION
## Summary

- Every dispatched ticket since 10:43 today produced a \"spawn_worker completed but no worktree found\" comment. Root cause: contract mismatch between the leaf CLI's behavior and lobster's finalize_dispatch step.
- Lobster now owns the worktree end-to-end. \`spawn_worker\` creates the worktree at the canonical path lobster's finalize step expects, \`cd\`s into it, then exec's the leaf CLI with an explicit working-environment header.
- Worker contract simplifies to: **edit, test, commit, exit.** No worktree creation, no push, no PR open — lobster does those.
- Also includes the #529 classify-step bypass that was missing from \`swarm/workflows/\` (it only landed in \`docs/governance-setup-extras/\`).

## Mechanism

\`spawn_worker\`:

1. Extracts ticket id from the JSON via jq (the \`${ticket_id}\` lobster arg-substitution doesn't fire inside the single-quoted heredoc — a quirk worth documenting).
2. Creates worktree at \`~/.cache/chitin/swarm-worktrees/swarm-<driver>-<ticket_id>/\` on branch \`swarm/<driver>-<ticket-short>\` off \`origin/main\`.
3. \`cd\`s into it.
4. Prepends a working-environment header to the worker prompt:
   - \"You are already in a fresh git worktree at <path> on branch <branch>\"
   - \"DO NOT create another worktree\"
   - \"DO NOT push or open a PR — lobster handles those after you exit\"
   - \"Make the change, run tests, commit. Then exit.\"
5. exec's leaf CLI.

\`finalize_dispatch\` already searches the canonical path, so it now reliably finds the worktree.

## Smoke (live)

Filed \`t_33dfc315\` asking codex to create \`scripts/swarm-smoke-marker.sh\`. End-to-end:

- ready → dispatch
- worktree pre-created at \`~/.cache/chitin/swarm-worktrees/swarm-codex-t_33dfc315/\`
- codex made the change in 1 commit
- finalize pushed \`swarm/codex-33dfc315\`
- **PR #532 opened** (closed as smoke artifact)
- kanban ticket \`pr_opened\` event recorded, ticket stays in_progress per #531
- ticket transitioned to done

**This is the first autonomous worker dispatch to produce a real PR.**

## Followup

\`docs/governance-setup-extras/kanban-dispatch.lobster\` is divergent from \`swarm/workflows/kanban-dispatch.lobster\` (the former has #529 but not Slice D's lifecycle wiring; the latter has Slice D + this PR but only got #529 here). They should be consolidated to one canonical file. File a ticket post-merge.

Kanban: t_2932dd4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)