### PR TITLE
fix(router-plugin-api): swallow stdin EPIPE when kernel spawn fails

### DIFF
--- a/libs/router-plugin-api/typescript/index.ts
+++ b/libs/router-plugin-api/typescript/index.ts
@@ -174,6 +174,10 @@ export async function gateAction(input: GateActionInput): Promise<GateDecision> 
       }
     });
 
+    child.stdin.on('error', () => {
+      // EPIPE on a dead pipe is expected when spawn fails with ENOENT;
+      // child.on('error') already records the spawn failure and fails open.
+    });
     child.stdin.write(JSON.stringify(payload));
     child.stdin.end();
   });


### PR DESCRIPTION
## Summary

`nx affected --target=validate` (added by #573) failed on `main` immediately after merge. Root cause: `libs/router-plugin-api/typescript/index.ts` writes to `child.stdin` after spawn, which fails asynchronously with EPIPE when the spawn itself errors (e.g. ENOENT in the test "falls open when kernel binary is missing"). No error handler is attached to `child.stdin`, so vitest treats it as an unhandled error and fails the run — even though all 9 assertions pass.

## Fix (2 lines)

Attach a noop `.on('error')` to `child.stdin`. EPIPE on a dead pipe is expected when spawn has already failed; the real spawn failure is logged by the existing `child.on('error')` handler at line 132.

## Verification

```
$ pnpm exec vitest run libs/router-plugin-api/typescript/index.test.ts
 ✓ libs/router-plugin-api/typescript/index.test.ts (9 tests) 162ms
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

No more "Unhandled Errors" section. Same 9 tests pass.

## Why this surfaced now

#573 added `nx affected --target=validate` to the CI workflow. The router-plugin-api tests had this latent EPIPE on every run; previously CI didn't exercise this exact path on every push, so it stayed hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)