### PR TITLE
fix(gov): reject empty Target in normalization for read/write/exec tools

### DIFF
--- a/go/execution-kernel/internal/gov/errors.go
+++ b/go/execution-kernel/internal/gov/errors.go
@@ -1,0 +1,8 @@
+package gov
+
+import "fmt"
+
+// ErrMissingTarget is returned when a required Target field is missing in normalization.
+func ErrMissingTarget(tool string) error {
+	return fmt.Errorf("required Target missing for tool: %s", tool)
+}

--- a/go/execution-kernel/internal/gov/normalize.go
+++ b/go/execution-kernel/internal/gov/normalize.go
@@ -17,17 +17,13 @@ import (
 func Normalize(toolName string, args map[string]any) (Action, error) {
 	switch toolName {
 	case "terminal", "bash", "shell":
-		return normalizeShell(args), nil
-	// openclaw pi-runtime core tools — same shape as terminal/bash/shell.
-	// `exec` runs a shell command via the gateway; `process` is the same
-	// surface for backgrounded/long-running commands. Both carry `cmd` (or
-	// `command`) so normalizeShell handles them uniformly.
+		return normalizeShell(args)
 	case "exec", "process":
-		return normalizeShell(args), nil
+		return normalizeShell(args)
 	case "execute_code":
 		return normalizeExecuteCode(args), nil
 	case "write_file", "patch":
-		return normalizeWriteFile(args), nil
+		return normalizeWriteFile(args)
 	// openclaw pi-runtime file tools. `write` creates/overwrites; `edit`
 	// modifies in-place. Both end at file.write because both are mutations
 	// from the policy's perspective — the existing `write_file` mapping
@@ -35,18 +31,23 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 	// "Write" is the Claude Code + Hermes tool name (capitalized); "write"
 	// is the lower-level alias. Both normalize identically.
 	case "write", "edit", "Write":
-		return normalizeWriteFile(args), nil
+		return normalizeWriteFile(args)
 	case "read_file":
 		path := stringArg(args, "path")
 		if path == "" {
 			path = stringArg(args, "file_path")
 		}
+		if path == "" {
+			return Action{}, ErrMissingTarget("read_file")
+		}
 		return Action{Type: ActFileRead, Target: path}, nil
 	case "read":
-		// openclaw pi-runtime read tool — path-based file read.
 		path := stringArg(args, "path")
 		if path == "" {
 			path = stringArg(args, "file_path")
+		}
+		if path == "" {
+			return Action{}, ErrMissingTarget("read")
 		}
 		return Action{Type: ActFileRead, Target: path}, nil
 	// openclaw chat-domain tools — slice 3 normalizer coverage.
@@ -177,12 +178,15 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 	return Action{Type: ActUnknown, Target: toolName, Params: args}, nil
 }
 
-func normalizeShell(args map[string]any) Action {
+func normalizeShell(args map[string]any) (Action, error) {
 	cmd := stringArg(args, "command")
 	if cmd == "" {
 		cmd = stringArg(args, "cmd")
 	}
-	return classifyShellCommand(cmd)
+	if strings.TrimSpace(cmd) == "" {
+		return Action{}, ErrMissingTarget("shell/exec/process/terminal")
+	}
+	return classifyShellCommand(cmd), nil
 }
 
 func normalizeExecuteCode(args map[string]any) Action {
@@ -197,12 +201,15 @@ func normalizeExecuteCode(args map[string]any) Action {
 	return Action{Type: ActFileWrite, Target: "execute_code"}
 }
 
-func normalizeWriteFile(args map[string]any) Action {
+func normalizeWriteFile(args map[string]any) (Action, error) {
 	path := stringArg(args, "path")
 	if path == "" {
 		path = stringArg(args, "file_path")
 	}
-	return Action{Type: ActFileWrite, Target: path}
+	if path == "" {
+		return Action{}, ErrMissingTarget("write_file/write/edit/patch")
+	}
+	return Action{Type: ActFileWrite, Target: path}, nil
 }
 
 // classifyShellCommand inspects a shell command string and returns the most
@@ -409,10 +416,10 @@ var reSelfMod = regexp.MustCompile(
 //
 // Patterns matched (ordered by specificity):
 //  1. subprocess.run/call/Popen/check_* with a LIST argument:
-//        subprocess.run(["rm", "-rf", "go/"])
+//     subprocess.run(["rm", "-rf", "go/"])
 //  2. subprocess.run/call/Popen/check_* with a STRING argument (typically
 //     shell=True, but matched regardless — string form is shell semantics):
-//        subprocess.run("rm -rf go/", shell=True)
+//     subprocess.run("rm -rf go/", shell=True)
 //  3. os.system("rm -rf go/") — always shell
 //  4. shutil.rmtree("go/") → rm -rf go/
 //  5. os.remove/unlink("x") → rm x
@@ -460,7 +467,9 @@ func extractShellIntent(code string) string {
 }
 
 // joinQuotedList takes the inside of a Python list literal like:
-//   "rm", "-rf", "go/"
+//
+//	"rm", "-rf", "go/"
+//
 // and returns the space-joined unquoted string: `rm -rf go/`
 func joinQuotedList(inside string) string {
 	parts := []string{}

--- a/go/execution-kernel/internal/gov/normalize.go
+++ b/go/execution-kernel/internal/gov/normalize.go
@@ -37,7 +37,7 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 		if path == "" {
 			path = stringArg(args, "file_path")
 		}
-		if path == "" {
+		if strings.TrimSpace(path) == "" {
 			return Action{}, ErrMissingTarget("read_file")
 		}
 		return Action{Type: ActFileRead, Target: path}, nil
@@ -46,7 +46,7 @@ func Normalize(toolName string, args map[string]any) (Action, error) {
 		if path == "" {
 			path = stringArg(args, "file_path")
 		}
-		if path == "" {
+		if strings.TrimSpace(path) == "" {
 			return Action{}, ErrMissingTarget("read")
 		}
 		return Action{Type: ActFileRead, Target: path}, nil
@@ -206,7 +206,7 @@ func normalizeWriteFile(args map[string]any) (Action, error) {
 	if path == "" {
 		path = stringArg(args, "file_path")
 	}
-	if path == "" {
+	if strings.TrimSpace(path) == "" {
 		return Action{}, ErrMissingTarget("write_file/write/edit/patch")
 	}
 	return Action{Type: ActFileWrite, Target: path}, nil

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -373,6 +373,9 @@ func TestNormalize_RejectsMissingTarget(t *testing.T) {
 		{"patch missing file_path", "patch", map[string]any{"content": "x"}},
 		{"read_file missing path", "read_file", map[string]any{}},
 		{"read missing file_path", "read", map[string]any{}},
+		{"write_file whitespace path", "write_file", map[string]any{"path": "   "}},
+		{"read whitespace path", "read", map[string]any{"path": "\t\n"}},
+		{"read_file whitespace file_path", "read_file", map[string]any{"file_path": "  "}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -316,7 +316,10 @@ func TestNormalize_RemoteCodeExec(t *testing.T) {
 }
 
 func TestNormalize_TerminalReadOnly(t *testing.T) {
-	cases := []struct{ cmd string; want ActionType }{
+	cases := []struct {
+		cmd  string
+		want ActionType
+	}{
 		{"ls -la", ActShellExec},
 		{"cat /etc/passwd", ActShellExec},
 		{"git status", ActGitStatus},
@@ -354,6 +357,32 @@ func TestNormalize_ReadFile_FilePathAlias(t *testing.T) {
 //
 // Invariant: an exec/process call with the same command as a terminal call
 // produces the same Action — one rule catches all routes (bypass closure).
+
+func TestNormalize_RejectsMissingTarget(t *testing.T) {
+	cases := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{"empty shell command", "terminal", map[string]any{"command": "   "}},
+		{"empty exec command", "exec", map[string]any{"cmd": ""}},
+		{"empty process command", "process", map[string]any{"command": ""}},
+		{"write_file missing path", "write_file", map[string]any{"content": "x"}},
+		{"write missing file_path", "write", map[string]any{"content": "x"}},
+		{"edit missing path", "edit", map[string]any{"content": "x"}},
+		{"patch missing file_path", "patch", map[string]any{"content": "x"}},
+		{"read_file missing path", "read_file", map[string]any{}},
+		{"read missing file_path", "read", map[string]any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := Normalize(tc.tool, tc.args)
+			if err == nil {
+				t.Errorf("expected error for %s, got nil (Action: %+v)", tc.name, a)
+			}
+		})
+	}
+}
 
 func TestNormalize_OpenclawExec(t *testing.T) {
 	// Same shape as terminal: passes cmd, lands on shell.exec.


### PR DESCRIPTION
Closes ticket t_d44e4648 (dispatched via clawta to copilot). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/copilot-d44e4648.

Clawta rebase/fix pass:
- rebased onto current main
- removed self-import cycle in `go/execution-kernel/internal/gov/normalize.go`
- preserved fail-closed missing-target normalization behavior and tests

Validation:
- /usr/local/go/bin/gofmt on touched Go files
- git diff --check
- /usr/local/go/bin/go test ./internal/gov
- /usr/local/go/bin/go test ./...
