### PR TITLE
feat(swarm): add board config reader

### DIFF
--- a/docs/swarm/board-config.md
+++ b/docs/swarm/board-config.md
@@ -37,6 +37,7 @@ chitin-kernel board-config <slug> <field>
 Behavior:
 
 - Precedence is `env > config.json > error`.
+- The helper validates the full required-field set before returning any value.
 - Environment overrides use:
   - `KANBAN_BOARD_REPO`
   - `KANBAN_BOARD_DEFAULT_BRANCH`
@@ -47,6 +48,7 @@ Behavior:
 - Unknown board exits `3` with `unknown board: <slug>`.
 - No boards initialized exits `3` with `no boards initialized`.
 - Missing required field exits `2` with `missing field: <name>`.
+- A board directory without `config.json` exits `2` with `missing config: <path>`.
 - A board directory without `config.json` is an error; the helper does not synthesize defaults for that board.
 
 Examples:

--- a/docs/swarm/board-config.md
+++ b/docs/swarm/board-config.md
@@ -4,13 +4,14 @@ Swarm board metadata now lives in a per-board sidecar at:
 
 `~/.hermes/kanban/boards/<slug>/config.json`
 
-For the `chitin` board, the seeded file is:
+For the `chitin` board, the seeded file (with absolute paths so
+downstream consumers don't need to expand `~`) is:
 
 ```json
 {
   "repo": "chitinhq/chitin",
   "default_branch": "main",
-  "workspace_root": "~/workspace/chitin",
+  "workspace_root": "/home/operator/workspace/chitin",
   "kernel_bin": "chitin-kernel",
   "chitin_yaml": "chitin.yaml"
 }
@@ -21,6 +22,8 @@ For the `chitin` board, the seeded file is:
 - `repo` — required GitHub `owner/name` repository slug.
 - `default_branch` — required default git branch for the board repo.
 - `workspace_root` — required operator workspace root for that repo.
+  A leading `~/` is expanded by the reader; all other consumers should
+  expect an absolute path.
 - `kernel_bin` — required kernel binary name or path.
 - `chitin_yaml` — optional policy file path relative to `workspace_root`; defaults to `chitin.yaml`.
 
@@ -45,11 +48,25 @@ Behavior:
   - `KANBAN_BOARD_KERNEL_BIN`
   - `KANBAN_BOARD_CHITIN_YAML`
 - `chitin_yaml` defaults to `chitin.yaml` when absent from both env and `config.json`.
-- Unknown board exits `3` with `unknown board: <slug>`.
-- No boards initialized exits `3` with `no boards initialized`.
-- Missing required field exits `2` with `missing field: <name>`.
-- A board directory without `config.json` exits `2` with `missing config: <path>`.
-- A board directory without `config.json` is an error; the helper does not synthesize defaults for that board.
+
+### Exit codes and error shapes
+
+Errors are emitted to stderr as a single JSON object
+(`{"error": "<kind>", "message": "<detail>"}`) and map to these
+exit codes:
+
+| Exit | `error` kind            | When                                                                 |
+| ---- | ----------------------- | -------------------------------------------------------------------- |
+| `2`  | `board_config_args`     | Argument count is wrong, or flag parsing fails.                      |
+| `2`  | `invalid_slug`          | Slug is empty, `.`, `..`, or contains a path separator (path traversal guard). |
+| `2`  | `unknown_field`         | Field name is not one of the schema keys.                            |
+| `2`  | `missing_field`         | A required field is empty in both env and `config.json`.             |
+| `2`  | `missing_config`        | The board directory exists but has no `config.json`.                 |
+| `3`  | `no_boards_initialized` | The boards root has no board directories yet.                        |
+| `3`  | `unknown_board`         | A different board exists but the requested slug does not.            |
+
+The helper does not synthesize defaults for a missing `config.json`;
+the seeder in `scripts/install-swarm.sh` is the canonical bootstrap.
 
 Examples:
 

--- a/docs/swarm/board-config.md
+++ b/docs/swarm/board-config.md
@@ -1,0 +1,58 @@
+# Board Config Sidecar
+
+Swarm board metadata now lives in a per-board sidecar at:
+
+`~/.hermes/kanban/boards/<slug>/config.json`
+
+For the `chitin` board, the seeded file is:
+
+```json
+{
+  "repo": "chitinhq/chitin",
+  "default_branch": "main",
+  "workspace_root": "~/workspace/chitin",
+  "kernel_bin": "chitin-kernel",
+  "chitin_yaml": "chitin.yaml"
+}
+```
+
+## Schema
+
+- `repo` — required GitHub `owner/name` repository slug.
+- `default_branch` — required default git branch for the board repo.
+- `workspace_root` — required operator workspace root for that repo.
+- `kernel_bin` — required kernel binary name or path.
+- `chitin_yaml` — optional policy file path relative to `workspace_root`; defaults to `chitin.yaml`.
+
+All fields are strings. There is no fallback to chitin hardcodes when a required field is missing.
+
+## Reader Contract
+
+Read board config through:
+
+```bash
+chitin-kernel board-config <slug> <field>
+```
+
+Behavior:
+
+- Precedence is `env > config.json > error`.
+- Environment overrides use:
+  - `KANBAN_BOARD_REPO`
+  - `KANBAN_BOARD_DEFAULT_BRANCH`
+  - `KANBAN_BOARD_WORKSPACE_ROOT`
+  - `KANBAN_BOARD_KERNEL_BIN`
+  - `KANBAN_BOARD_CHITIN_YAML`
+- `chitin_yaml` defaults to `chitin.yaml` when absent from both env and `config.json`.
+- Unknown board exits `3` with `unknown board: <slug>`.
+- No boards initialized exits `3` with `no boards initialized`.
+- Missing required field exits `2` with `missing field: <name>`.
+- A board directory without `config.json` is an error; the helper does not synthesize defaults for that board.
+
+Examples:
+
+```bash
+chitin-kernel board-config chitin repo
+chitin-kernel board-config chitin kernel_bin
+KANBAN_BOARD_REPO=override/example chitin-kernel board-config chitin repo
+```

--- a/go/execution-kernel/cmd/chitin-kernel/board_config.go
+++ b/go/execution-kernel/cmd/chitin-kernel/board_config.go
@@ -11,7 +11,8 @@ import (
 )
 
 func cmdBoardConfig(args []string) {
-	fs := flag.NewFlagSet("board-config", flag.ExitOnError)
+	fs := flag.NewFlagSet("board-config", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: chitin-kernel board-config <slug> <field>")
 	}
@@ -28,6 +29,10 @@ func cmdBoardConfig(args []string) {
 		case errors.Is(err, boardconfig.ErrNoBoardsInitialized):
 			boardConfigExit(3, "no_boards_initialized", err.Error())
 		default:
+			var slugErr boardconfig.InvalidSlugError
+			if errors.As(err, &slugErr) {
+				boardConfigExit(2, "invalid_slug", err.Error())
+			}
 			var boardErr boardconfig.UnknownBoardError
 			if errors.As(err, &boardErr) {
 				boardConfigExit(3, "unknown_board", err.Error())

--- a/go/execution-kernel/cmd/chitin-kernel/board_config.go
+++ b/go/execution-kernel/cmd/chitin-kernel/board_config.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/boardconfig"
+)
+
+func cmdBoardConfig(args []string) {
+	fs := flag.NewFlagSet("board-config", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: chitin-kernel board-config <slug> <field>")
+	}
+	if err := fs.Parse(args); err != nil {
+		boardConfigExit(2, "board_config_args", err.Error())
+	}
+	if fs.NArg() != 2 {
+		boardConfigExit(2, "board_config_args", "usage: chitin-kernel board-config <slug> <field>")
+	}
+
+	value, err := boardconfig.ResolveField(fs.Arg(0), fs.Arg(1))
+	if err != nil {
+		switch {
+		case errors.Is(err, boardconfig.ErrNoBoardsInitialized):
+			boardConfigExit(3, "no_boards_initialized", err.Error())
+		default:
+			var boardErr boardconfig.UnknownBoardError
+			if errors.As(err, &boardErr) {
+				boardConfigExit(3, "unknown_board", err.Error())
+			}
+			var missingFieldErr boardconfig.MissingFieldError
+			if errors.As(err, &missingFieldErr) {
+				boardConfigExit(2, "missing_field", err.Error())
+			}
+			var missingConfigErr boardconfig.MissingConfigError
+			if errors.As(err, &missingConfigErr) {
+				boardConfigExit(2, "missing_config", err.Error())
+			}
+			var unknownFieldErr boardconfig.UnknownFieldError
+			if errors.As(err, &unknownFieldErr) {
+				boardConfigExit(2, "unknown_field", err.Error())
+			}
+			boardConfigExit(2, "board_config_error", err.Error())
+		}
+	}
+
+	fmt.Println(value)
+}
+
+func boardConfigExit(code int, kind, msg string) {
+	out, _ := json.Marshal(map[string]string{
+		"error":   kind,
+		"message": msg,
+	})
+	fmt.Fprintln(os.Stderr, string(out))
+	os.Exit(code)
+}

--- a/go/execution-kernel/cmd/chitin-kernel/board_config_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/board_config_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCLI_BoardConfigFromConfig(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	stdout, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home}, "board-config", "chitin", "repo")
+	if code != 0 {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if strings.TrimSpace(stdout) != "chitinhq/chitin" {
+		t.Fatalf("stdout=%q, want chitinhq/chitin", stdout)
+	}
+}
+
+func TestCLI_BoardConfigEnvOverridesConfig(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	stdout, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{
+		"HOME=" + home,
+		"KANBAN_BOARD_REPO=override/repo",
+	}, "board-config", "chitin", "repo")
+	if code != 0 {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if strings.TrimSpace(stdout) != "override/repo" {
+		t.Fatalf("stdout=%q, want override/repo", stdout)
+	}
+}
+
+func TestCLI_BoardConfigMissingFieldExit2(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home}, "board-config", "chitin", "repo")
+	if code != 2 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "missing field: repo") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+func TestCLI_BoardConfigUnknownBoardExit3(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home}, "board-config", "readybench", "repo")
+	if code != 3 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "unknown board: readybench") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+func TestCLI_BoardConfigNoBoardsInitializedExit3(t *testing.T) {
+	home := t.TempDir()
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home}, "board-config", "chitin", "repo")
+	if code != 3 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "no boards initialized") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+func writeCLIConfig(t *testing.T, home, slug, raw string) {
+	t.Helper()
+	dir := filepath.Join(home, ".hermes", "kanban", "boards", slug)
+	writeFileForCLI(t, filepath.Join(dir, "config.json"), raw)
+}

--- a/go/execution-kernel/cmd/chitin-kernel/board_config_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/board_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -61,6 +62,22 @@ func TestCLI_BoardConfigUnknownBoardExit3(t *testing.T) {
 	}
 }
 
+func TestCLI_BoardConfigEnvSetUnknownBoardExit3(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{
+		"HOME=" + home,
+		"KANBAN_BOARD_REPO=override/repo",
+	}, "board-config", "readybench", "repo")
+	if code != 3 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "unknown board: readybench") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
 func TestCLI_BoardConfigNoBoardsInitializedExit3(t *testing.T) {
 	home := t.TempDir()
 
@@ -69,6 +86,53 @@ func TestCLI_BoardConfigNoBoardsInitializedExit3(t *testing.T) {
 		t.Fatalf("exit=%d stderr=%q", code, stderr)
 	}
 	if !strings.Contains(stderr, "no boards initialized") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+func TestCLI_BoardConfigEnvSetNoBoardsInitializedExit3(t *testing.T) {
+	home := t.TempDir()
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{
+		"HOME=" + home,
+		"KANBAN_BOARD_REPO=override/repo",
+	}, "board-config", "chitin", "repo")
+	if code != 3 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "no boards initialized") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+func TestCLI_BoardConfigEnvSetMissingConfigExit2(t *testing.T) {
+	home := t.TempDir()
+	boardDir := filepath.Join(home, ".hermes", "kanban", "boards", "chitin")
+	if err := os.MkdirAll(boardDir, 0o755); err != nil {
+		t.Fatalf("mkdir board dir: %v", err)
+	}
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{
+		"HOME=" + home,
+		"KANBAN_BOARD_REPO=override/repo",
+	}, "board-config", "chitin", "repo")
+	if code != 2 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "missing config:") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+func TestCLI_BoardConfigOptionalLookupStillFailsForMissingRequiredField(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home}, "board-config", "chitin", "chitin_yaml")
+	if code != 2 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "missing field: repo") {
 		t.Fatalf("stderr=%q", stderr)
 	}
 }

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -56,6 +56,8 @@ func main() {
 		cmdUninstall(args)
 	case "health":
 		cmdHealth(args)
+	case "board-config":
+		cmdBoardConfig(args)
 	case "gate":
 		cmdGate(args)
 	case "envelope":

--- a/go/execution-kernel/cmd/chitin-kernel/main_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main_test.go
@@ -64,6 +64,16 @@ func runCLI(t *testing.T, wd string, args ...string) (string, string, int) {
 	return string(stdout), string(stderr), cmd.ProcessState.ExitCode()
 }
 
+func writeFileForCLI(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
 // fixturePathForCLI returns the SP-1 synthesized fixture absolute path.
 func fixturePathForCLI(t *testing.T) string {
 	t.Helper()

--- a/go/execution-kernel/internal/boardconfig/boardconfig.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig.go
@@ -1,0 +1,158 @@
+package boardconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type FieldSpec struct {
+	EnvVar       string
+	Required     bool
+	DefaultValue string
+}
+
+var fieldSpecs = map[string]FieldSpec{
+	"repo": {
+		EnvVar:   "KANBAN_BOARD_REPO",
+		Required: true,
+	},
+	"default_branch": {
+		EnvVar:   "KANBAN_BOARD_DEFAULT_BRANCH",
+		Required: true,
+	},
+	"workspace_root": {
+		EnvVar:   "KANBAN_BOARD_WORKSPACE_ROOT",
+		Required: true,
+	},
+	"kernel_bin": {
+		EnvVar:   "KANBAN_BOARD_KERNEL_BIN",
+		Required: true,
+	},
+	"chitin_yaml": {
+		EnvVar:       "KANBAN_BOARD_CHITIN_YAML",
+		DefaultValue: "chitin.yaml",
+	},
+}
+
+var ErrNoBoardsInitialized = errors.New("no boards initialized")
+
+type UnknownBoardError struct {
+	Slug string
+}
+
+func (e UnknownBoardError) Error() string {
+	return fmt.Sprintf("unknown board: %s", e.Slug)
+}
+
+type UnknownFieldError struct {
+	Field string
+}
+
+func (e UnknownFieldError) Error() string {
+	return fmt.Sprintf("unknown field: %s", e.Field)
+}
+
+type MissingFieldError struct {
+	Field string
+}
+
+func (e MissingFieldError) Error() string {
+	return fmt.Sprintf("missing field: %s", e.Field)
+}
+
+type MissingConfigError struct {
+	Path string
+}
+
+func (e MissingConfigError) Error() string {
+	return fmt.Sprintf("missing config: %s", e.Path)
+}
+
+func ResolveField(slug, field string) (string, error) {
+	spec, ok := fieldSpecs[field]
+	if !ok {
+		return "", UnknownFieldError{Field: field}
+	}
+	if value := strings.TrimSpace(os.Getenv(spec.EnvVar)); value != "" {
+		return value, nil
+	}
+
+	config, err := loadConfig(slug)
+	if err != nil {
+		return "", err
+	}
+	if value := strings.TrimSpace(config[field]); value != "" {
+		return value, nil
+	}
+	if spec.DefaultValue != "" {
+		return spec.DefaultValue, nil
+	}
+	if spec.Required {
+		return "", MissingFieldError{Field: field}
+	}
+	return "", nil
+}
+
+func loadConfig(slug string) (map[string]string, error) {
+	root, err := boardsRoot()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNoBoardsInitialized
+		}
+		return nil, fmt.Errorf("read boards dir: %w", err)
+	}
+
+	hasBoardDir := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			hasBoardDir = true
+			break
+		}
+	}
+	if !hasBoardDir {
+		return nil, ErrNoBoardsInitialized
+	}
+
+	boardDir := filepath.Join(root, slug)
+	info, err := os.Stat(boardDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, UnknownBoardError{Slug: slug}
+		}
+		return nil, fmt.Errorf("stat board dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, UnknownBoardError{Slug: slug}
+	}
+
+	configPath := filepath.Join(boardDir, "config.json")
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, MissingConfigError{Path: configPath}
+		}
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var config map[string]string
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return config, nil
+}
+
+func boardsRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home: %w", err)
+	}
+	return filepath.Join(home, ".hermes", "kanban", "boards"), nil
+}

--- a/go/execution-kernel/internal/boardconfig/boardconfig.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig.go
@@ -79,7 +79,65 @@ func (e MissingConfigError) Error() string {
 	return fmt.Sprintf("missing config: %s", e.Path)
 }
 
+type InvalidSlugError struct {
+	Slug string
+}
+
+func (e InvalidSlugError) Error() string {
+	return fmt.Sprintf("invalid board slug: %q", e.Slug)
+}
+
+// validateSlug rejects slugs that would let a caller escape the boards
+// root. We forbid empty values, path separators, and `.`/`..` because
+// they would resolve to a sibling or parent directory once joined with
+// the boards root.
+func validateSlug(slug string) error {
+	if slug == "" {
+		return InvalidSlugError{Slug: slug}
+	}
+	if slug == "." || slug == ".." {
+		return InvalidSlugError{Slug: slug}
+	}
+	if strings.ContainsAny(slug, `/\`) {
+		return InvalidSlugError{Slug: slug}
+	}
+	if strings.ContainsRune(slug, 0) {
+		return InvalidSlugError{Slug: slug}
+	}
+	return nil
+}
+
+// expandHome replaces a leading `~/` (or bare `~`) with the operator's
+// home directory. Other tilde forms (e.g. `~user/...`) are left alone
+// since they aren't part of the board-config contract.
+func expandHome(value string) (string, error) {
+	if value == "" || (value[0] != '~') {
+		return value, nil
+	}
+	if value != "~" && !strings.HasPrefix(value, "~/") {
+		return value, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home: %w", err)
+	}
+	if value == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, value[2:]), nil
+}
+
+// tildeExpandableFields lists fields whose value is a filesystem path
+// the operator may write with a leading `~/`. We expand those at read
+// time so downstream tools see an absolute path.
+var tildeExpandableFields = map[string]struct{}{
+	"workspace_root": {},
+}
+
 func ResolveField(slug, field string) (string, error) {
+	if err := validateSlug(slug); err != nil {
+		return "", err
+	}
 	spec, ok := fieldSpecs[field]
 	if !ok {
 		return "", UnknownFieldError{Field: field}
@@ -91,19 +149,23 @@ func ResolveField(slug, field string) (string, error) {
 	if err := validateRequiredFields(config); err != nil {
 		return "", err
 	}
-	if value := strings.TrimSpace(os.Getenv(spec.EnvVar)); value != "" {
-		return value, nil
+	value := strings.TrimSpace(os.Getenv(spec.EnvVar))
+	if value == "" {
+		value = strings.TrimSpace(config[field])
 	}
-	if value := strings.TrimSpace(config[field]); value != "" {
-		return value, nil
+	if value == "" && spec.DefaultValue != "" {
+		value = spec.DefaultValue
 	}
-	if spec.DefaultValue != "" {
-		return spec.DefaultValue, nil
+	if value == "" {
+		if spec.Required {
+			return "", MissingFieldError{Field: field}
+		}
+		return "", nil
 	}
-	if spec.Required {
-		return "", MissingFieldError{Field: field}
+	if _, expand := tildeExpandableFields[field]; expand {
+		return expandHome(value)
 	}
-	return "", nil
+	return value, nil
 }
 
 func loadConfig(slug string) (map[string]string, error) {

--- a/go/execution-kernel/internal/boardconfig/boardconfig.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig.go
@@ -38,6 +38,13 @@ var fieldSpecs = map[string]FieldSpec{
 	},
 }
 
+var requiredFields = []string{
+	"repo",
+	"default_branch",
+	"workspace_root",
+	"kernel_bin",
+}
+
 var ErrNoBoardsInitialized = errors.New("no boards initialized")
 
 type UnknownBoardError struct {
@@ -77,13 +84,15 @@ func ResolveField(slug, field string) (string, error) {
 	if !ok {
 		return "", UnknownFieldError{Field: field}
 	}
-	if value := strings.TrimSpace(os.Getenv(spec.EnvVar)); value != "" {
-		return value, nil
-	}
-
 	config, err := loadConfig(slug)
 	if err != nil {
 		return "", err
+	}
+	if err := validateRequiredFields(config); err != nil {
+		return "", err
+	}
+	if value := strings.TrimSpace(os.Getenv(spec.EnvVar)); value != "" {
+		return value, nil
 	}
 	if value := strings.TrimSpace(config[field]); value != "" {
 		return value, nil
@@ -155,4 +164,14 @@ func boardsRoot() (string, error) {
 		return "", fmt.Errorf("user home: %w", err)
 	}
 	return filepath.Join(home, ".hermes", "kanban", "boards"), nil
+}
+
+func validateRequiredFields(config map[string]string) error {
+	for _, field := range requiredFields {
+		spec := fieldSpecs[field]
+		if strings.TrimSpace(config[field]) == "" && strings.TrimSpace(os.Getenv(spec.EnvVar)) == "" {
+			return MissingFieldError{Field: field}
+		}
+	}
+	return nil
 }

--- a/go/execution-kernel/internal/boardconfig/boardconfig_test.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig_test.go
@@ -178,6 +178,65 @@ func TestResolveFieldEnvCanCompleteRequiredConfig(t *testing.T) {
 	}
 }
 
+func TestResolveFieldRejectsPathTraversalSlug(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"/abs/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	for _, slug := range []string{"", ".", "..", "../etc", "chitin/../etc", `chitin\evil`, "with/slash"} {
+		_, err := ResolveField(slug, "repo")
+		var invalid InvalidSlugError
+		if !errors.As(err, &invalid) {
+			t.Fatalf("slug %q: want InvalidSlugError, got %v", slug, err)
+		}
+	}
+}
+
+func TestResolveFieldExpandsTildeInWorkspaceRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "workspace_root")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	want := filepath.Join(home, "workspace", "chitin")
+	if got != want {
+		t.Fatalf("workspace_root = %q, want %q", got, want)
+	}
+}
+
+func TestResolveFieldExpandsTildeFromEnvOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KANBAN_BOARD_WORKSPACE_ROOT", "~/other-root")
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"/abs/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "workspace_root")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	want := filepath.Join(home, "other-root")
+	if got != want {
+		t.Fatalf("workspace_root = %q, want %q", got, want)
+	}
+}
+
+func TestResolveFieldDoesNotExpandTildeForNonPathFields(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"~/literal","default_branch":"main","workspace_root":"/abs","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "repo")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got != "~/literal" {
+		t.Fatalf("repo = %q, want ~/literal", got)
+	}
+}
+
 func writeBoardConfig(t *testing.T, home, slug, raw string) {
 	t.Helper()
 	dir := filepath.Join(home, ".hermes", "kanban", "boards", slug)

--- a/go/execution-kernel/internal/boardconfig/boardconfig_test.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig_test.go
@@ -66,9 +66,36 @@ func TestResolveFieldUnknownBoard(t *testing.T) {
 	}
 }
 
+func TestResolveFieldEnvDoesNotSynthesizeUnknownBoard(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KANBAN_BOARD_REPO", "override/repo")
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, err := ResolveField("readybench", "repo")
+	var boardErr UnknownBoardError
+	if !errors.As(err, &boardErr) {
+		t.Fatalf("want UnknownBoardError, got %v", err)
+	}
+	if boardErr.Slug != "readybench" {
+		t.Fatalf("slug = %q, want readybench", boardErr.Slug)
+	}
+}
+
 func TestResolveFieldNoBoardsInitialized(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+
+	_, err := ResolveField("chitin", "repo")
+	if !errors.Is(err, ErrNoBoardsInitialized) {
+		t.Fatalf("want ErrNoBoardsInitialized, got %v", err)
+	}
+}
+
+func TestResolveFieldEnvDoesNotSynthesizeNoBoardsInitialized(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KANBAN_BOARD_REPO", "override/repo")
 
 	_, err := ResolveField("chitin", "repo")
 	if !errors.Is(err, ErrNoBoardsInitialized) {
@@ -91,10 +118,56 @@ func TestResolveFieldMissingConfig(t *testing.T) {
 	}
 }
 
+func TestResolveFieldEnvDoesNotSynthesizeMissingConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KANBAN_BOARD_REPO", "override/repo")
+	boardDir := filepath.Join(home, ".hermes", "kanban", "boards", "chitin")
+	if err := os.MkdirAll(boardDir, 0o755); err != nil {
+		t.Fatalf("mkdir board dir: %v", err)
+	}
+
+	_, err := ResolveField("chitin", "repo")
+	var configErr MissingConfigError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("want MissingConfigError, got %v", err)
+	}
+}
+
 func TestResolveFieldOptionalDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "chitin_yaml")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got != "chitin.yaml" {
+		t.Fatalf("chitin_yaml = %q, want chitin.yaml", got)
+	}
+}
+
+func TestResolveFieldOptionalDefaultStillRequiresCompleteConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, err := ResolveField("chitin", "chitin_yaml")
+	var missingErr MissingFieldError
+	if !errors.As(err, &missingErr) {
+		t.Fatalf("want MissingFieldError, got %v", err)
+	}
+	if missingErr.Field != "repo" {
+		t.Fatalf("missing field = %q, want repo", missingErr.Field)
+	}
+}
+
+func TestResolveFieldEnvCanCompleteRequiredConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KANBAN_BOARD_REPO", "override/repo")
+	writeBoardConfig(t, home, "chitin", `{"default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
 
 	got, err := ResolveField("chitin", "chitin_yaml")
 	if err != nil {

--- a/go/execution-kernel/internal/boardconfig/boardconfig_test.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig_test.go
@@ -1,0 +1,117 @@
+package boardconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveFieldFromConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "repo")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got != "chitinhq/chitin" {
+		t.Fatalf("repo = %q, want chitinhq/chitin", got)
+	}
+}
+
+func TestResolveFieldEnvOverridesConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KANBAN_BOARD_REPO", "override/repo")
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "repo")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got != "override/repo" {
+		t.Fatalf("repo = %q, want override/repo", got)
+	}
+}
+
+func TestResolveFieldMissingRequiredField(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, err := ResolveField("chitin", "repo")
+	var missingErr MissingFieldError
+	if !errors.As(err, &missingErr) {
+		t.Fatalf("want MissingFieldError, got %v", err)
+	}
+	if missingErr.Field != "repo" {
+		t.Fatalf("missing field = %q, want repo", missingErr.Field)
+	}
+}
+
+func TestResolveFieldUnknownBoard(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, err := ResolveField("readybench", "repo")
+	var boardErr UnknownBoardError
+	if !errors.As(err, &boardErr) {
+		t.Fatalf("want UnknownBoardError, got %v", err)
+	}
+	if boardErr.Slug != "readybench" {
+		t.Fatalf("slug = %q, want readybench", boardErr.Slug)
+	}
+}
+
+func TestResolveFieldNoBoardsInitialized(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := ResolveField("chitin", "repo")
+	if !errors.Is(err, ErrNoBoardsInitialized) {
+		t.Fatalf("want ErrNoBoardsInitialized, got %v", err)
+	}
+}
+
+func TestResolveFieldMissingConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	boardDir := filepath.Join(home, ".hermes", "kanban", "boards", "chitin")
+	if err := os.MkdirAll(boardDir, 0o755); err != nil {
+		t.Fatalf("mkdir board dir: %v", err)
+	}
+
+	_, err := ResolveField("chitin", "repo")
+	var configErr MissingConfigError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("want MissingConfigError, got %v", err)
+	}
+}
+
+func TestResolveFieldOptionalDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "chitin_yaml")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got != "chitin.yaml" {
+		t.Fatalf("chitin_yaml = %q, want chitin.yaml", got)
+	}
+}
+
+func writeBoardConfig(t *testing.T, home, slug, raw string) {
+	t.Helper()
+	dir := filepath.Join(home, ".hermes", "kanban", "boards", slug)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir board dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(raw), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}

--- a/scripts/install-swarm.sh
+++ b/scripts/install-swarm.sh
@@ -102,11 +102,11 @@ echo "  Backups (if any) at: ${WORKFLOWS_DST}/*.bak-${TS}, ${CARDS_DST}/*.bak-${
 
 mkdir -p "$BOARD_ROOT"
 if [ ! -f "$BOARD_CONFIG" ]; then
-    cat > "$BOARD_CONFIG" <<'EOF'
+    cat > "$BOARD_CONFIG" <<EOF
 {
   "repo": "chitinhq/chitin",
   "default_branch": "main",
-  "workspace_root": "~/workspace/chitin",
+  "workspace_root": "$HOME/workspace/chitin",
   "kernel_bin": "chitin-kernel",
   "chitin_yaml": "chitin.yaml"
 }

--- a/scripts/install-swarm.sh
+++ b/scripts/install-swarm.sh
@@ -31,6 +31,8 @@ CARDS_SRC="$REPO_ROOT/swarm/data/agent-cards"
 CARDS_DST="$DEPLOYED_ROOT/data/agent-cards"
 BIN_SRC="$REPO_ROOT/swarm/bin"
 BIN_DST="$DEPLOYED_ROOT/bin"
+BOARD_ROOT="$HOME/.hermes/kanban/boards/chitin"
+BOARD_CONFIG="$BOARD_ROOT/config.json"
 
 mkdir -p "$WORKFLOWS_DST" "$CARDS_DST" "$BIN_DST"
 
@@ -97,5 +99,20 @@ src_count=$(find "$WORKFLOWS_SRC" "$CARDS_SRC" "$BIN_SRC" -maxdepth 1 -type f \
 echo
 echo "install-swarm: ${src_count} canonical file(s) under swarm/ are now installed at $DEPLOYED_ROOT"
 echo "  Backups (if any) at: ${WORKFLOWS_DST}/*.bak-${TS}, ${CARDS_DST}/*.bak-${TS}"
+
+mkdir -p "$BOARD_ROOT"
+if [ ! -f "$BOARD_CONFIG" ]; then
+    cat > "$BOARD_CONFIG" <<'EOF'
+{
+  "repo": "chitinhq/chitin",
+  "default_branch": "main",
+  "workspace_root": "~/workspace/chitin",
+  "kernel_bin": "chitin-kernel",
+  "chitin_yaml": "chitin.yaml"
+}
+EOF
+    echo "  seeded board config at $BOARD_CONFIG"
+fi
+
 echo
 echo "To verify no drift: bash scripts/check-swarm-deployed-sync.sh"


### PR DESCRIPTION
Closes ticket t_0accdc3b (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-0accdc3b.