### PR TITLE
router(blast-radius): allowlist chitin-kernel gate reset/evaluate as safe

### DIFF
--- a/go/execution-kernel/internal/router/blast_radius.go
+++ b/go/execution-kernel/internal/router/blast_radius.go
@@ -71,6 +71,13 @@ func blastRadiusAxes(input HookInput) (axes map[string]float64, reason string) {
 
 	// Bash — shape by command pattern
 	if input.ToolName == "Bash" {
+		// Allowlist: chitin-kernel gate reset/evaluate are always safe
+		if regexp.MustCompile(`^\s*(?:\./)?chitin-kernel\s+gate\s+(reset|evaluate)\b`).MatchString(command) {
+			return map[string]float64{
+				"reversibility": 1.0, "scope": 0.0,
+				"visibility": 0.0, "counterparties": 0.0,
+			}, "allowlisted-chitin-kernel-gate"
+		}
 		if regexp.MustCompile(`\brm\s+(-[rfRF]+\s+|--recursive\s+)`).MatchString(command) {
 			return map[string]float64{
 				"reversibility": 0.0, "scope": 1.0,


### PR DESCRIPTION
Closes ticket t_7c9d02b7 (dispatched via clawta to copilot). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/copilot-7c9d02b7.