### PR TITLE
fix(gate): classify read-only diagnostics explicitly

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook.go
@@ -60,6 +60,90 @@ const (
 	chitinAdminMutation chitinAdminClass = "mutation"
 )
 
+type chitinAdminCommandSpec struct {
+	class       chitinAdminClass
+	subcommands map[string]chitinAdminClass
+}
+
+// chitinAdminCommandTable is the mutation-authority boundary for the
+// kernel's own operator surface. A command is read-only only when this
+// table says it cannot write governed state: chitin.yaml, gov.db,
+// gov-decisions-*.jsonl, chain JSONL, chain indexes, current-envelope, or
+// driver hook config. Unknown commands and known commands with unknown
+// write-shaped flags fail closed as mutation-required.
+//
+// Current command inventory:
+//   - read-only diagnostics: gate status; envelope inspect/list/tail;
+//     decisions recent/worktree-diagnostics; health; chain-info;
+//     chain-verify; chain replay/summarize/related/snapshot/stats/
+//     recommend-tier; simulate; gate/router evaluate only with --no-record.
+//   - mutations or mixed read/write: init, emit, ingest-*, sweep-transcripts,
+//     install*, uninstall*, gate evaluate/lockdown/reset, envelope
+//     create/use/grant/close, router evaluate, drive.
+var chitinAdminCommandTable = map[string]chitinAdminCommandSpec{
+	"chain": {
+		subcommands: map[string]chitinAdminClass{
+			"replay":         chitinAdminRead,
+			"summarize":      chitinAdminRead,
+			"related":        chitinAdminRead,
+			"snapshot":       chitinAdminRead,
+			"stats":          chitinAdminRead,
+			"recommend-tier": chitinAdminRead,
+		},
+	},
+	"chain-info":   {class: chitinAdminRead},
+	"chain-verify": {class: chitinAdminRead},
+	"decisions": {
+		subcommands: map[string]chitinAdminClass{
+			"recent":               chitinAdminRead,
+			"worktree-diagnostics": chitinAdminRead,
+		},
+	},
+	"drive": {class: chitinAdminMutation},
+	"emit":  {class: chitinAdminMutation},
+	"envelope": {
+		subcommands: map[string]chitinAdminClass{
+			"create":  chitinAdminMutation,
+			"use":     chitinAdminMutation,
+			"inspect": chitinAdminRead,
+			"list":    chitinAdminRead,
+			"grant":   chitinAdminMutation,
+			"close":   chitinAdminMutation,
+			"tail":    chitinAdminRead,
+		},
+	},
+	"gate": {
+		subcommands: map[string]chitinAdminClass{
+			"evaluate": chitinAdminMutation,
+			"status":   chitinAdminRead,
+			"lockdown": chitinAdminMutation,
+			"reset":    chitinAdminMutation,
+		},
+	},
+	"health":            {class: chitinAdminRead},
+	"ingest-hermes":     {class: chitinAdminMutation},
+	"ingest-otel":       {class: chitinAdminMutation},
+	"ingest-transcript": {class: chitinAdminMutation},
+	"init":              {class: chitinAdminMutation},
+	"install":           {class: chitinAdminMutation},
+	"install-hook":      {class: chitinAdminMutation},
+	"router": {
+		subcommands: map[string]chitinAdminClass{
+			"evaluate": chitinAdminMutation,
+		},
+	},
+	"simulate":          {class: chitinAdminRead},
+	"sweep-transcripts": {class: chitinAdminMutation},
+	"uninstall":         {class: chitinAdminMutation},
+	"uninstall-hook":    {class: chitinAdminMutation},
+}
+
+var chitinAdminMutationFlags = map[string]struct{}{
+	"--apply":  {},
+	"--repair": {},
+	"--write":  {},
+}
+
 func classifyChitinAdminCommand(a gov.Action) chitinAdminClass {
 	switch a.Type {
 	case gov.ActShellExec, gov.ActFileRecursiveDelete:
@@ -98,25 +182,60 @@ func classifyChitinKernelSegment(cmd canon.Command) chitinAdminClass {
 	if subcommandIndex >= len(fields) {
 		return chitinAdminRead
 	}
-	switch fields[subcommandIndex] {
-	case "gate":
-		if len(fields) > subcommandIndex+1 && fields[subcommandIndex+1] == "status" {
-			return chitinAdminRead
-		}
-		return chitinAdminMutation
-	case "envelope":
-		if len(fields) > subcommandIndex+1 {
-			switch fields[subcommandIndex+1] {
-			case "inspect", "list", "tail":
-				return chitinAdminRead
-			}
-		}
-		return chitinAdminMutation
-	case "decisions", "chain", "health", "chain-info", "chain-verify", "router", "simulate":
-		return chitinAdminRead
-	default:
+	if chitinKernelHasMutationFlag(fields[subcommandIndex+1:]) {
 		return chitinAdminMutation
 	}
+	spec, ok := chitinAdminCommandTable[fields[subcommandIndex]]
+	if !ok {
+		return chitinAdminMutation
+	}
+	if spec.subcommands == nil {
+		return spec.class
+	}
+	if len(fields) <= subcommandIndex+1 {
+		return chitinAdminMutation
+	}
+	cls, ok := spec.subcommands[fields[subcommandIndex+1]]
+	if !ok {
+		return chitinAdminMutation
+	}
+	if cls == chitinAdminMutation && chitinKernelEvaluateIsNoRecord(fields[subcommandIndex:]) {
+		return chitinAdminRead
+	}
+	return cls
+}
+
+func chitinKernelHasMutationFlag(fields []string) bool {
+	for _, field := range fields {
+		name := field
+		if before, _, ok := strings.Cut(field, "="); ok {
+			name = before
+		}
+		if _, ok := chitinAdminMutationFlags[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func chitinKernelEvaluateIsNoRecord(fields []string) bool {
+	if len(fields) < 2 {
+		return false
+	}
+	switch fields[0] {
+	case "gate", "router":
+	default:
+		return false
+	}
+	if fields[1] != "evaluate" {
+		return false
+	}
+	for _, field := range fields[2:] {
+		if field == "--no-record" {
+			return true
+		}
+	}
+	return false
 }
 
 func chitinKernelSubcommandIndex(fields []string) int {

--- a/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/gate_hook_test.go
@@ -392,14 +392,22 @@ func TestClassifyChitinAdminCommand(t *testing.T) {
 	}{
 		{"gate status", "chitin-kernel gate status --agent a", chitinAdminRead},
 		{"decisions recent", "chitin-kernel decisions recent --json", chitinAdminRead},
+		{"decisions worktree diagnostics", "chitin-kernel decisions worktree-diagnostics --limit 5", chitinAdminRead},
+		{"chain stats", "chitin-kernel chain stats --json", chitinAdminRead},
+		{"chain recommend tier", "chitin-kernel chain recommend-tier --action-type=shell.exec", chitinAdminRead},
 		{"envelope inspect", "env CHITIN_HOME=/tmp chitin-kernel envelope inspect e1", chitinAdminRead},
 		{"gate reset", "chitin-kernel gate reset --agent a", chitinAdminMutation},
 		{"gate lockdown", "chitin-kernel gate lockdown --agent a", chitinAdminMutation},
+		{"gate evaluate records", "chitin-kernel gate evaluate --tool Bash --agent a", chitinAdminMutation},
+		{"gate evaluate no record", "chitin-kernel gate evaluate --tool Bash --agent a --no-record", chitinAdminRead},
+		{"router evaluate records", "chitin-kernel router evaluate --hook-stdin", chitinAdminMutation},
+		{"router evaluate no record", "chitin-kernel router evaluate --hook-stdin --no-record", chitinAdminRead},
 		{"config before gate lockdown", "chitin-kernel --config /tmp/chitin.yaml gate lockdown", chitinAdminMutation},
 		{"verbose before decisions recent", "chitin-kernel --verbose decisions recent", chitinAdminRead},
 		{"envelope grant", "FOO=1 chitin-kernel envelope grant e1 --calls=+1", chitinAdminMutation},
 		{"install hook", "chitin-kernel install-hook --surface claude-code", chitinAdminMutation},
 		{"chained reset after read", "chitin-kernel gate status && chitin-kernel gate reset --agent a", chitinAdminMutation},
+		{"pipeline reset after read", "chitin-kernel decisions recent | chitin-kernel gate reset --agent a", chitinAdminMutation},
 		{"command wrapper", "command chitin-kernel gate reset --agent a", chitinAdminMutation},
 		{"path prefixed", "/usr/local/bin/chitin-kernel gate reset --agent a", chitinAdminMutation},
 		{"lookalike", "echo chitin-kernel gate reset --agent a", chitinAdminNone},
@@ -409,6 +417,50 @@ func TestClassifyChitinAdminCommand(t *testing.T) {
 			got := classifyChitinAdminCommand(gov.Action{Type: gov.ActShellExec, Target: tc.cmd})
 			if got != tc.want {
 				t.Fatalf("classify=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyChitinAdmin_ReadOnlyWithMutationFlagsRequiresAuthority(t *testing.T) {
+	for _, flag := range []string{"--repair", "--write", "--apply"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := "chitin-kernel decisions worktree-diagnostics " + flag
+			got := classifyChitinAdminCommand(gov.Action{Type: gov.ActShellExec, Target: cmd})
+			if got != chitinAdminMutation {
+				t.Fatalf("classify(%q)=%q want %q", cmd, got, chitinAdminMutation)
+			}
+		})
+	}
+}
+
+func TestClassifyChitinAdmin_FailClosedBoundaries(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{
+			name: "read command with apply flag is mixed",
+			cmd:  "chitin-kernel chain replay --session=latest --apply",
+		},
+		{
+			name: "unknown decisions subcommand",
+			cmd:  "chitin-kernel decisions recnet",
+		},
+		{
+			name: "unknown envelope alias",
+			cmd:  "chitin-kernel envelope ls",
+		},
+		{
+			name: "unknown root subcommand",
+			cmd:  "chitin-kernel gov decisions list",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyChitinAdminCommand(gov.Action{Type: gov.ActShellExec, Target: tc.cmd})
+			if got != chitinAdminMutation {
+				t.Fatalf("classify(%q)=%q want %q", tc.cmd, got, chitinAdminMutation)
 			}
 		})
 	}
@@ -501,6 +553,37 @@ func TestEvalHookStdin_ChitinAdmin_WorkerCanReadStatus(t *testing.T) {
 	st, _ := e2.Inspect()
 	if st.SpentCalls != 0 {
 		t.Fatalf("SpentCalls=%d want 0 — read-only governance command debited envelope", st.SpentCalls)
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_WorkerCanReadDecisionDiagnostics(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name": "Bash",
+		"tool_input": map[string]any{
+			"command": "chitin-kernel decisions worktree-diagnostics --window-hours 1 --limit 10",
+		},
+	}, "")
+	if code != 0 {
+		t.Fatalf("decisions worktree-diagnostics exit=%d want 0; stdout=%q", code, stdout)
+	}
+}
+
+func TestEvalHookStdin_ChitinAdmin_WorkerCannotUseMutationFlagOnDiagnostics(t *testing.T) {
+	env := setupHookEnv(t, baselinePolicy)
+
+	stdout, _, code := runHookCall(t, env, map[string]any{
+		"tool_name": "Bash",
+		"tool_input": map[string]any{
+			"command": "chitin-kernel decisions worktree-diagnostics --write",
+		},
+	}, "")
+	if code != 2 {
+		t.Fatalf("decisions worktree-diagnostics --write exit=%d want 2; stdout=%q", code, stdout)
+	}
+	if !strings.Contains(stdout, "governance-mutation-authority-required") {
+		t.Fatalf("stdout missing authority rule id: %q", stdout)
 	}
 }
 


### PR DESCRIPTION
Closes ticket t_580bc20e (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-580bc20e.