### PR TITLE
docs(analysis): library SPEC.md, per-module invariants, public API surface

### DIFF
--- a/python/analysis/SPEC.md
+++ b/python/analysis/SPEC.md
@@ -1,0 +1,315 @@
+# chitin/python/analysis — Library Spec
+
+**Status:** living spec for the `analysis` Python package. Extends the
+decisions-stream design at
+`docs/superpowers/specs/2026-04-30-analysis-decisions-design.md` to cover every
+sibling module that now lives in this directory.
+
+**Reading order:** start with §Positioning, then §Module map. The §Invariants
+section is the contract every module is graded against — if a module's code or
+docstring diverges from these, the docstring is wrong, not the spec.
+
+---
+
+## Positioning
+
+`analysis/` is the **read side** of the chitin loop. The Go kernel owns side
+effects (drivers, gates, chain emission). Python reads what the kernel wrote
+and produces JSON + markdown reports a human reviews.
+
+```
+                  ┌──────────────────────────────────────┐
+                  │  Go kernel (drivers, gov, chain)     │
+                  └─────┬─────────────────┬──────────────┘
+                        │ writes          │ writes
+                        ▼                 ▼
+            ~/.chitin/gov-decisions-*.jsonl
+            ~/.chitin/events-*.jsonl
+            ~/.codex/sessions/**/rollout-*.jsonl
+            docs/debt-ledger.md
+                        │ reads
+                        ▼
+                  ┌──────────────────────────────────────┐
+                  │  analysis/  (this package)           │
+                  │   - loaders, types, writers          │
+                  │   - decisions / debt / souls streams │
+                  │   - predict (P2 classifier)          │
+                  │   - codex_mine / skill_mine          │
+                  │   - floundering_calibration          │
+                  └─────┬────────────────────────────────┘
+                        │ writes (gitignored)
+                        ▼
+                  python/analysis/out/<stream>-<date>.{json,md}
+```
+
+Analysis **never** writes to the chain, never proposes actions to drivers,
+never auto-PRs. It is observation-only.
+
+---
+
+## Module map
+
+Each row names the one-sentence contract. Files prefixed `[stub]` are
+foundation-generalization proofs that emit valid empty findings.
+
+| Module | Contract |
+|---|---|
+| `__init__.py` | Public API surface — re-exports the canonical types and functions a consumer needs. |
+| `__main__.py` | `python -m analysis` lists submodules and exits 2. |
+| `models.py` | Dataclasses + JSONL parsers. `Decision`, `Pattern`, `RuleDraft`, `PredictedImpact`. Tolerant parser (`parse_decision_line`) never raises. |
+| `loaders.py` | `load_gov_decisions(dir, Window) -> LoadResult`. Half-open window. Bad lines counted, never fatal. |
+| `detect.py` | `detect_patterns(decisions) -> list[Pattern]`. Group-and-rank by (rule_id, action_type, agent_id) — denies only. Deterministic tie-breaker. |
+| `draft.py` | `draft_for_pattern(p) -> RuleDraft \| None`. Looks up `REGISTRY[rule_id]` and dispatches. |
+| `llm_draft.py` | `enrich_with_llm(pairs)`. Layer 2, opt-in. Any failure → `kind="heuristic-fallback"`. Off by default. |
+| `writers.py` | `write_json` (canonical) + `write_markdown_from_json` (projection). JSON is the contract; markdown is regenerable. |
+| `decisions.py` | CLI for the decisions stream. `python -m analysis.decisions`. |
+| `debt.py` | (a) Stream stub — emits empty findings. (b) `load_ledger(path) -> LedgerLoadResult` — parses `docs/debt-ledger.md`'s yaml-fenced sections. |
+| `souls.py` | [stub] Souls stream stub — emits empty findings to prove foundation generalizes. |
+| `predict.py` | Stdlib logistic regression. `extract_features → train → predict`. Used by the kernel advisor's predicted-failure gate. |
+| `codex_mine.py` | Post-hoc mine of `~/.codex/sessions/**/rollout-*.jsonl`. Two subcommands: `usage` (quota rollup) and `ingest` (project function_calls into chitin events JSONL). |
+| `skill_mine.py` | n-gram surface of repeat workflows from `~/.chitin/events-*.jsonl`. Groups by `chain_id` (NOT by file). |
+| `floundering_calibration.py` | Per-tier threshold suggestion for the kernel's floundering heuristic, derived from real session distributions. |
+| `templates/__init__.py` | Template registry. Maps `rule_id` → function `(Pattern) -> RuleDraft \| None`. |
+| `templates/<rule>.py` | One per known rule_id family. Heuristic / diagnostic / research kinds documented below. |
+| `templates/all.py` | Side-effect import of every template (registers them). |
+| `search_backends/base.py` | `SearchBackend` Protocol + `BackendError`. Empty results ≠ failure. |
+| `search_backends/tavily.py` | One implementation. Reads credentials from env. |
+
+---
+
+## Invariants (the contract)
+
+These are claims every relevant module must preserve. The mention in a
+docstring is evidence; the test suite is the proof.
+
+### I1 — Determinism by tie-breaker (decisions stream)
+
+Given N decisions in window W, `detect_patterns` returns a ranked list whose
+ordering is:
+
+1. count descending
+2. then alphabetic on `rule_id`
+3. then `action_type`
+4. then `agent_id`
+
+Two runs over identical input produce byte-identical JSON. See
+`detect.py::detect_patterns`. Tested in `tests/test_detect.py` and
+`tests/test_writers_json.py`.
+
+### I2 — JSON canonical, markdown projection
+
+Every stream emits both `out/<stream>-<date>.json` and
+`out/<stream>-<date>.md`. The markdown is regenerable from the JSON alone —
+no input dependency. `write_markdown_from_json` reads only the JSON path.
+
+### I3 — Layer 1 has zero network dependencies
+
+The default code path is a pure function of the JSONL input. Networked code
+lives behind opt-in flags: `--llm-draft` (decisions stream → `llm_draft.py`)
+and the search-backends subpackage (separate caller).
+
+### I4 — Determinism modulo wall clock
+
+With `--llm-draft` off, output is byte-identical given identical input *and
+identical `generated_at`*. CLIs accept `--now <iso8601>` to fix the clock for
+tests; production stamps wall-clock time.
+
+### I5 — Bad input never aborts a run
+
+A malformed JSONL line, missing field, or coercion failure is counted in
+`input_summary.parse_errors` and the run continues. Audit-log integrity is
+the chain's job, not analysis's. The contract holds for:
+
+- `models.parse_decision_line` — returns `None`, never raises.
+- `loaders.load_gov_decisions` — counts parse errors, never raises.
+- `debt.load_ledger` — increments `parse_errors`, single stderr warning at end.
+- `codex_mine.iter_session_events` — skips bad lines silently (post-hoc).
+- `skill_mine.iter_decision_events` — skips bad lines silently.
+
+### I6 — Side-effect-free reads
+
+No analysis module writes to the chain, the kernel state, or any
+gov-decisions JSONL. Outputs only go to `out/` (gitignored), to user-named
+paths for predict-model persistence, or to a usage-feed file under
+`~/.cache/chitin/usage/`.
+
+### I7 — Template return shape (`draft.py`)
+
+A template function returns either:
+
+- `RuleDraft` with `kind ∈ {"heuristic", "diagnostic", "research-prompt"}` —
+  the template knows what to say for this pattern.
+- `None` — template declines. Caller surfaces in `no_template_patterns`.
+
+`RuleDraft.predicted_impact` is `Optional[PredictedImpact]`:
+  - `kind == "heuristic"` (or `"heuristic-fallback"` / `"llm"`) MUST populate
+    it — these drafts propose rule changes whose impact must be predictable.
+  - `kind == "diagnostic"` / `"research-prompt"` MAY leave it `None` — these
+    surface a finding for human review, not a rule change. The writer
+    renders "_No predicted impact_" in markdown and `null` in JSON.
+
+A template never raises. A template never makes a network call (Layer 1).
+
+### I8 — Window semantics (`loaders.Window`)
+
+Half-open: a decision is in the window iff `since <= ts < until`. A
+boundary case (`ts == until`) belongs to the next window. Same convention
+applies wherever a window is computed (`predict.py`, `floundering_calibration.py`).
+
+---
+
+## Boundaries (named, then code)
+
+Per Knuth: every function names its empty / single / max / null cases before
+the implementation runs.
+
+### Decisions stream
+
+- Empty input (0 decisions) → `patterns: []`, valid JSON, exit 0.
+- Single decision → one pattern, count=1, draft attempted.
+- All-same-bucket → one pattern, count=N.
+- Tied counts → tie-breaker invoked (I1).
+- `rule_id is None` → bucket as `"<none>"`.
+- `agent is None` → bucket as `"<unknown>"`.
+- Malformed `ts` → skipped, counted in parse_errors.
+- Window edge: `ts == until` belongs to next window (I8).
+
+### Predict
+
+- Empty training set → degenerate model, `predict()` returns `base_rate` (0.0).
+- Unknown `action_type` / `agent` at predict time → `"<unk>"` column.
+- Class balance near 0.5 OR n_samples < 50 → `insufficient_signal: true`.
+- Hour default uses UTC, not local — match training timestamps.
+
+### Codex mine
+
+- Missing sessions dir → empty list, no crash.
+- `chain_id` containing path separators → sanitized via
+  `_safe_chain_id_basename` to keep ingest writes inside `out-dir`.
+- Function_call args not parseable as JSON → empty target string.
+
+### Skill mine
+
+- Events with no `chain_id` → bucket under `"<unknown>"` (not dropped).
+- N-grams composed of all-same verbs or all-`read-*` → flagged trivial.
+
+### Floundering calibration
+
+- Session with zero writes → `max_stall_s` = full session duration.
+- Session with one write → `max_stall_s` measured from first decision to that write.
+- Driver not in `DRIVER_TIER` → tier `"unknown"`.
+
+### Debt ledger
+
+- Missing file → empty result, no raise.
+- Yaml block missing a required field → skip + count parse_errors.
+- `discovered_at` may be a `datetime`, `date`, or string — normalized to ISO-8601 string.
+
+---
+
+## CLI surface
+
+```
+python -m analysis                        # list submodules + exit 2
+python -m analysis.decisions [--llm-draft]
+python -m analysis.debt
+python -m analysis.souls
+python -m analysis.predict {train|predict}
+python -m analysis.codex_mine {usage|ingest}
+python -m analysis.skill_mine
+python -m analysis.floundering_calibration
+```
+
+All CLIs accept `--out-dir` (default `python/analysis/out`) and a `--now`
+override where time matters (I4).
+
+Exit codes:
+
+- `0` — success (including empty windows).
+- `2` — input dir missing OR insufficient input.
+- `3` — output-write failure (decisions stream).
+
+---
+
+## Output schema (canonical)
+
+The JSON envelope every stream emits via `writers.write_json`:
+
+```json
+{
+  "schema_version": "1",
+  "stream": "decisions" | "debt" | "souls",
+  "generated_at": "<iso8601>",
+  "window": {
+    "size": "7d",
+    "since": "<iso8601>",
+    "until": "<iso8601>",
+    "total_seconds": <int>
+  },
+  "input_summary": { ... },
+  "patterns": [ ... ],
+  "no_template_patterns": [ ... ]
+}
+```
+
+`schema_version="1"` is the contract handle. Consumers should branch on
+`stream` for stream-specific fields and on `schema_version` for shape.
+
+---
+
+## Foundation extraction ("C lean")
+
+The decisions stream is the deepest implementation. `debt` and `souls` stubs
+exist to prove the foundation generalizes:
+
+- `loaders.py` — generic JSONL window loader.
+- `models.Finding` (currently `Pattern` plus `writers.Finding`) — the shape
+  `write_json` operates on.
+- `writers.py` — operates on `Finding` lists, not Pattern-specific.
+
+When `souls` and `debt` ship real detection, no foundation change is needed.
+
+---
+
+## Test surface
+
+`tests/` directory contents enforce the spec:
+
+- `test_loaders.py` — half-open window, bad-line tolerance.
+- `test_detect.py` — tie-breaker stability, boundary cases.
+- `test_writers_json.py` — determinism (run twice, byte-equal).
+- `test_writers_markdown.py` — markdown regenerable from JSON alone.
+- `test_predict.py` — empty input → degenerate model; insufficient_signal flag.
+- `test_template_<rule>.py` — per-template heuristic behavior.
+- `test_templates_auto_register.py` — every template module imports without error.
+- `test_codex_mine.py` — sanitization of chain_id; safe write paths.
+- `test_skill_mine.py` — chain_id grouping across files; trivial-ngram filter.
+- `test_debt_ledger.py` — yaml-fence parsing; parse_errors counting.
+- `test_cli.py` — exit codes, `--now` determinism, end-to-end shape.
+- `test_draft_registry.py` — template return-shape contract (I7).
+- `test_types.py` — model coercion invariants (I5).
+- `test_llm_draft.py` — fallback to heuristic on any failure.
+- `test_stubs.py` — debt + souls emit valid empty findings.
+
+A failing test invalidates the corresponding invariant claim. Fix the code,
+not the test.
+
+---
+
+## Self-review
+
+- ✓ Every module has a one-sentence contract.
+- ✓ Invariants I1–I8 each cite at least one module that enforces them.
+- ✓ Boundaries named before code — empty / single / all-same / tied / null /
+  window-edge for every stream.
+- ✓ JSON is canonical; markdown regenerable; demo path deterministic.
+- ✓ Side-effect-free reads stated as I6.
+- ✓ Network use behind opt-in flags (I3); default path is pure.
+
+Open question for review:
+
+- **Q.** Should `souls.py` be deleted now that the stream hasn't shipped real
+  detection in three months, or kept as a foundation-generalization proof
+  until v2? **Suggested answer:** keep until v2. The cost of the stub is one
+  ~50-line file; the cost of foundation drift if we delete it and reintroduce
+  it later is higher.

--- a/python/analysis/__init__.py
+++ b/python/analysis/__init__.py
@@ -1,2 +1,86 @@
-"""chitin analysis layer — decisions, debt, soul-routing, and swarm-run streams."""
+"""chitin analysis layer — decisions, debt, soul-routing, and swarm-run streams.
+
+The read side of the chitin loop. Loads what the kernel wrote, detects
+patterns, drafts candidate rules, emits JSON + markdown reports.
+
+Public API:
+
+    Models (analysis.models):
+        Decision              — one parsed gov-decisions row
+        Pattern               — a repeat (rule_id, action_type, agent_id) bucket
+        RuleDraft             — heuristic / diagnostic / research output
+        PredictedImpact       — would_allow / would_still_deny / method
+        parse_decision_line   — tolerant single-line parser (never raises)
+
+    Loaders (analysis.loaders):
+        Window                — half-open time window (since <= ts < until)
+        LoadResult            — decisions + files_read + parse_errors
+        load_gov_decisions    — directory → LoadResult
+        parse_window_str      — "7d" / "60m" / "24h" → Window
+
+    Detection (analysis.detect):
+        detect_patterns       — group + rank denies, deterministic tie-breaker
+
+    Drafting (analysis.draft):
+        draft_for_pattern     — REGISTRY dispatch, returns RuleDraft | None
+        reason_no_template    — human-readable decline reason
+
+    Writers (analysis.writers):
+        Finding               — (rank, pattern, draft) triple
+        build_finding         — Finding constructor
+        write_json            — canonical output (I2 / I4)
+        write_markdown_from_json — projection from JSON (regenerable, I2)
+
+See `python/analysis/SPEC.md` for the full library spec — module map,
+invariants I1-I8, named boundaries.
+"""
+from __future__ import annotations
+
 __version__ = "0.1.0"
+
+from analysis.models import (
+    Decision,
+    Pattern,
+    PredictedImpact,
+    RuleDraft,
+    parse_decision_line,
+)
+from analysis.loaders import (
+    LoadResult,
+    Window,
+    load_gov_decisions,
+    parse_window_str,
+)
+from analysis.detect import detect_patterns
+from analysis.draft import draft_for_pattern, reason_no_template
+from analysis.writers import (
+    Finding,
+    build_finding,
+    write_json,
+    write_markdown_from_json,
+)
+
+__all__ = [
+    "__version__",
+    # models
+    "Decision",
+    "Pattern",
+    "PredictedImpact",
+    "RuleDraft",
+    "parse_decision_line",
+    # loaders
+    "LoadResult",
+    "Window",
+    "load_gov_decisions",
+    "parse_window_str",
+    # detection
+    "detect_patterns",
+    # drafting
+    "draft_for_pattern",
+    "reason_no_template",
+    # writers
+    "Finding",
+    "build_finding",
+    "write_json",
+    "write_markdown_from_json",
+]

--- a/python/analysis/decisions.py
+++ b/python/analysis/decisions.py
@@ -1,4 +1,23 @@
-"""CLI entry: python -m analysis.decisions ..."""
+"""CLI entry: python -m analysis.decisions ...
+
+End-to-end driver for the decisions stream. Reads gov-decisions JSONL,
+detects deny patterns, drafts candidate rules, writes JSON + markdown.
+
+Invariants (see SPEC.md):
+    I1  Deterministic ranking via detect_patterns + sorted writers.
+    I2  JSON + markdown both written; markdown rendered from JSON.
+    I3  Default path is no-network. `--llm-draft` opts into ollama.
+    I4  Output is byte-identical given identical input + identical `--now`.
+    I5  Bad JSONL lines counted in parse_errors; never abort the run.
+    I6  Writes go only to `--out-dir` (default python/analysis/out, gitignored).
+
+Boundaries:
+    - Missing `--decisions-dir` → exit 2 with stderr note.
+    - Output-write failure → exit 3. JSON is written before markdown so
+      partial state is "JSON exists, markdown missing", never the reverse.
+    - Empty window → patterns=[], no_template_patterns=[], exit 0.
+    - `--llm-draft` on but no findings → LLM call skipped (nothing to enrich).
+"""
 from __future__ import annotations
 
 import argparse
@@ -131,10 +150,13 @@ def main(argv: list[str] | None = None) -> int:
         top1 = findings[0]
         print(f"\nTop finding: {top1.pattern.rule_id} × {top1.pattern.action_type} "
               f"× {top1.pattern.agent_id} — {top1.pattern.count} denies", file=sys.stderr)
-        if top1.draft:
+        if top1.draft and top1.draft.predicted_impact is not None:
             imp = top1.draft.predicted_impact
             print(f"  → predicted: {imp.would_allow} allows, "
                   f"{imp.would_still_deny} still deny", file=sys.stderr)
+        elif top1.draft:
+            print(f"  → diagnostic/{top1.draft.kind} draft (no predicted impact)",
+                  file=sys.stderr)
     return 0
 
 

--- a/python/analysis/floundering_calibration.py
+++ b/python/analysis/floundering_calibration.py
@@ -23,6 +23,21 @@ TIER_DRIVER_DEFAULTS:
     T3    → openclaw-glm-cloud
     T4    → claude-code-headless
 
+Invariants (see SPEC.md):
+    I3  No network. Pure function of `events-*.jsonl` contents.
+    I5  Malformed JSONL lines skipped; session with no usable decisions
+        returns None and is excluded from the rollup.
+    I6  Output goes to `out/` only — never to chain or kernel state.
+
+Boundaries:
+    - Session with zero writes → `max_stall_s` = full session duration.
+      The agent never wrote anything; the "stall" is the entire run.
+    - Session with one write → `max_stall_s` measured first-decision → that-write.
+    - Driver not in DRIVER_TIER → tier = "unknown" (still ranked, separately).
+    - Suggested `max_loop_count` floor is 2 even if p90 is 1, so the
+      heuristic stays meaningfully sensitive on small samples.
+    - Percentile on empty list → 0.0 (no division-by-zero, no exception).
+
 Usage:
     cd python/analysis && uv run python -m analysis.floundering_calibration
 

--- a/python/analysis/models.py
+++ b/python/analysis/models.py
@@ -137,9 +137,12 @@ class PredictedImpact:
 
 @dataclass(frozen=True)
 class RuleDraft:
-    kind: str  # "heuristic" | "heuristic-fallback" | "llm"
+    kind: str  # "heuristic" | "heuristic-fallback" | "llm" | "diagnostic" | "research-prompt"
     template: str
     confidence: str  # "low" | "medium" | "high"
     rule_yaml: str
-    predicted_impact: PredictedImpact
+    # Optional because diagnostic and research-prompt drafts don't propose a
+    # rule change — they surface a finding for human review. Heuristic and
+    # llm drafts MUST populate this; writers / consumers handle None.
+    predicted_impact: Optional[PredictedImpact]
     notes: str = ""

--- a/python/analysis/predict.py
+++ b/python/analysis/predict.py
@@ -10,6 +10,27 @@ operator boxes) and adding a heavy dep for a sub-second classifier
 on hundreds of rows is a bad trade. The math here is one numpy line
 expanded to ~30 stdlib lines; readability stays.
 
+Invariants (see SPEC.md):
+    I3  No network. Pure function of input rows.
+    I5  Bad input never aborts a run — handled in loaders, predict is
+        called only with well-formed Decision rows.
+    I8  1-year lookback window in `_cli_train` uses timedelta(days=365),
+        not now.replace(year=year-1) (leap-day crash). Half-open window.
+
+Boundaries:
+    - Empty training set → degenerate model; `predict()` returns base_rate
+      (0.0). `n_samples == 0` is the caller-visible signal.
+    - Unknown action_type / agent at predict time → "<unk>" column. Never
+      raises KeyError.
+    - n_samples < 50 OR |base_rate - 0.5| < 0.05 → `insufficient_signal: true`
+      at the CLI layer. Callers gate decisions on that flag, not on raw probability.
+    - Hour default at predict time uses UTC (training timestamps are UTC);
+      a local-time default on non-UTC hosts would bucket actions into a
+      different time-of-day feature than training saw.
+    - L2 regularization is applied to every weight including bias. Acceptable
+      for the data scale; if bias-shrinkage matters at higher n, exempt the
+      last column explicitly.
+
 Public API:
     extract_features(decisions) -> X, y, vocab
     train(X, y, vocab, ...) -> Model         # vocab is a positional

--- a/python/analysis/pyproject.toml
+++ b/python/analysis/pyproject.toml
@@ -20,8 +20,9 @@ build-backend = "setuptools.build_meta"
 packages = [
     "analysis",
     "analysis.templates",
+    "analysis.search_backends",
 ]
-package-dir = {"analysis" = ".", "analysis.templates" = "templates"}
+package-dir = {"analysis" = ".", "analysis.templates" = "templates", "analysis.search_backends" = "search_backends"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/analysis/skill_mine.py
+++ b/python/analysis/skill_mine.py
@@ -16,6 +16,22 @@ Two-pass strategy:
   (gh-pr-view, git-status, npm-test, edit-yaml, etc.) and mine
   n-grams over verbs. This is where real workflow shapes surface.
 
+Invariants (see SPEC.md):
+    I3  No network — pure function of events JSONL contents.
+    I5  Bad JSONL lines silently skipped (post-hoc miner, not safety-critical).
+    Determinism: outputs are sorted by `(n_sess * n, n_total)` desc with a
+    stable input ordering — events sorted chronologically per chain. Two runs
+    over identical files produce identical reports.
+
+Boundaries:
+    - Events with no `chain_id` → bucket under "<unknown>" (not dropped).
+    - A chain with zero decision events → silently ignored (no rows yielded).
+    - N-grams of all-same verbs or all-`read-*` / all-`edit-*` → trivial,
+      filtered out (see `is_trivial`).
+    - N-gram threshold: a candidate must appear in ≥3 distinct sessions to
+      surface in the report. Single-session repeats are not skills.
+    - No events files in CHITIN_DIR → exit 2.
+
 Verb extraction rules:
   - shell.exec target starting with "gh "      → gh-<subcommand>
   - shell.exec target starting with "git "     → git-<subcommand>

--- a/python/analysis/souls.py
+++ b/python/analysis/souls.py
@@ -1,4 +1,24 @@
-"""Souls stream stub. Foundation-generalization proof."""
+"""Souls stream stub. Foundation-generalization proof.
+
+This module exists to prove the writers + JSON schema generalize past
+the decisions stream. It produces a valid empty findings document for the
+souls stream so consumers can branch on `stream` without crashing on
+schema-mismatch when souls hasn't shipped real detection yet.
+
+Invariants (see SPEC.md):
+    I2  Emits both JSON canonical + markdown projection.
+    I3  No network.
+    I6  Output goes to `out/` only.
+    Schema-version stamping uses `stream="souls"` so downstream readers can
+    branch correctly.
+
+Boundaries:
+    - Always produces a 2-file artifact (JSON + markdown), even with zero
+      findings. The empty-write IS the proof.
+    - `--now` accepted for deterministic tests; otherwise wall-clock.
+
+Replace this stub with real detection when the souls stream ships in v2.
+"""
 from __future__ import annotations
 
 import argparse

--- a/python/analysis/templates/__init__.py
+++ b/python/analysis/templates/__init__.py
@@ -2,6 +2,22 @@
 
 A template function takes a Pattern and returns a RuleDraft, or None if the
 template can't draft for this specific pattern.
+
+Contract (I7, see SPEC.md):
+    - Templates NEVER raise. Decline-by-return-None is the only failure mode.
+    - Templates NEVER make a network call (Layer 1 is pure).
+    - The returned `RuleDraft.kind` is one of:
+        "heuristic"        — heuristic template, proposes YAML.
+        "diagnostic"       — surfaces a finding for operator review (no YAML draft).
+        "research-prompt"  — emits a research prompt instead of a rule draft.
+      The `kind` informs the markdown renderer how to present the draft.
+    - `register()` is idempotent: re-importing a template module won't crash,
+      but the last registration for a given rule_id wins.
+
+Boundaries:
+    - `pattern.decisions` empty → most templates return None defensively.
+    - No template registered for a rule_id → `draft.draft_for_pattern`
+      returns None; the caller surfaces the pattern under `no_template_patterns`.
 """
 from __future__ import annotations
 

--- a/python/analysis/writers.py
+++ b/python/analysis/writers.py
@@ -41,17 +41,22 @@ def _pattern_to_json(p: Pattern) -> dict[str, Any]:
 
 
 def _draft_to_json(d: RuleDraft) -> dict[str, Any]:
+    impact: Optional[dict[str, Any]]
+    if d.predicted_impact is None:
+        impact = None
+    else:
+        impact = {
+            "samples_evaluated": d.predicted_impact.samples_evaluated,
+            "would_allow": d.predicted_impact.would_allow,
+            "would_still_deny": d.predicted_impact.would_still_deny,
+            "method": d.predicted_impact.method,
+        }
     return {
         "kind": d.kind,
         "template": d.template,
         "confidence": d.confidence,
         "rule_yaml": d.rule_yaml,
-        "predicted_impact": {
-            "samples_evaluated": d.predicted_impact.samples_evaluated,
-            "would_allow": d.predicted_impact.would_allow,
-            "would_still_deny": d.predicted_impact.would_still_deny,
-            "method": d.predicted_impact.method,
-        },
+        "predicted_impact": impact,
         "notes": d.notes,
     }
 
@@ -173,16 +178,22 @@ def _render_pattern(p: dict[str, Any], lines: list[str]) -> None:
     lines.append(f"**Candidate rule** ({d['kind']}, {d['confidence']} confidence, "
                  f"template `{d['template']}`):")
     lines.append("")
-    lines.append("```yaml")
-    lines.append(d["rule_yaml"].rstrip())
-    lines.append("```")
-    lines.append("")
+    if d["rule_yaml"].strip():
+        lines.append("```yaml")
+        lines.append(d["rule_yaml"].rstrip())
+        lines.append("```")
+        lines.append("")
     impact = d["predicted_impact"]
-    lines.append(f"**Predicted impact:** samples_evaluated: {impact['samples_evaluated']}, "
-                 f"would_allow: {impact['would_allow']}, "
-                 f"would_still_deny: {impact['would_still_deny']} "
-                 f"(method: {impact['method']})")
-    lines.append("")
+    if impact is not None:
+        lines.append(f"**Predicted impact:** samples_evaluated: {impact['samples_evaluated']}, "
+                     f"would_allow: {impact['would_allow']}, "
+                     f"would_still_deny: {impact['would_still_deny']} "
+                     f"(method: {impact['method']})")
+        lines.append("")
+    else:
+        lines.append("_No predicted impact: diagnostic/research draft surfaces a finding, "
+                     "doesn't propose a rule change._")
+        lines.append("")
     if d["notes"]:
         lines.append(f"_Notes: {d['notes']}_")
         lines.append("")


### PR DESCRIPTION
## Summary

- Refines `python/analysis/` to be fully specified per the existing decisions-stream design pattern (Knuth: state the invariant before the code).
- Adds `python/analysis/SPEC.md` — library-wide module map, invariants I1–I8, named boundaries per stream. Extends the existing decisions-design spec (`docs/superpowers/specs/2026-04-30-analysis-decisions-design.md`) to cover every sibling module: `predict`, `codex_mine`, `skill_mine`, `floundering_calibration`, debt-ledger loader, souls stub, templates, search_backends.
- Promotes `__init__.py` from 2-line stub to public-API surface (17 re-exported symbols + module-map docstring).
- Adds `Invariants:` / `Boundaries:` docstring blocks to `predict.py`, `skill_mine.py`, `floundering_calibration.py`, `souls.py`, `decisions.py:main()`, `templates/__init__.py` — matching the Knuth pattern already present in `models.py` / `loaders.py` / `detect.py`.
- Fixes `pyproject.toml` to include `analysis.search_backends` in `tool.setuptools.packages`.
- **Bug fix surfaced by dogfooding the library on real data:** `RuleDraft.predicted_impact` is now `Optional[PredictedImpact]`. Diagnostic and research-prompt kind templates legitimately have no predicted impact — they surface a finding for human review, not a rule change. Updated `models.py` + `writers.py` (JSON `null` / markdown placeholder) + `decisions.py` CLI stdout + `SPEC.md` §I7 to document the contract.

## Why now

I ran every stream against live data (`~/.chitin/gov-decisions-*.jsonl`, `events-*.jsonl`, `~/.codex/sessions/`) immediately after the spec edits. The decisions stream crashed on real-world templates emitting diagnostic drafts because the `Optional` shape wasn't enforced. The mining run is what surfaced the type bug — proving the library does its job when actually used.

## Test plan

- [x] `pytest -q` — 121/121 pass before and after.
- [x] `python -m analysis.decisions --window 7d` runs cleanly end-to-end on live data (24,180 decisions, 1,043 denies, 57 patterns).
- [x] `python -m analysis.debt`, `python -m analysis.souls` (stubs) emit valid empty findings.
- [x] `python -m analysis.skill_mine`, `python -m analysis.floundering_calibration`, `python -m analysis.codex_mine usage` all run.
- [x] `from analysis import Decision, Pattern, RuleDraft, load_gov_decisions, detect_patterns, write_json, ...` — all 17 exports importable.
- [ ] Reviewer eyeball on `SPEC.md` invariants — are I1–I8 the right contract surface, or am I overspecifying?
- [ ] Reviewer eyeball on the Optional `predicted_impact` change — diagnostic/research drafts genuinely have no rule-change impact, so `None` reads cleaner than a sentinel `PredictedImpact(0,0,0,"n/a")`. Confirm preference.

## Follow-ups (out of scope here)

- Test gap: add a JSON-write round-trip for a diagnostic-kind draft to lock the I7 Optional contract.
- 3 deny rule_ids in the wild (`governance-mutation-authority-required`, `escalate-pending`, `worktree-required`) have no template — file as separate tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)