### PR TITLE
fix(swarm): per-dispatch envelope in lobster spawn_worker

### DIFF
--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -324,8 +324,15 @@ steps:
       printf '{"session_id":"%s","tool_name":"Bash","tool_input":{"command":"echo clawta-spawn-marker"}}' \
         "$SPAWN_RUN_ID" \
         | CHITIN_DRIVER=clawta chitin-kernel gate evaluate --hook-stdin --agent=clawta >/dev/null 2>&1 || true
-      echo "spawn_worker: exec $CMD ${ARGV[*]}" >&2
-      exec env CHITIN_DRIVER=clawta "$CMD" "${ARGV[@]}"
+      # Per-dispatch envelope: each worker gets its own spent_calls
+      # counter. Without this, the worker inherits the parent's
+      # CHITIN_BUDGET_ENVELOPE (which beats the ~/.chitin/current-envelope
+      # file in resolveEnvelope) and aggregates spend with every other
+      # agent dispatched under the same parent — one cap hit locks
+      # whichever agent calls next.
+      NEW_ENV=$(chitin-kernel envelope create --calls=10000 --bytes=33554432 --usd=2.0)
+      echo "spawn_worker: exec $CMD ${ARGV[*]} (envelope=$NEW_ENV)" >&2
+      exec env CHITIN_DRIVER=clawta CHITIN_BUDGET_ENVELOPE="$NEW_ENV" "$CMD" "${ARGV[@]}"
       BASH_SCRIPT
       )"
     stdin: $fetch_ticket.stdout


### PR DESCRIPTION
## Summary

Stops cross-agent envelope sharing in swarm dispatches. Closes the root cause behind the 2026-05-13 codex false-positive lockdown.

## What was broken

Every worker dispatched through `kanban-dispatch.lobster` inherited the parent process's `CHITIN_BUDGET_ENVELOPE` env var. Per `resolveEnvelope` precedence (`go/execution-kernel/cmd/chitin-kernel/gate_hook.go:604-624`), that env var beats the `~/.chitin/current-envelope` file. So every agent dispatched under one long-lived parent (e.g., the openclaw plugin host) accumulated spend against one shared envelope. When the cap was hit, whichever agent called next took the lifetime-ladder lockdown.

Concrete evidence: envelope `01KQRF7D66GYXZ829G3QGRKWQB` was alive for 9 days, accumulated 10,000 calls across 5 agents (claude-code 1310, codex 482, clawta 51, hermes 18, redeploy-smoke 6 — out of 1867 logged plus the rest in older dailies), and locked codex when it crossed the lifetime-denial threshold of 10.

Full diagnosis: kanban ticket `t_091766ff` (`[bug] Envelope lifetime + cross-agent sharing causes false-positive agent lockdowns`).

## The fix

Two lines added before the `exec` at line 328:

```bash
NEW_ENV=$(chitin-kernel envelope create --calls=10000 --bytes=33554432 --usd=2.0)
exec env CHITIN_DRIVER=clawta CHITIN_BUDGET_ENVELOPE="$NEW_ENV" "$CMD" "${ARGV[@]}"
```

Plus a 6-line comment explaining the invariant.

The flag-or-env precedence means even workers spawned under a parent with a stale envelope still use the fresh one. `set -euo pipefail` is already at the top of the script, so an `envelope create` failure aborts the spawn cleanly — no zombie.

## What this does NOT fix (intentional)

- Already-running long-lived parents (openclaw plugin host) still have `CHITIN_BUDGET_ENVELOPE` pinned to whatever it was at startup. Restart them after merge to drop the pin. The fix prevents NEW dispatches from getting trapped; the running parent unstuck is operational, not code.
- `resolveEnvelope` precedence (flag > env > file) stays as-is. Could re-order later if env-var inheritance bites on non-swarm paths, but flipping it has unknown blast radius on smoke scripts.
- Limits hardcoded at `(10000, 32MB, $2)` — same as the previous shared envelope. Should move to chitin.yaml as a follow-up.

## What this does NOT fix (out of sync, separate cleanup)

`docs/governance-setup-extras/kanban-dispatch.lobster` is the docs mirror; it's already out of sync with the runtime copy (~60 lines difference). Updating both was out of scope here. Filing as a follow-up.

## Test plan

- [ ] YAML parses cleanly (verified locally — `python3 -c "import yaml; yaml.safe_load(open(...))"` exits 0)
- [ ] `chitin-kernel envelope create --calls=10000 --bytes=33554432 --usd=2.0` works (verified — the command exists at `cmd/chitin-kernel/envelope.go:84-109`, emits one ULID per line)
- [ ] Operator-side smoke after merge: dispatch one ticket via clawta-poller, verify the worker's `gov-decisions-*.jsonl` entries carry a unique envelope_id (not the previous shared one)
- [ ] Spot-check `chitin-kernel envelope list` shows new envelopes appearing per dispatch
- [ ] Lockdown audit: 7d after merge, query `gov.db` for any new agent lockdowns; verify none are envelope-share false positives

## Operational sequence to fully recover

After merge:

```sh
chitin-kernel gate reset --agent codex          # clear current false-positive lockdown
chitin-kernel envelope close 01KQRF7D66GYXZ829G3QGRKWQB   # belt-and-suspenders
# Restart any long-running parent that may still hold the stale envelope pinned in env:
#   - openclaw plugin host
#   - hermes-agent daemon
#   - clawta-poller systemd unit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)