### PR TITLE
swarm: dispatch fix workers for PR review findings

### DIFF
--- a/swarm/bin/clawta-pr-fix-dispatcher
+++ b/swarm/bin/clawta-pr-fix-dispatcher
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""clawta-pr-fix-dispatcher — dispatch workers to address Clawta PR review comments.
+
+This is the next loop after `clawta-pr-reviewer`:
+- find open swarm/clawta PRs with a Clawta reviewer marker
+- parse verdict/findings
+- for REQUEST_CHANGES, dispatch a codex fix worker on the PR head branch
+- mark the PR with a one-shot dispatcher marker so repeated cron runs do not
+  spawn duplicate fix workers
+
+The worker runs in a dedicated worktree for the PR branch and is instructed to
+commit + push fixes to that same PR branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "chitinhq/chitin")
+BASE_REPO = Path(os.environ.get("CHITIN_REPO", str(Path.home() / "workspace/chitin")))
+WORKTREE_ROOT = Path(os.environ.get("CLAWTA_PR_FIX_WORKTREES", str(Path.home() / ".cache/chitin/pr-fix-worktrees")))
+LOG_DIR = Path.home() / ".openclaw" / "logs"
+LOG_FILE = LOG_DIR / "clawta-pr-fix-dispatcher.log"
+REVIEW_MARKER = "<!-- clawta-reviewer:v1 -->"
+DISPATCH_MARKER = "<!-- clawta-fix-dispatcher:v1 -->"
+DEFAULT_PREFIXES = ("swarm/", "clawta/")
+CODEX_MODEL = os.environ.get("CLAWTA_FIX_CODEX_MODEL", "gpt-5.5")
+
+VERDICT_RE = re.compile(r"\*\*Verdict:\*\*\s*(APPROVE|REQUEST_CHANGES|COMMENT)", re.I)
+
+
+def log(msg: str) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}"
+    print(line, file=sys.stderr)
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+
+
+def run(cmd: list[str], *, cwd: Path = BASE_REPO, timeout: int = 60, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), text=True, capture_output=True, timeout=timeout, check=check)
+
+
+def gh_json(cmd: list[str], *, timeout: int = 60) -> Any:
+    out = run(cmd, timeout=timeout)
+    if out.returncode != 0:
+        raise RuntimeError(f"command failed: {' '.join(cmd)}\n{out.stderr[-800:]}")
+    return json.loads(out.stdout or "null")
+
+
+def list_candidate_prs(prefixes: tuple[str, ...]) -> list[dict[str, Any]]:
+    prs = gh_json([
+        "gh", "pr", "list", "--repo", REPO, "--state", "open",
+        "--json", "number,title,headRefName,url,isDraft,updatedAt",
+        "--limit", "100",
+    ])
+    return [p for p in prs if any(str(p.get("headRefName", "")).startswith(prefix) for prefix in prefixes)]
+
+
+def comments(pr_number: int) -> list[dict[str, Any]]:
+    data = gh_json(["gh", "api", f"repos/{REPO}/issues/{pr_number}/comments"], timeout=60)
+    return data if isinstance(data, list) else []
+
+
+def latest_review_comment(comments_: list[dict[str, Any]]) -> str | None:
+    bodies = [str(c.get("body", "")) for c in comments_ if REVIEW_MARKER in str(c.get("body", ""))]
+    return bodies[-1] if bodies else None
+
+
+def already_dispatched(comments_: list[dict[str, Any]]) -> bool:
+    return any(DISPATCH_MARKER in str(c.get("body", "")) for c in comments_)
+
+
+def verdict(review_body: str) -> str:
+    m = VERDICT_RE.search(review_body)
+    return (m.group(1).upper() if m else "COMMENT")
+
+
+def needs_fix(review_body: str) -> bool:
+    v = verdict(review_body)
+    if v == "REQUEST_CHANGES":
+        return True
+    # Optional future expansion: COMMENT with actionable severity. Keep v1
+    # conservative so approving/comment-only reviews do not spawn workers.
+    return False
+
+
+
+def existing_worktree_for_branch(branch: str) -> Path | None:
+    out = run(["git", "worktree", "list", "--porcelain"], timeout=30)
+    if out.returncode != 0:
+        return None
+    current_path: Path | None = None
+    for line in out.stdout.splitlines():
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree "))
+        elif line == f"branch refs/heads/{branch}" and current_path is not None:
+            return current_path
+    return None
+
+def ensure_worktree(branch: str, pr_number: int) -> Path:
+    WORKTREE_ROOT.mkdir(parents=True, exist_ok=True)
+    existing = existing_worktree_for_branch(branch)
+    if existing is not None and existing.exists():
+        run(["git", "fetch", "origin", branch], timeout=120)
+        pull = run(["git", "pull", "--ff-only"], cwd=existing, timeout=120)
+        if pull.returncode != 0:
+            log(f"{branch}: existing worktree pull failed; continuing with current checkout: {pull.stderr[-300:]}")
+        return existing
+    wt = WORKTREE_ROOT / f"pr-{pr_number}"
+    if wt.exists():
+        run(["git", "fetch", "origin", branch], timeout=120)
+        run(["git", "checkout", branch], cwd=wt, timeout=60)
+        run(["git", "pull", "--ff-only"], cwd=wt, timeout=120)
+        return wt
+    run(["git", "fetch", "origin", branch], timeout=120, check=True)
+    run(["git", "worktree", "add", str(wt), branch], timeout=120, check=True)
+    return wt
+
+
+def build_prompt(pr: dict[str, Any], review_body: str) -> str:
+    return f"""You are a Chitin swarm fix worker addressing automated PR review comments.
+
+PR: #{pr['number']} {pr['title']}
+Branch: {pr['headRefName']}
+URL: {pr['url']}
+
+Task:
+- Address the Clawta automated review findings below.
+- Make the smallest correct code/docs/test changes on the current branch.
+- Run the most relevant validation you can afford.
+- Commit your changes with a clear message.
+- Push to origin {pr['headRefName']} so the existing PR updates.
+- If the review finding is invalid, add a short markdown note under `tmp/pr-{pr['number']}-review-response.md`, commit it, and explain why.
+
+Review comment:
+{review_body}
+"""
+
+
+def dispatch_worker(pr: dict[str, Any], review_body: str, dry_run: bool) -> str:
+    branch = str(pr["headRefName"])
+    pr_number = int(pr["number"])
+    wt = WORKTREE_ROOT / f"pr-{pr_number}"
+    log_path = LOG_DIR / f"pr-fix-{pr_number}.log"
+    prompt = build_prompt(pr, review_body)
+
+    if dry_run:
+        log(f"[dry-run] would dispatch codex fix worker for PR #{pr_number} branch {branch} worktree {wt}")
+        return str(log_path)
+
+    wt = ensure_worktree(branch, pr_number)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as out:
+        proc = subprocess.Popen(
+            ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--model", CODEX_MODEL, prompt],
+            cwd=str(wt),
+            stdout=out,
+            stderr=out,
+            start_new_session=True,
+        )
+    log(f"dispatched codex fix worker for PR #{pr_number} pid={proc.pid} log={log_path}")
+    return str(log_path)
+
+
+def mark_dispatched(pr: dict[str, Any], log_path: str, dry_run: bool) -> None:
+    body = f"{DISPATCH_MARKER}\n🦞 Dispatched codex fix worker for PR #{pr['number']} review findings. Log: `{log_path}`"
+    if dry_run:
+        print(f"--- DRY RUN DISPATCH MARKER PR #{pr['number']} ---\n{body}\n")
+        return
+    out = run(["gh", "pr", "comment", str(pr["number"]), "--repo", REPO, "--body", body], timeout=60)
+    if out.returncode != 0:
+        raise RuntimeError(f"failed to comment dispatch marker on PR #{pr['number']}: {out.stderr[-500:]}")
+
+
+def dispatch_once(prefixes: tuple[str, ...], max_prs: int, dry_run: bool) -> dict[str, Any]:
+    dispatched: list[dict[str, str]] = []
+    skipped: list[dict[str, str]] = []
+    for pr in list_candidate_prs(prefixes):
+        if len(dispatched) >= max_prs:
+            break
+        n = str(pr["number"])
+        try:
+            cs = comments(int(pr["number"]))
+            if already_dispatched(cs):
+                skipped.append({"pr": n, "reason": "already-dispatched"})
+                continue
+            review = latest_review_comment(cs)
+            if not review:
+                skipped.append({"pr": n, "reason": "no-clawta-review"})
+                continue
+            if not needs_fix(review):
+                skipped.append({"pr": n, "reason": f"verdict-{verdict(review).lower()}"})
+                continue
+            log_path = dispatch_worker(pr, review, dry_run)
+            mark_dispatched(pr, log_path, dry_run)
+            dispatched.append({"pr": n, "branch": pr["headRefName"], "log": log_path})
+        except Exception as e:
+            skipped.append({"pr": n, "reason": f"error: {e}"[:300]})
+            log(f"PR #{n}: fix dispatch failed: {e}")
+    return {"dispatched": dispatched, "skipped": skipped}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--max-prs", type=int, default=1)
+    ap.add_argument("--prefix", action="append")
+    args = ap.parse_args()
+    result = dispatch_once(tuple(args.prefix or DEFAULT_PREFIXES), max(args.max_prs, 0), args.dry_run)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swarm/bin/clawta-pr-fix-dispatcher
+++ b/swarm/bin/clawta-pr-fix-dispatcher
@@ -29,10 +29,15 @@ BASE_REPO = Path(os.environ.get("CHITIN_REPO", str(Path.home() / "workspace/chit
 WORKTREE_ROOT = Path(os.environ.get("CLAWTA_PR_FIX_WORKTREES", str(Path.home() / ".cache/chitin/pr-fix-worktrees")))
 LOG_DIR = Path.home() / ".openclaw" / "logs"
 LOG_FILE = LOG_DIR / "clawta-pr-fix-dispatcher.log"
-REVIEW_MARKER = "<!-- clawta-reviewer:v1 -->"
+REVIEW_MARKER_RE = re.compile(r"<!--\s*clawta-reviewer:v1(?:\s+head=[0-9a-f]+)?\s*-->")
 DISPATCH_MARKER = "<!-- clawta-fix-dispatcher:v1 -->"
 DEFAULT_PREFIXES = ("swarm/", "clawta/")
 CODEX_MODEL = os.environ.get("CLAWTA_FIX_CODEX_MODEL", "gpt-5.5")
+TRUSTED_REVIEW_AUTHORS = tuple(
+    author.strip()
+    for author in os.environ.get("CLAWTA_REVIEWER_TRUSTED_AUTHORS", "jpleva91").split(",")
+    if author.strip()
+)
 
 VERDICT_RE = re.compile(r"\*\*Verdict:\*\*\s*(APPROVE|REQUEST_CHANGES|COMMENT)", re.I)
 
@@ -73,8 +78,22 @@ def comments(pr_number: int) -> list[dict[str, Any]]:
     return data if isinstance(data, list) else []
 
 
+def comment_author(comment: dict[str, Any]) -> str:
+    user = comment.get("user")
+    if isinstance(user, dict):
+        return str(user.get("login") or "")
+    return ""
+
+
+def is_trusted_review_comment(comment: dict[str, Any]) -> bool:
+    body = str(comment.get("body", ""))
+    if not REVIEW_MARKER_RE.search(body):
+        return False
+    return comment_author(comment) in TRUSTED_REVIEW_AUTHORS
+
+
 def latest_review_comment(comments_: list[dict[str, Any]]) -> str | None:
-    bodies = [str(c.get("body", "")) for c in comments_ if REVIEW_MARKER in str(c.get("body", ""))]
+    bodies = [str(c.get("body", "")) for c in comments_ if is_trusted_review_comment(c)]
     return bodies[-1] if bodies else None
 
 
@@ -120,12 +139,11 @@ def ensure_worktree(branch: str, pr_number: int) -> Path:
         return existing
     wt = WORKTREE_ROOT / f"pr-{pr_number}"
     if wt.exists():
-        run(["git", "fetch", "origin", branch], timeout=120)
-        run(["git", "checkout", branch], cwd=wt, timeout=60)
-        run(["git", "pull", "--ff-only"], cwd=wt, timeout=120)
+        run(["git", "fetch", "origin", branch], timeout=120, check=True)
+        run(["git", "checkout", "-B", branch, f"origin/{branch}"], cwd=wt, timeout=60, check=True)
         return wt
-    run(["git", "fetch", "origin", branch], timeout=120, check=True)
-    run(["git", "worktree", "add", str(wt), branch], timeout=120, check=True)
+    run(["git", "fetch", "origin", f"{branch}:refs/remotes/origin/{branch}"], timeout=120, check=True)
+    run(["git", "worktree", "add", "-B", branch, str(wt), f"origin/{branch}"], timeout=120, check=True)
     return wt
 
 

--- a/swarm/tests/test_clawta_pr_fix_dispatcher.py
+++ b/swarm/tests/test_clawta_pr_fix_dispatcher.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Unit tests for clawta-pr-fix-dispatcher helper logic."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "bin" / "clawta-pr-fix-dispatcher"
+
+
+def load_module():
+    loader = importlib.machinery.SourceFileLoader("clawta_pr_fix_dispatcher", str(SCRIPT))
+    spec = importlib.util.spec_from_loader("clawta_pr_fix_dispatcher", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class FixDispatcherTests(unittest.TestCase):
+    def test_latest_review_comment_ignores_untrusted_marker_author(self):
+        module = load_module()
+        untrusted = {
+            "user": {"login": "random-contributor"},
+            "body": "<!-- clawta-reviewer:v1 head=badc0ffee -->\n**Verdict:** REQUEST_CHANGES",
+        }
+        trusted = {
+            "user": {"login": "jpleva91"},
+            "body": "<!-- clawta-reviewer:v1 head=abc123 -->\n**Verdict:** REQUEST_CHANGES",
+        }
+
+        self.assertIsNone(module.latest_review_comment([untrusted]))
+        self.assertEqual(module.latest_review_comment([untrusted, trusted]), trusted["body"])
+
+    def test_ensure_worktree_creates_local_branch_from_remote_branch(self):
+        module = load_module()
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            module.WORKTREE_ROOT = Path(tmp)
+            with mock.patch.object(module, "existing_worktree_for_branch", return_value=None), mock.patch.object(module, "run", side_effect=fake_run):
+                wt = module.ensure_worktree("clawta/pr-fix-dispatcher-v2", 542)
+
+        self.assertEqual(wt.name, "pr-542")
+        self.assertIn(
+            [
+                "git",
+                "fetch",
+                "origin",
+                "clawta/pr-fix-dispatcher-v2:refs/remotes/origin/clawta/pr-fix-dispatcher-v2",
+            ],
+            calls,
+        )
+        self.assertIn(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-B",
+                "clawta/pr-fix-dispatcher-v2",
+                str(wt),
+                "origin/clawta/pr-fix-dispatcher-v2",
+            ],
+            calls,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add clawta-pr-fix-dispatcher to parse Clawta reviewer comments and dispatch codex fix workers for REQUEST_CHANGES findings
- prevent duplicate fix dispatches with a PR comment marker
- reuse existing PR branch worktrees when the branch is already checked out

## Validation
- python3 -m py_compile swarm/bin/clawta-pr-fix-dispatcher
- ./swarm/bin/clawta-pr-fix-dispatcher --dry-run --max-prs 1
- live dispatch for PR #536 created marker and started codex fix worker

## Safety note
I accidentally committed the first version to main, immediately preserved it, reverted main, and reopened it properly from this branch.

Kanban: t_11a01c1d

