### PR TITLE
fix(swarm-sdlc): cron prompt asks for closing 'ok' so codex models don't trip metrics

### DIFF
--- a/swarm/bin/install-clawta-poller.sh
+++ b/swarm/bin/install-clawta-poller.sh
@@ -69,7 +69,9 @@ install_openclaw_cron() {
 
   clawta-poller --once --max-dispatch 2
 
-Wait for it to complete. If it prints JSON with dispatched/demoted counts, you are done — no follow-up turn needed. If it fails, that is logged in ~/.openclaw/logs/clawta-poller.log; do not retry, do not investigate, just exit." \
+After the exec tool returns (whether the command has finished or is still running in the background), reply with exactly the word 'ok' and nothing else. Do not retry. Do not investigate failures — those are logged in ~/.openclaw/logs/clawta-poller.log.
+
+The closing 'ok' token is REQUIRED — without it the cron metrics report the run as 'couldn't generate a response' even though the dispatch fired correctly. Newer codex-backed models (gpt-5.4+) emit an empty final-answer block when the system prompt says 'just exit', which the cron run-tracker labels as an error." \
     >/dev/null
   echo "openclaw cron: 'clawta-kanban-poller' registered (every 2m)."
   echo "  inspect: openclaw cron show clawta-kanban-poller"


### PR DESCRIPTION
## Summary

Cron run metrics flipped from green to red after swapping Clawta to \`openai-codex/gpt-5.5\` today. Investigation showed the dispatch infrastructure was fully functional — only the dashboard color was wrong.

## Root cause (from trajectory mining)

Codex-backed models (gpt-5.4, gpt-5.5) obey the cron's "no follow-up turn needed" guidance literally and emit an **empty final-answer block** once the exec tool yields. The cron run-tracker labels empty-text finals as ⚠️ "Agent couldn't generate a response" even when the underlying exec subprocess succeeded.

Trajectory evidence (cron run \`66951242-...\` at 2026-05-12 15:53):

\`\`\`
user      → "Run exactly one command... clawta-poller --once --max-dispatch 2"
assistant → toolCall: exec(clawta-poller --once --max-dispatch 2,
            yieldMs=1000, timeout=120)            [stop=toolUse]
toolResult→ "Command still running (pid 187754)"  [isError=false]
assistant → text: ""                              [stop=stop, phase=final_answer]
\`\`\`

The exec process kept running in the background and produced \`15:53:41 tick: empty queue\` in \`~/.openclaw/logs/clawta-poller.log\` — proving the dispatch fired.

## Fix

Ask the agent for one closing 'ok' token so the final-answer block is non-empty. The closing-token requirement is documented in the prompt itself, so a future operator who removes it understands what breaks.

## Verification

Cron run at 16:11:57 reports \`status=ok\` where prior 15:52 / 15:29 / 14:55 / 14:39 attempts all reported \`status=error\`. Dashboard column \`status: ok\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)