### PR TITLE
docs: salvage Hermes-deny + envelope-deny research outputs from broken-dispatch workers

### DIFF
--- a/docs/driver-conformance.md
+++ b/docs/driver-conformance.md
@@ -29,7 +29,8 @@ in one of these outcomes:
 
 1. Mine `default-deny` / `unknown` rows from `~/.chitin/gov-decisions-*.jsonl`
    by `(agent, tool_name, action_target)` and map the highest-volume real
-   tools first.
+   tools first. Last local Hermes pass: 2026-05-12; see
+   "Hermes unknown and lockdown classification" below.
 2. Add a fixture and normalizer test for each mapped tool before changing
    `chitin.yaml`.
 3. For Hermes modality tools, decide whether the canonical vocabulary needs
@@ -50,3 +51,48 @@ in one of these outcomes:
   and `chat.useAgentsMdFile` settings for these instruction surfaces.
 - None of those instruction files are a security boundary. They improve
   behavior but do not replace chitin's gate.
+
+## Hermes unknown and lockdown classification
+
+Local chain mining over `~/.chitin/gov-decisions-*.jsonl` from
+2026-04-22 through 2026-05-12 showed Hermes `unknown` denies only through
+2026-05-09. There were no Hermes `unknown` rows on or after 2026-05-10 in
+that state directory. Aggregate Hermes deny rows in the local slice were
+`lockdown x unknown` = 439, `lockdown x kanban.call` = 165, and
+`default-deny-unknown x unknown` = 23. The high-volume unknown rows are
+therefore historical unless a fresh chain slice reintroduces them.
+The pass grouped denied Hermes rows by `rule_id`, `action_type`,
+`action_target`, and decision day, then checked the post-2026-05-09 window
+for fresh `unknown` rows before recommending any normalizer or policy change.
+
+| Tool / action target | Local evidence | Bucket | Recommendation |
+|---|---:|---|---|
+| Current high-volume gap | 0 Hermes `unknown` rows found from 2026-05-10 through 2026-05-12 | Real current gap: none found | No normalizer or policy expansion for this ticket. Re-mine current chain data before adding mappings. |
+| `kanban_show` | 286 `unknown` rows, concentrated on 2026-05-07; plus 109 later `lockdown x kanban.call x show` rows after mapping shipped | Stale/archived surface, already fixed | Keep `ActKanbanCall` mapping. Do not add policy broadening for `unknown`; if an operator still sees `lockdown x kanban.call`, clear stale Hermes lockdown state rather than changing the normalizer. |
+| `kanban_block` | 116 `unknown` rows on 2026-05-07; plus 46 later `lockdown x kanban.call x block` rows | Stale/archived surface, already fixed | Keep `ActKanbanCall` mapping and per-verb target. No new action type needed. |
+| `kanban_comment`, `kanban_complete`, `kanban_heartbeat`, `kanban_link` | 29 combined `unknown` rows on 2026-05-07; comments/completes also appear later as `kanban.call` while Hermes was already locked down | Stale/archived surface, already fixed | Keep these in the Hermes `kanban_*` closed set. Add new kanban verbs only from live hook captures or Hermes display registry changes. |
+| `process` | 5 `default-deny-unknown` rows on 2026-05-07 | Stale/archived surface, already fixed | Keep `ActHermesProcess`; this is Hermes runtime plumbing, not shell execution. |
+| `Write` | 7 `unknown` rows on 2026-05-06 | Cross-driver leak | Keep Claude-Code leak re-normalization plus structured warning. Fix upstream dispatch wiring if this returns; do not create a Hermes-native `Write` mapping. |
+| `skills_list` | 3 `default-deny-unknown` rows and 1 `lockdown` row on 2026-05-09 | Stale/archived surface, already fixed | Keep `file.read` mapping. Treat future rows as evidence that an old kernel binary or stale hook is still installed. |
+| `memory` | 2 `default-deny-unknown` rows and 2 `lockdown` rows on 2026-05-09 | Stale/archived surface, already fixed | Keep `file.write` mapping with stable target `memory`; policy can govern durable memory as one sink. |
+| `todo` | 1 `default-deny-unknown` row on 2026-05-09 | Stale/archived surface, already fixed | Keep `file.write` mapping with stable target `todo`. |
+| `skill_manage` | 2 `lockdown` rows on 2026-05-09 | Stale/archived surface, already fixed | Keep `file.write` mapping. This is a write to operator skill state, so policy should decide allow/deny after classification. |
+| `session_search` | 1 `lockdown x unknown` row on 2026-05-07 | Stale/archived surface, already fixed | Keep `file.read` mapping with query target and `session_search` fallback. |
+| `browser_navigate` | 1 `lockdown x unknown` row on 2026-05-09, paired with a normalized `http.request` duplicate for the same envelope | Stale/archived surface, already fixed | Keep `http.request` mapping. If duplicates recur, inspect old hook/binary paths before changing policy. |
+| `clarify` | 8 `unknown` rows across 2026-05-07 and 2026-05-09 | Intentional fail-closed | Keep `ActUnknown` until Hermes gives this a stable machine-action contract. It is chat/control flow, not a host side effect, and should not gain a broad allow rule. |
+| `image_generate`, `text_to_speech`, `vision_analyze` | No local unknown rows in this slice, but explicitly listed as unmapped Hermes tools | Intentional fail-closed | Keep fail-closed for Hermes until there is a policy requirement for media side effects. Candidate future canonical types: `media.generate`, `speech.generate`, `vision.analyze`. |
+| `cronjob` | No local unknown rows in this slice, but explicitly listed as unmapped Hermes tool | Intentional fail-closed | Keep fail-closed. Scheduling belongs to Hermes as the substrate; add a canonical type only if chitin needs to govern schedule creation as a cross-driver action. Candidate future type: `schedule.job`. |
+| `lockdown x shell.exec` | 28 classified lockdown rows after Hermes was already locked, mostly kanban inspection shell commands plus a few explicit probe commands | Not a conformance gap | Leave policy and normalizers unchanged. Lockdown correctly denies every action regardless of action type. |
+| `lockdown x file.read`, `lockdown x file.write`, `lockdown x http.request` | 8 classified lockdown rows, including skill/memory/file probes and one `browser_navigate` duplicate already normalized as `http.request` | Not a conformance gap | Treat as consequences of existing lockdown state, not unmapped Hermes tools. Reset lockdown state operationally if appropriate. |
+
+Current high-volume Hermes conformance gap: none found in the local
+2026-05-10 through 2026-05-12 chain rows. The main historical failure was
+kanban/runtime plumbing falling to `unknown`, which is now classified by the
+Hermes normalizer. The remaining `lockdown x kanban.call` rows in the mined
+data reflect an already-locked agent continuing to make now-classified calls,
+not an unmapped tool.
+
+Recommendation: docs only for this ticket. Do not expand `chitin.yaml` to
+allow `unknown`, and do not add new canonical action types until a live,
+high-volume current surface proves that media or scheduling side effects need
+cross-driver governance.

--- a/docs/observations/2026-05-12-envelope-deny-audit.md
+++ b/docs/observations/2026-05-12-envelope-deny-audit.md
@@ -1,0 +1,132 @@
+# Envelope closed/exhausted deny audit
+
+Date: 2026-05-12
+
+## Question
+
+Do `envelope-closed` and `envelope-exhausted` denials block normal
+browse/status flows that should remain operable, or are they enforcing the
+intended operator boundary?
+
+## Data source
+
+Local chain rows from `~/.chitin/gov-decisions-*.jsonl` through
+2026-05-12, filtered to:
+
+```sh
+jq 'select(.allowed == false and (.rule_id == "envelope-closed" or .rule_id == "envelope-exhausted"))' \
+  ~/.chitin/gov-decisions-*.jsonl
+```
+
+The local sample contains 68 matching rows. The `driver` JSON field is absent
+on these rows; the `agent` field is `claude-code` except for one
+`codex` `file.write` row.
+
+## Matrix
+
+Blast level here uses the kernel's stamped tier: `T0` is low-blast local
+inspection, and `T2` is elevated/default-cost execution or mutation.
+
+| Envelope state | Blast | Action type | Count | Read/status/browse? | Notes |
+| --- | ---: | --- | ---: | --- | --- |
+| `envelope-closed` | `T0` | `file.read` | 32 | Yes | Plain Claude `Read`/`Glob`/`Grep`/`LS`-shaped inspection. |
+| `envelope-closed` | `T0` | `git.status` | 1 | Mixed | Target was `git add ... && git status`; normalized as status but contains a write-shaped staging operation. |
+| `envelope-closed` | `T2` | `shell.exec` | 17 | Mostly | Mostly `ls`, `cat`, `pwd`, status-style directory probes; one `chitin-kernel envelope grant ...` recovery attempt. |
+| `envelope-closed` | `T2` | `delegate.task` | 1 | No | Subagent delegation after envelope close. |
+| `envelope-closed` | `T2` | `file.write` | 1 | No | Codex write attempt with empty target. |
+| `envelope-exhausted` | `T0` | `file.read` | 6 | Yes | Plain file reads. |
+| `envelope-exhausted` | `T2` | `shell.exec` | 5 | Mixed | Includes `echo`, `find`, `docker ps/logs`, and `vitest ... | tail`; status-like but subprocess-shaped. |
+| `envelope-exhausted` | `T2` | `file.write` | 3 | No | Write attempts after budget exhaustion. |
+| `envelope-exhausted` | `T2` | `git.commit` | 2 | No | Real commit attempts after exhaustion. |
+
+Summary:
+
+| Bucket | Count |
+| --- | ---: |
+| Low-blast `T0` inspection rows | 39 |
+| Elevated/default `T2` shell rows | 22 |
+| Elevated/default `T2` mutation/delegation rows | 7 |
+
+## Denied read/status/diff samples
+
+No `git.diff`, `git.log`, `git.worktree.list`, GitHub view/list, or `T0`
+`shell.cat` rows appear in the sample.
+
+Representative `T0` read/status rows:
+
+| Timestamp | Rule | Action | Target |
+| --- | --- | --- | --- |
+| 2026-04-29T22:04:06Z | `envelope-exhausted` | `file.read` | `/home/red/workspace/chitin/docs/architecture/layer-contracts.md` |
+| 2026-04-30T16:10:53Z | `envelope-exhausted` | `file.read` | `/home/red/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md` |
+| 2026-04-30T16:11:05Z | `envelope-closed` | `git.status` | `cd /home/red/workspace/chitin-analysis && git add ... && git status` |
+| 2026-05-03T23:48:15Z | `envelope-closed` | `file.read` | `apps/temporal-worker/skills/**/*.md` |
+| 2026-05-04T01:13:06Z | `envelope-closed` | `file.read` | `docs/decisions/**` |
+| 2026-05-04T01:28:11Z | `envelope-closed` | `file.read` | `./go/execution-kernel/internal/router/**` |
+
+Representative shell browse/status rows currently stamped `T2`:
+
+| Timestamp | Rule | Target |
+| --- | --- | --- |
+| 2026-04-30T16:24:09Z | `envelope-closed` | `ls /home/red/workspace/chitin-analysis/` |
+| 2026-05-03T23:48:00Z | `envelope-exhausted` | `find .../apps/temporal-worker/src/skill-loader -type f` |
+| 2026-05-04T00:37:24Z | `envelope-closed` | `cat .../scripts/install-kernel.sh 2>&1 || echo "FILE_NOT_FOUND"` |
+| 2026-05-04T01:18:00Z | `envelope-closed` | `pwd && ls docs/` |
+| 2026-04-30T23:52:10Z | `envelope-exhausted` | `docker ps ... && docker logs ... | tail -10` |
+
+## Interpretation
+
+Most denied `T0` rows are harmless inspection actions. They do block normal
+browse flows after an envelope is closed or exhausted.
+
+That blocking is consistent with the current envelope contract. In
+`go/execution-kernel/internal/gov/gate.go`, envelope spend runs after policy
+allowance and converts an otherwise allowed decision into
+`envelope-closed`/`envelope-exhausted`. The comments describe caps as hard
+contracts, not monitor-mode advisories. The implementation also exempts
+budget denials from the lockdown counter, which means envelope denial is a
+boundary on continued work, not a punishment signal.
+
+The strongest reason not to add a broad read-only carveout is that normalized
+action type is not a sufficient proof of no side effect. The sample has
+`git add ... && git status` logged as `git.status` at `T0`. A carveout keyed
+only on `T0` or `file.read`/`git.status` would create a governance recovery
+loophole for compound shell commands that contain status/read tokens.
+
+Cost-control also weakens under a broad carveout. PreToolUse can only charge
+the proposed tool call and input bytes; it cannot know output size. Allowing
+unbounded post-exhaustion reads lets an agent continue generating large tool
+outputs and model follow-up context after the operator's envelope says stop.
+
+## Recommendation
+
+Do not add a general read-only bypass for closed or exhausted envelopes.
+The observed behavior is noisy for browse flows, but it matches the operator
+boundary: closed/exhausted means the current unit of work should stop until
+the operator or a trusted supervisor grants, switches, or closes out the
+envelope.
+
+Keep the existing chitin admin recovery bypass instead. The current hook path
+already sets `spendEnvelope = nil` for `chitin-kernel` admin commands, so
+operator recovery commands can run through policy without consuming or being
+blocked by the active envelope. Mutation-shaped admin commands are separately
+guarded by trusted authority rules.
+
+## Safe scope if this changes later
+
+A carveout would only be defensible if it is narrow, explicit, and
+syntax-aware:
+
+1. Apply only to `envelope-exhausted`, not `envelope-closed`. A closed envelope
+   is an operator stop signal; exhaustion is a budget edge.
+2. Apply only to structured driver tools whose normalizer proves read shape:
+   Claude `Read`, `Glob`, `Grep`, `LS`, `TaskGet`, `TaskList`, `TaskOutput`,
+   `ToolSearch`, `CronList`, `EnterPlanMode`, and `ExitPlanMode`.
+3. Do not apply to `shell.exec`, even when the command looks like `ls`, `cat`,
+   `find`, `git status`, or `tail`. Shell syntax needs compound-command
+   analysis before it can safely claim read-only.
+4. Cap the carveout separately, for example a small post-exhaustion inspection
+   counter per envelope, and stamp a distinct rule such as
+   `envelope-exhausted-readonly-grace` so analytics can see it.
+
+The current sample does not warrant that change. It shows friction, but also
+shows exactly the loophole class a broad bypass would open.


### PR DESCRIPTION
## Summary

Two research tickets dispatched today produced real output but never got committed because the workers ran during the classify-recursive-trap window (fixed in #529 / #530). The files were sitting modified/untracked in the operator's main worktree. This PR salvages them so the work isn't lost.

## Changes

- \`docs/driver-conformance.md\` — adds *Hermes unknown and lockdown classification* (from kanban \`t_710e0d1b\`). 30-day chain-row mining; classifies each Hermes unknown/lockdown bucket; bottom line: no current Hermes conformance gap in the 2026-05-10→2026-05-12 window.
- \`docs/observations/2026-05-12-envelope-deny-audit.md\` — answers \`t_652e9b88\`'s question by matrixing 68 chain rows; conclusion: envelope-closed/exhausted denials are enforcing the intended operator boundary, not breaking flows.

Closes kanban \`t_710e0d1b\`, \`t_652e9b88\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)