### PR TITLE
docs: re-sync thesis/roadmap with swarm-in-monorepo direction

### DIFF
--- a/apps/cli/src/commands/init-claude-code.ts
+++ b/apps/cli/src/commands/init-claude-code.ts
@@ -51,12 +51,6 @@ export function initClaudeCodeCommand(opts: { workspace?: string }): void {
 
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
 
-  mkdirSync(join(workspace, '.chitin'), { recursive: true });
-  writeFileSync(
-    join(workspace, '.chitin', 'init.json'),
-    JSON.stringify({ surface: 'claude-code', kernelBin, ts: new Date().toISOString() }, null, 2),
-  );
-
   process.stdout.write(
     `wired Claude Code PreToolUse hook → ${kernelBin}\nsettings: ${settingsPath}\nworkspace: ${workspace}\n`,
   );

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,11 +44,12 @@ Chitin is a small Go kernel with thin TypeScript adapters per surface. The kerne
 | `claude-code-headless` | PreToolUse hook (settings.json) | claudecode.HookInput | yes |
 | `codex` | PreToolUse hook (~/.codex/config.toml) | codex.HookInput (byte-compatible w/ Claude Code; hooks/list RPC) | yes |
 | `gemini` | BeforeTool hook (~/.gemini/settings.json) | gemini.HookInput (byte-compatible w/ Claude Code) | yes |
+| `hermes` | `pre_tool_call` hook (~/.hermes/config.yaml) | hermes.HookInput (byte-compatible w/ Claude Code) | yes |
 | `copilot` | wrapping orchestrator (`chitin-kernel drive copilot`) | Copilot SDK PermissionRequest | yes |
-| `local-qwen`/`-glm`/`-deepseek` | openclaw `before_tool_call` plugin | openclaw plugin context | yes |
+| `openclaw` (local-qwen/-glm/-deepseek + clawta orchestrator) | openclaw `before_tool_call` plugin (`apps/openclaw-plugin-governance/`) | openclaw plugin context | yes |
 | MCP tools | flow through whichever agent dispatched | parent driver's hook | yes (via parent) |
 
-Codex + gemini both speak the Claude Code PreToolUse wire format byte-for-byte; only the per-tool name set differs (`Bash`/`apply_patch` for codex, `run_shell_command`/`edit`/`replace` for gemini). The `chitin-router-hook` shim is shared across all three; `internal/driver/<vendor>/normalize.go` does the per-vendor translation.
+Codex, gemini, and hermes all speak the Claude Code PreToolUse wire format byte-for-byte; only the per-tool name set differs (`Bash`/`apply_patch` for codex, `run_shell_command`/`edit`/`replace` for gemini, hermes-specific names for hermes). The `chitin-router-hook` shim — a compiled Go binary at `bin/chitin-router-hook` (source: `go/execution-kernel/cmd/chitin-router-hook/router_hook.go`) — is shared across all four PreToolUse-class drivers; `internal/driver/<vendor>/normalize.go` does the per-vendor translation. The shim stamps `CHITIN_DRIVER` from its `--agent=<cli>` flag (deferring to a caller-set value if one is exported) so every chain event carries an unambiguous driver identity.
 
 ## Layers
 
@@ -92,7 +93,7 @@ Operator-side scripts (under `scripts/`):
 ```
 chitin-status                 # dashboard: timers + chain + router + spend + tier-recs
 chitin-budget                 # per-driver $-spend + universal usage feeds (codex 5h/weekly, etc)
-chitin-router-hook            # bash shim that all PreToolUse hooks point at
+chitin-router-hook            # compiled Go binary (bin/chitin-router-hook); all PreToolUse-class hooks point at it; stamps CHITIN_DRIVER
 install-kernel.sh             # idempotent rebuild/install + per-vendor hook refresh
 install-gemini-hook.sh        # writes hooks block into ~/.gemini/settings.json
 install-codex-hook.sh         # writes [features] codex_hooks=true + [[hooks.PreToolUse]] into ~/.codex/config.toml
@@ -103,7 +104,7 @@ install-codex-hook.sh         # writes [features] codex_hooks=true + [[hooks.Pre
 These are non-negotiable. New code, specs, and plans must respect them. See [`architecture/layer-contracts.md`](./architecture/layer-contracts.md) for the locked statement.
 
 1. **Kernel Authority.** All execution passes through `gov.Gate.Evaluate`. The kernel is the only enforcement point.
-2. **Driver Constraint.** The kernel exposes `AllowedDrivers(req)` as the feasible-driver set. Orchestrators consume it; they cannot derive their own or override it.
+2. **Driver Constraint.** `allowed_drivers` is a typed, schema-validated field on `ExecutionRequest` (non-empty, closed enum). The orchestrator picks within it; cannot expand. Active kernel-side narrowing (`chitin-kernel task validate`) is deferred per the 2026-04-30 addendum; downstream enforcement at every leaf hook by `gov.Gate.Evaluate` is the load-bearing guarantee. See `architecture/layer-contracts.md` for the full statement.
 3. **Routing Scope.** Routing optimizes for capacity (latency, availability, hardware) within the allowed set. It cannot expand it.
 4. **Aggregation Role.** The event chain is canonical; OTEL is a non-authoritative projection. Aggregation never affects live execution.
 
@@ -117,11 +118,11 @@ These are non-negotiable. New code, specs, and plans must respect them. See [`ar
 
 Per-vendor integration shape varies by vendor posture; the `gov.Gate` API is shared.
 
-- **Open vendors with native hook surface → in-process extension.** Vendor ships a PreToolUse-style hook config; chitin's router-hook shim is wired in via the vendor's config, kernel does normalization. Examples: Claude Code (`~/.claude/settings.json` PreToolUse), Codex (`~/.codex/config.toml` [features] codex_hooks=true + [[hooks.PreToolUse]]), Gemini (`~/.gemini/settings.json` BeforeTool — same wire shape, different event name).
-- **Open vendors with plugin runtime → openclaw plugin.** openclaw's `before_tool_call` plugin path. Examples: local-qwen / local-glm / local-glm-flash / local-deepseek.
+- **Open vendors with native hook surface → in-process extension.** Vendor ships a PreToolUse-style hook config; chitin's router-hook binary is wired in via the vendor's config, kernel does normalization. Examples: Claude Code (`~/.claude/settings.json` PreToolUse), Codex (`~/.codex/config.toml` [features] codex_hooks=true + [[hooks.PreToolUse]]), Gemini (`~/.gemini/settings.json` BeforeTool — same wire shape, different event name), Hermes (`~/.hermes/config.yaml` `pre_tool_call`).
+- **Open vendors with plugin runtime → openclaw plugin.** openclaw's `before_tool_call` plugin path via `apps/openclaw-plugin-governance/`. Examples: local-qwen / local-glm / local-glm-flash / local-deepseek, plus the clawta orchestrator agent itself.
 - **Closed vendors → wrapping orchestrator.** Vendor ships a closed binary; chitin spawns the agent as a child of a chitin-driven harness. Example: Copilot CLI (`chitin-kernel drive copilot`).
 
-Codex + gemini both ship native PreToolUse hook systems that are byte-compatible with Claude Code's wire shape — gemini's `gemini hooks migrate --from-claude` is explicit about the equivalence. That's why all three slot into the same `chitin-router-hook` pipeline; the only per-vendor work is the tool-name normalizer in `internal/driver/<vendor>/normalize.go`.
+Codex, gemini, and hermes all ship native PreToolUse-class hook systems that are byte-compatible with Claude Code's wire shape — gemini's `gemini hooks migrate --from-claude` is explicit about the equivalence. That's why all four slot into the same `chitin-router-hook` pipeline; the only per-vendor work is the tool-name normalizer in `internal/driver/<vendor>/normalize.go`.
 
 Classify the vendor first; let the classification pick the integration shape, not the other way around.
 

--- a/docs/architecture/layer-contracts.md
+++ b/docs/architecture/layer-contracts.md
@@ -1,21 +1,64 @@
 # Chitin Layer Contracts v1
 
-Locked 2026-04-29. These are the architectural invariants that hold across the chitin system. New code, specs, and plans must respect them.
+Locked 2026-04-29. Driver-constraint clause restated 2026-05-13 to
+match shipping reality (the 2026-04-30 addendum's deferral codified
+into the contract instead of pending against it). These are the
+architectural invariants that hold across the chitin system. New
+code, specs, and plans must respect them.
 
 ## 1. Kernel Authority
 
-All execution passes through `gov.Gate.Evaluate`. The kernel is the only enforcement point. No driver, orchestrator, or adapter may bypass it.
+All execution passes through `gov.Gate.Evaluate`. The kernel is the
+only enforcement point. No driver, orchestrator, or adapter may
+bypass it.
 
 ## 2. Driver Constraint
 
-The kernel exposes an `AllowedDrivers` primitive that returns the kernel-derived feasible driver set for a given execution request. The orchestrator must consume this primitive; it cannot derive its own allowed set or override the result.
+An execution request carries `allowed_drivers` as a typed, schema-
+validated field on `ExecutionRequest` (`libs/contracts/src/execution-
+request.schema.ts`). The schema enforces:
 
-The kernel remains authoritative: all execution performed by any selected driver is still subject to `gov.Gate.Evaluate`.
+- non-empty (rejects `[]`)
+- closed enum (rejects unknown driver ids; rejects ToS-disallowed
+  drivers, e.g., raw `claude-code` as a worker subagent)
+
+The dispatcher constructs the field; the orchestrator picks within
+it (`swarm/workflows/_pick_driver.py` ranks by capability + cost
+from the agent-cards). The orchestrator cannot expand to drivers
+outside the enum (the schema rejects the request at parse time) and
+cannot pick a driver absent from `allowed_drivers` (the schema
+constrains `selected_driver` to the same enum).
+
+The kernel remains authoritative: all execution performed by any
+selected driver is still subject to `gov.Gate.Evaluate` at the leaf
+hook surface. What this clause guarantees is upstream typing +
+schema-enforced narrowing; what `gov.Gate` guarantees is downstream
+enforcement. Together they form the authority chain.
+
+### Deferred (active kernel narrowing)
+
+The 2026-04-30 local-worker addendum deferred the active narrowing
+path (`chitin-kernel task validate <req.json>` that asks the kernel
+to shrink `allowed_drivers` from policy before dispatch). That path
+remains deferred — the schema-typed contract is sufficient for
+today's swarm pipeline. When ledger signal shows the cost-ranked
+picker drifting from policy intent, wire the active primitive: a
+`chitin-kernel task validate` subcommand that takes an
+`ExecutionRequest`, applies the policy, and returns a possibly-
+shrunk `allowed_drivers`. The contract above stands either way:
+"policy can shrink, never expand."
 
 ## 3. Routing Scope
 
-Routing within the orchestrator optimizes for capacity (latency, availability, hardware). Routing cannot expand the allowed set returned by `AllowedDrivers`.
+Routing within the orchestrator optimizes for capacity (latency,
+availability, hardware) within the `allowed_drivers` set. Routing
+cannot expand the set. With the active narrowing path deferred,
+routing also cannot shrink it beyond schema-imposed constraints —
+the shrink is the orchestrator's cost-and-capability ranking,
+operating within the schema-typed enum.
 
 ## 4. Aggregation Role
 
-The event chain informs future policy via post-hoc derivation and replay. It does not affect live execution. OTEL emit is a projection of the chain, never its source.
+The event chain informs future policy via post-hoc derivation and
+replay. It does not affect live execution. OTEL emit is a projection
+of the chain, never its source.

--- a/docs/decisions/2026-05-13-swarm-readopted-composing-substrates.md
+++ b/docs/decisions/2026-05-13-swarm-readopted-composing-substrates.md
@@ -1,0 +1,212 @@
+# Swarm re-adopted: chitin composes hermes + openclaw substrates
+
+Status: durable boundary. Supersedes
+[`2026-05-06-chitin-scope-narrow-to-kernel.md`](./2026-05-06-chitin-scope-narrow-to-kernel.md)
+on the "what lives in the chitin repo" question. Keeps everything that
+decision said about the kernel being the single side-effect authority.
+
+Date: 2026-05-13
+
+## The change in one sentence
+
+Chitin owns a swarm — but it builds that swarm by composing two
+substrates it does not own: **hermes** (kanban as source of truth) and
+**openclaw** (agent runtime + Lobster workflow + agent cards). Chitin's
+contribution at every hop is the chain event, the `CHITIN_DRIVER`
+identity stamp, and the `gov.Gate` enforcement.
+
+## What 2026-05-06 got right (kept)
+
+- The kernel is the only side-effect authority. `gov.Gate.Evaluate` is
+  the only enforcement point. `~/.chitin/*` has one writer.
+- `apps/runner/`, `infra/temporal/`, the markdown work-tracking file,
+  the chitin-side dispatcher and PR mirror are gone and stay gone.
+  Reintroducing any of them would re-create the duplicate-orchestration
+  problem the 05-06 cull resolved.
+- Layer Contracts v1 (kernel authority, driver constraint, routing
+  scope, aggregation role) still hold, with the driver-constraint
+  clause restated 2026-05-13 to match the schema-typed shipping
+  reality.
+
+## What changed (and why)
+
+The 05-06 decision said "whatever orchestrator the operator runs is
+agnostic — chitin doesn't know or care." That was the right move at
+the time because chitin's in-tree orchestration code was duplicating
+hermes' kanban without leveraging it. Once that duplication was
+deleted, two things became visible:
+
+1. **Hermes kanban is a real substrate, not just another consumer.**
+   It exposes a SQLite-backed task graph, status transitions,
+   comments, and `task_events`. The chitin-owned audit invariant
+   ("every status change has a matching comment + event") rides ON
+   TOP of that substrate.
+
+2. **OpenClaw + Lobster + agent cards is a real agent-runtime
+   substrate.** Lobster workflows handle multi-step dispatch with
+   approval gates; agent cards parameterize `(driver, model, role)`
+   triples; the openclaw plugin runtime gates `before_tool_call`
+   through `chitin-kernel`. Building a parallel runtime in chitin
+   would duplicate that.
+
+The 2026-05-11 spec
+([`docs/superpowers/specs/2026-05-11-hermes-clawta-lobster-finish-design.md`](../superpowers/specs/2026-05-11-hermes-clawta-lobster-finish-design.md))
+crystallized the four-hop pipeline that emerges when those two
+substrates are composed:
+
+```
+hermes (kanban substrate)
+  → clawta (chitin-owned tick + dispatch wrapper)
+    → openclaw / kanban-dispatch.lobster (runtime substrate)
+      → frontier-coder CLI (leaf execution under gov.Gate)
+```
+
+Every hop emits a chain event keyed by `CHITIN_DRIVER`. Every leaf
+tool call is gated by `gov.Gate.Evaluate`. The chain is the unifying
+contract.
+
+## The boundary, restated
+
+Chitin owns:
+
+1. **Kernel** — `go/execution-kernel/`. Gate, escalation, lockdown,
+   envelope, ingest, OTEL projection. Single side-effect authority.
+   Unchanged from 05-06.
+2. **Driver integrations** — `internal/driver/{claudecode,codex,
+   gemini,hermes,copilot}` (hook normalizers + decision formatters)
+   and `apps/openclaw-plugin-governance/` (openclaw plugin shape;
+   different by design — plugin runtime, not hook runtime). Plus
+   `bin/chitin-router-hook` (the compiled Go shim every PreToolUse-
+   class hook points at).
+3. **The chain + analysis surface** — `~/.chitin/*`, `python/analysis/*`,
+   `internal/ingest/*`. Unchanged from 05-06.
+4. **The swarm (new since 05-06)** — `swarm/`:
+   - `swarm/bin/` — clawta tick scripts: `clawta-poller` (ready→
+     dispatch), `clawta-pr-lifecycle` (PR→kanban reflection),
+     `clawta-worker-pool-guard`, `clawta-blocked-escalator`, audit +
+     report scripts.
+   - `swarm/workflows/` — `kanban-dispatch.lobster` (the four-hop
+     pipeline expressed as a Lobster workflow), `_pick_driver.py`
+     (operator-side driver picker; see open question below),
+     `spawn_worker_subprocess.py`, judge + ELO helpers.
+   - `swarm/data/agent-cards/` — git-tracked agent-card source;
+     deployed via symlink to `~/.openclaw/data/agent-cards/`.
+   - `swarm/roles/` — git-tracked SKILL.md per worker role; deployed
+     via symlink to `~/.openclaw/roles/`.
+   - `swarm/systemd/` — `clawta-poller.timer`, `swarm-audit.timer`,
+     `architecture-audit.timer`. These are operationally chitin-owned
+     because they drive chitin-owned scripts; not the "11 timers"
+     deleted on 05-06.
+   - `swarm/prompts/` — operator-tunable prompts for hermes grooming
+     and clawta classification.
+5. **Operational scaffolding** — `infra/systemd/` (kernel redeploy,
+   agent-unlock, chain-watch, envelope-rotate). Unchanged from 05-06.
+
+Chitin does NOT own:
+
+- The kanban data itself. The SQLite DB lives in hermes; chitin reads
+  and writes via `kanban-flow` (which goes through the hermes CLI).
+- The openclaw agent runtime, the Lobster workflow engine, or the
+  acpx subprocess gateway. These are upstream substrates chitin
+  composes.
+- Anthropic / OpenAI / Google API auth. Each frontier-coder CLI
+  speaks to its own backend under its own auth.
+- The chitin-aware bits of hermes itself (e.g.,
+  `tools/approval.py`). Those live in hermes.
+
+## What this supersedes from 2026-05-06
+
+The 05-06 decision listed under "what chitin does NOT own":
+
+| 05-06 said | 05-13 reality |
+|---|---|
+| Work tracking, kanban, board state | Hermes substrate, but chitin's clawta-poller reads kanban + dispatches |
+| Dispatch (picking what to run next, spawning runners) | `swarm/workflows/kanban-dispatch.lobster` + `clawta-poller` do this; they compose openclaw, they don't reimplement it |
+| Scheduling (when to run, how often, in what order) | `swarm/systemd/clawta-poller.timer` fires the tick |
+| Workflow definitions | `kanban-dispatch.lobster` IS a workflow definition, expressed in Lobster (substrate-native), not chitin TS |
+| PR-merge → status-flip pipelines | `clawta-pr-lifecycle` does this — reading PR state and writing kanban via `kanban-flow` |
+| Mirroring between work-tracking surfaces | N/A — single substrate (hermes kanban), no mirror |
+| "Don't add hermes-aware features to chitin" | Reversed: chitin IS hermes-aware by design now |
+
+Everything else from 05-06 stands.
+
+## Why the swarm lives in this repo (not hermes / not openclaw)
+
+The chitin contribution at each hop is what unifies the pipeline:
+
+- The chain event schema (`bounded_context_v1` + `chitin.driver`
+  identity stamping) is chitin's contract. The swarm scripts that
+  emit those events need to live alongside the schema.
+- `gov.Gate` policy authoring (`chitin.yaml` driver-keyed rules) is
+  chitin's contract. Rules that gate the swarm's hops live in the
+  same repo as the rules engine.
+- The `chitin-router-hook` Go binary is shared across all four
+  frontier CLIs. The swarm dispatches to those CLIs and expects
+  inner-hop events with `driver=<cli>`. The driver identity
+  guarantee comes from a binary chitin compiles.
+- Audit invariants ("every status change has a matching
+  `task_events` row + comment") are enforced by `kanban-flow`, which
+  is a chitin chokepoint over a hermes-owned database.
+
+Putting the swarm in hermes would require shipping chitin's chain +
+policy + router-hook contract surface there. Putting it in openclaw
+would require shipping hermes' kanban contract there. The composition
+point is the natural home.
+
+## Things NOT to do (durable warnings, updated)
+
+- **Don't move kanban data into chitin.** The kanban DB stays in
+  hermes. Chitin reads/writes via `kanban-flow` only.
+- **Don't add a second source-of-truth for ticket state.** The
+  hermes kanban + `task_events` table is canonical; chitin's chain
+  is canonical for execution events. Don't try to denormalize one
+  into the other.
+- **Don't reintroduce `apps/runner/`** or any chitin-side Temporal
+  worker. The Lobster workflow + clawta-poller subprocess pair
+  replaces all of it.
+- **Don't add a TypeScript "kanban adapter" library.** `kanban-flow`
+  (bash) is the boundary; the substrate is the SQLite DB underneath.
+  Wrapping it in TS adds a layer without value.
+- **Don't fork driver-picking into chitin.** `_pick_driver.py` lives
+  operator-side (under `swarm/workflows/`) because the picking heuristic
+  is fast-changing operational logic.
+
+## Open questions surfaced by this change
+
+1. **Conformance test coverage for the four-hop chain.** The 05-11
+   spec calls for per-CLI tests that assert `(chain shows
+   allowed:false) AND (leaf CLI did not execute the tool)`. Until
+   those land, the enforcement invariant is asserted but not proven.
+
+2. **`swarm/data/agent-cards/` → `~/.openclaw/data/agent-cards/` sync.**
+   Today: operator-side symlink. Make this an idempotent install
+   step in a `scripts/install-swarm.sh` so a fresh box reaches the
+   same state.
+
+## Resolved alongside this decision
+
+- **Layer Contract v1 #2 (driver constraint).** Originally posited an
+  active `AllowedDrivers(req)` kernel primitive. The 2026-04-30
+  addendum deferred that. Two weeks of shipping showed the schema-
+  typed `allowed_drivers` field + leaf-gate enforcement is sufficient
+  for the four-hop pipeline; the cost-ranked `_pick_driver.py` is not
+  drifting from policy intent. Contract restated 2026-05-13 to match
+  shipping reality: typed schema field + closed enum + leaf-gate
+  authority; active kernel narrowing is a future tightening, not an
+  unfulfilled invariant. See `docs/architecture/layer-contracts.md`.
+
+## References
+
+- Predecessor: [`2026-05-06-chitin-scope-narrow-to-kernel.md`](./2026-05-06-chitin-scope-narrow-to-kernel.md)
+  — established kernel single-writer + deleted `apps/runner/`. Still
+  load-bearing for everything except the "no orchestration in chitin"
+  exclusion.
+- Architectural shape: [`docs/superpowers/specs/2026-05-11-hermes-clawta-lobster-finish-design.md`](../superpowers/specs/2026-05-11-hermes-clawta-lobster-finish-design.md)
+  — the four-hop pipeline.
+- Observability shape: [`docs/superpowers/specs/2026-05-12-swarm-observability-via-chitin-cli.md`](../superpowers/specs/2026-05-12-swarm-observability-via-chitin-cli.md)
+  — chitin-kernel CLI as the canonical observability plane.
+- State machine: [`docs/runbooks/swarm-sdlc-status-machine.md`](../runbooks/swarm-sdlc-status-machine.md)
+  — the kanban states + transitions the swarm walks.
+- Layer Contracts: [`docs/architecture/layer-contracts.md`](../architecture/layer-contracts.md)
+  — driver-constraint clause restated 2026-05-13; the four invariants
+  still hold.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,13 +1,14 @@
 # Roadmap
 
-The strategic arc, what's shipped, what's in flight, what's deferred. Updated 2026-05-08 (post-cull rewrite).
+The strategic arc, what's shipped, what's in flight, what's deferred.
+Updated 2026-05-13 (substrate-composition rev).
 
 ## Strategic arc
 
 ```
    1. Aggregate          2. Align policy        3. Compose with
-      capture across       to data (debt          orchestrators
-      all drivers          ledger → rules)        (hermes, openclaw)
+      capture across       to data (debt          orchestration
+      all drivers          ledger → rules)        substrates
           │                    │                      │
           └────────►───────────┴────────►─────────────┤
                                                       │
@@ -21,9 +22,18 @@ The strategic arc, what's shipped, what's in flight, what's deferred. Updated 20
           └────────►───────────┴────────►─────────────┘
 ```
 
-Each step funds and de-risks the next. We're between 1 and 2 today: aggregation is always-on across 6 drivers; the policy layer is shipped but the rules are still mostly hand-written rather than ledger-derived.
+We're firmly in step 3: aggregation is always-on across 6 drivers;
+the four-hop swarm pipeline (`hermes → clawta → openclaw/lobster →
+frontier-coder CLI`) is shipping; the policy layer exists but rules
+are still mostly hand-written rather than ledger-derived.
 
-The 2026-05-06 narrowing (`docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`) and the 2026-05-08 cull (`docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`) are the load-bearing positioning moves: chitin = kernel + plugins + data; orchestration / approvals / scheduling all live in the substrate (hermes today; whatever tomorrow).
+The 2026-05-13 substrate-composition rev
+(`docs/decisions/2026-05-13-swarm-readopted-composing-substrates.md`)
+codifies the current shape: chitin = kernel + drivers + chain + the
+swarm that composes hermes (kanban) and openclaw (Lobster + acpx).
+Supersedes the "no orchestration in chitin" exclusion from the
+2026-05-06 narrow, but keeps everything 05-06 said about kernel
+authority + single-writer discipline.
 
 ## Shipped
 
@@ -43,18 +53,22 @@ Go execution kernel (canon, normalize, emit, hook), `libs/contracts` (zod schema
 
 ### Drivers (six live)
 
-- **Claude Code hook driver** — PR #66
-- **Codex CLI hook driver** — `--agent=codex` PreToolUse handler
-- **Gemini CLI hook driver** — `--agent=gemini` PreToolUse handler
-- **Copilot CLI in-kernel SDK driver** — PR #51 (`chitin-kernel drive copilot`)
-- **OpenClaw before_tool_call plugin** — `~/.openclaw/plugins/chitin-governance/`
-- **Hermes pre_tool_call hook** — `scripts/install-hermes-hook.sh` wires `~/.hermes/config.yaml`
+- **Claude Code hook driver** — `internal/driver/claudecode/`; PR #66
+- **Codex CLI hook driver** — `internal/driver/codex/`; same wire shape as Claude Code
+- **Gemini CLI hook driver** — `internal/driver/gemini/`; same wire shape as Claude Code
+- **Hermes hook driver** — `internal/driver/hermes/`; `scripts/install-hermes-hook.sh`
+- **Copilot CLI in-kernel SDK driver** — `chitin-kernel drive copilot`; PR #51
+- **OpenClaw plugin driver** — `apps/openclaw-plugin-governance/`. Different shape from the four hook drivers by design — plugin runtime, not native hook. Slice 3 ships default-`enforce` covering all 19 pi-runtime tools.
+
+The four PreToolUse-class drivers (Claude Code, Codex, Gemini, Hermes)
+all point at the same compiled Go shim `bin/chitin-router-hook`, which
+stamps `CHITIN_DRIVER` and dispatches to the per-vendor normalizer.
 
 The hero sentence names six drivers. Bitrot in any is a hero-sentence bug.
 
-### Layer Contracts v1 (locked 2026-04-29)
+### Layer Contracts v1 (locked 2026-04-29; #2 restated 2026-05-13)
 
-Four invariants: kernel authority, driver constraint (`AllowedDrivers` primitive), routing scope, aggregation role. See `docs/architecture/layer-contracts.md`.
+Four invariants: kernel authority, driver constraint (schema-typed `allowed_drivers` + leaf-gate enforcement; active kernel narrowing deferred per the 2026-04-30 addendum), routing scope, aggregation role. See `docs/architecture/layer-contracts.md`.
 
 ### F4 — OTEL emit MVP (merged 2026-05-02)
 
@@ -64,15 +78,20 @@ Kernel projects every chain event onto an OTLP/HTTP JSON span after the canonica
 
 `MaxToolCalls`, `MaxInputBytes`, tier classification (T0/T2 audit-log labels), cross-process envelope (`gov.db` WAL). Supersedes v2.
 
-### 2026-05-06 narrowing
+### 2026-05-06 narrowing (kernel single-writer discipline)
 
-Chitin scope narrowed from "execution governance + autonomous swarm runtime" to "execution governance only." Removed: `apps/runner` (Temporal-backed swarm dispatcher), `docs/swarm-backlog.md`, 11 orchestration systemd timers. Boundary: `docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`.
+Chitin scope cleared of duplicate orchestration: removed `apps/runner`
+(Temporal-backed swarm dispatcher), `docs/swarm-backlog.md`, 11
+chitin-side dispatch timers. The kernel-single-writer +
+no-in-tree-duplicate-runtime parts of this still stand. The "chitin
+doesn't know hermes exists" part is superseded by the 2026-05-13
+composition rev. Boundary: `docs/decisions/2026-05-06-chitin-scope-narrow-to-kernel.md`.
 
 ### 2026-05-07 → 2026-05-08 escalate-effect cull
 
 Built an in-gate operator-approval escalate flow (PRs #380–#396, ~16 PRs, ~1500 LOC). External recipe survey on 2026-05-08 surfaced that hermes' `tools/approval.py` already provides operator-prompt + reply-parse + persistent-allowlist natively. Culled the entire chitin parallel implementation (PRs #397–#400). Decision: `docs/decisions/2026-05-08-cull-escalate-defer-to-hermes.md`.
 
-### 2026-05-08 audit-driven cuts (this rev)
+### 2026-05-08 audit-driven cuts
 
 External-survey audit through three lenses (Knuth correctness, da Vinci architecture, Sun Tzu positioning). Findings convergent across lenses:
 
@@ -84,36 +103,76 @@ External-survey audit through three lenses (Knuth correctness, da Vinci architec
 
 Net result: ~5000+ LOC removed; chitin's surface tightened to the moat.
 
+### Swarm composition (shipping incrementally since 2026-05-11)
+
+Four-hop pipeline from
+`docs/superpowers/specs/2026-05-11-hermes-clawta-lobster-finish-design.md`:
+
+```
+hermes kanban (substrate)
+  → clawta tick (chitin: poller + dispatch wrapper)
+    → openclaw kanban-dispatch.lobster (substrate: workflow + acpx)
+      → frontier-coder CLI (gov.Gate at the leaf)
+```
+
+Concretely:
+
+- `bin/chitin-router-hook` — compiled Go shim; stamps `CHITIN_DRIVER`
+  from `--agent=<cli>`; defers to caller-set value if exported
+- `chitin.yaml` rule `hermes-no-frontier-spawn` — blocks direct
+  frontier-CLI spawning from `driver=hermes`; forces the four-hop path
+- `swarm/workflows/kanban-dispatch.lobster` — workflow expressed in
+  Lobster; calls clawta for classification, picks driver via
+  `_pick_driver.py`, spawns the leaf CLI via `spawn_worker`
+- `swarm/bin/clawta-poller` + `swarm/systemd/clawta-poller.timer` —
+  dispatch tick reading the hermes kanban
+- `swarm/bin/clawta-pr-lifecycle` — PR-state → kanban reflection
+- `swarm/data/agent-cards/{claude-code,codex,gemini,copilot}.json` —
+  git-tracked agent-card source (symlink-deployed to
+  `~/.openclaw/data/agent-cards/`)
+- `swarm/roles/{programmer,researcher,reviewer}/SKILL.md` —
+  git-tracked per-role prompts
+- `scripts/kanban-flow` — bash chokepoint over the hermes kanban DB;
+  enforces the audit invariant (every status change pairs a comment +
+  `task_events` row)
+
+See `docs/runbooks/swarm-sdlc-status-machine.md` for the state
+machine the swarm walks.
+
 ## In flight
 
 | ID | Slice | Why it ships now |
 |----|-------|------------------|
-| **D1** | Chain-mined driver conformance gaps | The next high-leverage work comes from real `default-deny-unknown` rows: extend per-driver normalizers, then redeploy hooks/binaries so the chain proves the gap closed. |
+| **S11-1** | Close the `gov.Gate` enforcement leak | Per 2026-05-11 spec slice 1: a denied tool call (`governance-mutation-authority-required`) logged `allowed:false` but the command still produced output. Observation without enforcement breaks the kernel-authority invariant. Per-CLI conformance tests assert `(chain shows allowed:false) AND (leaf CLI did not execute)`. |
+| **S11-2** | `kanban-dispatch.lobster` slices 2-5: clawta classify, step-output interpolation, `spawn_worker`, per-leaf-CLI smoke | Pipeline scaffold exists; the four leaf-CLI legs aren't yet end-to-end-tested. |
+| **S12** | `swarm-audit` reads via CLI + emits `swarm.audit.summary` chain events | Today's audit greps raw JSONL and writes a log file Hermes can't ingest. Two small CLI flags + a Python refactor make the chain the canonical observability surface. |
+| **D1** | Chain-mined driver conformance gaps | High-leverage work comes from real `default-deny-unknown` rows: extend per-driver normalizers, then redeploy hooks/binaries so the chain proves the gap closed. |
 
 ## Deferred
 
-These are real ideas that wait for either operator demand or an asymmetric-strength signal:
+Real ideas waiting for operator demand or an asymmetric-strength signal:
 
 - **Action vocabulary expansion** — extend `internal/gov/action.go` to cover the predictive-execution spec's `rewrite` / `redirect` / `stage` decisions. Lean into asymmetry without growing surface.
-- **Chain summarization + causal slicing** — surface in the positioning doc's "replay hydration" note. Make the chain useful at higher abstraction than per-event.
+- **Chain summarization + causal slicing** — make the chain useful at higher abstraction than per-event.
 - **Driver coverage** — add new drivers as the ecosystem's tool-call vocabulary stabilizes.
 - **Policy packs** — per-domain rule bundles (security, cost, compliance) operators install via `chitin-kernel install-pack`. Step 4 of the strategic arc.
+- **Semantic indexer over chain events** — vectorize chain payloads for fuzzy retrieval. Built on top of the 2026-05-12 event-emission contract.
+- **Web/TUI dashboard** — chitin-dashboard spec; data source is the same CLI surface the 2026-05-12 spec aligns swarm-audit with.
+- **`chitin-kernel task validate` (active `allowed_drivers` narrowing)** — Layer Contract v1 #2 originally posited an active kernel primitive that narrows `allowed_drivers` per policy before dispatch. The 2026-04-30 addendum deferred this; the 2026-05-13 contract restatement codified the deferral. Today's schema-typed `allowed_drivers` + leaf-gate enforcement is sufficient. Wire the active narrowing path when ledger signal shows the cost-ranked picker drifting from policy intent.
+- **`init-claude-code.ts` → `chitin-kernel install --surface=claude-code` convergence** — the TS path still writes `~/.claude/settings.json` directly. Different settings.json shape than the kernel's `hookinstall.InstallGlobal` (the TS path stamps `_tag: chitin-v2` + `env.CHITIN_WORKSPACE`); converging requires reconciling those shapes. Low risk to leave; should land when the kernel's install grows the missing fields or the TS shape is no longer needed.
 
-## What chitin will NOT do
+## What chitin still does NOT do
 
-Per the 2026-05-06 boundary doc:
+(Narrowed from the 2026-05-06 list, which over-corrected. Hermes and
+openclaw are upstream substrates the swarm composes, not external
+boundaries.)
 
-- Work tracking, kanban, board state — **hermes**
-- Dispatch, spawning runners — **hermes**
-- Scheduling (cron, intervals) — **hermes**
-- Workflow definitions, retries, durable state — **hermes**
-- PR-merge → status-flip pipelines — **hermes**
-- Operator approvals — **hermes' tools/approval.py**
-- Model routing — **driver-side**
-- Mirroring between work-tracking surfaces — **operator's choice**
-
-Whatever orchestrator the operator runs is *agnostic* — chitin doesn't know or care. The orchestrator dispatches, agents do work, every tool call passes through chitin's gate, every decision lands in chitin's chain.
+- **Own the kanban data.** Hermes ships the SQLite DB + UI; chitin reads and writes via `kanban-flow` (which goes through the hermes CLI). Don't denormalize kanban into chitin.
+- **Ship a workflow engine.** Lobster (openclaw-side) executes `kanban-dispatch.lobster`. Chitin authors the workflow; it doesn't ship a runner.
+- **Run a TypeScript/Temporal worker.** `apps/runner/` stays deleted. The clawta-poller tick + Lobster workflow replaces it.
+- **Speak to LLM backends directly.** Each vendor's CLI talks to its own backend under its own auth. Chitin governs the actions those CLIs take.
+- **Run as SaaS.** Local-only: operator's box, operator's data.
 
 ## Cut order if scope tightens further
 
-When the next external-substrate survey shows another chitin surface that re-implements a substrate primitive, the answer is the same as 2026-05-08: cull it. The pattern: invest deeper into asymmetric strengths (canonical vocabulary, chain depth, driver coverage); divest from anything symmetric with the substrate (orchestration, approvals, scheduling, model routing).
+When a future external-substrate survey shows another chitin surface that re-implements a substrate primitive, the cull pattern from 2026-05-08 still applies: invest deeper into asymmetric strengths (canonical vocabulary, chain depth, driver coverage, the four-hop pipeline's unifying contracts); divest from anything that duplicates a substrate's job.

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -1,26 +1,81 @@
 # Thesis
 
-> Chitin is an execution kernel for AI coding agents. Every tool call across Claude Code, Codex CLI, Gemini CLI, Hermes, Copilot CLI, and openclaw is gated by a single policy and recorded in a hash-linked event chain that also emits OTEL spans into your existing observability stack.
+> Chitin is an execution kernel for AI coding agents — and the swarm
+> that drives them. Every tool call across Claude Code, Codex CLI,
+> Gemini CLI, Hermes, Copilot CLI, and openclaw is gated by a single
+> policy and recorded in a hash-linked event chain that emits OTEL
+> spans into your existing observability stack. The chitin-owned swarm
+> composes hermes (kanban) and openclaw (Lobster + agent runtime) as
+> substrates; chitin contributes governance, identity, and chain at
+> every hop.
 
 ## What chitin is
 
-A small Go kernel that sits between AI coding agents and the operating system. Six vendor surfaces are gated through it today:
+A small Go kernel that sits between AI coding agents and the
+operating system, plus the swarm that dispatches work to those agents.
+Six vendor surfaces are gated through it today:
 
 - **Claude Code** — `PreToolUse` hook in `~/.claude/settings.json`.
 - **Codex CLI** — `PreToolUse` hook in `~/.codex/config.toml` (`[features] codex_hooks=true` + `[[hooks.PreToolUse]]`); same wire shape as Claude Code.
 - **Gemini CLI** — `BeforeTool` hook in `~/.gemini/settings.json`; same wire shape as Claude Code (renamed event).
 - **Hermes** — `pre_tool_call` hook in `~/.hermes/config.yaml`; same wire shape as Claude Code.
 - **Copilot CLI** — in-kernel SDK driver (`chitin-kernel drive copilot`); wrapping orchestrator pattern (closed vendor).
-- **openclaw** (`local-*` drivers: qwen / glm / glm-flash / deepseek) — `before_tool_call` plugin path.
+- **openclaw** (`local-*` drivers: qwen / glm / glm-flash / deepseek, plus the clawta orchestrator agent itself) — `before_tool_call` plugin path via `apps/openclaw-plugin-governance/`. Different shape from the hook drivers by design: plugin runtime, not native hook.
 
-Same `gov.Gate` API across all six. Same canonical event chain on disk. Same OTEL projection out the back. Vendor-specific normalization lives in `internal/driver/<vendor>/normalize.go`.
+Same `gov.Gate` API across all six. Same canonical event chain on
+disk. Same OTEL projection out the back. Vendor-specific
+normalization lives in `internal/driver/<vendor>/normalize.go` for
+the four hook drivers; in the openclaw plugin source for openclaw;
+in the in-kernel SDK driver for copilot.
+
+The four hook-based PreToolUse drivers (Claude Code, Codex, Gemini,
+Hermes) all point at the same compiled Go shim `bin/chitin-router-hook`,
+which stamps `CHITIN_DRIVER` and dispatches to the per-vendor
+normalizer.
+
+## The chitin-owned swarm
+
+Six drivers gated is necessary but not sufficient. Chitin also owns
+the swarm that drives those drivers — a four-hop pipeline composing
+hermes (kanban substrate) and openclaw (Lobster + agent runtime
+substrate):
+
+```
+hermes kanban (substrate)
+  → clawta tick (chitin: poller + dispatch wrapper)
+    → openclaw kanban-dispatch.lobster (substrate: workflow + acpx)
+      → frontier-coder CLI (gov.Gate at the leaf)
+```
+
+Every hop emits a chain event keyed by `CHITIN_DRIVER`. Every leaf
+tool call is gated by `gov.Gate.Evaluate`. The chain is the unifying
+contract.
+
+The swarm lives in `swarm/` in this repo (not hermes, not openclaw)
+because the unifying contracts — chain schema, `CHITIN_DRIVER`
+identity, policy authoring, the router-hook binary — are chitin's. The
+substrates underneath are upstream. See
+[`docs/decisions/2026-05-13-swarm-readopted-composing-substrates.md`](./decisions/2026-05-13-swarm-readopted-composing-substrates.md)
+for the boundary.
 
 ## What chitin is not
 
-- Not a tick-loop / agent-runner. Hermes owns orchestration, approvals, kanban, and scheduling; chitin gates the tool calls Hermes and the standalone drivers attempt.
-- Not an OTEL ingest target. Chitin **emits** spans as a projection of its canonical chain. The chain is the source of truth; OTEL is one-way out.
-- Not an LLM provider abstraction. Chitin doesn't proxy or re-call models. Each vendor's CLI talks to its own backend (codex → OpenAI under your ChatGPT Plus auth; gemini → Google under Pro auth; etc.); chitin governs the actions those CLIs take.
-- Not a SaaS. Chitin is local-only: the operator's box, the operator's data.
+- Not a kanban server. Hermes owns the kanban data + UI; chitin reads
+  and writes via `kanban-flow`, which goes through the hermes CLI.
+- Not a workflow engine. Lobster (openclaw-side) executes
+  `kanban-dispatch.lobster`; chitin authors the workflow but doesn't
+  ship its own runner.
+- Not an agent runtime. Openclaw's acpx + pi-agent-core run the
+  agents; chitin's plugin gates their tool calls.
+- Not an OTEL ingest target. Chitin **emits** spans as a projection
+  of its canonical chain. The chain is the source of truth; OTEL is
+  one-way out.
+- Not an LLM provider abstraction. Chitin doesn't proxy or re-call
+  models. Each vendor's CLI talks to its own backend (codex → OpenAI
+  under your ChatGPT Plus auth; gemini → Google under Pro auth;
+  etc.); chitin governs the actions those CLIs take.
+- Not a SaaS. Chitin is local-only: the operator's box, the
+  operator's data.
 
 ## The closed loop
 
@@ -40,22 +95,39 @@ Same `gov.Gate` API across all six. Same canonical event chain on disk. Same OTE
    new execution ── back to top
 ```
 
-Most agent-observability tools are open-loop (capture only) or heuristic (LLM-judges). Chitin's loop is grounded in real captured execution; that's the moat.
+Most agent-observability tools are open-loop (capture only) or
+heuristic (LLM-judges). Chitin's loop is grounded in real captured
+execution; that's the moat. The swarm is the workload that keeps the
+loop fed.
 
 ## Strategic arc
 
 1. **Aggregate** — always-on capture across supported drivers.
-2. **Align policies to data** — governance rules emerge from the debt ledger, not from a-priori spec.
-3. **Ecosystem distribution** — chitin runs inside agent ecosystems (openclaw, future frameworks), not just Claude Code.
-4. **Policy packs** — reusable governance bundles for everyone running chitin-instrumented agents.
-5. **Local operator leverage** — better policy packs, replay, and chain-derived analytics without sending the operator's governance data to a service.
+2. **Align policies to data** — governance rules emerge from the
+   debt ledger, not from a-priori spec.
+3. **Compose with orchestration substrates** — we're here. Chitin's
+   swarm runs on hermes (kanban) + openclaw (Lobster + acpx),
+   contributing chain + identity + gate at every hop. The four-hop
+   pipeline is the load-bearing artifact.
+4. **Policy packs** — reusable governance bundles for everyone
+   running chitin-instrumented agents.
+5. **Local operator leverage** — better policy packs, replay, and
+   chain-derived analytics without sending the operator's governance
+   data to a service.
 
 ## Audience sequencing
 
-A1 (agent framework builders) → A2 (platform/infra) → A4 (security/compliance). A3 (solo operators) is a side channel. A1 messaging is not diluted with platform/dashboard/cost narratives.
+A1 (agent framework builders) → A2 (platform/infra) → A4
+(security/compliance). A3 (solo operators) is a side channel. A1
+messaging is not diluted with platform/dashboard/cost narratives.
 
 ## Principle
 
-> Real execution before policy. Policy before automation. Automation gated by the same kernel.
+> Real execution before policy. Policy before automation. Automation
+> gated by the same kernel. Substrates owned upstream, composition
+> owned here.
 
-See [`architecture.md`](./architecture.md) for the layer map and [`architecture/layer-contracts.md`](./architecture/layer-contracts.md) for the four invariants this thesis rests on.
+See [`architecture.md`](./architecture.md) for the layer map,
+[`architecture/layer-contracts.md`](./architecture/layer-contracts.md)
+for the four invariants this thesis rests on, and the 2026-05-13
+substrate-composition decision for the swarm boundary.


### PR DESCRIPTION
## Summary

- **New decision doc** `docs/decisions/2026-05-13-swarm-readopted-composing-substrates.md` — supersedes the 2026-05-06 narrow on the "no orchestration in chitin" point while keeping every other 05-06 invariant (kernel single-writer, no `apps/runner/`, layer-contracts). Names the four-hop pipeline (hermes → clawta → openclaw/lobster → frontier-coder CLI) and the concrete swarm inventory now living in this repo.
- **Thesis + roadmap rewrites** — the 2026-05-08 docs contradicted the 2026-05-11+ direction (swarm in this repo, leveraging hermes + openclaw as upstream substrates). Strategic arc is now correctly in step 3 ("compose with orchestration substrates"); openclaw listed as the sixth live driver via its plugin shape; in-flight items reflect the actual S11-1 / S11-2 / S12 work; the over-corrected "what chitin will NOT do" list from 05-06 is replaced with a narrower "doesn't own kanban DB / workflow engine / TS-Temporal worker / LLM auth / SaaS" list.
- **Layer Contract v1 #2 restated** to match shipping reality: `allowed_drivers` as a typed, schema-validated field on `ExecutionRequest` (non-empty, closed enum) + leaf-gate enforcement by `gov.Gate.Evaluate`. The active kernel narrowing primitive (`chitin-kernel task validate`) was deferred by the 2026-04-30 addendum and remains so; codifying the deferral instead of leaving the contract aspirational.
- **`docs/architecture.md` fixes** — integration matrix gains a `hermes` row, openclaw integration path clarified to `apps/openclaw-plugin-governance/`, `chitin-router-hook` correctly identified as a compiled Go binary in `bin/` (was wrongly labeled bash shim), and the integration-patterns paragraph is extended to four PreToolUse-class hook drivers.
- **One single-writer fix**: `apps/cli/src/commands/init-claude-code.ts` no longer writes `.chitin/init.json` directly. Verified zero readers; the file was a dead diagnostic. Closes the TS-writes-to-chitin-state violation surfaced by the audit. Settings.json convergence is documented as a deferred follow-up.

## Test plan

- [ ] Markdown renders correctly on GitHub (decision doc, thesis, roadmap, layer-contracts, architecture)
- [ ] Cross-references resolve: thesis → decision doc → layer-contracts → architecture
- [ ] No broken links in the new decision doc (the 05-11 spec, 05-12 spec, swarm-sdlc-status-machine runbook all exist on `main`)
- [ ] `pnpm exec nx run apps/cli:typecheck` passes after the `init-claude-code.ts` edit (only an `mkdirSync` import remains used; line 20 still references it)
- [ ] Roadmap's "Drivers (six live)" hero sentence still matches the codebase (openclaw plugin + four hook normalizers + copilot SDK driver)
- [ ] No production code changes outside the documented one-line TS deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)