### PR TITLE
fix(swarm): clarify PR-open dispatch status

### DIFF
--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -470,7 +470,7 @@ steps:
         # Slice D: PR failed — block so it gets human attention.
         kanban-flow block ${ticket_id} "branch $BRANCH pushed but gh pr create failed" --author clawta 2>/dev/null || true
       else
-        MSG="🦞 ${ticket_id}: done. Branch: $BRANCH. PR: $PR_URL"
+        MSG="🦞 ${ticket_id}: PR opened; ticket remains in_progress for review/merge. Branch: $BRANCH. PR: $PR_URL"
         # PR opened — record the URL on the ticket. Ticket stays in
         # in_progress (Hermes UI has no code_review column; the PR's
         # GitHub state is the review-phase truth).

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -470,7 +470,7 @@ steps:
         # Slice D: PR failed — block so it gets human attention.
         kanban-flow block ${ticket_id} "branch $BRANCH pushed but gh pr create failed" --author clawta 2>/dev/null || true
       else
-        MSG="🦞 ${ticket_id}: done. Branch: $BRANCH. PR: $PR_URL"
+        MSG="🦞 ${ticket_id}: PR opened; ticket remains in_progress for review/merge. Branch: $BRANCH. PR: $PR_URL"
         # PR opened — record the URL on the ticket. Ticket stays in
         # in_progress (Hermes UI has no code_review column; the PR's
         # GitHub state is the review-phase truth).


### PR DESCRIPTION
Clarify the dispatch finalizer message after a worker opens a PR. The ticket remains in `in_progress` for review/merge via `kanban-flow pr`; the old message said `done`, which made in-flight work look like it skipped straight from ready to done even though the board status stayed in progress.\n\nRuntime workflow under `~/.openclaw/workflows/kanban-dispatch.lobster` has already been patched.