### PR TITLE
swarm: repair transient dispatch finalize failures

### DIFF
--- a/scripts/kanban-flow
+++ b/scripts/kanban-flow
@@ -17,7 +17,7 @@
 #
 # Usage:
 #   kanban-flow start <id> [--author NAME] [--worktree PATH]
-#       triage|ready → in_progress. Comments "picking up at <ts>".
+#       triage|todo|ready → in_progress. Comments "picking up at <ts>".
 #
 #   kanban-flow pr <id> <pr-url> [--author NAME]
 #       in_progress stays. Comments with PR url + emits pr_opened event.
@@ -29,7 +29,7 @@
 #       blocked → ready.
 #
 #   kanban-flow demote <id> <reason...> [--author NAME]
-#       ready → triage. Comments with reason. Used by clawta when a
+#       ready|todo → triage. Comments with reason. Used by clawta when a
 #       ticket isn't actually ready to dispatch.
 #
 #   kanban-flow done <id> --result "<summary>" [--author NAME]
@@ -124,7 +124,7 @@ case "$cmd" in
   start)
     parse_flags "$@"
     id="${REST[0]:-}"; require_id "$id"
-    assert_status "$id" triage ready in_progress
+    assert_status "$id" triage todo ready in_progress
     from="$(ticket_status "$id")"
     body="Picking up at $(date -Iseconds)"
     [[ -n "$worktree" ]] && body="$body — worktree: $worktree"
@@ -178,11 +178,12 @@ case "$cmd" in
     id="${REST[0]:-}"; require_id "$id"
     reason="${REST[*]:1}"
     [[ -n "$reason" ]] || die "missing reason"
-    assert_status "$id" ready
-    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Demoted ready→triage: $reason" >/dev/null
+    assert_status "$id" ready todo
+    from="$(ticket_status "$id")"
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Demoted ${from}→triage: $reason" >/dev/null
     flip_status "$id" triage 0 0
-    emit_transition "$id" ready triage "$author"
-    echo "$id: ready → triage ($reason)"
+    emit_transition "$id" "$from" triage "$author"
+    echo "$id: $from → triage ($reason)"
     ;;
   ready)
     parse_flags "$@"

--- a/swarm/bin/clawta-invariants
+++ b/swarm/bin/clawta-invariants
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""clawta-invariants — board self-healing checks for the Chitin swarm.
+
+This is a small, conservative control-loop companion to clawta-poller.
+It repairs board states that are safe to infer from durable external facts:
+
+- blocked ticket says PR creation failed, but a PR now exists for its branch
+  -> move blocked -> ready -> in_progress and record the PR URL.
+- blocked ticket says PR creation failed and the pushed branch exists with no PR
+  -> retry `gh pr create`, then record the PR if successful.
+
+Everything else is reported but left alone. The goal is to unstick transient
+finalize failures without inventing work completion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+DB_PATH = Path(os.environ.get("KANBAN_DB", str(Path.home() / ".hermes/kanban/boards/chitin/kanban.db")))
+BOARD = os.environ.get("KANBAN_BOARD", "chitin")
+AUTHOR = "clawta-invariants"
+REPO = Path(os.environ.get("CHITIN_REPO", str(Path.home() / "workspace/chitin")))
+LOG_DIR = Path.home() / ".openclaw" / "logs"
+LOG_FILE = LOG_DIR / "clawta-invariants.log"
+
+PR_RE = re.compile(r"https://github\.com/[^\s)]+/pull/\d+")
+BRANCH_RE = re.compile(r"branch\s+(swarm/[A-Za-z0-9._/-]+)")
+TRANSIENT_PR_FAILURE_RE = re.compile(r"gh pr create failed|Manual PR open needed", re.I)
+
+
+def log(msg: str) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}"
+    print(line, file=sys.stderr)
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+
+
+def run(cmd: list[str], *, cwd: Path = REPO, timeout: int = 30, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), text=True, capture_output=True, timeout=timeout, check=check)
+
+
+def fetch_blocked() -> list[dict[str, Any]]:
+    with sqlite3.connect(str(DB_PATH)) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT id, title, assignee, status
+              FROM tasks
+             WHERE status = 'blocked'
+             ORDER BY priority DESC, created_at ASC
+            """
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def fetch_comments(ticket_id: str) -> list[str]:
+    out = run(["hermes", "kanban", "--board", BOARD, "show", ticket_id, "--json"], timeout=20)
+    if out.returncode != 0:
+        log(f"{ticket_id}: failed to fetch comments: {out.stderr[:200]}")
+        return []
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        log(f"{ticket_id}: invalid JSON from hermes show")
+        return []
+    return [str(c.get("body", "")) for c in data.get("comments", [])]
+
+
+def branch_from_comments(comments: list[str], ticket_id: str, assignee: str | None) -> str | None:
+    for body in reversed(comments):
+        m = BRANCH_RE.search(body)
+        if m:
+            return m.group(1)
+    if assignee:
+        return f"swarm/{assignee}-{ticket_id.removeprefix('t_')}"
+    return None
+
+
+def pr_from_comments(comments: list[str]) -> str | None:
+    for body in reversed(comments):
+        m = PR_RE.search(body)
+        if m:
+            return m.group(0)
+    return None
+
+
+def existing_pr_for_branch(branch: str) -> str | None:
+    out = run(["gh", "pr", "list", "--head", branch, "--json", "url", "--jq", ".[0].url // empty"], timeout=30)
+    if out.returncode != 0:
+        log(f"{branch}: gh pr list failed: {out.stderr[:200]}")
+        return None
+    url = out.stdout.strip()
+    return url or None
+
+
+def remote_branch_exists(branch: str) -> bool:
+    out = run(["git", "ls-remote", "--heads", "origin", branch], timeout=30)
+    return out.returncode == 0 and bool(out.stdout.strip())
+
+
+def create_pr(branch: str, ticket_id: str, assignee: str | None) -> str | None:
+    title_out = run(["git", "log", "-1", "--pretty=%s", f"origin/{branch}"], timeout=30)
+    title = title_out.stdout.strip() if title_out.returncode == 0 and title_out.stdout.strip() else f"{ticket_id}: swarm work"
+    body = (
+        f"Closes ticket {ticket_id}.\n\n"
+        f"Auto-opened by clawta-invariants after detecting a transient finalize failure.\n"
+        f"Branch: {branch}\n"
+        f"Assignee: {assignee or 'unknown'}"
+    )
+    out = run(["gh", "pr", "create", "--head", branch, "--title", title, "--body", body], timeout=120)
+    text = out.stdout + "\n" + out.stderr
+    m = PR_RE.search(text)
+    if m:
+        return m.group(0)
+    log(f"{ticket_id}: gh pr create retry failed for {branch}: {text[-500:]}")
+    return None
+
+
+def record_pr(ticket_id: str, pr_url: str, dry_run: bool) -> bool:
+    if dry_run:
+        log(f"[dry-run] would unblock/start/pr {ticket_id}: {pr_url}")
+        return True
+
+    # kanban-flow pr requires in_progress, so walk blocked -> ready -> in_progress.
+    for cmd in (
+        ["kanban-flow", "unblock", ticket_id, "--author", AUTHOR],
+        ["kanban-flow", "start", ticket_id, "--author", AUTHOR],
+        ["kanban-flow", "pr", ticket_id, pr_url, "--author", AUTHOR],
+    ):
+        out = run(cmd, timeout=20)
+        if out.returncode != 0:
+            log(f"{ticket_id}: {' '.join(cmd)} failed: {out.stderr[:300]}")
+            return False
+
+    msg = f"🦞 invariant repaired: transient PR finalize recovered. PR: {pr_url}"
+    run(["hermes", "kanban", "--board", BOARD, "comment", ticket_id, "--author", AUTHOR, msg], timeout=20)
+    log(f"repaired {ticket_id}: {pr_url}")
+    return True
+
+
+def repair_transient_pr_failure(ticket: dict[str, Any], dry_run: bool) -> str | None:
+    ticket_id = ticket["id"]
+    comments = fetch_comments(ticket_id)
+    joined = "\n".join(comments[-8:])
+    if not TRANSIENT_PR_FAILURE_RE.search(joined):
+        return None
+
+    branch = branch_from_comments(comments, ticket_id, ticket.get("assignee"))
+    if not branch:
+        log(f"{ticket_id}: transient PR failure but no branch could be inferred")
+        return None
+
+    pr_url = pr_from_comments(comments) or existing_pr_for_branch(branch)
+    if not pr_url:
+        if not remote_branch_exists(branch):
+            log(f"{ticket_id}: branch {branch} not found on origin; cannot retry PR")
+            return None
+        if dry_run:
+            log(f"[dry-run] would retry gh pr create for {ticket_id} branch {branch}")
+            return None
+        pr_url = create_pr(branch, ticket_id, ticket.get("assignee"))
+
+    if not pr_url:
+        return None
+    if record_pr(ticket_id, pr_url, dry_run):
+        return pr_url
+    return None
+
+
+def run_once(dry_run: bool) -> dict[str, Any]:
+    repaired: list[dict[str, str]] = []
+    observed: list[str] = []
+    for ticket in fetch_blocked():
+        observed.append(ticket["id"])
+        pr_url = repair_transient_pr_failure(ticket, dry_run)
+        if pr_url:
+            repaired.append({"ticket_id": ticket["id"], "pr_url": pr_url})
+    return {"blocked_seen": observed, "repaired": repaired}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    if not DB_PATH.exists():
+        print(f"kanban DB not found: {DB_PATH}", file=sys.stderr)
+        return 2
+    result = run_once(args.dry_run)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -312,17 +312,21 @@ def route_ticket(ticket: dict[str, Any], dry_run: bool) -> str | None:
         if dry_run:
             log(f"[dry-run] would route {ticket['id']} -> {driver}: {reasoning[:80]}")
             return driver
-        # Reassign in kanban
+        # Reassign in kanban. Treat failures as routing failures so the
+        # ticket stays visible for a later retry instead of being counted as
+        # routed when kanban did not actually change.
         subprocess.run(
             ["hermes", "kanban", "--board", "chitin", "assign",
              ticket["id"], driver],
             timeout=15,
+            check=True,
         )
         subprocess.run(
             ["hermes", "kanban", "--board", "chitin", "comment",
              ticket["id"], "--author", AUTHOR,
              f"Routed by clawta-poller: {ROUTING_LANE} -> {driver}. Reasoning: {reasoning}"],
             timeout=15,
+            check=True,
         )
         log(f"routed {ticket['id']} {ROUTING_LANE} -> {driver} ({reasoning[:60]})")
         return driver

--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -11,17 +11,19 @@ poller existed, nobody owned the polling for those tickets — they sat
 in `ready` forever.
 
 What it does. On each tick:
-  1. Demote any ready ticket whose assignee is NULL or not a terminal
-     lane — these are grooming-step gaps; surfacing them is loud-by-
-     design so they can't pile up silently in `ready` forever.
-  2. SELECT remaining ready tickets WHERE assignee IN {codex, copilot,
-     claude-code, gemini}
-  3. Sequence them via a frontier-LLM call (clawta CLI). The LLM
+  1. Route any ready/todo tickets assigned to the routing lane (clawta)
+     through _pick_driver, reassigning to a terminal lane.
+  2. Demote any remaining ready/todo ticket whose assignee is NULL or
+     not a terminal lane — these are grooming-step gaps; surfacing them
+     is loud-by-design so they can't pile up silently.
+  3. SELECT remaining ready/todo tickets WHERE assignee IN {codex,
+     copilot, claude-code, gemini}
+  4. Sequence them via a frontier-LLM call (openclaw agent). The LLM
      returns: which to dispatch (in order), which to demote back to
      triage (with reason).
-  4. Dispatch top-N via lobster (background). Cap concurrency.
-  5. Demote any flagged-not-ready with `kanban-flow demote`.
-  6. Comment + audit each transition. Kanban remains source of truth.
+  5. Dispatch top-N via lobster (background). Cap concurrency.
+  6. Demote any flagged-not-ready with `kanban-flow demote`.
+  7. Comment + audit each transition. Kanban remains source of truth.
 
 Invocation:
   clawta-poller --once          one tick, print plan, exit
@@ -33,6 +35,7 @@ Configured via env:
   KANBAN_DB                 default: ~/.hermes/kanban/boards/chitin/kanban.db
   POLL_SEC                  default: 120
   TERMINAL_LANES            comma list, default: codex,copilot,claude-code,gemini
+  ROUTING_LANE              assignee for routing-level tickets, default: clawta
   CLAWTA_BIN                default: clawta (must be on PATH)
   KANBAN_FLOW_BIN           default: kanban-flow
 
@@ -67,6 +70,7 @@ TERMINAL_LANES = tuple(
         "TERMINAL_LANES", "codex,copilot,claude-code,gemini"
     ).split(",") if s.strip()
 )
+ROUTING_LANE = os.environ.get("ROUTING_LANE", "clawta")
 CLAWTA_BIN = os.environ.get("CLAWTA_BIN", "clawta")
 # Direct openclaw client for the sequencer LLM call. The `clawta` wrapper
 # has unanchored regex pattern detection — any prompt containing a
@@ -82,9 +86,15 @@ OPENCLAW_BIN = os.environ.get(
 )
 SEQUENCER_AGENT = os.environ.get("SEQUENCER_AGENT", "clawta")
 KANBAN_FLOW_BIN = os.environ.get("KANBAN_FLOW_BIN", "kanban-flow")
+DISPATCHABLE_STATUSES = ("ready", "todo")
 LOG_DIR = Path.home() / ".openclaw" / "logs"
 LOG_FILE = LOG_DIR / "clawta-poller.log"
 DISPATCH_TIMEOUT = int(os.environ.get("DISPATCH_TIMEOUT", "300"))
+PICK_DRIVER = Path.home() / ".openclaw" / "workflows" / "_pick_driver.py"
+INVARIANT_BIN = Path(os.environ.get(
+    "CLAWTA_INVARIANT_BIN",
+    str(Path.home() / "workspace/chitin/swarm/bin/clawta-invariants"),
+))
 AUTHOR = "clawta-poller"
 
 
@@ -99,50 +109,200 @@ def log(msg: str) -> None:
         pass
 
 
+
+# ---------------------------------------------------------------------------
+# Invariant repair — recover transient finalize failures before dispatching more
+# ---------------------------------------------------------------------------
+
+def run_invariant_repairs(dry_run: bool) -> dict[str, Any]:
+    if not INVARIANT_BIN.exists():
+        log(f"invariants: missing helper at {INVARIANT_BIN}; skipping")
+        return {"skipped": "missing-helper"}
+    cmd = [str(INVARIANT_BIN)]
+    if dry_run:
+        cmd.append("--dry-run")
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=90
+        )
+    except subprocess.TimeoutExpired:
+        log("invariants: timed out; skipping this tick")
+        return {"error": "timeout"}
+    if result.returncode != 0:
+        log(f"invariants: rc={result.returncode}; stderr={result.stderr[-300:]}")
+        return {"error": f"rc={result.returncode}"}
+    try:
+        parsed = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        log(f"invariants: non-json stdout={result.stdout[-300:]!r}")
+        return {"error": "non-json"}
+    repaired = parsed.get("repaired") or []
+    if repaired:
+        log(f"invariants: repaired {len(repaired)} ticket(s): {repaired}")
+    return parsed
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
 def fetch_ready_for_terminal_lanes() -> list[dict[str, Any]]:
-    """Return ready tickets whose assignee is a terminal lane."""
+    """Return ready/todo tickets whose assignee is a terminal lane.
+
+    Hermes' UI has historically used `todo` as the visible ready lane, while
+    clawta-poller originally selected only the internal `ready` status. Treat
+    both as dispatchable so Hermes/Ares promotions cannot strand work.
+    """
     placeholders = ",".join("?" * len(TERMINAL_LANES))
+    status_placeholders = ",".join("?" * len(DISPATCHABLE_STATUSES))
     with sqlite3.connect(str(DB_PATH)) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             f"""
             SELECT id, title, body, assignee, priority, created_at
               FROM tasks
-             WHERE status = 'ready'
+             WHERE status IN ({status_placeholders})
                AND assignee IN ({placeholders})
              ORDER BY priority DESC, created_at ASC
             """,
-            TERMINAL_LANES,
+            (*DISPATCHABLE_STATUSES, *TERMINAL_LANES),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def fetch_routable() -> list[dict[str, Any]]:
+    """Return ready/todo tickets assigned to the routing lane (clawta by default).
+
+    These tickets need their assignee resolved to a terminal lane via the
+    LLM router (/_pick_driver) before they can be dispatched. The poller
+    routes them and reassigns to the chosen terminal lane.
+    """
+    status_placeholders = ",".join("?" * len(DISPATCHABLE_STATUSES))
+    with sqlite3.connect(str(DB_PATH)) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            f"""
+            SELECT id, title, body, assignee, priority, created_at
+              FROM tasks
+             WHERE status IN ({status_placeholders})
+               AND assignee = ?
+             ORDER BY priority DESC, created_at ASC
+            """,
+            (*DISPATCHABLE_STATUSES, ROUTING_LANE),
         ).fetchall()
     return [dict(r) for r in rows]
 
 
 def fetch_ungroomed_ready() -> list[dict[str, Any]]:
-    """Return ready tickets that grooming missed — no assignee, or assignee
-    in a non-terminal lane the poller can't dispatch. Hermes is the groomer
-    and is supposed to attach a terminal-lane assignee when promoting
-    triage→ready; tickets that show up here bypassed that step (most often
-    because they were created directly with --status ready instead of going
-    through triage). Demoting them back to triage with a specific reason
-    keeps kanban honest about where work actually stands.
+    """Return ready/todo tickets that grooming missed — no assignee, or assignee
+    in a non-terminal, non-routing lane the poller can't dispatch.
+
+    Hermes is the groomer and is supposed to attach a terminal-lane assignee
+    (or the routing lane) when promoting triage→ready; tickets that show up
+    here bypassed that step (most often because they were created directly
+    with --status ready instead of going through triage). Demoting them back
+    to triage with a specific reason keeps kanban honest about where work
+    actually stands.
+
+    IMPORTANT: tickets assigned to the routing lane (clawta) are NOT
+    considered ungroomed — they go through route_ticket() instead.
     """
     placeholders = ",".join("?" * len(TERMINAL_LANES))
+    status_placeholders = ",".join("?" * len(DISPATCHABLE_STATUSES))
     with sqlite3.connect(str(DB_PATH)) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             f"""
             SELECT id, title, assignee, priority, created_at
               FROM tasks
-             WHERE status = 'ready'
+             WHERE status IN ({status_placeholders})
                AND (assignee IS NULL
                     OR assignee = ''
-                    OR assignee NOT IN ({placeholders}))
+                    OR (assignee NOT IN ({placeholders})
+                        AND assignee != ?))
              ORDER BY priority DESC, created_at ASC
             """,
-            TERMINAL_LANES,
+            (*DISPATCHABLE_STATUSES, *TERMINAL_LANES, ROUTING_LANE),
         ).fetchall()
     return [dict(r) for r in rows]
 
+
+# ---------------------------------------------------------------------------
+# Routing step — resolve clawta-assigned tickets to a terminal lane
+# ---------------------------------------------------------------------------
+
+def route_ticket(ticket: dict[str, Any], dry_run: bool) -> str | None:
+    """Route a clawta-assigned ticket through _pick_driver and reassign.
+
+    Returns the chosen terminal-lane assignee, or None on failure.
+    """
+    classify_json = json.dumps({
+        "complexity": "medium",
+        "capabilities": [],
+        "estimated_loc": 50,
+        "needs_frontier": False,
+    })
+    try:
+        result = subprocess.run(
+            [sys.executable, str(PICK_DRIVER)],
+            input=classify_json,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, "ROUTER_MODE": "llm"},
+        )
+        if result.returncode != 0:
+            log(f"route_ticket({ticket['id']}): _pick_driver rc={result.returncode}; skipping")
+            return None
+        pick = json.loads(result.stdout.strip())
+        driver = pick.get("driver")
+        if driver not in TERMINAL_LANES:
+            log(f"route_ticket({ticket['id']}): _pick_driver chose {driver!r}, not a terminal lane; skipping")
+            return None
+        reasoning = pick.get("reasoning", "no reasoning provided")
+        if dry_run:
+            log(f"[dry-run] would route {ticket['id']} -> {driver}: {reasoning[:80]}")
+            return driver
+        # Reassign in kanban
+        subprocess.run(
+            ["hermes", "kanban", "--board", "chitin", "assign",
+             ticket["id"], driver],
+            timeout=15,
+        )
+        subprocess.run(
+            ["hermes", "kanban", "--board", "chitin", "comment",
+             ticket["id"], "--author", AUTHOR,
+             f"Routed by clawta-poller: {ROUTING_LANE} -> {driver}. Reasoning: {reasoning}"],
+            timeout=15,
+        )
+        log(f"routed {ticket['id']} {ROUTING_LANE} -> {driver} ({reasoning[:60]})")
+        return driver
+    except Exception as e:
+        log(f"route_ticket({ticket['id']}): routing failed: {e}")
+        return None
+
+
+def route_clawta_assigned(dry_run: bool) -> list[str]:
+    """Route all clawta-assigned tickets through _pick_driver.
+
+    Returns list of ticket IDs that were successfully routed.
+    """
+    routable = fetch_routable()
+    if not routable:
+        return []
+    log(f"tick: {len(routable)} routing-lane ({ROUTING_LANE}) ticket(s) to resolve")
+    routed: list[str] = []
+    for t in routable:
+        driver = route_ticket(t, dry_run)
+        if driver:
+            routed.append(t["id"])
+        else:
+            log(f"tick: {t['id']} routing failed; leaving for next tick")
+    return routed
+
+
+# ---------------------------------------------------------------------------
+# Sequencer — ask LLM which tickets to dispatch and in what order
+# ---------------------------------------------------------------------------
 
 def sequence_with_llm(tickets: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Ask the frontier LLM how to sequence. Returns a list of action dicts.
@@ -257,6 +417,10 @@ Rules:
     return cleaned_dispatch + cleaned_demote
 
 
+# ---------------------------------------------------------------------------
+# Dispatch + demote actions
+# ---------------------------------------------------------------------------
+
 def dispatch_ticket(ticket_id: str, assignee: str, reason: str, dry_run: bool) -> bool:
     """Flip ready→in_progress, then spawn clawta dispatch in background."""
     if dry_run:
@@ -290,7 +454,7 @@ def dispatch_ticket(ticket_id: str, assignee: str, reason: str, dry_run: bool) -
     except FileNotFoundError as e:
         log(f"dispatch_ticket({ticket_id}): clawta binary not found: {e}")
         return False
-    log(f"dispatched {ticket_id} → {assignee} (log: {log_path})")
+    log(f"dispatched {ticket_id} -> {assignee} (log: {log_path})")
     return True
 
 
@@ -311,13 +475,17 @@ def demote_ticket(ticket_id: str, reason: str, dry_run: bool) -> bool:
 
 
 def demote_ungroomed(dry_run: bool) -> list[str]:
-    """Demote any ready ticket whose assignee isn't a terminal lane.
+    """Demote any ready/todo ticket whose assignee isn't a terminal lane
+    and isn't the routing lane.
 
-    Hermes is the groomer; clawta is the enforcer. A ticket in `ready` with
-    no terminal-lane assignee is a grooming-step output we can't act on, so
-    we surface the gap by sending it back to triage with a comment that
-    names the exact missing piece. This is loud-by-design — better a noisy
-    triage backlog than tickets silently aging in `ready`.
+    Hermes is the groomer; clawta is the enforcer. A ticket in `ready` or
+    `todo` with no dispatchable assignee is a grooming-step output we can't
+    act on, so we surface the gap by sending it back to triage with a comment
+    that names the exact missing piece. This is loud-by-design — better a
+    noisy triage backlog than tickets silently aging in `ready`.
+
+    Tickets assigned to the routing lane (clawta) are NOT demoted — they
+    go through route_clawta_assigned() instead.
     """
     ungroomed = fetch_ungroomed_ready()
     if not ungroomed:
@@ -330,7 +498,8 @@ def demote_ungroomed(dry_run: bool) -> list[str]:
         if not t["assignee"]:
             reason = (
                 f"missing assignee — grooming step must route to a terminal "
-                f"lane ({lanes}) before clawta-poller can dispatch"
+                f"lane ({lanes}) or the routing lane ({ROUTING_LANE}) before "
+                f"clawta-poller can dispatch"
             )
         else:
             reason = (
@@ -342,13 +511,25 @@ def demote_ungroomed(dry_run: bool) -> list[str]:
     return demoted
 
 
+# ---------------------------------------------------------------------------
+# Main tick loop
+# ---------------------------------------------------------------------------
+
 def tick(max_dispatch: int, dry_run: bool) -> dict[str, Any]:
+    # Step 0: Self-heal safe board/finalize invariants before starting new work
+    invariants = run_invariant_repairs(dry_run)
+
+    # Step 1: Route clawta-assigned tickets through _pick_driver
+    routed = route_clawta_assigned(dry_run)
+
+    # Step 2: Demote ungroomed tickets (no assignee or non-dispatchable)
     ungroomed_demoted = demote_ungroomed(dry_run)
 
+    # Step 3: Fetch tickets ready for dispatch (terminal-lane assigned)
     queue = fetch_ready_for_terminal_lanes()
     if not queue:
         log(f"tick: empty queue (terminal lanes: {','.join(TERMINAL_LANES)})")
-        return {"dispatched": [], "demoted": ungroomed_demoted, "queue_size": 0}
+        return {"dispatched": [], "demoted": ungroomed_demoted, "routed": routed, "invariants": invariants, "queue_size": 0}
 
     log(f"tick: {len(queue)} ready tickets in terminal lanes")
     plan = sequence_with_llm(queue)
@@ -370,7 +551,7 @@ def tick(max_dispatch: int, dry_run: bool) -> dict[str, Any]:
             if demote_ticket(tid, action["reason"], dry_run):
                 demoted.append(tid)
 
-    return {"dispatched": dispatched, "demoted": demoted, "queue_size": len(queue)}
+    return {"dispatched": dispatched, "demoted": demoted, "routed": routed, "invariants": invariants, "queue_size": len(queue)}
 
 
 def main() -> int:
@@ -397,7 +578,7 @@ def main() -> int:
         return 0
 
     if args.loop:
-        log(f"loop start (poll_sec={POLL_SEC}, lanes={','.join(TERMINAL_LANES)})")
+        log(f"loop start (poll_sec={POLL_SEC}, lanes={','.join(TERMINAL_LANES)}, routing_lane={ROUTING_LANE})")
         while True:
             try:
                 tick(args.max_dispatch, dry_run=False)

--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -230,18 +230,68 @@ def fetch_ungroomed_ready() -> list[dict[str, Any]]:
 # Routing step — resolve clawta-assigned tickets to a terminal lane
 # ---------------------------------------------------------------------------
 
+def classify_ticket_for_routing(ticket: dict[str, Any]) -> str:
+    """Classify a routing-lane ticket before passing it to _pick_driver.
+
+    _pick_driver expects a compact classification JSON object. Do not feed it
+    a hard-coded default: that erases the ticket's actual language/scope needs
+    and routes everything as generic medium work.
+    """
+    prompt = f"""Classify this Chitin kanban ticket for worker routing.
+Reply with ONLY a JSON object (no prose, no markdown fences):
+{{
+  "complexity": "low" | "med" | "high",
+  "capabilities": ["go" | "ts" | "python" | "refactor" | "debug" | "review"],
+  "estimated_loc": <integer>,
+  "needs_frontier": <true|false>
+}}
+
+Ticket JSON:
+{json.dumps(ticket, indent=2)}
+"""
+    result = subprocess.run(
+        [OPENCLAW_BIN, "agent", "--agent", SEQUENCER_AGENT, "--message", prompt],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"classification failed rc={result.returncode}: {result.stderr[-300:]}")
+    body = result.stdout or ""
+    match = re.search(r"\{.*\}", body, re.DOTALL)
+    if not match:
+        raise RuntimeError(f"classification returned no JSON: {body[:200]!r}")
+    parsed = json.loads(match.group(0))
+    # Normalize/validate the shape before routing.
+    complexity = str(parsed.get("complexity", "med")).lower()
+    if complexity == "medium":
+        complexity = "med"
+    if complexity not in ("low", "med", "high"):
+        complexity = "med"
+    caps = parsed.get("capabilities")
+    if not isinstance(caps, list):
+        caps = []
+    caps = [str(c) for c in caps if str(c) in {"go", "ts", "python", "refactor", "debug", "review"}]
+    try:
+        estimated_loc = int(parsed.get("estimated_loc", 50))
+    except (TypeError, ValueError):
+        estimated_loc = 50
+    needs_frontier = bool(parsed.get("needs_frontier", complexity == "high"))
+    return json.dumps({
+        "complexity": complexity,
+        "capabilities": caps,
+        "estimated_loc": max(1, estimated_loc),
+        "needs_frontier": needs_frontier,
+    })
+
+
 def route_ticket(ticket: dict[str, Any], dry_run: bool) -> str | None:
     """Route a clawta-assigned ticket through _pick_driver and reassign.
 
     Returns the chosen terminal-lane assignee, or None on failure.
     """
-    classify_json = json.dumps({
-        "complexity": "medium",
-        "capabilities": [],
-        "estimated_loc": 50,
-        "needs_frontier": False,
-    })
     try:
+        classify_json = classify_ticket_for_routing(ticket)
         result = subprocess.run(
             [sys.executable, str(PICK_DRIVER)],
             input=classify_json,

--- a/swarm/bin/clawta-pr-reviewer
+++ b/swarm/bin/clawta-pr-reviewer
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""clawta-pr-reviewer — comment-once automated reviews for swarm PRs.
+
+The script is intentionally conservative:
+- only reviews open PRs whose head branch starts with an allowed prefix
+- skips PRs that already contain the marker in an issue comment
+- posts a single summary comment, not line comments
+- limits how many PRs it handles per run
+
+It is suitable for cron: repeated runs are idempotent because of the marker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+from typing import Any
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "chitinhq/chitin")
+OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", str(Path.home() / ".vite-plus/bin/openclaw"))
+REVIEW_AGENT = os.environ.get("CLAWTA_REVIEW_AGENT", "clawta")
+MARKER = "<!-- clawta-reviewer:v1 -->"
+LOG_DIR = Path.home() / ".openclaw" / "logs"
+LOG_FILE = LOG_DIR / "clawta-pr-reviewer.log"
+DEFAULT_PREFIXES = ("swarm/", "clawta/")
+MAX_DIFF_CHARS = int(os.environ.get("CLAWTA_REVIEW_MAX_DIFF_CHARS", "45000"))
+MAX_META_CHARS = 12000
+
+
+def log(msg: str) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}"
+    print(line, file=sys.stderr)
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+
+
+def run(cmd: list[str], *, timeout: int = 60, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, input=input_text, capture_output=True, timeout=timeout)
+
+
+def gh_json(cmd: list[str], *, timeout: int = 60) -> Any:
+    out = run(cmd, timeout=timeout)
+    if out.returncode != 0:
+        raise RuntimeError(f"command failed: {' '.join(cmd)}\n{out.stderr[-800:]}")
+    return json.loads(out.stdout or "null")
+
+
+def list_candidate_prs(prefixes: tuple[str, ...]) -> list[dict[str, Any]]:
+    prs = gh_json([
+        "gh", "pr", "list", "--repo", REPO, "--state", "open",
+        "--json", "number,title,headRefName,author,url,isDraft,updatedAt",
+        "--limit", "100",
+    ])
+    return [p for p in prs if any(str(p.get("headRefName", "")).startswith(prefix) for prefix in prefixes)]
+
+
+def has_marker(pr_number: int) -> bool:
+    comments = gh_json([
+        "gh", "api", f"repos/{REPO}/issues/{pr_number}/comments",
+        "--jq", ".[].body",
+    ])
+    if isinstance(comments, str):
+        return MARKER in comments
+    return MARKER in json.dumps(comments)
+
+
+def fetch_pr_context(pr_number: int) -> tuple[dict[str, Any], str]:
+    meta = gh_json([
+        "gh", "pr", "view", str(pr_number), "--repo", REPO,
+        "--json", "number,title,body,headRefName,baseRefName,author,additions,deletions,changedFiles,files,url",
+    ])
+    diff_out = run(["gh", "pr", "diff", str(pr_number), "--repo", REPO, "--patch"], timeout=120)
+    if diff_out.returncode != 0:
+        raise RuntimeError(f"gh pr diff failed for #{pr_number}: {diff_out.stderr[-800:]}")
+    diff = diff_out.stdout
+    if len(diff) > MAX_DIFF_CHARS:
+        diff = diff[:MAX_DIFF_CHARS] + "\n\n[diff truncated by clawta-pr-reviewer]"
+    return meta, diff
+
+
+def build_prompt(meta: dict[str, Any], diff: str) -> str:
+    meta_json = json.dumps(meta, indent=2)[:MAX_META_CHARS]
+    return f"""You are Clawta acting as an automated senior code reviewer for the Chitin swarm.
+Review this GitHub PR using the metadata and diff below.
+
+Output a concise GitHub comment in Markdown. Do not use tables.
+Use this exact structure:
+
+**Clawta automated review**
+
+**Verdict:** APPROVE | REQUEST_CHANGES | COMMENT
+
+**Summary**
+- ...
+
+**Findings**
+- Severity: high|medium|low — file/path or area — actionable finding
+- If no issues, write: No blocking issues found.
+
+**Validation notes**
+- Mention tests/checks you infer should run, and any gaps.
+
+Rules:
+- Be specific. Cite files/functions when possible.
+- Do not invent files not present in the diff.
+- If the diff is truncated, say coverage is partial.
+- Prefer COMMENT unless there is a clear correctness/security/test blocker.
+
+# PR metadata
+```json
+{meta_json}
+```
+
+# Diff
+```diff
+{diff}
+```
+"""
+
+
+def generate_review(meta: dict[str, Any], diff: str) -> str:
+    prompt = build_prompt(meta, diff)
+    out = run([OPENCLAW_BIN, "agent", "--agent", REVIEW_AGENT, "--message", prompt], timeout=300)
+    if out.returncode != 0:
+        raise RuntimeError(f"openclaw review failed: {out.stderr[-1000:]} {out.stdout[-1000:]}")
+    body = out.stdout.strip()
+    # Strip accidental JSON-ish wrapper from CLI modes if present, best effort.
+    if body.startswith("{"):
+        try:
+            parsed = json.loads(body)
+            body = str(parsed.get("message") or parsed.get("text") or parsed.get("output") or body)
+        except json.JSONDecodeError:
+            pass
+    return body
+
+
+def post_comment(pr_number: int, review: str, dry_run: bool) -> None:
+    body = f"{MARKER}\n{review.strip()}"
+    if dry_run:
+        print(f"--- DRY RUN PR #{pr_number} COMMENT ---\n{body}\n")
+        return
+    out = run(["gh", "pr", "comment", str(pr_number), "--repo", REPO, "--body", body], timeout=60)
+    if out.returncode != 0:
+        raise RuntimeError(f"gh pr comment failed for #{pr_number}: {out.stderr[-800:]}")
+
+
+def review_once(prefixes: tuple[str, ...], max_prs: int, dry_run: bool, include_drafts: bool) -> dict[str, Any]:
+    reviewed: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+    candidates = list_candidate_prs(prefixes)
+    for pr in candidates:
+        if len(reviewed) >= max_prs:
+            break
+        n = int(pr["number"])
+        if pr.get("isDraft") and not include_drafts:
+            skipped.append({"pr": str(n), "reason": "draft"})
+            continue
+        try:
+            if has_marker(n):
+                skipped.append({"pr": str(n), "reason": "already-reviewed"})
+                continue
+            meta, diff = fetch_pr_context(n)
+            review = generate_review(meta, diff)
+            post_comment(n, review, dry_run)
+            reviewed.append({"pr": str(n), "url": pr.get("url", "")})
+            log(f"reviewed PR #{n} {pr.get('headRefName')}")
+        except Exception as e:
+            skipped.append({"pr": str(n), "reason": f"error: {e}"[:300]})
+            log(f"PR #{n}: review failed: {e}")
+    return {"reviewed": reviewed, "skipped": skipped, "candidate_count": len(candidates)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--max-prs", type=int, default=2)
+    ap.add_argument("--prefix", action="append", help="head branch prefix to review; repeatable")
+    ap.add_argument("--include-drafts", action="store_true")
+    args = ap.parse_args()
+    prefixes = tuple(args.prefix or DEFAULT_PREFIXES)
+    result = review_once(prefixes, max(args.max_prs, 0), args.dry_run, args.include_drafts)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swarm/bin/clawta-pr-reviewer
+++ b/swarm/bin/clawta-pr-reviewer
@@ -68,11 +68,10 @@ def list_candidate_prs(prefixes: tuple[str, ...]) -> list[dict[str, Any]]:
 def has_marker(pr_number: int) -> bool:
     comments = gh_json([
         "gh", "api", f"repos/{REPO}/issues/{pr_number}/comments",
-        "--jq", ".[].body",
     ])
-    if isinstance(comments, str):
-        return MARKER in comments
-    return MARKER in json.dumps(comments)
+    if not isinstance(comments, list):
+        return False
+    return any(MARKER in str(comment.get("body", "")) for comment in comments if isinstance(comment, dict))
 
 
 def fetch_pr_context(pr_number: int) -> tuple[dict[str, Any], str]:


### PR DESCRIPTION
## Summary\n- add clawta-invariants helper to recover blocked tickets when a PR exists or PR creation can be retried\n- run invariant repairs at the start of clawta-poller ticks\n- treat Hermes todo lane as dispatchable alongside ready and let kanban-flow start/demote todo tickets\n\n## Validation\n- python3 -m py_compile swarm/bin/clawta-invariants swarm/bin/clawta-poller\n- bash -n scripts/kanban-flow\n- swarm/bin/clawta-invariants --dry-run\n- swarm/bin/clawta-poller --dry-run --max-dispatch 2\n- swarm/bin/clawta-poller --once --max-dispatch 2\n\n## Live repair evidence\n- repaired t_917e2aaf from blocked to in_progress with PR https://github.com/chitinhq/chitin/pull/539\n- repaired t_33dd70f7 from blocked to in_progress with PR https://github.com/chitinhq/chitin/pull/536\n- left t_2f7fffab blocked because PR retry failed: no commits between main and swarm/copilot-2f7fffab