### PR TITLE
fix(dispatch): honor model-aware routing

### DIFF
--- a/docs/governance-setup-extras/_pick_driver.py
+++ b/docs/governance-setup-extras/_pick_driver.py
@@ -79,31 +79,139 @@ def model_ids(card: dict) -> set[str]:
     }
 
 
+DEPTH_SCORE = {"expert": 4, "strong": 3, "moderate": 2, "basic": 1}
+
+
+def capability_depth_score(card: dict, caps_needed: set[str]) -> int:
+    depths = {
+        x.get("skill"): DEPTH_SCORE.get(str(x.get("depth", "")).lower(), 0)
+        for x in card.get("capabilities", [])
+        if isinstance(x, dict)
+    }
+    return sum(depths.get(cap, 0) for cap in caps_needed)
+
+
+def min_model_cost(card: dict) -> float:
+    return min(
+        (
+            m.get("premium_cost", 99.0)
+            for m in card.get("models", [])
+            if isinstance(m, dict)
+        ),
+        default=99.0,
+    )
+
+
+def max_model_cost(card: dict) -> float:
+    return max(
+        (
+            m.get("premium_cost", -1.0)
+            for m in card.get("models", [])
+            if isinstance(m, dict)
+        ),
+        default=-1.0,
+    )
+
+
 def deterministic_pick(classify: dict, cards: list[dict]) -> tuple[dict, list[dict]]:
-    """Capability-filter + cheapest-model rank. Returns (picked_card, candidates)."""
+    """Capability-filter plus complexity-aware driver rank."""
     caps_needed = set(classify.get("capabilities", []))
     candidates = [c for c in cards if caps_needed.issubset(card_capabilities(c))]
+    bucket = complexity_bucket(classify)
 
-    ranked = sorted(
-        candidates,
-        key=lambda c: min(
-            (
-                m.get("premium_cost", 99.0)
-                for m in c.get("models", [])
-                if isinstance(m, dict)
+    if bucket == "high":
+        ranked = sorted(
+            candidates,
+            key=lambda c: (
+                -capability_depth_score(c, caps_needed),
+                -max_model_cost(c),
+                min_model_cost(c),
             ),
-            default=99.0,
-        ),
-    )
+        )
+    elif bucket == "medium":
+        ranked = sorted(
+            candidates,
+            key=lambda c: (
+                -capability_depth_score(c, caps_needed),
+                min_model_cost(c),
+            ),
+        )
+    else:
+        ranked = sorted(candidates, key=min_model_cost)
+
     pick = ranked[0] if ranked else {"id": "unassigned"}
     return pick, candidates
 
 
-def cheapest_model(card: dict) -> str | None:
-    models = sorted(
+def sorted_models(card: dict) -> list[dict]:
+    return sorted(
         (m for m in card.get("models", []) if isinstance(m, dict)),
         key=lambda m: m.get("premium_cost", 99.0),
     )
+
+
+def complexity_bucket(classify: dict) -> str:
+    raw = str(classify.get("complexity", "")).strip().lower()
+    if raw in {"hi", "high", "hard", "complex"}:
+        return "high"
+    if raw in {"med", "medium", "moderate"}:
+        return "medium"
+    if classify.get("needs_frontier") is True:
+        return "high"
+    return "low"
+
+
+def select_model(card: dict, classify: dict) -> str | None:
+    """Pick the minimum acceptable model for this task complexity.
+
+    Low complexity gets the cheapest model. Medium gets a middle-cost model
+    when available. High/needs_frontier gets the strongest listed model. The
+    card order is not trusted; premium_cost is the operator-maintained strength
+    proxy used elsewhere by the dispatch stack.
+    """
+    models = sorted_models(card)
+    if not models:
+        return None
+    bucket = complexity_bucket(classify)
+    if bucket == "high":
+        return models[-1].get("id")
+    if bucket == "medium":
+        return models[len(models) // 2].get("id")
+    return models[0].get("id")
+
+
+def model_cost(card: dict, model_id: str | None) -> float:
+    if not model_id:
+        return -1.0
+    for model in sorted_models(card):
+        if model.get("id") == model_id:
+            try:
+                return float(model.get("premium_cost", -1.0))
+            except (TypeError, ValueError):
+                return -1.0
+    return -1.0
+
+
+def effective_model(card: dict, classify: dict, requested_model: str | None) -> str | None:
+    """Honor a valid LLM model only if it is strong enough for complexity.
+
+    The LLM may prefer cheap models too aggressively. Enforce the
+    complexity-derived model floor so Copilot does not collapse to GPT-4.1
+    for medium/high work just because it is cheapest. Stronger-than-floor
+    requests are kept.
+    """
+    floor = select_model(card, classify)
+    if not requested_model:
+        return floor
+    if requested_model not in model_ids(card):
+        return floor
+    if model_cost(card, requested_model) < model_cost(card, floor):
+        return floor
+    return requested_model
+
+
+def cheapest_model(card: dict) -> str | None:
+    models = sorted_models(card)
     return models[0].get("id") if models else None
 
 
@@ -254,7 +362,7 @@ def main() -> None:
         forced_card = next((c for c in cards if c.get("id") == force), {})
         emit_result(
             driver=force,
-            model=cheapest_model(forced_card),
+            model=select_model(forced_card, classify),
             classify=classify,
             caps_needed=caps_needed,
             candidates_considered=1,
@@ -273,7 +381,7 @@ def main() -> None:
         if chosen_card is not None:
             emit_result(
                 driver=llm_result["driver"],
-                model=llm_result.get("model") or cheapest_model(chosen_card),
+                model=effective_model(chosen_card, classify, llm_result.get("model")),
                 classify=classify,
                 caps_needed=caps_needed,
                 candidates_considered=len(cards),
@@ -285,13 +393,13 @@ def main() -> None:
 
     pick, candidates = deterministic_pick(classify, cards)
     picked = pick.get("id")
-    model = cheapest_model(pick) if picked != "unassigned" else None
+    model = select_model(pick, classify) if picked != "unassigned" else None
     if picked == "unassigned":
         reasoning = "no candidates covered required capabilities"
     elif llm_rejection:
-        reasoning = f"LLM fallback: {llm_rejection}; deterministic capability-filter + cheapest-cost rank"
+        reasoning = f"LLM fallback: {llm_rejection}; deterministic capability-filter + complexity-aware model rank"
     else:
-        reasoning = "deterministic capability-filter + cheapest-cost rank"
+        reasoning = "deterministic capability-filter + complexity-aware model rank"
     if load_errors:
         reasoning = f"{reasoning}; {len(load_errors)} card load error(s)"
 

--- a/docs/governance-setup-extras/agent-cards/copilot.json
+++ b/docs/governance-setup-extras/agent-cards/copilot.json
@@ -1,23 +1,61 @@
 {
   "id": "copilot",
-  "description": "GitHub Copilot CLI — free GPT-4.1 tier. Cheap, fast, used liberally as worker AND judge.",
+  "description": "GitHub Copilot CLI \u2014 invoked via chitin-kernel drive copilot (Go SDK driver) so every tool call passes through gov.Gate.Evaluate inline. Byte-equivalent to the PreToolUse hooks used by codex/gemini/claude-code; just in-process instead of stdin-piped.",
   "auth": "github-copilot-subscription",
   "capabilities": [
-    {"skill": "ts", "depth": "strong"},
-    {"skill": "python", "depth": "strong"},
-    {"skill": "go", "depth": "moderate"},
-    {"skill": "docs", "depth": "strong"},
-    {"skill": "review", "depth": "strong"},
-    {"skill": "refactor", "depth": "moderate"}
+    {
+      "skill": "ts",
+      "depth": "strong"
+    },
+    {
+      "skill": "python",
+      "depth": "strong"
+    },
+    {
+      "skill": "go",
+      "depth": "moderate"
+    },
+    {
+      "skill": "docs",
+      "depth": "strong"
+    },
+    {
+      "skill": "review",
+      "depth": "strong"
+    },
+    {
+      "skill": "refactor",
+      "depth": "moderate"
+    }
   ],
   "models": [
-    {"id": "gpt-4.1", "tier": "T1", "premium_cost": 0.0},
-    {"id": "claude-haiku-4.5", "tier": "T2", "premium_cost": 0.33},
-    {"id": "gpt-5.4", "tier": "T3", "premium_cost": 1.0}
+    {
+      "id": "gpt-4.1",
+      "tier": "T1",
+      "premium_cost": 0.0
+    },
+    {
+      "id": "claude-haiku-4.5",
+      "tier": "T2",
+      "premium_cost": 0.33
+    },
+    {
+      "id": "gpt-5.4",
+      "tier": "T3",
+      "premium_cost": 1.0
+    }
   ],
   "invocation": {
-    "cmd": "copilot",
-    "args": ["--allow-all", "--model", "{model}", "-p", "{prompt}"]
+    "cmd": "/home/red/.local/bin/chitin-kernel",
+    "args": [
+      "drive",
+      "copilot",
+      "--model",
+      "{model}",
+      "--cwd",
+      ".",
+      "{prompt}"
+    ]
   },
-  "notes": "GPT-4.1 is free per Copilot subscription. Use this tier liberally for low-stakes work and as a judge / sanity-check helper. Hermes is allowed to invoke copilot directly (per hermes-no-frontier-spawn rule exception). --allow-all replaces the non-existent --dangerously-skip-permissions; it is equivalent to --allow-all-tools + --allow-all-paths + --allow-all-urls. Model name uses dot form `claude-haiku-4.5` — the dash form `claude-haiku-4-5` is rejected by the copilot CLI (verified 2026-05-11)."
+  "notes": "Routed through `chitin-kernel drive copilot` (Go SDK driver at go/execution-kernel/internal/driver/copilot/) so each tool call lands `gov.Gate.Evaluate()` inline. The bare copilot CLI's --allow-all flag is NOT needed; the SDK driver handles permissions via the inline gate. Model name uses dot form `claude-haiku-4.5` \u2014 the dash form `claude-haiku-4-5` is rejected by the copilot CLI (verified 2026-05-11). Authority: this card invocation succeeds because gate_hook.go's `isClawtaDriveCarveout` allows agent=clawta + `chitin-kernel drive <lane>` without supervisor authority (the launched session's tool calls remain fully gated). Pre-2026-05-13 invocation was bare /home/red/.vite-plus/bin/copilot with --allow-all (bypassed chitin entirely); rolled forward in this PR. Model routing policy: GPT-4.1 is only the low-complexity/cheap lane; medium Copilot tasks should use claude-haiku-4.5 or better, and high/needs_frontier Copilot tasks should use gpt-5.4. _pick_driver enforces this as a model floor even if the LLM router asks for the cheaper model."
 }

--- a/docs/governance-setup-extras/agent-cards/gemini.json
+++ b/docs/governance-setup-extras/agent-cards/gemini.json
@@ -1,6 +1,6 @@
 {
   "id": "gemini",
-  "description": "Google Gemini CLI — Flash-Lite → Flash → 2.5-Pro escalation, picks model for situation. Multimodal capable.",
+  "description": "Google Gemini CLI — Auto (Gemini 3) routing; CLI chooses the best Gemini 3 model for the task.",
   "auth": "google-gemini-subscription",
   "capabilities": [
     {"skill": "python", "depth": "strong"},
@@ -10,13 +10,18 @@
     {"skill": "review", "depth": "moderate"}
   ],
   "models": [
-    {"id": "gemini-2.5-flash-lite", "tier": "T1", "premium_cost": 0.05},
-    {"id": "gemini-2.5-flash", "tier": "T2", "premium_cost": 0.1},
-    {"id": "gemini-2.5-pro", "tier": "T3", "premium_cost": 0.5}
+    {"id": "auto", "tier": "T3", "premium_cost": 0.5}
   ],
   "invocation": {
     "cmd": "gemini",
-    "args": ["-y", "-p", "{prompt}", "--model", "{model}"]
+    "args": [
+      "-y",
+      "--skip-trust",
+      "-p",
+      "{prompt}",
+      "--model",
+      "{model}"
+    ]
   },
-  "notes": "$20/mo subscription. Auto-scales model up/down based on task. Multimodal use case is unusual for chitin but worth keeping for diagrams / UI work. Models verified against the gemini CLI on 2026-05-11: gemma-2-local, gemini-flash, and gemini-3 all return ModelNotFoundError (code 404); only the gemini-2.5-* family resolves. -y enables YOLO mode (auto-approve all tool calls); the old --skip-trust flag is insufficient for non-interactive runs."
+  "notes": "Updated 2026-05-13 after Gemini CLI model selector showed Auto (Gemini 3): CLI auto-selects between current Gemini 3 models such as gemini-3.1-pro and gemini-3-flash. Direct model ids gemini-3-flash and gemini-3.1-pro returned ModelNotFoundError via CLI, while --model auto and omitted --model both succeeded. Use --skip-trust for headless automated worktrees."
 }

--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -187,19 +187,19 @@ steps:
   - id: audit_comment
     description: Announce dispatch + flip ready→in_progress + broadcast to Discord
     run: |
-      hermes kanban --board chitin comment ${ticket_id} --author clawta "🦞 Starting dispatch to $pick_driver.json.driver | complexity $pick_driver.json.complexity | via kanban-dispatch workflow"
+      hermes kanban --board chitin comment ${ticket_id} --author clawta "🦞 Starting dispatch to $pick_driver.json.driver/$pick_driver.json.model | complexity $pick_driver.json.complexity | via kanban-dispatch workflow"
       # Slice D: lifecycle discipline. Flip to in_progress so the board
       # reflects reality. kanban-flow is idempotent when the ticket is
       # already in_progress (e.g. clawta-poller flipped it before this
       # workflow ran), so failure here is benign.
       kanban-flow start ${ticket_id} --author clawta 2>/dev/null || true
-      openclaw message send --channel discord --account default --text "🦞 Starting ${ticket_id} to $pick_driver.json.driver | complexity $pick_driver.json.complexity" 2>/dev/null || true
+      openclaw message send --channel discord --account default --text "🦞 Starting ${ticket_id} to $pick_driver.json.driver/$pick_driver.json.model | complexity $pick_driver.json.complexity" 2>/dev/null || true
 
   # ─────────────────────────────────────────────────────────────────────
   # 8. Spawn the picked frontier-coder CLI as a worker.
   #
-  # Reads ~/.openclaw/data/agent-cards/<driver>.json, picks the cheapest
-  # model (lowest premium_cost — matches _pick_driver.py's ranking),
+  # Reads ~/.openclaw/data/agent-cards/<driver>.json and honors the
+  # model selected by _pick_driver.py (complexity-aware and ELO-ready).
   # substitutes {model} and {prompt} into card.invocation.args, execs
   # the leaf CLI. The exec is gated by chitin under driver=clawta (the
   # spawning surface); the leaf CLI's own PreToolUse/BeforeTool hook
@@ -301,7 +301,14 @@ steps:
       ENV_HEADER=$(printf '# Working environment\n\nYou are already in a fresh git worktree at %s on branch %s (based on origin/main).\n\nDO NOT create another worktree or branch — you are in one.\nDO NOT run `git push` or `gh pr create` — lobster handles those after you exit.\n\nYour job: make the code change for the ticket, run any relevant tests, then commit with a clear message referencing %s. Then exit. That is it.\n\n# Ticket %s\n\n' \
         "$WORKTREE_DIR" "$BRANCH" "$TICKET_ID" "$TICKET_ID")
       PROMPT="${ROLE_HEADER}${ENV_HEADER}${TICKET_BODY}"
-      MODEL=$(jq -r '[.models[]] | sort_by(.premium_cost) | .[0].id' "$CARD_PATH")
+      MODEL='$pick_driver.json.model'
+      if [[ -z "$MODEL" || "$MODEL" == "null" || "$MODEL" == '$pick_driver.json.model' ]]; then
+        MODEL=$(jq -r '[.models[]] | sort_by(.premium_cost) | .[0].id' "$CARD_PATH")
+      fi
+      if ! jq -e --arg model "$MODEL" '.models[]? | select(.id == $model)' "$CARD_PATH" >/dev/null; then
+        echo "spawn_worker: selected model $MODEL is not present on driver=$DRIVER card" >&2
+        exit 1
+      fi
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
       ARGS_JSON=$(jq -c --arg model "$MODEL" --arg prompt "$PROMPT" \
         '.invocation.args | map(if . == "{model}" then $model elif . == "{prompt}" then $prompt else . end)' \

--- a/docs/governance-setup-extras/tests/test_pick_driver.py
+++ b/docs/governance-setup-extras/tests/test_pick_driver.py
@@ -108,6 +108,72 @@ class PickDriverTest(unittest.TestCase):
         self.assertEqual(payload["router_mode"], "deterministic")
         self.assertIn("invalid model", payload["reasoning"])
 
+    def test_deterministic_model_selection_uses_complexity(self):
+        cards = {
+            "claude-code.json": json.dumps(
+                {
+                    "id": "claude-code",
+                    "capabilities": [{"skill": "python"}],
+                    "models": [
+                        {"id": "claude-haiku-4-5", "premium_cost": 0.15},
+                        {"id": "claude-sonnet-4-6", "premium_cost": 0.5},
+                        {"id": "claude-opus-4-7", "premium_cost": 1.0},
+                    ],
+                }
+            )
+        }
+
+        low = self.run_picker(
+            {"complexity": "low", "capabilities": ["python"]},
+            cards,
+            llm_json={"driver": "missing", "model": "x", "reasoning": "bad"},
+        )
+        med = self.run_picker(
+            {"complexity": "med", "capabilities": ["python"]},
+            cards,
+            llm_json={"driver": "missing", "model": "x", "reasoning": "bad"},
+        )
+        high = self.run_picker(
+            {"complexity": "high", "capabilities": ["python"]},
+            cards,
+            llm_json={"driver": "missing", "model": "x", "reasoning": "bad"},
+        )
+
+        self.assertEqual(json.loads(low.stdout)["model"], "claude-haiku-4-5")
+        self.assertEqual(json.loads(med.stdout)["model"], "claude-sonnet-4-6")
+        self.assertEqual(json.loads(high.stdout)["model"], "claude-opus-4-7")
+
+    def test_llm_model_choice_has_complexity_floor(self):
+        classify = {"complexity": "med", "capabilities": ["docs"]}
+        cards = {
+            "copilot.json": json.dumps(
+                {
+                    "id": "copilot",
+                    "capabilities": [{"skill": "docs"}],
+                    "models": [
+                        {"id": "gpt-4.1", "premium_cost": 0.0},
+                        {"id": "claude-haiku-4.5", "premium_cost": 0.33},
+                        {"id": "gpt-5.4", "premium_cost": 1.0},
+                    ],
+                }
+            )
+        }
+
+        result = self.run_picker(
+            classify,
+            cards,
+            llm_json={
+                "driver": "copilot",
+                "model": "gpt-4.1",
+                "reasoning": "cheap docs",
+            },
+        )
+        payload = json.loads(result.stdout)
+
+        self.assertEqual(payload["driver"], "copilot")
+        self.assertEqual(payload["router_mode"], "llm")
+        self.assertEqual(payload["model"], "claude-haiku-4.5")
+
     def test_corrupt_cards_are_reported(self):
         classify = {"complexity": "low", "capabilities": ["ts"]}
         cards = {

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -187,19 +187,19 @@ steps:
   - id: audit_comment
     description: Announce dispatch + flip ready→in_progress + broadcast to Discord
     run: |
-      hermes kanban --board chitin comment ${ticket_id} --author clawta "🦞 Starting dispatch to $pick_driver.json.driver | complexity $pick_driver.json.complexity | via kanban-dispatch workflow"
+      hermes kanban --board chitin comment ${ticket_id} --author clawta "🦞 Starting dispatch to $pick_driver.json.driver/$pick_driver.json.model | complexity $pick_driver.json.complexity | via kanban-dispatch workflow"
       # Slice D: lifecycle discipline. Flip to in_progress so the board
       # reflects reality. kanban-flow is idempotent when the ticket is
       # already in_progress (e.g. clawta-poller flipped it before this
       # workflow ran), so failure here is benign.
       kanban-flow start ${ticket_id} --author clawta 2>/dev/null || true
-      openclaw message send --channel discord --account default --text "🦞 Starting ${ticket_id} to $pick_driver.json.driver | complexity $pick_driver.json.complexity" 2>/dev/null || true
+      openclaw message send --channel discord --account default --text "🦞 Starting ${ticket_id} to $pick_driver.json.driver/$pick_driver.json.model | complexity $pick_driver.json.complexity" 2>/dev/null || true
 
   # ─────────────────────────────────────────────────────────────────────
   # 8. Spawn the picked frontier-coder CLI as a worker.
   #
-  # Reads ~/.openclaw/data/agent-cards/<driver>.json, picks the cheapest
-  # model (lowest premium_cost — matches _pick_driver.py's ranking),
+  # Reads ~/.openclaw/data/agent-cards/<driver>.json and honors the
+  # model selected by _pick_driver.py (complexity-aware and ELO-ready).
   # substitutes {model} and {prompt} into card.invocation.args, execs
   # the leaf CLI. The exec is gated by chitin under driver=clawta (the
   # spawning surface); the leaf CLI's own PreToolUse/BeforeTool hook
@@ -301,7 +301,14 @@ steps:
       ENV_HEADER=$(printf '# Working environment\n\nYou are already in a fresh git worktree at %s on branch %s (based on origin/main).\n\nDO NOT create another worktree or branch — you are in one.\nDO NOT run `git push` or `gh pr create` — lobster handles those after you exit.\n\nYour job: make the code change for the ticket, run any relevant tests, then commit with a clear message referencing %s. Then exit. That is it.\n\n# Ticket %s\n\n' \
         "$WORKTREE_DIR" "$BRANCH" "$TICKET_ID" "$TICKET_ID")
       PROMPT="${ROLE_HEADER}${ENV_HEADER}${TICKET_BODY}"
-      MODEL=$(jq -r '[.models[]] | sort_by(.premium_cost) | .[0].id' "$CARD_PATH")
+      MODEL='$pick_driver.json.model'
+      if [[ -z "$MODEL" || "$MODEL" == "null" || "$MODEL" == '$pick_driver.json.model' ]]; then
+        MODEL=$(jq -r '[.models[]] | sort_by(.premium_cost) | .[0].id' "$CARD_PATH")
+      fi
+      if ! jq -e --arg model "$MODEL" '.models[]? | select(.id == $model)' "$CARD_PATH" >/dev/null; then
+        echo "spawn_worker: selected model $MODEL is not present on driver=$DRIVER card" >&2
+        exit 1
+      fi
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
       ARGS_JSON=$(jq -c --arg model "$MODEL" --arg prompt "$PROMPT" \
         '.invocation.args | map(if . == "{model}" then $model elif . == "{prompt}" then $prompt else . end)' \


### PR DESCRIPTION
Fixes the dispatch gap where _pick_driver selected a model but spawn_worker ignored it and ran the cheapest card model.\n\nChanges:\n- make deterministic fallback choose driver/model by complexity instead of cheapest-only\n- make spawn_worker honor $pick_driver.json.model and validate it exists on the selected card\n- include selected model in audit/start messages\n- add tests for low/medium/high model selection\n\nValidation:\n- python3 -m unittest docs/governance-setup-extras/tests/test_pick_driver.py\n- python3 -m py_compile docs/governance-setup-extras/_pick_driver.py\n\nRuntime copy updated under ~/.openclaw/workflows with backups timestamped 20260513-162625.