### PR TITLE
feat(regression-gate): aggregator + clawta-pr-lifecycle integration (t_ac6da121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,11 @@ jobs:
       - name: Oxlint
         run: pnpm exec oxlint . || true  # warnings only for phase-1
 
-      - name: Spec front-matter + INDEX.md drift check
+      - name: Regression gate
         run: |
-          # Enforces the lifecycle schema from
-          # docs/superpowers/specs/2026-05-13-spec-lifecycle-metadata.md:
-          # every spec has a 6-field YAML front-matter block, status is
-          # in the closed enum, and the committed INDEX.md matches what
-          # the generator produces. See docs/runbooks/spec-lifecycle.md.
+          # Runs every registered invariant in scripts/check-*.{sh,py}
+          # against the merged-state tree. Hard-block: failure = CI failure.
+          # See docs/superpowers/specs/2026-05-13-regression-gate.md
+          # and docs/runbooks/regression-gate.md.
           python3 -m pip install --quiet --user pyyaml
-          python3 scripts/check-spec-frontmatter.py
-          python3 scripts/regen-spec-index.py --check
+          bash scripts/regression-gate.sh

--- a/docs/runbooks/regression-gate.md
+++ b/docs/runbooks/regression-gate.md
@@ -1,0 +1,123 @@
+# Regression-gate runbook
+
+How the regression-gate works, how to author an invariant, how to
+override a false positive, and the one-time operator setup.
+
+Schema and design in
+[`docs/superpowers/specs/2026-05-13-regression-gate.md`](../superpowers/specs/2026-05-13-regression-gate.md).
+
+## What the gate does
+
+For every PR, every invariant in `scripts/check-*.{sh,py}` runs against
+the PR's merged-state tree. If any invariant exits non-zero, the gate
+fails and the PR cannot auto-merge until the failure is resolved.
+
+The gate runs in two places:
+
+1. **CI** — as part of the `test` job in `.github/workflows/ci.yml`.
+   This is the binding gate visible to humans on the PR page.
+2. **`swarm/bin/clawta-pr-lifecycle`** — reruns the gate against the
+   PR's merge-ref tree as the 6th auto-merge check, after CI passes,
+   to close the stale-CI race (commit pushed after last CI run).
+
+Both venues run the same `scripts/regression-gate.sh` script.
+
+## Invariant author contract
+
+A file under `scripts/` is an invariant iff it matches the glob
+`scripts/check-*.{sh,py}` (top level only — no recursion). To add a
+new invariant:
+
+1. Create `scripts/check-<your-invariant>.sh` (or `.py`).
+2. Make it executable: `chmod +x scripts/check-<name>.sh`.
+3. Follow the contract:
+
+   | Concern | Contract |
+   |---|---|
+   | Exit code | `0` = preserved · `1` = broken · `≥ 2` = tool error (treated as broken) |
+   | Stdout | One human-readable line per violation; ideally `path:line  reason` |
+   | Stderr | Tool errors only |
+   | Input | Runs from the repo root; assume merged-state tree is checked out |
+   | Allowlist | Optional `scripts/<name>.allow` next to the script; format `<path-or-pattern> # <reason>`; load it inside your script |
+   | Timeout | 30 seconds per invariant (configurable via `REGRESSION_GATE_TIMEOUT` env var for local debugging) |
+
+4. **Test it locally** by running:
+
+   ```bash
+   bash scripts/regression-gate.sh
+   ```
+
+   Your new check should appear in the summary.
+
+### warn-* — invariants in a soak period
+
+If your invariant is not yet ready to be gating (e.g., legacy data
+still violates it during a migration window), name it
+`scripts/warn-<name>.{sh,py}` instead. Warn scripts follow the same
+contract but the aggregator **ignores** their exit code — their
+output surfaces but never fails the gate. Promote `warn-` → `check-`
+by renaming the file when ready.
+
+## Overriding a false positive
+
+The gate does not have a per-PR override mechanism. False positives
+are addressed by editing the invariant's allowlist file:
+
+1. Open `scripts/<invariant-name>.allow`. Create it if it doesn't
+   exist.
+2. Add a line: `<path-or-pattern> # <reason>`. The reason is
+   mandatory — invariant linters typically reject entries missing
+   it.
+3. Commit the allowlist change in the same PR (or a follow-up PR).
+4. Push; CI reruns; the gate passes.
+
+This is by design — bypasses are auditable in git history and force
+a written reason.
+
+## When the gate fails in clawta-pr-lifecycle
+
+The `clawta-pr-lifecycle` cron reruns the gate against the PR's
+merge ref. Two failure modes:
+
+| Aggregator exit | clawta action |
+|---|---|
+| `1` — invariant broken | Posts a structured comment on the PR; reassigns the kanban ticket to `red`. PR stays open; no merge. |
+| `≥ 2` — tool error (aggregator crashed, worktree fetch failed, timeout) | Posts a comment flagging "could not evaluate"; **does NOT reassign**. Operator must investigate (it's a tooling issue, not a PR-content issue). |
+
+## One-time operator setup (branch protection)
+
+The `Regression gate` step rides inside the existing `test` job in
+`.github/workflows/ci.yml`. Make sure your branch protection rule
+on `main` includes:
+
+1. Repo settings → Branches → `main` rule → Required status checks.
+2. Add or confirm `test` is in the required list.
+3. Enable **"Require branches to be up to date before merging"** so
+   that a stale PR re-runs CI (and the gate) against the latest
+   `main`.
+
+This is a one-time settings change, not a code change.
+
+## Inaugural registry (Day-0)
+
+When this runbook ships, the registry contains two invariants:
+
+| Script | Enforces |
+|---|---|
+| `scripts/check-spec-frontmatter.py` | Every spec under `docs/superpowers/specs/**` has a valid 6-field YAML front-matter block. See `docs/runbooks/spec-lifecycle.md`. |
+| `scripts/check-spec-index-sync.sh` | `docs/superpowers/specs/INDEX.md` matches what `regen-spec-index.py` produces. |
+
+The five already-specced audit-response invariants (governance
+boundary, kanban-isolation, scripts-classification,
+worktree-status, worktree-naming) join the registry as their
+implementation PRs land — no coordination required; the aggregator
+picks them up by filename match.
+
+## Followups (file as kanban tickets if needed)
+
+- Promote `regression-gate` to its own CI job if check-list
+  legibility on the PR page becomes a debugging cost.
+- Reimplement the aggregator as `chitin-kernel regression-gate` if
+  a dashboard or audit surface needs typed metadata.
+- Chain-event logging of gate decisions for the analyzer cron in
+  `docs/superpowers/specs/2026-05-12-chitin-dashboard.md` Slice 5.

--- a/scripts/check-spec-index-sync.sh
+++ b/scripts/check-spec-index-sync.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# check-spec-index-sync — invariant: docs/superpowers/specs/INDEX.md is
+# in sync with the regen-spec-index.py generator output.
+#
+# Part of the regression-gate registry — exit 0 = preserved, 1 = drift.
+exec python3 "$(dirname "$0")/regen-spec-index.py" --check

--- a/scripts/regression-gate.sh
+++ b/scripts/regression-gate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# regression-gate — run every registered invariant against the current tree.
+# Exit 0 iff every check-*.{sh,py} passes; exit 1 on any failure.
+# warn-*.{sh,py} run informationally and never affect the exit code.
+#
+# Spec: docs/superpowers/specs/2026-05-13-regression-gate.md
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+mapfile -t gates < <(find scripts -maxdepth 1 -type f \
+    \( -name 'check-*.sh' -o -name 'check-*.py' \) | sort)
+mapfile -t warns < <(find scripts -maxdepth 1 -type f \
+    \( -name 'warn-*.sh'  -o -name 'warn-*.py'  \) | sort)
+
+PER_INVARIANT_TIMEOUT="${REGRESSION_GATE_TIMEOUT:-30}"
+
+run_one() {
+    local s="$1"
+    echo "── $s ──"
+    case "$s" in
+        *.py) timeout "$PER_INVARIANT_TIMEOUT" python3 "$s" ;;
+        *)    timeout "$PER_INVARIANT_TIMEOUT" bash    "$s" ;;
+    esac
+}
+
+declare -A rc
+fails=0
+for s in "${gates[@]}"; do
+    run_one "$s"; r=$?
+    rc["$s"]=$r
+    [ "$r" -eq 0 ] || fails=$((fails+1))
+done
+for s in "${warns[@]}"; do run_one "$s" || true; done
+
+echo
+echo "═══ regression-gate summary ═══"
+for s in "${gates[@]}"; do
+    [ "${rc[$s]}" -eq 0 ] && tag=PASS || tag=FAIL
+    printf "  %-5s  %s\n" "$tag" "$s"
+done
+
+if [ "$fails" -gt 0 ]; then
+    echo
+    echo "$fails/${#gates[@]} invariant(s) broken."
+    echo "False positive? Add an entry to scripts/<name>.allow with a # reason."
+    echo "Spec: docs/superpowers/specs/2026-05-13-regression-gate.md"
+    exit 1
+fi
+echo "All ${#gates[@]} invariants preserved."
+exit 0

--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -22,9 +22,11 @@ import argparse
 import json
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -55,6 +57,62 @@ def log(msg: str) -> None:
 
 def run(cmd: list[str], *, timeout: int = 60, check: bool = False) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, text=True, capture_output=True, timeout=timeout, check=check)
+
+
+GATE_PER_INVARIANT_TIMEOUT = 30
+GATE_TOTAL_TIMEOUT = 180  # All invariants combined.
+
+
+def run_regression_gate(pr_number: int, head: str) -> tuple[int, str]:
+    """Fetch the PR's merged-state tree into a temp worktree and run
+    scripts/regression-gate.sh against it.
+
+    Returns:
+        (rc, stdout_tail) where:
+          rc = 0    → all invariants passed
+          rc = 1    → at least one invariant broken (invariant fail)
+          rc >= 2   → aggregator/tool error (fail-closed; do not merge)
+
+        stdout_tail is the last ~40 lines of aggregator output, suitable
+        for posting as a kanban comment.
+    """
+    workdir = tempfile.mkdtemp(prefix=f"regression-gate-pr-{pr_number}-")
+    try:
+        # Worktree the PR's merge ref into the temp dir. --detach because
+        # we don't need a branch and want to avoid name collisions.
+        wt = run(
+            ["git", "worktree", "add", "--detach", workdir,
+             f"refs/pull/{pr_number}/merge"],
+            timeout=60,
+        )
+        if wt.returncode != 0:
+            return (2, f"git worktree add failed:\n{wt.stderr or wt.stdout}")
+
+        # Run the aggregator against the merged-state tree.
+        result = subprocess.run(
+            ["bash", "scripts/regression-gate.sh"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=GATE_TOTAL_TIMEOUT,
+            env=dict(
+                os.environ,
+                REGRESSION_GATE_TIMEOUT=str(GATE_PER_INVARIANT_TIMEOUT),
+            ),
+        )
+        tail = "\n".join(result.stdout.splitlines()[-40:])
+        return (result.returncode, tail)
+    except subprocess.TimeoutExpired as e:
+        return (2, f"aggregator total timeout ({GATE_TOTAL_TIMEOUT}s):\n{e}")
+    except Exception as e:  # noqa: BLE001 — fail-closed on any orchestration error
+        return (2, f"regression-gate orchestration error:\n{e}")
+    finally:
+        # Always tear down the worktree; ignore errors (best-effort cleanup).
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", workdir],
+            capture_output=True, timeout=30,
+        )
+        shutil.rmtree(workdir, ignore_errors=True)
 
 
 def gh_json(cmd: list[str], *, timeout: int = 60) -> Any:

--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -262,7 +262,8 @@ def classify(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> dict[str, A
         and check_state in {"pass", "none", "unknown"}
         and is_review_nonblocking(review, head)
     )
-    auto_merge_ready = (
+    # Gates a–e: existing shape checks (cheap; no subprocess).
+    gates_a_through_e = (
         base_ready
         and check_state == "pass"
         and bool(ticket)
@@ -271,8 +272,28 @@ def classify(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> dict[str, A
         and review.get("verdict") == "APPROVE"
         and is_review_nonblocking(review, head, require_current_head=True)
     )
+
+    # Gate f: regression-gate. Only invoked if (a–e) all pass — running the
+    # gate is expensive (~5-30s worktree + subprocess), so short-circuit.
+    gate_status: str = "skipped"
+    gate_diagnostic: str = ""
+    if gates_a_through_e and not merged:
+        gate_rc, gate_diagnostic = run_regression_gate(int(pr["number"]), head)
+        if gate_rc == 0:
+            gate_status = "pass"
+        elif gate_rc == 1:
+            gate_status = "fail-invariant"
+        else:
+            gate_status = "fail-tool"
+
+    auto_merge_ready = gates_a_through_e and gate_status == "pass"
+
     if merged:
         action = "mark-done" if ticket and status != "done" else "merged-noop"
+    elif gate_status == "fail-invariant":
+        action = "regression-gate-fail"
+    elif gate_status == "fail-tool":
+        action = "regression-gate-error"
     elif base_ready:
         action = "ready-to-merge"
     elif pr.get("mergeable") == "CONFLICTING":
@@ -295,6 +316,8 @@ def classify(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> dict[str, A
         "review": review.get("verdict") if review else "none",
         "review_current_head": review_matches_head(review, head),
         "auto_merge_ready": auto_merge_ready,
+        "gate_status": gate_status,          # NEW
+        "gate_diagnostic": gate_diagnostic,  # NEW
         "action": action,
     }
 
@@ -346,6 +369,13 @@ def needs_operator_escalation(item: dict[str, Any]) -> bool:
         return False
     if item.get("auto_merge_ready"):
         return False
+    if item.get("action") == "regression-gate-fail":
+        # Already handled by post_regression_gate_comment + reassign.
+        return False
+    if item.get("action") == "regression-gate-error":
+        # Tool error — operator must investigate, but skip the generic
+        # escalation path (it's a tooling issue, not a PR-content issue).
+        return False
     if item.get("action") in {"needs-fix", "needs-rebase"}:
         return True
     if item.get("action") == "ready-to-merge" and item.get("applied") in {"ready-marker", "would-ready-marker", "noop"}:
@@ -384,6 +414,42 @@ def escalate_to_operator(item: dict[str, Any], operator: str | None, apply: bool
     return True
 
 
+def post_regression_gate_comment(item: dict[str, Any], apply: bool,
+                                 *, request_changes: bool) -> None:
+    """Post a comment on the PR explaining the gate result. If
+    request_changes is True, the comment is shaped as a request-for-changes
+    (broken invariant); otherwise as an evaluation-failure note (tool error)."""
+    if not apply:
+        return
+    tag = "broken invariant" if request_changes else "could not evaluate"
+    body = (
+        f"<!-- clawta-pr-lifecycle:regression-gate head={item['head']} -->\n"
+        f"**Regression gate: {tag}** "
+        f"(`gate_status={item.get('gate_status')}`).\n\n"
+        f"```\n{item.get('gate_diagnostic', '(no diagnostic)')}\n```\n\n"
+        f"See docs/runbooks/regression-gate.md for override and triage."
+    )
+    run([
+        "gh", "pr", "comment", item["pr"], "--repo", REPO,
+        "--body", body,
+    ], timeout=60, check=False)
+
+
+def assign_ticket_to_operator(item: dict[str, Any], operator: str,
+                              apply: bool) -> None:
+    """Reassign the PR's kanban ticket to the operator after a gate failure."""
+    ticket = item.get("ticket")
+    if not ticket or not apply:
+        return
+    run([
+        "hermes", "kanban", "--board", BOARD,
+        "reassign", ticket, operator,
+        "--reclaim",
+        "--reason", "regression-gate fail-invariant on PR "
+                    f"#{item['pr']} head={item['head']}",
+    ], timeout=60, check=False)
+
+
 def run_once(prefixes: tuple[str, ...], apply: bool, auto_merge: bool, escalate_to: str | None) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
     for pr in list_prs(prefixes):
@@ -401,6 +467,16 @@ def run_once(prefixes: tuple[str, ...], apply: bool, auto_merge: bool, escalate_
             elif item["action"] == "mark-done":
                 mark_done(item, apply)
                 item["applied"] = "done" if apply else "would-done"
+            elif item["action"] == "regression-gate-fail":
+                # Invariant broken on this head. Comment + reassign ticket; no merge.
+                post_regression_gate_comment(item, apply, request_changes=True)
+                assign_ticket_to_operator(item, "red", apply)
+                item["applied"] = "gate-fail" if apply else "would-gate-fail"
+            elif item["action"] == "regression-gate-error":
+                # Tool error (aggregator crashed / worktree fetch failed / timeout).
+                # Comment only — do NOT reassign; operator must investigate.
+                post_regression_gate_comment(item, apply, request_changes=False)
+                item["applied"] = "gate-error" if apply else "would-gate-error"
             elif escalate_to_operator(item, escalate_to, apply):
                 escalation_applied = "escalated" if apply else "would-escalate"
                 if item.get("applied") and item["applied"] != "noop":

--- a/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
+++ b/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Tests for the regression-gate integration in clawta-pr-lifecycle."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "bin" / "clawta-pr-lifecycle"
+
+
+def load_module():
+    loader = importlib.machinery.SourceFileLoader("clawta_pr_lifecycle", str(SCRIPT))
+    spec = importlib.util.spec_from_loader("clawta_pr_lifecycle", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def base_pr(**overrides) -> dict:
+    """A canonical 'ready-to-merge' PR dict from gh pr list JSON output.
+
+    headRefName uses a swarm branch pattern so infer_ticket() resolves to
+    t_deadbeef (8-hex suffix after the last '-').
+
+    headRefOid is a full 40-char SHA that starts with the 7-char abbreviated
+    head used in approve_comment() so that review_matches_head() returns True
+    (it checks head.startswith(reviewed_head)).
+
+    REVIEW_MARKER_RE requires [0-9a-f]{7,40} so the head abbreviation in the
+    review comment must be at least 7 hex chars; "abc123" (6 chars) does not
+    match, hence the 7-char "abc1234" prefix used here.
+    """
+    pr = {
+        "number": 999,
+        "url": "https://github.com/chitinhq/chitin/pull/999",
+        "title": "test pr",
+        "headRefName": "swarm/agent-deadbeef",
+        "headRefOid": "abc1234deadbeefdeadbeefdeadbeef12345678",
+        "baseRefName": "main",
+        "state": "OPEN",
+        "mergeable": "MERGEABLE",
+        "mergedAt": None,
+        "body": "",
+        "isDraft": False,
+        "updatedAt": "2026-05-13T20:00:00Z",
+    }
+    pr.update(overrides)
+    return pr
+
+
+def approve_comment(head: str = "abc1234") -> dict:
+    """A canonical APPROVE review comment from gh pr comments.
+
+    The head abbreviation must be at least 7 hex chars to satisfy
+    REVIEW_MARKER_RE (which requires [0-9a-f]{7,40} in the head= field).
+    """
+    return {
+        "user": {"login": "jpleva91"},
+        "body": f"<!-- clawta-reviewer:v1 head={head} -->\n**Verdict:** APPROVE",
+    }
+
+
+# ticket_info returns {"status": ..., "assignee": ...} — the "id" key in the
+# plan spec was a typo; the real return shape has "status" + "assignee".
+_TICKET_INFO_PASS = {"status": "in_progress", "assignee": None}
+
+
+class GateShortCircuitTests(unittest.TestCase):
+    def test_gate_skipped_when_base_gates_fail(self) -> None:
+        """If (a-e) fail, gate is NOT invoked (expensive subprocess avoided)."""
+        m = load_module()
+        # PR is draft → base_ready false → gate skipped.
+        pr = base_pr(isDraft=True)
+        with mock.patch.object(m, "run_regression_gate") as gate, \
+             mock.patch.object(m, "checks_state", return_value="pass"), \
+             mock.patch.object(m, "ticket_info",
+                               return_value=_TICKET_INFO_PASS):
+            result = m.classify(pr, [approve_comment()])
+        self.assertEqual(result["gate_status"], "skipped")
+        self.assertFalse(result["auto_merge_ready"])
+        gate.assert_not_called()
+
+
+class GatePassTests(unittest.TestCase):
+    def test_gate_pass_sets_auto_merge_ready(self) -> None:
+        m = load_module()
+        pr = base_pr()
+        with mock.patch.object(m, "run_regression_gate",
+                               return_value=(0, "All 2 invariants preserved.")) as gate, \
+             mock.patch.object(m, "checks_state", return_value="pass"), \
+             mock.patch.object(m, "ticket_info",
+                               return_value=_TICKET_INFO_PASS):
+            result = m.classify(pr, [approve_comment()])
+        self.assertEqual(result["gate_status"], "pass")
+        self.assertTrue(result["auto_merge_ready"])
+        self.assertEqual(result["action"], "ready-to-merge")
+        gate.assert_called_once()
+
+
+class GateFailInvariantTests(unittest.TestCase):
+    def test_gate_fail_invariant_sets_action_and_diagnostic(self) -> None:
+        m = load_module()
+        pr = base_pr()
+        diagnostic = "1/2 invariant(s) broken.\nFAIL  scripts/check-foo.sh"
+        with mock.patch.object(m, "run_regression_gate",
+                               return_value=(1, diagnostic)), \
+             mock.patch.object(m, "checks_state", return_value="pass"), \
+             mock.patch.object(m, "ticket_info",
+                               return_value=_TICKET_INFO_PASS):
+            result = m.classify(pr, [approve_comment()])
+        self.assertEqual(result["gate_status"], "fail-invariant")
+        self.assertEqual(result["gate_diagnostic"], diagnostic)
+        self.assertFalse(result["auto_merge_ready"])
+        self.assertEqual(result["action"], "regression-gate-fail")
+
+
+class GateFailToolTests(unittest.TestCase):
+    def test_gate_fail_tool_sets_separate_action(self) -> None:
+        m = load_module()
+        pr = base_pr()
+        with mock.patch.object(m, "run_regression_gate",
+                               return_value=(2, "git worktree add failed: ...")), \
+             mock.patch.object(m, "checks_state", return_value="pass"), \
+             mock.patch.object(m, "ticket_info",
+                               return_value=_TICKET_INFO_PASS):
+            result = m.classify(pr, [approve_comment()])
+        self.assertEqual(result["gate_status"], "fail-tool")
+        self.assertFalse(result["auto_merge_ready"])
+        self.assertEqual(result["action"], "regression-gate-error")
+
+
+class EscalationExclusionTests(unittest.TestCase):
+    def test_regression_gate_fail_not_escalated_generically(self) -> None:
+        """needs_operator_escalation must skip regression-gate-fail items
+        because post_regression_gate_comment already handles them."""
+        m = load_module()
+        item = {
+            "ticket": "t_deadbeef",
+            "state": "OPEN",
+            "ticket_status": "in_progress",
+            "auto_merge_ready": False,
+            "action": "regression-gate-fail",
+        }
+        self.assertFalse(m.needs_operator_escalation(item))
+
+    def test_regression_gate_error_not_escalated_generically(self) -> None:
+        m = load_module()
+        item = {
+            "ticket": "t_deadbeef",
+            "state": "OPEN",
+            "ticket_status": "in_progress",
+            "auto_merge_ready": False,
+            "action": "regression-gate-error",
+        }
+        self.assertFalse(m.needs_operator_escalation(item))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -169,5 +169,34 @@ class TimeoutTests(unittest.TestCase):
         self.assertIn("check-hang.sh", result.stdout)
 
 
+class WarnOnlyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write(self, prefix: str, name: str, body: str) -> None:
+        p = self.sandbox / "scripts" / f"{prefix}-{name}.sh"
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def test_warn_exit_one_does_not_fail_aggregator(self) -> None:
+        self._write("warn", "drift",
+            "#!/usr/bin/env bash\necho 'WARN: 8 legacy worktrees still in tree'\nexit 1\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("WARN: 8 legacy worktrees still in tree", result.stdout)
+
+    def test_warn_does_not_appear_in_gate_summary(self) -> None:
+        self._write("check", "ok", "#!/usr/bin/env bash\nexit 0\n")
+        self._write("warn",  "info", "#!/usr/bin/env bash\necho 'info'\nexit 0\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0)
+        summary_section = result.stdout.split("═══ regression-gate summary ═══", 1)[-1]
+        self.assertIn("check-ok.sh", summary_section)
+        self.assertNotIn("warn-info.sh", summary_section)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -120,5 +120,26 @@ class NoShortCircuitTests(unittest.TestCase):
         self.assertIn("1/3 invariant(s) broken", result.stdout)
 
 
+class ToolErrorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write_check(self, name: str, body: str) -> None:
+        p = self.sandbox / "scripts" / f"check-{name}.sh"
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def test_tool_error_counts_as_failure(self) -> None:
+        self._write_check("crash",
+            "#!/usr/bin/env bash\necho 'crash'\nexit 2\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("FAIL", result.stdout)
+        self.assertIn("check-crash.sh", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -93,5 +93,32 @@ class FailingInvariantTests(unittest.TestCase):
         self.assertIn("violation: thing X broke", result.stdout)
 
 
+class NoShortCircuitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write_check(self, name: str, body: str) -> None:
+        p = self.sandbox / "scripts" / f"check-{name}.sh"
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def test_mixed_pass_fail_pass_all_run(self) -> None:
+        self._write_check("a-pass", "#!/usr/bin/env bash\necho 'a ran'\nexit 0\n")
+        self._write_check("b-fail", "#!/usr/bin/env bash\necho 'b ran'\nexit 1\n")
+        self._write_check("c-pass", "#!/usr/bin/env bash\necho 'c ran'\nexit 0\n")
+
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("a ran", result.stdout)
+        self.assertIn("b ran", result.stdout)
+        self.assertIn("c ran", result.stdout)
+        self.assertIn("PASS", result.stdout)
+        self.assertIn("FAIL", result.stdout)
+        self.assertIn("1/3 invariant(s) broken", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Behavior tests for scripts/regression-gate.sh."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGGREGATOR_SRC = REPO_ROOT / "scripts" / "regression-gate.sh"
+
+
+def make_sandbox() -> Path:
+    """Build a throwaway tree with a `scripts/` dir + a copy of the
+    aggregator, then return the tree root. Callers add stub invariants
+    into <tree>/scripts/ before running the aggregator."""
+    tmp = Path(tempfile.mkdtemp(prefix="regression-gate-test-"))
+    (tmp / "scripts").mkdir()
+    shutil.copy(AGGREGATOR_SRC, tmp / "scripts" / "regression-gate.sh")
+    (tmp / "scripts" / "regression-gate.sh").chmod(0o755)
+    return tmp
+
+
+def run_aggregator(sandbox: Path, timeout: int = 60) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "scripts/regression-gate.sh"],
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+class EmptyRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def test_empty_registry_exits_zero(self) -> None:
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("All 0 invariants preserved", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -70,5 +70,28 @@ class PassingInvariantTests(unittest.TestCase):
         self.assertIn("All 1 invariants preserved", result.stdout)
 
 
+class FailingInvariantTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write_check(self, name: str, body: str) -> None:
+        p = self.sandbox / "scripts" / f"check-{name}.sh"
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def test_single_failing_invariant(self) -> None:
+        self._write_check("broken",
+            "#!/usr/bin/env bash\necho 'violation: thing X broke'\nexit 1\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("FAIL", result.stdout)
+        self.assertIn("check-broken.sh", result.stdout)
+        self.assertIn("1/1 invariant(s) broken", result.stdout)
+        self.assertIn("violation: thing X broke", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -141,5 +141,33 @@ class ToolErrorTests(unittest.TestCase):
         self.assertIn("check-crash.sh", result.stdout)
 
 
+class TimeoutTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write_check(self, name: str, body: str) -> None:
+        p = self.sandbox / "scripts" / f"check-{name}.sh"
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def test_timeout_kills_hung_invariant(self) -> None:
+        self._write_check("hang",
+            "#!/usr/bin/env bash\nsleep 5\nexit 0\n")
+        env = dict(os.environ, REGRESSION_GATE_TIMEOUT="2")
+        result = subprocess.run(
+            ["bash", "scripts/regression-gate.sh"],
+            cwd=self.sandbox,
+            capture_output=True, text=True,
+            env=env,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("FAIL", result.stdout)
+        self.assertIn("check-hang.sh", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -49,5 +49,26 @@ class EmptyRegistryTests(unittest.TestCase):
         self.assertIn("All 0 invariants preserved", result.stdout)
 
 
+class PassingInvariantTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write_check(self, name: str, body: str) -> None:
+        p = self.sandbox / "scripts" / f"check-{name}.sh"
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def test_single_passing_invariant(self) -> None:
+        self._write_check("ok", "#!/usr/bin/env bash\nexit 0\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("PASS", result.stdout)
+        self.assertIn("check-ok.sh", result.stdout)
+        self.assertIn("All 1 invariants preserved", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_regression_gate.py
+++ b/swarm/tests/test_regression_gate.py
@@ -198,5 +198,42 @@ class WarnOnlyTests(unittest.TestCase):
         self.assertNotIn("warn-info.sh", summary_section)
 
 
+class DiscoveryHygieneTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = make_sandbox()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.sandbox, ignore_errors=True)
+
+    def _write(self, relpath: str, body: str) -> None:
+        full = self.sandbox / relpath
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(body)
+        full.chmod(0o755)
+
+    def test_wrong_extension_not_invoked(self) -> None:
+        self._write("scripts/check-foo.txt",
+            "#!/usr/bin/env bash\necho 'WAS_RUN'\nexit 1\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("WAS_RUN", result.stdout)
+
+    def test_subdirectory_not_recursed(self) -> None:
+        self._write("scripts/nested/check-foo.sh",
+            "#!/usr/bin/env bash\necho 'WAS_RUN'\nexit 1\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("WAS_RUN", result.stdout)
+
+    def test_allow_file_not_invoked_as_invariant(self) -> None:
+        self._write("scripts/governance-boundary.allow",
+            "some/path # reason here\n")
+        self._write("scripts/check-real.sh", "#!/usr/bin/env bash\nexit 0\n")
+        result = run_aggregator(self.sandbox)
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("governance-boundary.allow", result.stdout)
+        self.assertIn("check-real.sh", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/specs/2026-05-13-regression-gate.md` (PR #584). Closes `t_ac6da121`.

- `scripts/regression-gate.sh` — pure-shell aggregator; discovers `scripts/check-*.{sh,py}` at top level; per-invariant `timeout 30`; exit 0 iff every gate passes.
- `scripts/check-spec-index-sync.sh` — thin wrapper around `regen-spec-index.py --check`, joining the registry uniformly.
- `swarm/bin/clawta-pr-lifecycle` — adds `run_regression_gate()` helper; extends `classify()` to call the gate after (a-e) pass; new actions `regression-gate-fail` and `regression-gate-error` with structured-comment + reassign-ticket flow.
- `.github/workflows/ci.yml` — single `Regression gate` step replaces the PR #581 standalone steps (single chokepoint).
- `docs/runbooks/regression-gate.md` — operator + invariant-author runbook.
- Day-0 registry: 2 invariants (`check-spec-frontmatter.py` + `check-spec-index-sync.sh`). The five already-specced audit-response invariants will join as their PRs land — zero coordination.

## Tests

- Aggregator behavior tests in `swarm/tests/test_regression_gate.py` (empty registry, passing, failing, no-short-circuit, tool error, timeout, warn-only, discovery hygiene) — 11 cases.
- Lifecycle integration tests in `swarm/tests/test_clawta_pr_lifecycle_regression_gate.py` (gate skipped on a-e fail, gate pass → auto-merge, fail-invariant → action + diagnostic, fail-tool → separate action, escalation exclusions) — 6 cases.
- Full suite: 19 tests, all pass.

## Operator action required after merge

Update branch protection on `main`: confirm `test` is in required status checks, and enable "Require branches to be up to date before merging." See `docs/runbooks/regression-gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)