### PR TITLE
chore(dispatch): add codex model tiers

### DIFF
--- a/docs/governance-setup-extras/agent-cards/codex.json
+++ b/docs/governance-setup-extras/agent-cards/codex.json
@@ -1,21 +1,54 @@
 {
   "id": "codex",
-  "description": "OpenAI Codex CLI — deep code reasoning, Go expert, refactoring",
+  "description": "OpenAI Codex CLI \u2014 deep code reasoning, Go expert, refactoring",
   "auth": "openai-pro-oauth",
   "capabilities": [
-    {"skill": "go", "depth": "expert"},
-    {"skill": "ts", "depth": "strong"},
-    {"skill": "python", "depth": "strong"},
-    {"skill": "refactor", "depth": "expert"},
-    {"skill": "debug", "depth": "expert"},
-    {"skill": "review", "depth": "strong"}
+    {
+      "skill": "go",
+      "depth": "expert"
+    },
+    {
+      "skill": "ts",
+      "depth": "strong"
+    },
+    {
+      "skill": "python",
+      "depth": "strong"
+    },
+    {
+      "skill": "refactor",
+      "depth": "expert"
+    },
+    {
+      "skill": "debug",
+      "depth": "expert"
+    },
+    {
+      "skill": "review",
+      "depth": "strong"
+    }
   ],
   "models": [
-    {"id": "gpt-5.5", "tier": "T4", "premium_cost": 1.0}
+    {
+      "id": "gpt-5.4",
+      "tier": "T3",
+      "premium_cost": 0.65
+    },
+    {
+      "id": "gpt-5.5",
+      "tier": "T4",
+      "premium_cost": 1.0
+    }
   ],
   "invocation": {
-    "cmd": "codex",
-    "args": ["exec", "--dangerously-bypass-approvals-and-sandbox", "--model", "{model}", "{prompt}"]
+    "cmd": "/home/red/.vite-plus/bin/codex",
+    "args": [
+      "exec",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--model",
+      "{model}",
+      "{prompt}"
+    ]
   },
-  "notes": "Spawn from a worktree under ~/.cache/chitin/swarm-worktrees/. Honors chitin gate hooks. Only gpt-5.5 is supported with ChatGPT Pro account auth — gpt-5/gpt-5.3/gpt-5.4/gpt-5-codex return 'not supported when using Codex with a ChatGPT account' (verified 2026-05-11). Non-interactive mode requires `codex exec` subcommand; the old --message flag does not exist. --dangerously-bypass-approvals-and-sandbox replaces the now-removed --yolo flag."
+  "notes": "Spawn from a worktree under ~/.cache/chitin/swarm-worktrees/. Honors chitin gate hooks. Non-interactive mode requires `codex exec` subcommand; the old --message flag does not exist. --dangerously-bypass-approvals-and-sandbox replaces the now-removed --yolo flag. Absolute invocation path set 2026-05-12 by Clawta after isolated lobster env could not resolve PATH binaries. Model policy updated 2026-05-13: gpt-5.4 and gpt-5.5 both work with the ChatGPT/Codex account; gpt-5.3, gpt-5, and gpt-5-codex still return not-supported. Use gpt-5.4 for low-complexity Codex tasks and gpt-5.5 for medium/high or needs_frontier work; _pick_driver enforces this as the complexity floor."
 }


### PR DESCRIPTION
Add verified Codex model tiers to the mirrored agent card so routing is not driver-only for Codex.\n\nRuntime behavior already updated under ~/.openclaw/data/agent-cards/codex.json.\n\nPolicy:\n- low complexity Codex tasks -> gpt-5.4\n- medium/high or needs_frontier Codex tasks -> gpt-5.5\n\nVerification:\n- codex exec smoke: gpt-5.4 and gpt-5.5 return OK\n- gpt-5.3, gpt-5, gpt-5-codex remain unsupported with ChatGPT/Codex account\n- python3 -m unittest docs/governance-setup-extras/tests/test_pick_driver.py\n- deterministic route smoke for low/medium Go+debug tasks