### PR TITLE
feat(gov): add Write and Agent tool normalizations

### DIFF
--- a/go/execution-kernel/internal/gov/normalize.go
+++ b/go/execution-kernel/internal/gov/normalize.go
@@ -32,7 +32,9 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 	// modifies in-place. Both end at file.write because both are mutations
 	// from the policy's perspective — the existing `write_file` mapping
 	// already encodes that policy.
-	case "write", "edit":
+	// "Write" is the Claude Code + Hermes tool name (capitalized); "write"
+	// is the lower-level alias. Both normalize identically.
+	case "write", "edit", "Write":
 		return normalizeWriteFile(args), nil
 	case "read_file":
 		path := stringArg(args, "path")
@@ -149,6 +151,22 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 		return Action{Type: ActHTTPRequest, Target: stringArg(args, "url")}, nil
 	case "delegate_task":
 		return Action{Type: ActDelegateTask, Target: stringArg(args, "goal")}, nil
+	// Agent is the Claude Code + Hermes agent-spawn tool. Maps to delegate.task
+	// because spawning a subagent is the same shape as delegating work: cede
+	// a tool budget to a subordinate agent. Target extraction follows the
+	// driver-layer pattern: description > subagent_type > agent_id > toolName.
+	case "Agent":
+		target := stringArg(args, "description")
+		if target == "" {
+			target = stringArg(args, "subagent_type")
+		}
+		if target == "" {
+			target = stringArg(args, "agent_id")
+		}
+		if target == "" {
+			target = "Agent"
+		}
+		return Action{Type: ActDelegateTask, Target: target}, nil
 	case "search_files":
 		return Action{Type: ActFileRead, Target: stringArg(args, "query")}, nil
 	case "skill_view":

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -719,3 +719,57 @@ func TestNormalize_OpenclawChatDomain_NoneUnknown(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalize_CapitalizedWrite(t *testing.T) {
+	// Capitalized "Write" (Claude Code tool) maps to file.write.
+	// Closes: deny cluster analysis showing 23+ hermes/claude-code Write
+	// calls denied as unknown actions.
+	a, err := Normalize("Write", map[string]any{"file_path": "/tmp/test"})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if a.Type != ActFileWrite {
+		t.Errorf("Type: got %q want file.write", a.Type)
+	}
+	if a.Target != "/tmp/test" {
+		t.Errorf("Target: got %q want /tmp/test", a.Target)
+	}
+}
+
+func TestNormalize_Agent(t *testing.T) {
+	// Capitalized "Agent" (Claude Code + Hermes tool) maps to delegate.task.
+	// Closes: deny cluster analysis showing 17+ claude-code Agent calls
+	// denied as unknown actions.
+	a, err := Normalize("Agent", map[string]any{"description": "search the repo"})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if a.Type != ActDelegateTask {
+		t.Errorf("Type: got %q want delegate.task", a.Type)
+	}
+	if a.Target != "search the repo" {
+		t.Errorf("Target: got %q want 'search the repo'", a.Target)
+	}
+}
+
+func TestNormalize_Agent_TargetExtraction(t *testing.T) {
+	// Agent target extraction: description > subagent_type > agent_id.
+	cases := []struct {
+		name       string
+		input      map[string]any
+		wantTarget string
+	}{
+		{"description wins", map[string]any{"description": "search", "subagent_type": "Explore"}, "search"},
+		{"subagent_type wins", map[string]any{"subagent_type": "Explore", "agent_id": "ag1"}, "Explore"},
+		{"agent_id alone", map[string]any{"agent_id": "ag1"}, "ag1"},
+		{"empty payload", map[string]any{}, "Agent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, _ := Normalize("Agent", tc.input)
+			if a.Target != tc.wantTarget {
+				t.Errorf("Target = %q, want %q", a.Target, tc.wantTarget)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes ticket t_57f4e07c (dispatched via clawta to claude-code). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/claude-code-57f4e07c.