### PR TITLE
fix(router): calibrate floundering loop threshold

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/replay_cmd.go
+++ b/go/execution-kernel/cmd/chitin-kernel/replay_cmd.go
@@ -16,9 +16,10 @@ import (
 // current policy at cwd; prints diffs.
 //
 // Flags:
-//   --session=<id>   session_id to replay (or "latest" for most recent)
-//   --json           emit JSON report instead of human-readable
-//   --policy-cwd=<d> cwd for policy resolution (default: $PWD)
+//
+//	--session=<id>   session_id to replay (or "latest" for most recent)
+//	--json           emit JSON report instead of human-readable
+//	--policy-cwd=<d> cwd for policy resolution (default: $PWD)
 func cmdChainReplay(args []string) {
 	sessionID := ""
 	jsonOut := false
@@ -273,6 +274,16 @@ Default: tool_name.`)
 	}
 	fmt.Printf("chitin chain stats — by %s\n", axis)
 	fmt.Printf("  total decisions: %d\n\n", stats.Total)
+	if stats.Floundering != nil {
+		f := stats.Floundering
+		fmt.Printf("  floundering calibration (%d sessions):\n", f.Sessions)
+		fmt.Printf("    fixed:    precision %.3f  recall %.3f  false_positive_rate %.3f  false_negative_rate %.3f\n",
+			f.FixedPrecision, f.FixedRecall, f.FixedFalsePositiveRate, f.FixedFalseNegativeRate)
+		fmt.Printf("    adaptive: precision %.3f  recall %.3f  false_positive_rate %.3f  false_negative_rate %.3f\n",
+			f.AdaptivePrecision, f.AdaptiveRecall, f.AdaptiveFalsePositiveRate, f.AdaptiveFalseNegativeRate)
+		fmt.Printf("    false_positive_reduction %.1f%%  loop_misfire_increase %.3f\n\n",
+			f.FalsePositiveReduction*100, f.LoopMisfireIncrease)
+	}
 	fmt.Printf("  %-30s %10s %10s %10s %10s\n", "bucket", "decisions", "allows", "denies", "success%")
 	fmt.Printf("  %-30s %10s %10s %10s %10s\n", "------", "---------", "------", "------", "--------")
 	for _, k := range stats.SortedBucketKeys() {

--- a/go/execution-kernel/internal/replay/floundering_calibration.go
+++ b/go/execution-kernel/internal/replay/floundering_calibration.go
@@ -1,0 +1,251 @@
+package replay
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"strings"
+)
+
+const flounderingFixedLoopCount = 2
+
+type flounderingDecision struct {
+	ToolName     string
+	ActionType   string
+	ActionTarget string
+	Decision     string
+}
+
+type flounderingConfusion struct {
+	tp int
+	fp int
+	fn int
+	tn int
+}
+
+func computeFlounderingCalibration(paths []string) *FlounderingCalibration {
+	fixed := flounderingConfusion{}
+	adaptive := flounderingConfusion{}
+	sessions := 0
+	for _, p := range paths {
+		decisions := readFlounderingDecisions(p)
+		if len(decisions) == 0 {
+			continue
+		}
+		sessions++
+		actual := terminalLoopProxy(decisions)
+		fixedPred := fixedLoopPrediction(decisions, flounderingFixedLoopCount)
+		adaptivePred := adaptiveLoopPrediction(decisions, flounderingFixedLoopCount)
+		fixed.add(fixedPred, actual)
+		adaptive.add(adaptivePred, actual)
+	}
+	out := &FlounderingCalibration{
+		Sessions:                  sessions,
+		FixedPrecision:            precision(fixed),
+		FixedRecall:               recall(fixed),
+		FixedFalsePositiveRate:    falsePositiveRate(fixed),
+		FixedFalseNegativeRate:    falseNegativeRate(fixed),
+		AdaptivePrecision:         precision(adaptive),
+		AdaptiveRecall:            recall(adaptive),
+		AdaptiveFalsePositiveRate: falsePositiveRate(adaptive),
+		AdaptiveFalseNegativeRate: falseNegativeRate(adaptive),
+		LoopMisfireIncrease:       falseNegativeRate(adaptive) - falseNegativeRate(fixed),
+	}
+	if out.FixedFalsePositiveRate > 0 {
+		out.FalsePositiveReduction = (out.FixedFalsePositiveRate - out.AdaptiveFalsePositiveRate) / out.FixedFalsePositiveRate
+	}
+	return out
+}
+
+func readFlounderingDecisions(path string) []flounderingDecision {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var out []flounderingDecision
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if etype, _ := ev["event_type"].(string); etype != "decision" {
+			continue
+		}
+		payload, _ := ev["payload"].(map[string]interface{})
+		if payload == nil {
+			continue
+		}
+		toolName, _ := payload["tool_name"].(string)
+		actionTarget, _ := payload["action_target"].(string)
+		if toolName == "" || actionTarget == "" {
+			continue
+		}
+		actionType, _ := payload["action_type"].(string)
+		decision, _ := payload["decision"].(string)
+		out = append(out, flounderingDecision{
+			ToolName:     toolName,
+			ActionType:   actionType,
+			ActionTarget: actionTarget,
+			Decision:     decision,
+		})
+	}
+	return out
+}
+
+func terminalLoopProxy(decisions []flounderingDecision) bool {
+	for i := 1; i < len(decisions); i++ {
+		if !sameFlounderingSignature(decisions[i-1], decisions[i]) {
+			continue
+		}
+		if isLowRiskFileLoopForStats(decisions[i].ActionType) || decisions[i].ActionType == "delegate.task" {
+			continue
+		}
+		if !hasFutureWriteProgress(decisions, i) {
+			return true
+		}
+	}
+	return false
+}
+
+func fixedLoopPrediction(decisions []flounderingDecision, threshold int) bool {
+	if threshold <= 0 {
+		threshold = 3
+	}
+	runLen := 0
+	last := flounderingDecision{}
+	for i, d := range decisions {
+		if i > 0 && sameFlounderingSignature(last, d) {
+			runLen++
+		} else {
+			runLen = 1
+		}
+		if runLen >= threshold {
+			return true
+		}
+		last = d
+	}
+	return false
+}
+
+func adaptiveLoopPrediction(decisions []flounderingDecision, configured int) bool {
+	if configured <= 0 {
+		configured = 3
+	}
+	runLen := 0
+	last := flounderingDecision{}
+	var completedRuns []int
+	for i, d := range decisions {
+		if i > 0 && sameFlounderingSignature(last, d) {
+			runLen++
+		} else {
+			if runLen > 1 {
+				completedRuns = appendRecentRun(completedRuns, runLen, 8)
+			}
+			runLen = 1
+		}
+		if runLen >= adaptiveLoopThresholdForStats(configured, d.ActionType, completedRuns) {
+			return true
+		}
+		last = d
+	}
+	return false
+}
+
+func adaptiveLoopThresholdForStats(configured int, actionType string, completedRuns []int) int {
+	floor := configured
+	if isLowRiskFileLoopForStats(actionType) {
+		floor = maxReplayInt(floor, configured+2)
+	}
+	if len(completedRuns) < 3 {
+		return floor
+	}
+	sum := 0
+	for _, n := range completedRuns {
+		sum += n
+	}
+	adaptive := int(math.Ceil(float64(sum)/float64(len(completedRuns)))) + 1
+	if adaptive > configured+2 {
+		adaptive = configured + 2
+	}
+	return maxReplayInt(floor, adaptive)
+}
+
+func isLowRiskFileLoopForStats(actionType string) bool {
+	return actionType == "file.read" || actionType == "file.write"
+}
+
+func appendRecentRun(runs []int, n int, window int) []int {
+	runs = append(runs, n)
+	if len(runs) > window {
+		return runs[1:]
+	}
+	return runs
+}
+
+func sameFlounderingSignature(a, b flounderingDecision) bool {
+	return a.ToolName == b.ToolName && a.ActionTarget == b.ActionTarget
+}
+
+func hasFutureWriteProgress(decisions []flounderingDecision, idx int) bool {
+	for _, d := range decisions[idx+1:] {
+		if d.Decision != "allow" {
+			continue
+		}
+		if d.ActionType == "file.write" || d.ActionType == "git.commit" || d.ActionType == "git.push" {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *flounderingConfusion) add(predicted, actual bool) {
+	switch {
+	case predicted && actual:
+		c.tp++
+	case predicted && !actual:
+		c.fp++
+	case !predicted && actual:
+		c.fn++
+	default:
+		c.tn++
+	}
+}
+
+func precision(c flounderingConfusion) float64 {
+	if c.tp+c.fp == 0 {
+		return 0
+	}
+	return float64(c.tp) / float64(c.tp+c.fp)
+}
+
+func recall(c flounderingConfusion) float64 {
+	if c.tp+c.fn == 0 {
+		return 0
+	}
+	return float64(c.tp) / float64(c.tp+c.fn)
+}
+
+func falsePositiveRate(c flounderingConfusion) float64 {
+	if c.fp+c.tn == 0 {
+		return 0
+	}
+	return float64(c.fp) / float64(c.fp+c.tn)
+}
+
+func falseNegativeRate(c flounderingConfusion) float64 {
+	if c.fn+c.tp == 0 {
+		return 0
+	}
+	return float64(c.fn) / float64(c.fn+c.tp)
+}
+
+func maxReplayInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/go/execution-kernel/internal/replay/stats.go
+++ b/go/execution-kernel/internal/replay/stats.go
@@ -11,10 +11,11 @@ import (
 
 // Stats — aggregate chain analytics keyed by an axis.
 type Stats struct {
-	Axis    string                 `json:"axis"`
-	Buckets map[string]BucketStats `json:"buckets"`
-	Total   int                    `json:"total_decisions"`
-	Window  string                 `json:"window,omitempty"`
+	Axis        string                  `json:"axis"`
+	Buckets     map[string]BucketStats  `json:"buckets"`
+	Total       int                     `json:"total_decisions"`
+	Window      string                  `json:"window,omitempty"`
+	Floundering *FlounderingCalibration `json:"floundering,omitempty"`
 }
 
 // BucketStats — per-axis-bucket counts.
@@ -25,6 +26,26 @@ type BucketStats struct {
 	// SuccessRate is allows / decisions (0.0-1.0). NaN-safe: 0
 	// when decisions=0.
 	SuccessRate float64 `json:"success_rate"`
+}
+
+// FlounderingCalibration compares the fixed loop threshold historically used
+// in chitin.yaml with the adaptive loop detector used by the router. Labels
+// are chain-derived proxies: a predicted loop is a false positive when later
+// write progress occurs in the same session or when the repeated calls are
+// low-risk file edit/read churn, and a false negative when a terminal
+// non-progress repeated-call loop had no detector fire.
+type FlounderingCalibration struct {
+	Sessions                  int     `json:"sessions"`
+	FixedPrecision            float64 `json:"fixed_precision"`
+	FixedRecall               float64 `json:"fixed_recall"`
+	FixedFalsePositiveRate    float64 `json:"fixed_false_positive_rate"`
+	FixedFalseNegativeRate    float64 `json:"fixed_false_negative_rate"`
+	AdaptivePrecision         float64 `json:"adaptive_precision"`
+	AdaptiveRecall            float64 `json:"adaptive_recall"`
+	AdaptiveFalsePositiveRate float64 `json:"adaptive_false_positive_rate"`
+	AdaptiveFalseNegativeRate float64 `json:"adaptive_false_negative_rate"`
+	FalsePositiveReduction    float64 `json:"false_positive_reduction"`
+	LoopMisfireIncrease       float64 `json:"loop_misfire_increase"`
 }
 
 // SupportedAxes is the closed set of axis labels accepted by
@@ -80,8 +101,9 @@ func ComputeStatsIn(axis, chitinDir string) (*Stats, error) {
 		return nil, err
 	}
 	stats := &Stats{
-		Axis:    axis,
-		Buckets: make(map[string]BucketStats),
+		Axis:        axis,
+		Buckets:     make(map[string]BucketStats),
+		Floundering: computeFlounderingCalibration(matches),
 	}
 	for _, p := range matches {
 		// Note: we read the whole file and split on newlines for

--- a/go/execution-kernel/internal/replay/stats_test.go
+++ b/go/execution-kernel/internal/replay/stats_test.go
@@ -46,6 +46,9 @@ func TestComputeStatsIn_BucketCountsAndSuccessRate(t *testing.T) {
 	if read.Decisions != 1 || read.Allows != 1 {
 		t.Errorf("Read bucket=%+v", read)
 	}
+	if s.Floundering == nil {
+		t.Fatal("expected floundering calibration metrics")
+	}
 }
 
 func TestComputeStatsIn_UnknownAxisErrors(t *testing.T) {
@@ -82,6 +85,44 @@ func TestComputeStatsIn_EmptyDirYieldsEmptyStats(t *testing.T) {
 	}
 	if s.Total != 0 || len(s.Buckets) != 0 {
 		t.Errorf("expected empty stats, got %+v", s)
+	}
+	if s.Floundering == nil || s.Floundering.Sessions != 0 {
+		t.Errorf("expected empty floundering stats, got %+v", s.Floundering)
+	}
+}
+
+func TestComputeStatsIn_FlounderingFalsePositiveRates(t *testing.T) {
+	tmp := t.TempDir()
+	writeChain(t, tmp, "legit-edit",
+		`{"event_type":"decision","payload":{"tool_name":"file.write","action_type":"file.write","action_target":"/repo/a.go","decision":"allow"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"file.write","action_type":"file.write","action_target":"/repo/a.go","decision":"allow"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"git.commit","action_type":"git.commit","action_target":"git commit","decision":"allow"}}`+"\n",
+	)
+	writeChain(t, tmp, "terminal-file-read",
+		`{"event_type":"decision","payload":{"tool_name":"file.read","action_type":"file.read","action_target":"/repo/a.go","decision":"allow"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"file.read","action_type":"file.read","action_target":"/repo/a.go","decision":"allow"}}`+"\n",
+	)
+	writeChain(t, tmp, "terminal-loop",
+		`{"event_type":"decision","payload":{"tool_name":"shell.exec","action_type":"shell.exec","action_target":"ollama ps || true","decision":"allow"}}`+"\n"+
+			`{"event_type":"decision","payload":{"tool_name":"shell.exec","action_type":"shell.exec","action_target":"ollama ps || true","decision":"allow"}}`+"\n",
+	)
+
+	s, err := ComputeStatsIn("tool_name", tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := s.Floundering
+	if f == nil {
+		t.Fatal("expected floundering stats")
+	}
+	if f.FixedFalsePositiveRate <= f.AdaptiveFalsePositiveRate {
+		t.Fatalf("adaptive false-positive rate did not improve: fixed=%v adaptive=%v", f.FixedFalsePositiveRate, f.AdaptiveFalsePositiveRate)
+	}
+	if f.AdaptiveFalseNegativeRate != f.FixedFalseNegativeRate {
+		t.Fatalf("adaptive false-negative rate changed: fixed=%v adaptive=%v", f.FixedFalseNegativeRate, f.AdaptiveFalseNegativeRate)
+	}
+	if f.FalsePositiveReduction < 0.2 {
+		t.Fatalf("false-positive reduction=%v want >= 0.2", f.FalsePositiveReduction)
 	}
 }
 

--- a/go/execution-kernel/internal/router/floundering.go
+++ b/go/execution-kernel/internal/router/floundering.go
@@ -3,6 +3,7 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +60,8 @@ func ReadChainEvents(sessionID string) []ChainEvent {
 // share both tool_name AND non-empty action_target. Same-tool with
 // no target is too loose to flag as a loop.
 func detectLoop(events []ChainEvent, maxLoopCount int) (bool, string) {
-	if len(events) < maxLoopCount {
+	effectiveLoopCount := adaptiveLoopCount(events, maxLoopCount)
+	if len(events) < effectiveLoopCount {
 		return false, ""
 	}
 	// Filter for decision events with tool_name AND non-empty
@@ -76,10 +78,10 @@ func detectLoop(events []ChainEvent, maxLoopCount int) (bool, string) {
 		}
 		recent = append(recent, ev)
 	}
-	if len(recent) < maxLoopCount {
+	if len(recent) < effectiveLoopCount {
 		return false, ""
 	}
-	recent = recent[len(recent)-maxLoopCount:]
+	recent = recent[len(recent)-effectiveLoopCount:]
 	sig := func(e ChainEvent) string {
 		t, _ := e.Payload["tool_name"].(string)
 		tg, _ := e.Payload["action_target"].(string)
@@ -95,7 +97,90 @@ func detectLoop(events []ChainEvent, maxLoopCount int) (bool, string) {
 	if len(short) > 80 {
 		short = short[:80]
 	}
-	return true, fmt.Sprintf("looping-tool-call:%s-x%d", short, maxLoopCount)
+	return true, fmt.Sprintf("looping-tool-call:%s-x%d", short, effectiveLoopCount)
+}
+
+func adaptiveLoopCount(events []ChainEvent, configured int) int {
+	if configured <= 0 {
+		configured = 3
+	}
+	var decisions []ChainEvent
+	for _, ev := range events {
+		if ev.EventType != "decision" {
+			continue
+		}
+		toolName, _ := ev.Payload["tool_name"].(string)
+		target, _ := ev.Payload["action_target"].(string)
+		if toolName == "" || target == "" {
+			continue
+		}
+		decisions = append(decisions, ev)
+	}
+	if len(decisions) == 0 {
+		return configured
+	}
+
+	actionType, _ := decisions[len(decisions)-1].Payload["action_type"].(string)
+	floor := configured
+	if isLowRiskFileLoopAction(actionType) {
+		// Chain calibration showed most false positives were normal
+		// read/write pairs during edit flows. Require a stronger run
+		// before calling those loops floundering.
+		floor = maxInt(floor, configured+2)
+	}
+
+	runs := recentCompletedRunLengths(decisions, 8)
+	if len(runs) < 3 {
+		return floor
+	}
+	sum := 0
+	for _, n := range runs {
+		sum += n
+	}
+	movingAverage := float64(sum) / float64(len(runs))
+	adaptive := int(math.Ceil(movingAverage)) + 1
+	if adaptive > configured+2 {
+		adaptive = configured + 2
+	}
+	return maxInt(floor, adaptive)
+}
+
+func recentCompletedRunLengths(decisions []ChainEvent, window int) []int {
+	if window <= 0 {
+		return nil
+	}
+	var runs []int
+	last := ""
+	runLen := 0
+	for _, ev := range decisions {
+		toolName, _ := ev.Payload["tool_name"].(string)
+		target, _ := ev.Payload["action_target"].(string)
+		sig := fmt.Sprintf("%s|%s", toolName, target)
+		if sig == last {
+			runLen++
+			continue
+		}
+		if runLen > 1 {
+			runs = append(runs, runLen)
+			if len(runs) > window {
+				runs = runs[1:]
+			}
+		}
+		last = sig
+		runLen = 1
+	}
+	return runs
+}
+
+func isLowRiskFileLoopAction(actionType string) bool {
+	return actionType == "file.read" || actionType == "file.write"
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // detectStall returns (true, reason) if no write-shape decisions

--- a/go/execution-kernel/internal/router/floundering_test.go
+++ b/go/execution-kernel/internal/router/floundering_test.go
@@ -40,6 +40,52 @@ func TestDetectFloundering_Loop(t *testing.T) {
 	}
 }
 
+func TestDetectFloundering_AdaptiveLoopThresholdAvoidsLegitimateFileEditPairs(t *testing.T) {
+	ev := func(actionType, target string) ChainEvent {
+		return ChainEvent{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":     actionType,
+				"action_type":   actionType,
+				"action_target": target,
+				"decision":      "allow",
+			},
+		}
+	}
+	res := DetectFloundering(
+		[]ChainEvent{ev("file.write", "/repo/a.go"), ev("file.write", "/repo/a.go")},
+		FlounderingThresholds{MaxLoopCount: 2, MaxStallSeconds: 600},
+		mustParse("2026-05-03T20:00:30Z"),
+	)
+	if res.Fired {
+		t.Errorf("Fired=true on a normal file edit pair; want adaptive threshold to suppress it (reason=%q)", res.Reason)
+	}
+}
+
+func TestDetectFloundering_AdaptiveLoopThresholdStillCatchesShellRetries(t *testing.T) {
+	ev := func(target string) ChainEvent {
+		return ChainEvent{
+			Ts:        "2026-05-03T20:00:00Z",
+			EventType: "decision",
+			Payload: map[string]interface{}{
+				"tool_name":     "shell.exec",
+				"action_type":   "shell.exec",
+				"action_target": target,
+				"decision":      "allow",
+			},
+		}
+	}
+	res := DetectFloundering(
+		[]ChainEvent{ev("ollama ps || true"), ev("ollama ps || true")},
+		FlounderingThresholds{MaxLoopCount: 2, MaxStallSeconds: 600},
+		mustParse("2026-05-03T20:00:30Z"),
+	)
+	if !res.Fired {
+		t.Error("Fired=false on repeated shell retry; want adaptive threshold to preserve loop detection")
+	}
+}
+
 func TestDetectFloundering_VaryingTargets(t *testing.T) {
 	ev := func(target string) ChainEvent {
 		return ChainEvent{


### PR DESCRIPTION
Closes ticket t_7b96a78f (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-7b96a78f.