### PR TITLE
feat(swarm-sdlc): daily swarm-audit cron — operator-controlled overnight watcher

### DIFF
--- a/swarm/bin/install-swarm-audit.sh
+++ b/swarm/bin/install-swarm-audit.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# install-swarm-audit.sh — wire the daily swarm audit into systemd user.
+#
+# Idempotent: re-runs are safe and just refresh the unit files + symlink.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LOCAL_BIN="$HOME/.local/bin"
+SYSD="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+ENV_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/chitin"
+ENV_FILE="$ENV_DIR/swarm-audit.env"
+
+mkdir -p "$LOCAL_BIN" "$SYSD" "$ENV_DIR"
+
+ln -sfn "$REPO_ROOT/swarm/bin/swarm-audit" "$LOCAL_BIN/swarm-audit"
+echo "linked: $LOCAL_BIN/swarm-audit → $REPO_ROOT/swarm/bin/swarm-audit"
+
+install -m 0644 "$REPO_ROOT/swarm/systemd/swarm-audit.service" "$SYSD/swarm-audit.service"
+install -m 0644 "$REPO_ROOT/swarm/systemd/swarm-audit.timer"   "$SYSD/swarm-audit.timer"
+
+# Bootstrap env file template if it doesn't exist yet. Operator fills in
+# the Discord channel id (or removes the file to keep delivery local).
+if [[ ! -f "$ENV_FILE" ]]; then
+  cat > "$ENV_FILE" <<'ENV'
+# Daily swarm-audit configuration. Edit and save; changes pick up on
+# next timer fire.
+
+# Discord channel id to post the summary to. Leave commented to print to
+# the service journal instead of Discord (useful for first-run sanity).
+# SWARM_AUDIT_DISCORD_CHANNEL=1503...
+
+# Which openclaw agent runs the summarization step. clawta gives you
+# gpt-5.5 reasoning today; main is gpt-5.4. Leave unset for default.
+# SWARM_AUDIT_AGENT=clawta
+
+# Override the audit window (in hours). Default 24.
+# SWARM_AUDIT_HOURS=24
+ENV
+  echo "created env template: $ENV_FILE"
+fi
+
+systemctl --user daemon-reload
+systemctl --user enable --now swarm-audit.timer
+
+echo ""
+echo "swarm-audit.timer enabled (next fire: daily 08:00 America/Detroit)."
+echo "  status:    systemctl --user status swarm-audit.timer"
+echo "  fire now:  systemctl --user start swarm-audit.service"
+echo "  journal:   journalctl --user -u swarm-audit.service -n 50 --no-pager"
+echo "  config:    $ENV_FILE"

--- a/swarm/bin/swarm-audit
+++ b/swarm/bin/swarm-audit
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""swarm-audit — operator-controlled daily audit of the chitin swarm.
+
+Reads the previous 24h of:
+  - chain ledger (~/.chitin/gov-decisions-*.jsonl) — denials, unknown
+    actions, governance gaps
+  - kanban (~/.hermes/kanban/.../kanban.db) — stale in_progress,
+    grooming-gap demotes, completions
+  - GitHub PRs — opened, merged, with review state
+  - Clawta autonomous activity — cron run history, invariants repairs,
+    PR-reviewer comments, direct-to-main commits
+
+Composes a structured facts blob, prompts a frontier model via openclaw
+to summarize into AT MOST 5 actionable bullets each tagged
+[fix-now]/[verify]/[watch]/[ok], and posts via Discord if a channel is
+configured.
+
+Intended for cron — run daily ~8am ET before the operator's day starts.
+
+Env:
+  SWARM_AUDIT_DISCORD_CHANNEL  Discord channel id to post the summary
+                               (omit to print to stdout only)
+  SWARM_AUDIT_AGENT            openclaw agent to call (default: clawta)
+  KANBAN_DB                    kanban sqlite path
+  CHITIN_LEDGER_DIR            ~/.chitin/ override
+  GITHUB_REPOSITORY            default: chitinhq/chitin
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any
+
+DB_PATH = Path(
+    os.environ.get(
+        "KANBAN_DB",
+        str(Path.home() / ".hermes/kanban/boards/chitin/kanban.db"),
+    )
+)
+LEDGER_DIR = Path(os.environ.get("CHITIN_LEDGER_DIR", str(Path.home() / ".chitin")))
+REPO = os.environ.get("GITHUB_REPOSITORY", "chitinhq/chitin")
+DISCORD_CHANNEL = os.environ.get("SWARM_AUDIT_DISCORD_CHANNEL", "")
+AGENT = os.environ.get("SWARM_AUDIT_AGENT", "clawta")
+OPENCLAW_BIN = os.environ.get(
+    "OPENCLAW_BIN", str(Path.home() / ".vite-plus/bin/openclaw")
+)
+LOG_DIR = Path.home() / ".openclaw" / "logs"
+LOG_FILE = LOG_DIR / "swarm-audit.log"
+
+
+def log(msg: str) -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}"
+    print(line, file=sys.stderr)
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+
+
+def iter_ledger_rows_since(cutoff_iso: str):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    for date in (yesterday, today):
+        p = LEDGER_DIR / f"gov-decisions-{date}.jsonl"
+        if not p.exists():
+            continue
+        with p.open() as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                    if row.get("ts", "") >= cutoff_iso:
+                        yield row
+                except json.JSONDecodeError:
+                    continue
+
+
+def gather_chain_facts(cutoff_iso: str) -> dict[str, Any]:
+    denial_buckets: Counter[tuple[str, str, str]] = Counter()
+    unknown_actions: Counter[str] = Counter()
+    protected_branch_writes: list[dict[str, str]] = []
+    clawta_spawn_count = 0
+    total_rows = 0
+
+    for row in iter_ledger_rows_since(cutoff_iso):
+        total_rows += 1
+        agent = row.get("agent", "-")
+        action = row.get("action_type", "-")
+        target = row.get("action_target", "") or ""
+        allowed = row.get("allowed", True)
+        rule = row.get("rule_id", "")
+
+        if not allowed:
+            denial_buckets[(rule, action, agent)] += 1
+        # protected-branch detector — agent-only (operator is excluded);
+        # match `git commit` (not `git reset/diff/log/...`), exclude
+        # immediately-followed `git checkout -b` patterns (the safe form).
+        # This is intentionally heuristic: chain rows don't carry HEAD
+        # state, so we can't be exact. Tune via false-positives observed.
+        if (
+            action == "shell.exec"
+            and agent in ("clawta", "codex", "copilot", "gemini")
+            and "git commit" in target
+            and "checkout -b" not in target
+        ):
+            head_hint = target[:160]
+            protected_branch_writes.append(
+                {"agent": agent, "target": head_hint, "ts": row.get("ts", "?")}
+            )
+        if rule == "" and action == "unknown":
+            unknown_actions[target[:80]] += 1
+        if agent == "clawta" and "clawta-spawn-marker" in target:
+            clawta_spawn_count += 1
+
+    return {
+        "total_rows": total_rows,
+        "top_denials": [
+            {"rule": r, "action": a, "agent": ag, "count": c}
+            for (r, a, ag), c in denial_buckets.most_common(8)
+        ],
+        "unknown_action_targets": [
+            {"target": t, "count": c} for t, c in unknown_actions.most_common(5)
+        ],
+        "protected_branch_writes": protected_branch_writes[:5],
+        "clawta_spawn_count": clawta_spawn_count,
+    }
+
+
+def gather_kanban_facts(cutoff_unix: int) -> dict[str, Any]:
+    import sqlite3
+
+    facts: dict[str, Any] = {}
+    if not DB_PATH.exists():
+        return {"error": f"kanban db not found at {DB_PATH}"}
+
+    with sqlite3.connect(str(DB_PATH)) as conn:
+        c = conn.cursor()
+        c.execute(
+            """SELECT status, COUNT(*) FROM tasks
+               WHERE status NOT IN ('done','archived')
+               GROUP BY status"""
+        )
+        facts["lane_counts"] = {row[0]: row[1] for row in c.fetchall()}
+        c.execute(
+            """SELECT id, assignee, started_at, substr(title, 1, 60)
+               FROM tasks
+              WHERE status = 'in_progress'
+                AND started_at < ?
+              ORDER BY started_at ASC""",
+            (cutoff_unix,),
+        )
+        facts["stale_in_progress"] = [
+            {
+                "id": r[0],
+                "assignee": r[1] or "-",
+                "stale_hours": round((time.time() - (r[2] or 0)) / 3600, 1),
+                "title": r[3],
+            }
+            for r in c.fetchall()
+        ]
+        c.execute(
+            """SELECT id, substr(title, 1, 70) FROM tasks
+               WHERE status = 'done'
+                 AND completed_at >= ?
+               ORDER BY completed_at DESC""",
+            (cutoff_unix,),
+        )
+        facts["recently_done"] = [{"id": r[0], "title": r[1]} for r in c.fetchall()]
+    return facts
+
+
+def gather_github_facts(cutoff_iso: str) -> dict[str, Any]:
+    try:
+        r = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                REPO,
+                "--state",
+                "all",
+                "--search",
+                f"created:>{cutoff_iso[:10]}",
+                "--limit",
+                "30",
+                "--json",
+                "number,title,state,createdAt,mergedAt,headRefName,reviewDecision",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        prs = json.loads(r.stdout) if r.stdout else []
+    except (subprocess.SubprocessError, json.JSONDecodeError) as e:
+        return {"error": f"gh pr list failed: {e}"}
+    return {
+        "opened": [p for p in prs if p["state"] == "OPEN"],
+        "merged": [p for p in prs if p["state"] == "MERGED"],
+        "closed": [p for p in prs if p["state"] == "CLOSED"],
+    }
+
+
+def gather_clawta_facts() -> dict[str, Any]:
+    facts: dict[str, Any] = {}
+    poller_log = LOG_DIR / "clawta-poller.log"
+    if poller_log.exists():
+        with poller_log.open() as f:
+            lines = f.readlines()[-200:]
+        facts["recent_ticks"] = len([l for l in lines if "tick:" in l])
+        facts["dispatched_count"] = len([l for l in lines if "dispatched " in l])
+        facts["demoted_count"] = len([l for l in lines if "demoted " in l])
+    inv_log = LOG_DIR / "clawta-invariants.log"
+    if inv_log.exists():
+        with inv_log.open() as f:
+            lines = f.readlines()[-100:]
+        facts["invariant_repairs"] = len([l for l in lines if "repaired" in l.lower()])
+    rev_log = LOG_DIR / "clawta-pr-reviewer.log"
+    if rev_log.exists():
+        with rev_log.open() as f:
+            lines = f.readlines()[-200:]
+        facts["pr_reviews_posted"] = len([l for l in lines if "posted" in l.lower()])
+    return facts
+
+
+def build_prompt(facts: dict[str, Any]) -> str:
+    return f"""You are the operator's daily swarm-audit reporter. Last 24h of facts below. Produce AT MOST 5 actionable bullets, each tagged with one of:
+
+  [fix-now]   actionable now, real risk or blocker
+  [verify]    looks suspicious, operator should check
+  [watch]     anomaly to monitor over the next 24h
+  [ok]        notable but expected/healthy
+
+Reference specific ticket ids, PR numbers, rule_ids, ticket counts. No prose preamble. No restating the facts. Just the bullets, one per line, starting with the tag.
+
+Hard requirement: if `protected_branch_writes` is non-empty, the FIRST bullet must flag it with [fix-now] — that's the no-commit-to-main rule which chitin gate doesn't catch yet (see kanban t_6e6376b2).
+
+FACTS:
+{json.dumps(facts, indent=2, default=str)}
+
+OUTPUT:
+"""
+
+
+def call_model(prompt: str) -> str:
+    try:
+        r = subprocess.run(
+            [OPENCLAW_BIN, "agent", "--agent", AGENT, "--message", prompt],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as e:
+        log(f"model call failed: {e}")
+        return f"(swarm-audit: model call failed: {e})"
+    if r.returncode != 0:
+        log(f"model rc={r.returncode}; stderr={r.stderr[-300:]}")
+        return f"(swarm-audit: model rc={r.returncode})"
+    return r.stdout.strip()
+
+
+def deliver(summary: str, dry_run: bool) -> None:
+    if dry_run or not DISCORD_CHANNEL:
+        print(summary)
+        return
+    body = f"📊 Swarm audit (last 24h):\n{summary}"
+    try:
+        subprocess.run(
+            [
+                OPENCLAW_BIN,
+                "message",
+                "send",
+                "--channel",
+                "discord",
+                "--account",
+                "default",
+                "--target",
+                f"channel:{DISCORD_CHANNEL}",
+                "--text",
+                body,
+            ],
+            timeout=30,
+            check=False,
+        )
+    except subprocess.SubprocessError as e:
+        log(f"Discord deliver failed: {e}")
+        print(summary)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="print summary, do not post")
+    ap.add_argument(
+        "--hours",
+        type=int,
+        default=24,
+        help="window size in hours (default 24)",
+    )
+    args = ap.parse_args()
+
+    now = datetime.now(timezone.utc)
+    cutoff_iso = (now - timedelta(hours=args.hours)).isoformat()
+    cutoff_unix = int((now - timedelta(hours=args.hours)).timestamp())
+    log(f"swarm-audit: window {cutoff_iso} → now ({args.hours}h)")
+
+    facts = {
+        "window_hours": args.hours,
+        "chain": gather_chain_facts(cutoff_iso),
+        "kanban": gather_kanban_facts(cutoff_unix),
+        "github": gather_github_facts(cutoff_iso),
+        "clawta": gather_clawta_facts(),
+    }
+    log(f"facts gathered: {sum(1 for _ in facts)} top-level keys")
+
+    prompt = build_prompt(facts)
+    summary = call_model(prompt)
+    deliver(summary, args.dry_run)
+    log(f"swarm-audit: complete ({len(summary)} chars)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swarm/systemd/swarm-audit.service
+++ b/swarm/systemd/swarm-audit.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Daily swarm audit — operator-controlled (claude-code) summary
+Documentation=https://github.com/chitinhq/chitin/blob/main/swarm/bin/swarm-audit
+After=network-online.target hermes-gateway.service openclaw-gateway.service
+
+[Service]
+Type=oneshot
+# The script needs:
+#   - kanban sqlite read
+#   - chain ledger read (~/.chitin/gov-decisions-*.jsonl)
+#   - gh CLI for PR queries
+#   - openclaw CLI for the agent call and the Discord post
+# Set SWARM_AUDIT_DISCORD_CHANNEL=<id> in the user environment (e.g. via
+# EnvironmentFile) to deliver to Discord; without it the audit logs the
+# summary locally and exits — useful for first-run verification.
+ExecStart=%h/.local/bin/swarm-audit
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/chitin/swarm-audit.env
+TimeoutStartSec=300
+Nice=10
+
+# Hardening — reads several user-state directories, writes only to logs.
+ProtectSystem=strict
+ReadWritePaths=%h/.openclaw/logs
+ProtectHome=read-only
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/swarm/systemd/swarm-audit.timer
+++ b/swarm/systemd/swarm-audit.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Daily swarm audit — 8am ET operator standup
+Documentation=https://github.com/chitinhq/chitin/blob/main/swarm/bin/swarm-audit
+
+[Timer]
+# Fire daily at 8am America/Detroit (set TZ in environment file).
+# Persistent=true means a missed run (sleeping laptop, restart) catches
+# up on next available wakeup instead of being silently skipped.
+OnCalendar=*-*-* 08:00:00 America/Detroit
+Persistent=true
+AccuracySec=1min
+Unit=swarm-audit.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

claude-code is the operator-controlled agent in the chitin swarm. Clawta is autonomous (dispatch + invariants + PR-reviewer), Hermes grooms, workers execute. Nobody currently watches the swarm AS A WHOLE for anomalies, policy violations, or drift across all surfaces. This PR fills that gap.

## What it does

Once per day (default 08:00 America/Detroit), pulls 24h of structured facts from:

- chitin chain ledger (denials by rule_id × agent, unknown actions, protected-branch writes by non-operator agents)
- kanban (lane counts, stale in_progress, recently done)
- GitHub PRs (opened / merged / closed)
- Clawta logs (poller ticks, dispatches, demotes, invariant repairs, PR-reviewer posts)

Calls a frontier model via openclaw (default \`clawta\`=gpt-5.5) to summarize into AT MOST 5 actionable bullets each tagged \`[fix-now]\` / \`[verify]\` / \`[watch]\` / \`[ok]\`. Hard requirement: any non-operator protected-branch write opens with \`[fix-now]\` — cross-references kanban \`t_6e6376b2\` (the chitin policy gap that lets \`git commit\` while HEAD=main slip through).

## Delivery

Posts to a configured Discord channel (operator thread). With no channel set, prints to the service journal — useful for first-run sanity-check.

## Wire-up

\`swarm/systemd/swarm-audit.{service,timer}\` + install script. Idempotent.

\`\`\`
bash swarm/bin/install-swarm-audit.sh   # one-shot installer
\`\`\`

Symlinks the bin to \`~/.local/bin/\`, drops a config template at \`~/.config/chitin/swarm-audit.env\`, enables the timer. Service hardened (ProtectSystem=strict, ReadWritePaths=just \`~/.openclaw/logs\`).

## Verification (live dry-run)

\`\`\`
$ swarm-audit --dry-run
[fix-now] Protected branch writes detected from codex at 2026-05-12T00:50:29Z, 02:21:39Z, and 02:27:38Z (`git add`/`git commit` on likely main); audit/revert if needed and prioritize kanban t_6e6376b2 because chitin gate still misses no-commit-to-main.
[fix-now] PR #542 fix-dispatcher is open with real automation risk: it can spawn codex fix workers with bypass flags; require trusted-author gating and branch-safe worktree handling before enabling.
[verify] Open PR queue has duplicate/stacked Nx work: #517/#518 plus newer #535/#539 overlap depConstraints/project metadata; choose canonical PRs and close/rebase stale branches.
[watch] Claude-code denials dominate: 7 \`default-deny\` unknown, 7 \`router-heuristic:deny\`, 3 \`no-rm-recursive\`; check whether normalizer fixes reduce this tomorrow.
[ok] Swarm throughput looks healthy: 27 Clawta spawns, 171 ticks, 9 dispatches, 12 demotions, 2 invariant repairs, 18 merged PRs, and 0 stale in-progress tickets.
\`\`\`

The agent-filtered detector correctly caught real codex direct-to-main commits (the autonomous rule-break pattern we surfaced today). LLM call through clawta returned a 5-bullet summary in ~21s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)