### PR TITLE
swarm: escalate PR lifecycle blockers to operator

### DIFF
--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -6,6 +6,7 @@ Responsibilities, deliberately gated:
 - classify PRs as ready-to-merge / needs-fix / conflicted / merged
 - comment once when a PR is ready-to-merge (no auto-merge)
 - when a PR is already merged, mark its kanban ticket done
+- optionally assign escalations to an operator on the kanban board
 - report cleanup candidates without deleting worktrees
 
 By default, no merge operation is performed. With --auto-merge, the script
@@ -127,12 +128,18 @@ def infer_ticket(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> str | N
     return None
 
 
-def ticket_status(ticket_id: str | None) -> str | None:
+def ticket_info(ticket_id: str | None) -> dict[str, str | None]:
     if not ticket_id or not DB_PATH.exists():
-        return None
+        return {"status": None, "assignee": None}
     with sqlite3.connect(str(DB_PATH)) as conn:
-        row = conn.execute("SELECT status FROM tasks WHERE id=?", (ticket_id,)).fetchone()
-        return str(row[0]) if row else None
+        row = conn.execute("SELECT status, assignee FROM tasks WHERE id=?", (ticket_id,)).fetchone()
+        if not row:
+            return {"status": None, "assignee": None}
+        return {"status": str(row[0]) if row[0] is not None else None, "assignee": str(row[1]) if row[1] is not None else None}
+
+
+def ticket_status(ticket_id: str | None) -> str | None:
+    return ticket_info(ticket_id)["status"]
 
 
 def checks_state(pr_number: int) -> str:
@@ -186,7 +193,9 @@ def classify(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> dict[str, A
     review = latest_review(comments_)
     check_state = checks_state(int(pr["number"])) if pr.get("state") == "OPEN" else "n/a"
     ticket = infer_ticket(pr, comments_)
-    status = ticket_status(ticket)
+    info = ticket_info(ticket)
+    status = info["status"]
+    assignee = info["assignee"]
     merged = pr.get("state") == "MERGED" or bool(pr.get("mergedAt"))
     base_ready = (
         pr.get("state") == "OPEN"
@@ -221,6 +230,7 @@ def classify(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> dict[str, A
         "branch": pr.get("headRefName", ""),
         "ticket": ticket,
         "ticket_status": status,
+        "ticket_assignee": assignee,
         "state": pr.get("state"),
         "mergeable": pr.get("mergeable"),
         "checks": check_state,
@@ -269,7 +279,54 @@ def merge_pr(item: dict[str, Any], apply: bool) -> None:
     ], timeout=120, check=True)
 
 
-def run_once(prefixes: tuple[str, ...], apply: bool, auto_merge: bool) -> dict[str, Any]:
+def needs_operator_escalation(item: dict[str, Any]) -> bool:
+    if not item.get("ticket"):
+        return False
+    if item.get("state") != "OPEN":
+        return False
+    if item.get("ticket_status") in {"done", None}:
+        return False
+    if item.get("auto_merge_ready"):
+        return False
+    if item.get("action") in {"needs-fix", "needs-rebase"}:
+        return True
+    if item.get("action") == "ready-to-merge" and item.get("applied") in {"ready-marker", "would-ready-marker", "noop"}:
+        return True
+    if item.get("checks") == "fail" or item.get("mergeable") == "CONFLICTING":
+        return True
+    return False
+
+
+def escalation_reason(item: dict[str, Any]) -> str:
+    if item.get("action") == "needs-fix":
+        return f"review requested changes for PR #{item['pr']}"
+    if item.get("action") == "needs-rebase":
+        return f"PR #{item['pr']} needs rebase or conflict resolution"
+    if item.get("checks") == "fail":
+        return f"PR #{item['pr']} has failing checks"
+    if item.get("review") != "APPROVE":
+        return f"PR #{item['pr']} is not auto-merge eligible because review={item.get('review')}"
+    return f"PR #{item['pr']} requires operator decision"
+
+
+def escalate_to_operator(item: dict[str, Any], operator: str | None, apply: bool) -> bool:
+    if not operator or not needs_operator_escalation(item):
+        return False
+    if item.get("ticket_assignee") == operator:
+        return False
+    reason = escalation_reason(item)
+    if not apply:
+        return True
+    run(["hermes", "kanban", "--board", BOARD, "assign", item["ticket"], operator], timeout=30, check=True)
+    run([
+        "hermes", "kanban", "--board", BOARD, "comment", item["ticket"], "--author", AUTHOR,
+        f"Escalated to {operator}: {reason}. {item['url']}",
+    ], timeout=30, check=True)
+    item["ticket_assignee"] = operator
+    return True
+
+
+def run_once(prefixes: tuple[str, ...], apply: bool, auto_merge: bool, escalate_to: str | None) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
     for pr in list_prs(prefixes):
         cs = comments(int(pr["number"]))
@@ -286,22 +343,24 @@ def run_once(prefixes: tuple[str, ...], apply: bool, auto_merge: bool) -> dict[s
             elif item["action"] == "mark-done":
                 mark_done(item, apply)
                 item["applied"] = "done" if apply else "would-done"
+            elif escalate_to_operator(item, escalate_to, apply):
+                item["applied"] = "escalated" if apply else "would-escalate"
         except Exception as e:
             item["applied"] = "error"
             item["error"] = str(e)[-500:]
             log(f"PR #{item['pr']}: lifecycle action failed: {e}")
         items.append(item)
     cleanup_candidates = [i for i in items if i["state"] == "MERGED" and i.get("branch")]
-    return {"apply": apply, "auto_merge": auto_merge, "items": items, "cleanup_candidates": cleanup_candidates}
-
+    return {"apply": apply, "auto_merge": auto_merge, "escalate_to": escalate_to, "items": items, "cleanup_candidates": cleanup_candidates}
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--apply", action="store_true", help="write comments / kanban status updates")
     ap.add_argument("--auto-merge", action="store_true", help="squash-merge PRs that satisfy strict autonomous gates")
+    ap.add_argument("--escalate-to", help="assign mapped PR tickets that need operator action to this board profile")
     ap.add_argument("--prefix", action="append")
     args = ap.parse_args()
-    result = run_once(tuple(args.prefix or DEFAULT_PREFIXES), args.apply, args.auto_merge)
+    result = run_once(tuple(args.prefix or DEFAULT_PREFIXES), args.apply, args.auto_merge, args.escalate_to)
     print(json.dumps(result, indent=2))
     return 0
 

--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -344,7 +344,11 @@ def run_once(prefixes: tuple[str, ...], apply: bool, auto_merge: bool, escalate_
                 mark_done(item, apply)
                 item["applied"] = "done" if apply else "would-done"
             elif escalate_to_operator(item, escalate_to, apply):
-                item["applied"] = "escalated" if apply else "would-escalate"
+                escalation_applied = "escalated" if apply else "would-escalate"
+                if item.get("applied") and item["applied"] != "noop":
+                    item["applied"] = f"{item['applied']}+{escalation_applied}"
+                else:
+                    item["applied"] = escalation_applied
         except Exception as e:
             item["applied"] = "error"
             item["error"] = str(e)[-500:]


### PR DESCRIPTION
## Summary
- add --escalate-to to clawta-pr-lifecycle
- assign mapped tickets to an operator when PRs need human action
- add an idempotency guard: only assign/comment when the ticket is not already assigned to that operator

## Validation
- python3 -m py_compile swarm/bin/clawta-pr-lifecycle
- dry-run: ./swarm/bin/clawta-pr-lifecycle --auto-merge --escalate-to red
- dry-run would escalate #543/t_6e6376b2 and #540/t_3877d61f; skipped already-assigned #539/t_917e2aaf