### PR TITLE
fix(gov): avoid recursive-delete false positives

### DIFF
--- a/docs/observations/2026-05-12-recursive-delete-denial-replay.md
+++ b/docs/observations/2026-05-12-recursive-delete-denial-replay.md
@@ -1,0 +1,34 @@
+# Recursive Delete Denial Replay
+
+Ticket: `t_af9d0df1`
+
+Source: local replay over `~/.chitin/gov-decisions-2026-05-10.jsonl` through
+`~/.chitin/gov-decisions-2026-05-13.jsonl`.
+
+## Summary
+
+Recent recursive-delete-shaped denials split into 11 rows:
+
+- 5 rows normalized to `file.recursive_delete` under `no-rm-recursive`.
+- 6 rows stayed `shell.exec` under the legacy substring fallback
+  `no-destructive-rm`.
+- True positives were actual recursive cleanup or clone-reset commands under
+  `/tmp`.
+- False positives were commands whose arguments mentioned destructive cleanup
+  text or wrapped GitHub CLI PR commands with `--delete-branch`.
+
+## Replay Classification
+
+| Sample | Previous classification | Replay result after fix | Notes |
+| --- | --- | --- | --- |
+| `rtk gh pr close 532 ... --delete-branch` | `file.recursive_delete` deny | `github.pr.close` | False positive. `--delete-branch` is GitHub branch cleanup, not filesystem recursion. |
+| `rg -n "...rm -rf..." ...` | `shell.exec` deny | `file.read` | False positive. Searching for a literal destructive command is read-only. |
+| `tmp=$(mktemp -d); ...; rm -rf "$tmp"` | `file.recursive_delete` deny | `file.recursive_delete` deny | True positive. Variable-backed recursive cleanup remains blocked. |
+| `cd /tmp && rm -rf <dir> && git clone ...` | `file.recursive_delete` deny | `file.recursive_delete` deny | True positive. Clone-reset convenience cleanup is still recursive deletion. |
+
+## Follow-Up Guidance
+
+Worker temp cleanup remains intentionally blocked. Use
+`docs/runbooks/safe-temp-work.md` for the safe alternatives: framework-owned
+temp directories, exact-file deletion followed by `rmdir`, or leaving unique
+`mktemp -d` directories for host temp cleanup.

--- a/docs/runbooks/safe-temp-work.md
+++ b/docs/runbooks/safe-temp-work.md
@@ -1,0 +1,31 @@
+# Safe Temporary Work
+
+Chitin intentionally blocks recursive filesystem deletion, including
+temporary-directory cleanup such as `rm -rf "$tmp"`. The gate cannot prove a
+variable still points at the directory the worker created, so recursive delete
+stays denied even under `/tmp`.
+
+Use one of these patterns instead:
+
+- Prefer language or test-framework temp helpers such as Go's `t.TempDir()`.
+  The harness owns cleanup outside the agent's shell command.
+- If a shell script creates known files, delete those files by exact path and
+  then remove the empty directory with `rmdir "$tmp"`.
+- If the temp tree is large or dynamic, leave it under `/tmp` with a unique
+  `mktemp -d` name and let the host's normal temp cleanup handle it.
+
+Example worker-safe shell cleanup:
+
+```sh
+tmp=$(mktemp -d)
+printf '%s\n' example > "$tmp/output.txt"
+
+# ...use "$tmp/output.txt"...
+
+rm "$tmp/output.txt"
+rmdir "$tmp"
+```
+
+Do not use recursive cleanup as a convenience step in shared commands. If a
+task genuinely requires deleting a populated tree, hand it to the operator or
+remove only the specific files that the task created.

--- a/go/execution-kernel/internal/gov/integration_test.go
+++ b/go/execution-kernel/internal/gov/integration_test.go
@@ -49,6 +49,34 @@ rules:
 	}
 }
 
+func TestIntegration_TempCleanupRecursiveDeleteStillDenied(t *testing.T) {
+	g, _ := newIntegrationGate(t, `
+id: test
+mode: guide
+rules:
+  - id: no-rm-recursive
+    action: file.recursive_delete
+    effect: deny
+    reason: "blocked"
+`)
+	a, err := Normalize("terminal", map[string]any{
+		"command": `tmp=$(mktemp -d); touch "$tmp/file"; rm -rf "$tmp"`,
+	})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if a.Type != ActFileRecursiveDelete {
+		t.Fatalf("Type=%q want %q", a.Type, ActFileRecursiveDelete)
+	}
+	d := g.Evaluate(a, "worker", nil)
+	if d.Allowed {
+		t.Fatalf("expected temp cleanup deny, got %+v", d)
+	}
+	if d.RuleID != "no-rm-recursive" {
+		t.Fatalf("RuleID=%q want no-rm-recursive", d.RuleID)
+	}
+}
+
 // Flow B: execute_code subprocess.run bypass produces the same denial.
 // Both terminal `rm -rf` and execute_code-via-subprocess flow through
 // the same canon detector and land on the same Action class — one rule

--- a/go/execution-kernel/internal/gov/normalize.go
+++ b/go/execution-kernel/internal/gov/normalize.go
@@ -232,9 +232,9 @@ func normalizeWriteFile(args map[string]any) (Action, error) {
 //     bypass-class detectors in canon (IsRecursiveDelete, IsBareGitPush,
 //     IsInfraDestroy, IsRemoteCodeExec, ContainsProcSubstFetch,
 //     WriteDestinations) — never a raw-string regex.
-//   - Each concrete dispatch (git.status, gh.pr.create, etc.) is keyed
-//     on canon.Command{Tool, Action} for the FIRST segment of the
-//     pipeline. Commands with no canon mapping fall through to ActShellExec.
+//   - Each concrete dispatch (git.status, gh.pr.create, file.read, etc.) is
+//     keyed on canon.Command{Tool, Action} for parsed pipeline segments.
+//     Commands with no canon mapping fall through to ActShellExec.
 //   - Per-segment shape annotations (curl-pipe-bash, remote-code-exec)
 //     are set in Params for policy target_regex matching.
 //
@@ -250,10 +250,6 @@ func classifyShellCommand(cmd string) Action {
 	// back to the tokenizer-grade Parse on parse failure, so we never
 	// regress below the prior tokenizer behavior.
 	pipeline := canon.ParseAST(trimmed)
-	first := canon.Command{}
-	if len(pipeline.Segments) > 0 {
-		first = pipeline.Segments[0].Command
-	}
 
 	// === Destructive / re-tag patterns (consulted before per-tool dispatch) ===
 
@@ -296,12 +292,16 @@ func classifyShellCommand(cmd string) Action {
 	}
 
 	// === Per-tool dispatch (keyed on canon's Tool/Action) ===
-
-	switch first.Tool {
-	case "git":
-		return classifyGit(first, trimmed)
-	case "gh":
-		return classifyGh(first, trimmed)
+	//
+	// Dispatch over all parsed segments, not only argv[0] of the raw shell
+	// string. Common worker commands prefix structured operations with
+	// `cd <repo> && ...`; those should still normalize as the underlying
+	// git/gh/search operation. The destructive detectors above already scanned
+	// all segments first, so this cannot hide recursive deletion.
+	for _, seg := range pipeline.Segments {
+		if action, ok := classifyStructuredShellSegment(seg.Command, trimmed); ok {
+			return action
+		}
 	}
 
 	// === Default: generic shell.exec with optional shape annotation ===
@@ -314,6 +314,34 @@ func classifyShellCommand(cmd string) Action {
 		action.Params = map[string]any{"shape": "remote-code-exec"}
 	}
 	return action
+}
+
+func classifyStructuredShellSegment(c canon.Command, raw string) (Action, bool) {
+	switch c.Tool {
+	case "git":
+		a := classifyGit(c, raw)
+		return a, a.Type != ActShellExec
+	case "gh":
+		a := classifyGh(c, raw)
+		return a, a.Type != ActShellExec
+	case "rtk":
+		if len(c.Args) > 0 && c.Args[0] == "gh" {
+			nested := canon.ParseOne(strings.Join(c.Args, " "))
+			a := classifyGh(nested, raw)
+			return a, a.Type != ActShellExec
+		}
+	case "grep":
+		target := raw
+		if len(c.Args) > 0 {
+			target = strings.Join(c.Args, " ")
+		}
+		return Action{
+			Type:   ActFileRead,
+			Target: target,
+			Params: map[string]any{"tool": c.Tool},
+		}, true
+	}
+	return Action{}, false
 }
 
 // classifyGit dispatches the git family (force-push, push, status, log,

--- a/go/execution-kernel/internal/gov/normalize_test.go
+++ b/go/execution-kernel/internal/gov/normalize_test.go
@@ -172,6 +172,44 @@ func TestNormalize_TerminalGhPRCreate(t *testing.T) {
 	}
 }
 
+func TestNormalize_TerminalGhPRCloseDeleteBranchIsNotRecursiveDelete(t *testing.T) {
+	cases := []string{
+		`gh pr close 123 --delete-branch`,
+		`rtk gh pr close 123 --repo chitinhq/chitin --comment "close without merge" --delete-branch`,
+		`cd /work/chitin && gh pr close 123 --delete-branch`,
+		`cd /work/chitin && gh pr close 123 --delete-branch 2>&1 | tail -5`,
+	}
+	for _, cmd := range cases {
+		t.Run(cmd, func(t *testing.T) {
+			a, err := Normalize("terminal", map[string]any{"command": cmd})
+			if err != nil {
+				t.Fatalf("Normalize: %v", err)
+			}
+			if a.Type == ActFileRecursiveDelete {
+				t.Fatalf("Type=%q; --delete-branch is a GitHub PR flag, not filesystem deletion", a.Type)
+			}
+			if a.Type != ActGithubPRClose {
+				t.Fatalf("Type=%q want %q", a.Type, ActGithubPRClose)
+			}
+		})
+	}
+}
+
+func TestNormalize_TerminalSearchForRmRfLiteralIsRead(t *testing.T) {
+	a, err := Normalize("terminal", map[string]any{
+		"command": `rg -n "rm -rf|recursive_delete" go/execution-kernel docs`,
+	})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if a.Type == ActFileRecursiveDelete {
+		t.Fatalf("Type=%q; searching for a destructive literal is not deletion", a.Type)
+	}
+	if a.Type != ActFileRead {
+		t.Fatalf("Type=%q want %q", a.Type, ActFileRead)
+	}
+}
+
 func TestNormalize_WriteFileEnv(t *testing.T) {
 	a, _ := Normalize("write_file", map[string]any{"path": ".env", "content": "X=1"})
 	if a.Type != ActFileWrite {


### PR DESCRIPTION
Closes ticket t_af9d0df1 (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-af9d0df1.