### PR TITLE
chore(swarm-sdlc): rename glm-agent → clawta across chitin code refs

### DIFF
--- a/docs/governance-setup-extras/clawta.sh
+++ b/docs/governance-setup-extras/clawta.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 OPENCLAW_BIN="/home/red/.vite-plus/bin/openclaw"
-AGENT="glm-agent"
+AGENT="clawta"
 FORMAT="json"
 LOBSTER_WORKFLOW="${LOBSTER_WORKFLOW:-$HOME/.openclaw/workflows/kanban-dispatch.lobster}"
 LOBSTER_REPO="${LOBSTER_REPO:-$HOME/workspace/chitin}"

--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -80,7 +80,7 @@ CLAWTA_BIN = os.environ.get("CLAWTA_BIN", "clawta")
 OPENCLAW_BIN = os.environ.get(
     "OPENCLAW_BIN", str(Path.home() / ".vite-plus/bin/openclaw")
 )
-SEQUENCER_AGENT = os.environ.get("SEQUENCER_AGENT", "glm-agent")
+SEQUENCER_AGENT = os.environ.get("SEQUENCER_AGENT", "clawta")
 KANBAN_FLOW_BIN = os.environ.get("KANBAN_FLOW_BIN", "kanban-flow")
 LOG_DIR = Path.home() / ".openclaw" / "logs"
 LOG_FILE = LOG_DIR / "clawta-poller.log"

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -93,7 +93,7 @@ steps:
       TICKET=$(cat)
       PROMPT="Classify this ticket and reply with ONLY a JSON object (no prose, no markdown fences): {\"complexity\": \"low\" | \"med\" | \"high\", \"capabilities\": [\"go\" | \"ts\" | \"python\" | \"refactor\" | \"debug\" | \"review\"], \"estimated_loc\": <integer>, \"needs_frontier\": <true|false>}. Ticket JSON: $TICKET"
       OPENCLAW_BIN="${OPENCLAW_BIN:-/home/red/.vite-plus/bin/openclaw}"
-      "$OPENCLAW_BIN" agent --agent glm-agent --message "$PROMPT"
+      "$OPENCLAW_BIN" agent --agent clawta --message "$PROMPT"
       BASH_SCRIPT
       )"
     stdin: $fetch_ticket.stdout


### PR DESCRIPTION
## Summary

The openclaw agent's id was \`glm-agent\` from when it ran \`ollama-cloud/glm-5.1:cloud\`. After today's swap to \`openai-codex/gpt-5.5\` (Clawta is now frontier-class) the id became misleading; the agent's identity has always been "🦞 Clawta", and the CLI wrapper, Discord bot, and binding all already use that name. The id was the last surface still on the old name.

This PR updates chitin's references to match the renamed openclaw agent:

- \`swarm/bin/clawta-poller\` — \`SEQUENCER_AGENT\` env default: \`glm-agent\` → \`clawta\`
- \`swarm/workflows/kanban-dispatch.lobster\` — classify step's \`openclaw agent --agent <name>\` flag: \`glm-agent\` → \`clawta\`
- \`docs/governance-setup-extras/clawta.sh\` — wrapper's chat-mode \`AGENT\` default: \`glm-agent\` → \`clawta\`

The openclaw-side rename (\`~/.openclaw/openclaw.json\` agent id + filesystem dirs + Discord binding) was done in the same operator session and verified end-to-end: \`clawta CLI\` and \`openclaw agent --agent clawta\` both return responses via gpt-5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)