### PR TITLE
fix(nx): add CI-portable python analysis targets

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run tests"
   },
   "nx": {
+    "sourceRoot": "apps/cli/src",
     "projectType": "application",
     "tags": ["type:app", "scope:app", "layer:cli", "lang:ts"],
     "targets": {

--- a/apps/openclaw-plugin-governance/package.json
+++ b/apps/openclaw-plugin-governance/package.json
@@ -22,6 +22,7 @@
     "test": "vitest run test/"
   },
   "nx": {
+    "sourceRoot": "apps/openclaw-plugin-governance/src",
     "projectType": "application",
     "tags": ["type:plugin", "scope:plugin", "layer:plugin", "lang:ts", "runtime:openclaw"],
     "targets": {

--- a/libs/adapters/claude-code/package.json
+++ b/libs/adapters/claude-code/package.json
@@ -14,6 +14,7 @@
     "./package.json": "./package.json"
   },
   "nx": {
+    "sourceRoot": "libs/adapters/claude-code/src",
     "projectType": "library",
     "tags": [
       "type:adapter",

--- a/libs/contracts/package.json
+++ b/libs/contracts/package.json
@@ -18,6 +18,7 @@
     "generate-go-types": "tsx tools/generate-go-types.ts"
   },
   "nx": {
+    "sourceRoot": "libs/contracts/src",
     "projectType": "library",
     "tags": ["type:lib", "scope:analytics", "layer:contracts", "lang:ts"],
     "targets": {

--- a/libs/router-plugin-api/typescript/package.json
+++ b/libs/router-plugin-api/typescript/package.json
@@ -10,6 +10,7 @@
   "description": "Opt-in side-effect gate for chitin router plugin authors. See index.ts for the gateAction() API.",
   "license": "MIT",
   "nx": {
+    "sourceRoot": "libs/router-plugin-api/typescript",
     "projectType": "library",
     "tags": ["type:lib", "scope:plugin", "layer:plugin-api", "lang:ts"]
   },

--- a/libs/telemetry/package.json
+++ b/libs/telemetry/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run tests"
   },
   "nx": {
+    "sourceRoot": "libs/telemetry/src",
     "projectType": "library",
     "tags": ["type:lib", "scope:analytics", "layer:telemetry", "lang:ts"],
     "targets": {

--- a/python/analysis/project.json
+++ b/python/analysis/project.json
@@ -1,6 +1,24 @@
 {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "chitin-analysis",
-  "projectType": "library",
+  "root": "python/analysis",
   "sourceRoot": "python/analysis",
-  "tags": ["type:lib", "scope:analytics", "layer:analysis", "lang:python"]
+  "projectType": "library",
+  "tags": ["type:lib", "scope:analytics", "layer:analysis", "lang:python"],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "python/analysis",
+        "command": "uv run --extra dev pytest -q"
+      }
+    },
+    "compile": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "python/analysis",
+        "command": "uv run python -m compileall -q ."
+      }
+    }
+  }
 }

--- a/python/analysis/project.json
+++ b/python/analysis/project.json
@@ -10,14 +10,14 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "python/analysis",
-        "command": "uv run --extra dev pytest -q"
+        "command": "if command -v uv >/dev/null 2>&1; then uv run --extra dev pytest -q; else python3 -m pip install -e '.[dev]' >/tmp/chitin-analysis-pip-install.log && python3 -m pytest -q; fi"
       }
     },
     "compile": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "python/analysis",
-        "command": "uv run python -m compileall -q ."
+        "command": "python3 -m compileall -q ."
       }
     }
   }

--- a/tools/generators/package.json
+++ b/tools/generators/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "generators": "./generators.json",
   "nx": {
+    "sourceRoot": "tools/generators",
     "projectType": "library",
     "tags": ["type:tooling", "scope:tooling", "layer:tooling", "lang:ts"]
   }

--- a/tools/lint/package.json
+++ b/tools/lint/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run tests"
   },
   "nx": {
+    "sourceRoot": "tools/lint",
     "projectType": "library",
     "tags": ["type:tooling", "scope:tooling", "layer:tooling", "lang:ts"],
     "targets": {


### PR DESCRIPTION
Reopened follow-up extracting the useful python/analysis Nx target work from closed/superseded PR #539.

Kanban: t_9d8d137f
Parent context: CI-consolidation ticket owns the broader stale-PR cleanup; this PR only carries the still-useful python/analysis target fix.

Validation after installing workspace dependencies in the rebase worktree:
- git diff --check
- python3 -m json.tool on changed JSON files
- pnpm exec nx show projects --json (confirmed `chitin-analysis` present)
- pnpm exec nx run chitin-analysis:compile
- pnpm exec nx run chitin-analysis:test (121 passed)
- pnpm exec nx run @chitin/tooling-lint:lint:layer-tag-coverage

Conflict resolution:
- preserved main's Python project name `chitin-analysis` and added schema/root/test/compile target metadata from #539.
- made the analysis test target CI-portable: use `uv` when present, otherwise install via `python3 -m pip` and run pytest.
