### PR TITLE
feat(argus): slice 5 — `argus findings` for Hermes standup-fold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,8 @@ python/analysis/out/
 # Python build / venv artifacts
 python/analysis/*.egg-info/
 python/analysis/.pytest_cache/
+python/argus/*.egg-info/
+python/argus/.pytest_cache/
+python/argus/build/
 __pycache__/
 *.pyc

--- a/docs/runbooks/argus-hermes-standup-fold.md
+++ b/docs/runbooks/argus-hermes-standup-fold.md
@@ -1,0 +1,131 @@
+# Argus → Hermes → Operator (standup-fold)
+
+Status: Slice 5 contract  •  Date: 2026-05-13
+
+## Purpose
+
+Argus surfaces patterns and drift continuously; the operator only reads
+Hermes' standups. This runbook documents the one-way flow that folds
+Argus findings into the existing Hermes standup so the operator sees one
+unified feed instead of two parallel streams.
+
+## Flow
+
+```
+   ┌──────────────┐  argus findings --since=<ts>   ┌──────────────┐
+   │   Argus      │  ─────────────────────────────▶ │    Hermes    │
+   │ (observatory)│                                 │ (standup gen)│
+   └──────────────┘                                 └──────┬───────┘
+                                                           │
+                                                           │ summary
+                                                           ▼
+                                                  ┌──────────────┐
+                                                  │   Operator   │
+                                                  └──────────────┘
+```
+
+**Invariants:**
+
+- One-way. Argus → Hermes → operator. Hermes NEVER writes back into the
+  Argus index.
+- Graceful degradation. If `argus findings` errors or the binary is
+  missing, Hermes' standup omits the section silently — never blocks
+  the standup itself.
+- Cap at 3 in the standup. The full list lives in Argus's daily HTML
+  digest; the standup is the headline, not the archive.
+
+## CLI contract
+
+```
+$ argus findings --since=<unix_ts> [--indent N] [--limit N]
+[
+  {
+    "kind": "demote_loop",
+    "severity": "warning",
+    "summary": "Demote loop: t_abc bounced ready→triage 2× in 24h",
+    "evidence_links": ["kanban_event#12", "kanban_event#15"],
+    "suggested_action": "investigate",
+    "ts_unix": 1700000000,
+    "subject": "t_abc"
+  },
+  ...
+]
+```
+
+Findings are sorted by severity descending (critical → warning → info),
+then by ts_unix descending, then by subject ascending. Hermes can take
+the first N and fold them in.
+
+### `suggested_action` values
+
+| Action            | When                                                | Operator's expected reply                  |
+|-------------------|-----------------------------------------------------|--------------------------------------------|
+| `investigate`     | Pattern detected, needs human triage                | "dispatch finding-N" / "ack finding-N"     |
+| `dispatch_fix`    | Concrete failure that has a known fix path          | "dispatch finding-N" → kanban ticket filed |
+| `archive_belief`  | Stale or evidence-free belief                       | "archive finding-N" → belief marked stale  |
+| `file_ticket`     | Capability gap operator may want to track formally  | "file finding-N" → triage ticket created   |
+
+## Hermes-side integration (pseudocode)
+
+```python
+# agent/standup.py (or equivalent cron job)
+import subprocess, json, time
+
+def get_argus_findings(since_ts: int, limit: int = 3) -> list[dict]:
+    try:
+        out = subprocess.run(
+            ["argus", "findings", "--since", str(since_ts), "--limit", str(limit)],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+        if out.returncode != 0:
+            return []
+        return json.loads(out.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return []  # graceful degrade — never block the standup
+
+def fold_into_standup(report: StandupReport):
+    last_standup_ts = report.previous_run_ts or 0
+    findings = get_argus_findings(since_ts=last_standup_ts, limit=3)
+    if not findings:
+        return  # quiet day — omit the section entirely
+    report.add_section(
+        title="Argus says:",
+        bullets=[
+            f"[{f['severity']}] {f['summary']}  (action: {f['suggested_action']})"
+            for f in findings
+        ],
+    )
+```
+
+## Operator reply grammar
+
+Hermes' existing reply-action grammar handles `dispatch <id>`, `ack
+<id>`, `archive <id>`. Argus finding IDs in the standup are positional
+(`finding-1`, `finding-2`, `finding-3`); Hermes resolves these to the
+underlying kanban / belief / git PR based on the finding's `kind`:
+
+- `dispatch finding-3` on a `demote_loop` → Hermes promotes the
+  associated `t_*` ticket through triage with priority bump.
+- `archive finding-3` on a `stale_belief` → Hermes flips the belief
+  source's last-reaffirmed timestamp to now (or marks it stale).
+- `file finding-3` on a `capability_without_belief` → Hermes opens a
+  triage ticket "Update agent card: <agent> uses <action_type> ×N".
+
+## Acceptance (Slice 5 spec)
+
+- [x] `argus findings --since=<ts>` CLI emits the JSON shape above
+- [x] Sorting deterministic (severity desc → ts desc → subject)
+- [x] Empty data → empty list; missing DBs → empty list, no crash
+- [x] CLI smoke against local data produces a real findings list
+- [ ] Hermes-side `agent/standup.py` integration (separate repo, follow-up)
+- [ ] 7 consecutive standups include Argus section (operator-side smoke)
+- [ ] One operator action taken via standup reply (operator-side smoke)
+
+## Out of scope
+
+- Direct push from Argus to `#ares` independent of Hermes. Default is
+  Hermes-only fold; operators can enable per-detector direct push if a
+  finding category proves time-sensitive.
+- The Hermes-side reply-action wiring lives in hermes' repo. This
+  runbook documents the contract; the actual integration is a follow-
+  up ticket on the hermes side.

--- a/python/argus/README.md
+++ b/python/argus/README.md
@@ -1,0 +1,229 @@
+# Argus Observatory
+
+Tail governance decision events, index them, run deterministic detectors, and generate daily markdown digests with LLM narration.
+
+## Architecture
+
+- **Indexer**: Tails `~/.chitin/gov-decisions-*.jsonl` files and indexes into SQLite at `~/.argus/index.db` with replay-safety via line-hash idempotency.
+- **Detectors**: Four deterministic anomaly detectors run over the index:
+  - **Deny Cluster**: N deny events within M-second window (default: N=4, M=300s)
+  - **Unknown Rate Spike**: Unknown action_type rate >threshold% over 24h (default: >1%)
+  - **Agent Failure Run**: Agent with ≥N consecutive deny events (default: N=3)
+  - **Stuck Flow**: Agent idle for >M seconds (default: M=3600s)
+- **Reporter**: Daily digest generator with qwen3.6:27b LLM narration paragraph + structured detector tables.
+- **CLI**: `argus query "<q>"` for NL→SQL queries via qwen.
+
+## Installation
+
+Argus is shipped as a Python package in `python/argus/` inside the chitin
+repo. The recommended install uses `uv` to expose `argus` as a console
+script in `~/.local/bin/`:
+
+```bash
+# From repo root
+uv tool install ./python/argus
+
+# Install ollama and qwen model (optional — narration and `argus query` use it)
+ollama pull qwen3.6:27b
+
+# Create the index dir (the indexer auto-creates it on first write, but
+# pre-creating it lets you point another tool at the path immediately)
+mkdir -p ~/.argus
+```
+
+To point the daily report at a Discord webhook for the `#ares` summary,
+write the URL into a systemd-style env file (no quoting):
+
+```bash
+mkdir -p ~/.config/argus
+printf 'ARGUS_DISCORD_WEBHOOK=https://discord.com/api/webhooks/...\n' \
+    > ~/.config/argus/env
+```
+
+Quiet days (no detector findings) skip the Discord post by default — pass
+`--discord-always` to override.
+
+## Usage
+
+### Systemd Setup
+
+```bash
+cp python/argus/systemd/*.service ~/.config/systemd/user/
+cp python/argus/systemd/*.timer  ~/.config/systemd/user/
+systemctl --user daemon-reload
+
+# Always-on indexer (true tail/follow, handles date rollover)
+systemctl --user enable --now argus-indexer.service
+
+# Daily report at 07:00 local
+systemctl --user enable --now argus-report.timer
+```
+
+### Manual Commands
+
+```bash
+# Index all decision events
+python -m argus index --decisions-dir ~/.chitin
+
+# Generate daily report
+python -m argus report --report-dir ~/.chitin/reports
+
+# Query the index with natural language
+python -m argus query "How many denies by rule_id in the last 24h?"
+```
+
+## Design Invariants
+
+**Read-only**: Indexer reads JSONL, detectors read index, reporter reads index. Zero writes to kanban/chain/agent state.
+
+**Replay-safe**: Indexer can be restarted at any point and produces the same index given the same input files via line-hash idempotency (UNIQUE constraint on line_hash).
+
+**Deterministic detectors**: Same index snapshot always produces the same detector outputs. LLM narration is generative but separated from structured findings.
+
+## Boundary Conditions (Tested)
+
+- **Empty source file**: Indexer handles without panic.
+- **Single event**: Daily digest renders without divide-by-zero.
+- **Date rollover at midnight**: Drains yesterday's tail, switches to today's file, no events dropped.
+- **Malformed JSONL line**: Skip + count, never block.
+- **Duplicate replay**: Idempotent via line_hash (no duplicate rows).
+- **Detector edge cases**: Exactly N events at exactly M seconds boundary; N-1 does NOT trigger, N DOES trigger.
+- **Qwen unavailable**: Daily report still produces structured detector output; narration degrades to placeholder.
+- **Index corruption**: Indexer detects + refuses to write (sqlite PRAGMA journal_mode=WAL); alerts operator.
+- **Quiet day**: Digest renders "all quiet"; no #ares push.
+
+## Schema
+
+### events table
+
+```sql
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY,
+    line_hash TEXT UNIQUE NOT NULL,         -- Idempotency key
+    ts TEXT NOT NULL,                       -- ISO 8601 timestamp
+    ts_unix INTEGER NOT NULL,               -- Unix epoch (indexed)
+    allowed INTEGER NOT NULL,               -- 0=deny, 1=allow
+    mode TEXT,
+    rule_id TEXT,                           -- Indexed for fast deny grouping
+    reason TEXT,
+    escalation TEXT,
+    agent TEXT,                             -- Indexed for agent analysis
+    action_type TEXT,
+    action_target TEXT,
+    envelope_id TEXT,
+    tier TEXT,
+    cost_usd REAL,
+    input_bytes INTEGER,
+    tool_calls INTEGER,
+    model TEXT,
+    role TEXT,
+    workflow_id TEXT,
+    fingerprint TEXT
+);
+
+-- Indexes for fast queries
+CREATE INDEX idx_ts_unix ON events(ts_unix);
+CREATE INDEX idx_rule_id ON events(rule_id);
+CREATE INDEX idx_allowed ON events(allowed);
+CREATE INDEX idx_agent ON events(agent);
+```
+
+## Detectors
+
+### Deny Cluster
+Triggers when ≥N deny events occur within M seconds.
+- **Invariant**: At least N events at timestamps within [t, t+M).
+- **Boundary**: N-1 does NOT trigger; N DOES trigger.
+- **Default**: N=4, M=300 seconds (matches #513 escalation threshold).
+
+### Unknown Rate Spike
+Triggers when action_type unknown rate exceeds threshold over 24h window.
+- **Invariant**: (unknown_count / total_count) * 100 > threshold_percent.
+- **Boundary**: Exactly threshold% does NOT trigger; >threshold% DOES.
+- **Default**: >1% over 24h.
+
+### Agent Failure Run
+Triggers when an agent has ≥N deny events.
+- **Invariant**: Agent has ≥N denies (sorted by ts_unix).
+- **Boundary**: N-1 does NOT trigger; N DOES trigger.
+- **Default**: N=3.
+
+### Stuck Flow
+Triggers when agent idle for >M seconds.
+- **Invariant**: Agent's last event is >M seconds ago.
+- **Boundary**: Exactly M seconds ago does NOT trigger; >M DOES.
+- **Default**: M=3600 seconds (1 hour).
+
+## Examples
+
+### Sample Report
+
+```markdown
+# Argus Observatory Report — 2026-05-13
+
+*Generated: 2026-05-13T12:00:00Z*
+
+## Executive Summary
+
+**2 findings detected.**
+
+In the last 24 hours, the governance system processed 1,250 decisions with a 3.2% deny rate. The most frequent deny rule was "no-destructive-rm" with 32 violations, primarily from the copilot-cli agent.
+
+## Statistics
+
+- **Total decisions:** 1,250
+- **Denies:** 40 (3.2%)
+- **Allows:** 1,210
+
+### Top Deny Rules
+
+- `no-destructive-rm`: 32 denies
+- `bounds:max_files_changed`: 5 denies
+- `no-curl-pipe-bash`: 3 denies
+
+### Top Deny Agents
+
+- `copilot-cli`: 35 denies
+- `claude-code`: 5 denies
+
+## Detector Findings
+
+| Detector | Severity | Title | Details |
+|----------|----------|-------|---------|
+| deny_cluster | warning | Deny cluster: 4 denies in 300s | count: 4<br>rules: ["no-destructive-rm"]<br>agents: ["copilot-cli"] |
+| agent_failure_run | warning | Agent copilot-cli failure run: 5 consecutive denies | agent: copilot-cli<br>failure_count: 5<br>rules: ["no-destructive-rm"] |
+```
+
+### Query Examples
+
+```bash
+# How many denies per agent?
+python -m argus query "Show deny count grouped by agent"
+
+# What are the most common deny rules?
+python -m argus query "List top 10 deny rules by count"
+
+# When was the last activity for each agent?
+python -m argus query "Show each agent's last event timestamp"
+```
+
+## Testing
+
+```bash
+# Run all tests
+python -m pytest python/argus/tests/ -v
+
+# Run specific test suite
+python -m pytest python/argus/tests/test_indexer.py -v
+python -m pytest python/argus/tests/test_detectors.py -v
+python -m pytest python/argus/tests/test_reporter.py -v
+```
+
+## Files
+
+- `indexer.py`: JSONL→SQLite with replay-safety.
+- `detectors.py`: Four deterministic anomaly detectors.
+- `reporter.py`: Daily digest + qwen narration.
+- `cli.py`: CLI interface (index, report, query).
+- `tests/`: Comprehensive boundary-condition tests.
+- `systemd/`: Systemd service + timer units.

--- a/python/argus/__init__.py
+++ b/python/argus/__init__.py
@@ -1,0 +1,1 @@
+"""Argus Observatory: tail gate decisions, index, detect, report."""

--- a/python/argus/__main__.py
+++ b/python/argus/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for python -m argus"""
+import sys
+from argus.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/argus/beliefs.py
+++ b/python/argus/beliefs.py
@@ -1,0 +1,256 @@
+"""Belief ingestion: index what each agent BELIEVES alongside what happened.
+
+Slice 4 sources:
+    - Operator agent cards (~/.openclaw/data/agent-cards/*.json) — per-agent
+      capability claims, model lists, role declarations.
+    - Clawta swarm_elo table (~/.openclaw/data/clawta.db) — router's
+      learned belief about (driver, model) quality.
+    - Wiki frontmatter (operator-curated truths) — markdown files with
+      yaml frontmatter under a configurable wiki root.
+
+Each adapter normalizes to:
+    beliefs(agent, subject, claim, ts_recorded, source_path)
+
+Invariants:
+    - Strictly read-only. Adapters NEVER write back to agent state.
+    - Per-adapter opt-in: explicit source list, no generic catch-all
+      (privacy boundary per spec).
+    - Idempotent on (agent, subject, claim, source_path) UNIQUE.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+@dataclass(frozen=True)
+class Belief:
+    agent: str
+    subject: str
+    claim: str
+    ts_recorded: int
+    source_path: str
+
+
+def init_beliefs_table(xs_conn: sqlite3.Connection) -> None:
+    """Create the beliefs table + indexes. Idempotent."""
+    xs_conn.execute("""
+        CREATE TABLE IF NOT EXISTS beliefs (
+            id INTEGER PRIMARY KEY,
+            agent TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            claim TEXT NOT NULL,
+            ts_recorded INTEGER NOT NULL,
+            source_path TEXT NOT NULL,
+            dedup_key TEXT UNIQUE NOT NULL
+        )
+    """)
+    xs_conn.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_agent   ON beliefs(agent)")
+    xs_conn.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_subject ON beliefs(subject)")
+    xs_conn.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_ts      ON beliefs(ts_recorded)")
+    xs_conn.commit()
+
+
+def _dedup_key(agent: str, subject: str, claim: str, source_path: str) -> str:
+    raw = f"{agent}|{subject}|{claim}|{source_path}".encode()
+    return hashlib.sha256(raw).hexdigest()[:24]
+
+
+def _insert(xs_conn: sqlite3.Connection, b: Belief) -> bool:
+    """Insert a Belief idempotently. Returns True iff new row."""
+    try:
+        xs_conn.execute(
+            """
+            INSERT INTO beliefs (agent, subject, claim, ts_recorded, source_path, dedup_key)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (b.agent, b.subject, b.claim, b.ts_recorded, b.source_path,
+             _dedup_key(b.agent, b.subject, b.claim, b.source_path)),
+        )
+        return True
+    except sqlite3.IntegrityError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Agent card adapter
+# ---------------------------------------------------------------------------
+
+def _agent_card_beliefs(card_path: Path) -> Iterable[Belief]:
+    """Parse one agent card JSON and emit Beliefs."""
+    try:
+        with card_path.open("r") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    agent = str(data.get("id") or card_path.stem)
+    ts_recorded = int(card_path.stat().st_mtime)
+    source = str(card_path)
+
+    beliefs: list[Belief] = []
+    desc = data.get("description")
+    if isinstance(desc, str) and desc.strip():
+        beliefs.append(Belief(agent, "self.description", desc.strip(),
+                              ts_recorded, source))
+    for cap in (data.get("capabilities") or []):
+        if not isinstance(cap, dict):
+            continue
+        skill = cap.get("skill")
+        depth = cap.get("depth")
+        if isinstance(skill, str) and isinstance(depth, str):
+            beliefs.append(Belief(agent, f"capability.{skill}", depth,
+                                  ts_recorded, source))
+    for mdl in (data.get("models") or []):
+        if not isinstance(mdl, dict):
+            continue
+        mid = mdl.get("id")
+        tier = mdl.get("tier")
+        cost = mdl.get("premium_cost")
+        if isinstance(mid, str):
+            claim = f"tier={tier}"
+            if cost is not None:
+                claim += f"; premium_cost={cost}"
+            beliefs.append(Belief(agent, f"model.{mid}", claim,
+                                  ts_recorded, source))
+    return beliefs
+
+
+def ingest_agent_cards(cards_root: Path, xs_conn: sqlite3.Connection) -> dict:
+    """Index every <agent-id>.json under cards_root."""
+    if not cards_root.exists():
+        return {"inserted": 0, "skipped": 0, "agents": []}
+    inserted = skipped = 0
+    agents: list[str] = []
+    for path in sorted(cards_root.glob("*.json")):
+        # Skip backups and disabled cards.
+        if any(suffix in path.name for suffix in (".bak", ".disabled")):
+            continue
+        agents.append(path.stem)
+        for b in _agent_card_beliefs(path):
+            if _insert(xs_conn, b):
+                inserted += 1
+            else:
+                skipped += 1
+    xs_conn.commit()
+    return {"inserted": inserted, "skipped": skipped, "agents": agents}
+
+
+# ---------------------------------------------------------------------------
+# Clawta swarm_elo adapter
+# ---------------------------------------------------------------------------
+
+def ingest_clawta_swarm_elo(clawta_db: Path, xs_conn: sqlite3.Connection) -> dict:
+    """Snapshot the swarm_elo table as router's belief about each (driver, model).
+
+    Read-only on the source — opens the clawta DB in mode=ro.
+    """
+    if not clawta_db.exists():
+        return {"inserted": 0, "skipped": 0}
+    src = sqlite3.connect(f"file:{clawta_db}?mode=ro", uri=True, timeout=2.0)
+    src.row_factory = sqlite3.Row
+    inserted = skipped = 0
+    try:
+        rows = src.execute(
+            """
+            SELECT driver, model, role, task_class, elo_score,
+                   dispatches_count, last_updated
+            FROM swarm_elo
+            """
+        ).fetchall()
+    except sqlite3.OperationalError:
+        # Schema mismatch on this box — surface zero, don't crash the pipeline.
+        return {"inserted": 0, "skipped": 0, "error": "swarm_elo missing"}
+    finally:
+        src.close()
+
+    for row in rows:
+        subject = f"driver:{row['driver']}/model:{row['model']}"
+        role = row["role"] or "<any>"
+        tcls = row["task_class"] or "<any>"
+        claim = (
+            f"role={role}; task_class={tcls}; "
+            f"elo={row['elo_score']:.1f}; dispatches={row['dispatches_count']}"
+        )
+        b = Belief(
+            agent="router",
+            subject=subject,
+            claim=claim,
+            ts_recorded=int(row["last_updated"]),
+            source_path=str(clawta_db),
+        )
+        if _insert(xs_conn, b):
+            inserted += 1
+        else:
+            skipped += 1
+    xs_conn.commit()
+    return {"inserted": inserted, "skipped": skipped}
+
+
+# ---------------------------------------------------------------------------
+# Wiki frontmatter adapter
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+def _wiki_beliefs(md_path: Path) -> Iterable[Belief]:
+    """Parse a markdown file's yaml frontmatter as a set of operator beliefs."""
+    try:
+        text = md_path.read_text(errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return []
+    m = _FRONTMATTER_RE.match(text)
+    ts_recorded = int(md_path.stat().st_mtime)
+    source = str(md_path)
+    if m is None:
+        # Degraded: emit a single belief that records the article title
+        # (first '# ' heading) so the article shows up in drift surveys.
+        for line in text.splitlines():
+            if line.startswith("# "):
+                return [Belief("operator", f"wiki:{md_path.stem}",
+                               f"title={line[2:].strip()}", ts_recorded, source)]
+        return []
+    beliefs: list[Belief] = []
+    body = m.group(1)
+    for line in body.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if not key:
+            continue
+        beliefs.append(Belief(
+            agent="operator",
+            subject=f"wiki:{md_path.stem}/{key}",
+            claim=value,
+            ts_recorded=ts_recorded,
+            source_path=source,
+        ))
+    return beliefs
+
+
+def ingest_wiki(wiki_root: Path, xs_conn: sqlite3.Connection) -> dict:
+    """Walk a wiki root for *.md files and ingest frontmatter as beliefs."""
+    if not wiki_root.exists():
+        return {"inserted": 0, "skipped": 0, "files": 0}
+    inserted = skipped = files = 0
+    for path in sorted(wiki_root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        files += 1
+        for b in _wiki_beliefs(path):
+            if _insert(xs_conn, b):
+                inserted += 1
+            else:
+                skipped += 1
+    xs_conn.commit()
+    return {"inserted": inserted, "skipped": skipped, "files": files}

--- a/python/argus/cli.py
+++ b/python/argus/cli.py
@@ -1,0 +1,201 @@
+"""CLI entry: argus command."""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+from argus.indexer import follow_all_decisions, tail_all_decisions
+from argus.reporter import generate_daily_report
+
+
+def cmd_index(args) -> int:
+    """Index gov-decisions JSONL files from decisions_dir."""
+    decisions_dir = Path(args.decisions_dir)
+    if not decisions_dir.exists():
+        print(f"Error: decisions_dir not found: {decisions_dir}", file=sys.stderr)
+        return 1
+
+    try:
+        if args.follow:
+            print(f"Following {decisions_dir} into {Path.home() / '.argus' / 'index.db'}", file=sys.stderr)
+            follow_all_decisions(decisions_dir, poll_seconds=args.poll_seconds)
+            return 0
+        db_path = tail_all_decisions(decisions_dir)
+        print(f"Indexed to {db_path}", file=sys.stderr)
+        return 0
+    except KeyboardInterrupt:
+        return 130
+    except Exception as e:
+        print(f"Error indexing: {e}", file=sys.stderr)
+        return 2
+
+
+def cmd_report(args) -> int:
+    """Generate daily digest report."""
+    db_path = Path(args.db_path)
+    if not db_path.exists():
+        print(f"Error: index not found: {db_path}", file=sys.stderr)
+        print("Run 'argus index' first.", file=sys.stderr)
+        return 1
+
+    # Webhook precedence: --discord-webhook flag, then ARGUS_DISCORD_WEBHOOK env.
+    import os
+    webhook = args.discord_webhook or os.environ.get("ARGUS_DISCORD_WEBHOOK") or None
+
+    try:
+        report_path = generate_daily_report(
+            str(db_path),
+            Path(args.report_dir),
+            discord_webhook=webhook,
+            quiet_day_skip_discord=not args.discord_always,
+        )
+        print(f"Wrote {report_path}", file=sys.stderr)
+        print(report_path)
+        return 0
+    except Exception as e:
+        print(f"Error generating report: {e}", file=sys.stderr)
+        return 2
+
+
+def cmd_query(args) -> int:
+    """Query the index with a natural language question.
+
+    Converts NL to SQL via qwen. Returns JSON results.
+    """
+    db_path = Path(args.db_path)
+    if not db_path.exists():
+        print(f"Error: index not found: {db_path}", file=sys.stderr)
+        return 1
+
+    question = args.query
+
+    # Simple qwen-based NL to SQL translation
+    try:
+        import subprocess
+        prompt = f"""
+        Convert this question to a SQLite query against a table called 'events' with columns:
+        ts, allowed, mode, rule_id, reason, escalation, agent, action_type, action_target,
+        envelope_id, tier, cost_usd, input_bytes, tool_calls, model, role, workflow_id, fingerprint
+
+        Question: {question}
+
+        Return ONLY the SQL query, no explanation.
+        """
+
+        result = subprocess.run(
+            ["ollama", "run", "qwen3.6:27b", prompt],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            print(f"Error from qwen: {result.stderr}", file=sys.stderr)
+            return 2
+
+        sql = _sanitize_readonly_select(result.stdout)
+        if not sql:
+            print("qwen returned no safe read-only SELECT query", file=sys.stderr)
+            return 2
+
+        # Execute query on a read-only SQLite connection.
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.execute("PRAGMA query_only = ON")
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(sql).fetchall()
+            import json
+            results = [dict(row) for row in rows]
+            print(json.dumps(results, indent=2, default=str))
+            return 0
+        except Exception as e:
+            print(f"Query error: {e}", file=sys.stderr)
+            print(f"SQL: {sql}", file=sys.stderr)
+            return 2
+        finally:
+            conn.close()
+
+    except FileNotFoundError:
+        print("Error: ollama not found. Install ollama and run: ollama pull qwen3.6:27b",
+              file=sys.stderr)
+        return 3
+
+
+
+def _sanitize_readonly_select(raw_sql: str) -> str | None:
+    """Return a single read-only SELECT statement, or None if unsafe."""
+    sql = raw_sql.strip()
+    if sql.startswith("```"):
+        sql = sql.strip("`").strip()
+        if sql.lower().startswith("sql"):
+            sql = sql[3:].strip()
+    if sql.endswith(";"):
+        sql = sql[:-1].strip()
+    lowered = sql.lower()
+    if not lowered.startswith("select "):
+        return None
+    if ";" in sql:
+        return None
+    forbidden = ("insert ", "update ", "delete ", "drop ", "alter ", "create ", "replace ", "attach ", "detach ", "pragma ", "vacuum ")
+    padded = f" {lowered} "
+    if any(token in padded for token in forbidden):
+        return None
+    return sql
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    p = argparse.ArgumentParser(prog="argus", description="Observatory: tail, index, detect, report.")
+    p.add_argument("--db-path", default=str(Path.home() / ".argus" / "index.db"),
+                   help="Path to index.db")
+
+    subparsers = p.add_subparsers(dest="cmd", required=True)
+
+    # index subcommand
+    index_p = subparsers.add_parser("index", help="Index gov-decisions JSONL files")
+    index_p.add_argument("--decisions-dir",
+                         default=str(Path.home() / ".chitin"),
+                         help="Directory containing gov-decisions-*.jsonl")
+    index_p.add_argument("--follow", action="store_true",
+                         help="Stay running and index appended lines/date-rollover files")
+    index_p.add_argument("--poll-seconds", type=float, default=1.0,
+                         help="Polling interval for --follow")
+
+    # report subcommand
+    report_p = subparsers.add_parser("report", help="Generate daily digest report")
+    report_p.add_argument("--report-dir",
+                          default=str(Path.home() / ".chitin" / "reports"),
+                          help="Output directory for reports")
+    report_p.add_argument("--discord-webhook",
+                          default=None,
+                          help="Discord webhook URL for #ares summary (overrides ARGUS_DISCORD_WEBHOOK)")
+    report_p.add_argument("--discord-always",
+                          action="store_true",
+                          help="Post Discord summary even on quiet days (default: skip if no findings)")
+
+    # query subcommand
+    query_p = subparsers.add_parser("query", help="Query index with NL question")
+    query_p.add_argument("query", nargs="+", help="Natural language question")
+
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = parse_args(argv)
+
+    if args.cmd == "index":
+        return cmd_index(args)
+    elif args.cmd == "report":
+        return cmd_report(args)
+    elif args.cmd == "query":
+        # Join query args back into a string
+        args.query = " ".join(args.query)
+        return cmd_query(args)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/argus/cli.py
+++ b/python/argus/cli.py
@@ -17,6 +17,7 @@ from argus.beliefs import (
     ingest_wiki,
 )
 from argus.cross_source_db import init_cross_source_db
+from argus.findings import collect_findings, render_findings_json
 
 
 def cmd_index(args) -> int:
@@ -212,6 +213,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                        default=str(Path.home() / ".argus" / "cross_source.db"),
                        help="Cross-source SQLite index path")
 
+    # findings subcommand (Slice 5: Hermes standup-fold contract)
+    fnd_p = subparsers.add_parser(
+        "findings",
+        help="Emit JSON-encoded findings since <ts> for downstream Hermes fold",
+    )
+    fnd_p.add_argument("--since", type=int, default=0,
+                       help="Unix ts; only emit findings at or after this time")
+    fnd_p.add_argument("--xs-db",
+                       default=str(Path.home() / ".argus" / "cross_source.db"),
+                       help="Cross-source SQLite index path")
+    fnd_p.add_argument("--indent", type=int, default=None,
+                       help="Pretty-print JSON with this indent (default: compact)")
+    fnd_p.add_argument("--limit", type=int, default=None,
+                       help="Cap output to top-N findings (after severity sort)")
+
     # ingest-beliefs subcommand (Slice 4)
     inb_p = subparsers.add_parser(
         "ingest-beliefs",
@@ -250,8 +266,21 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_ingest_git(args)
     elif args.cmd == "ingest-beliefs":
         return cmd_ingest_beliefs(args)
+    elif args.cmd == "findings":
+        return cmd_findings(args)
 
     return 1
+
+
+def cmd_findings(args) -> int:
+    """Emit structured findings JSON for Hermes' standup-fold consumer."""
+    chain_db = Path(args.db_path)
+    xs_db = Path(args.xs_db)
+    findings = collect_findings(chain_db, xs_db, since_ts=args.since)
+    if args.limit is not None:
+        findings = findings[: args.limit]
+    print(render_findings_json(findings, indent=args.indent))
+    return 0
 
 
 def cmd_ingest_beliefs(args) -> int:

--- a/python/argus/cli.py
+++ b/python/argus/cli.py
@@ -10,6 +10,13 @@ from argus.indexer import follow_all_decisions, tail_all_decisions
 from argus.reporter import generate_daily_report
 from argus.kanban_ingest import ingest_all_kanban
 from argus.git_ingest import ingest_repo, discover_repos
+from argus.beliefs import (
+    init_beliefs_table,
+    ingest_agent_cards,
+    ingest_clawta_swarm_elo,
+    ingest_wiki,
+)
+from argus.cross_source_db import init_cross_source_db
 
 
 def cmd_index(args) -> int:
@@ -205,6 +212,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                        default=str(Path.home() / ".argus" / "cross_source.db"),
                        help="Cross-source SQLite index path")
 
+    # ingest-beliefs subcommand (Slice 4)
+    inb_p = subparsers.add_parser(
+        "ingest-beliefs",
+        help="One-shot snapshot of agent cards + clawta ELO + wiki into the cross-source index",
+    )
+    inb_p.add_argument("--agent-cards",
+                       default=str(Path.home() / ".openclaw" / "data" / "agent-cards"),
+                       help="Directory containing per-agent JSON cards")
+    inb_p.add_argument("--clawta-db",
+                       default=str(Path.home() / ".openclaw" / "data" / "clawta.db"),
+                       help="Path to clawta.db with the swarm_elo table")
+    inb_p.add_argument("--wiki-root", default=None,
+                       help="Wiki markdown root (default: skipped)")
+    inb_p.add_argument("--xs-db",
+                       default=str(Path.home() / ".argus" / "cross_source.db"),
+                       help="Cross-source SQLite index path")
+
     return p.parse_args(argv)
 
 
@@ -224,8 +248,30 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_ingest_kanban(args)
     elif args.cmd == "ingest-git":
         return cmd_ingest_git(args)
+    elif args.cmd == "ingest-beliefs":
+        return cmd_ingest_beliefs(args)
 
     return 1
+
+
+def cmd_ingest_beliefs(args) -> int:
+    """Pull operator agent cards + clawta ELO + (optional) wiki into beliefs."""
+    xs_db = Path(args.xs_db)
+    xs_conn = init_cross_source_db(xs_db)
+    try:
+        init_beliefs_table(xs_conn)
+        ac = ingest_agent_cards(Path(args.agent_cards), xs_conn)
+        print(f"agent cards: agents={ac['agents']} inserted={ac['inserted']} skipped={ac['skipped']}",
+              file=sys.stderr)
+        ce = ingest_clawta_swarm_elo(Path(args.clawta_db), xs_conn)
+        print(f"clawta ELO: inserted={ce['inserted']} skipped={ce['skipped']}", file=sys.stderr)
+        if args.wiki_root:
+            wk = ingest_wiki(Path(args.wiki_root), xs_conn)
+            print(f"wiki: files={wk['files']} inserted={wk['inserted']} skipped={wk['skipped']}",
+                  file=sys.stderr)
+    finally:
+        xs_conn.close()
+    return 0
 
 
 def cmd_ingest_kanban(args) -> int:

--- a/python/argus/cli.py
+++ b/python/argus/cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from argus.indexer import follow_all_decisions, tail_all_decisions
 from argus.reporter import generate_daily_report
+from argus.kanban_ingest import ingest_all_kanban
+from argus.git_ingest import ingest_repo, discover_repos
 
 
 def cmd_index(args) -> int:
@@ -178,6 +180,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     query_p = subparsers.add_parser("query", help="Query index with NL question")
     query_p.add_argument("query", nargs="+", help="Natural language question")
 
+    # ingest-kanban subcommand
+    ink_p = subparsers.add_parser(
+        "ingest-kanban",
+        help="Poll ~/.hermes/kanban/boards/*/kanban.db into the cross-source index",
+    )
+    ink_p.add_argument("--boards-root",
+                       default=str(Path.home() / ".hermes" / "kanban" / "boards"),
+                       help="Root directory containing per-board kanban DBs")
+    ink_p.add_argument("--xs-db",
+                       default=str(Path.home() / ".argus" / "cross_source.db"),
+                       help="Cross-source SQLite index path")
+
+    # ingest-git subcommand
+    ing_p = subparsers.add_parser(
+        "ingest-git",
+        help="Poll commits + PRs for tracked repos into the cross-source index",
+    )
+    ing_p.add_argument("--repo", action="append", default=None,
+                       help="Repo path to poll (repeatable). Default: auto-discover under --root")
+    ing_p.add_argument("--root", action="append", default=None,
+                       help="Directory to scan for child .git repos (repeatable)")
+    ing_p.add_argument("--xs-db",
+                       default=str(Path.home() / ".argus" / "cross_source.db"),
+                       help="Cross-source SQLite index path")
+
     return p.parse_args(argv)
 
 
@@ -193,8 +220,52 @@ def main(argv: list[str] | None = None) -> int:
         # Join query args back into a string
         args.query = " ".join(args.query)
         return cmd_query(args)
+    elif args.cmd == "ingest-kanban":
+        return cmd_ingest_kanban(args)
+    elif args.cmd == "ingest-git":
+        return cmd_ingest_git(args)
 
     return 1
+
+
+def cmd_ingest_kanban(args) -> int:
+    """Pull kanban events into the cross-source index."""
+    boards_root = Path(args.boards_root)
+    xs_db = Path(args.xs_db)
+    if not boards_root.exists():
+        print(f"Error: boards root not found: {boards_root}", file=sys.stderr)
+        return 1
+    result = ingest_all_kanban(boards_root, xs_db)
+    print(f"kanban ingest: boards={result['boards']} inserted={result['inserted']} skipped={result['skipped']}",
+          file=sys.stderr)
+    return 0
+
+
+def cmd_ingest_git(args) -> int:
+    """Pull git commits + PRs into the cross-source index for the given repos."""
+    xs_db = Path(args.xs_db)
+    repos: list[Path] = []
+    if args.repo:
+        repos.extend(Path(p) for p in args.repo)
+    if args.root:
+        repos.extend(discover_repos([Path(r) for r in args.root]))
+    if not repos:
+        # Default: cwd if it's a repo
+        cwd = Path.cwd()
+        if (cwd / ".git").exists():
+            repos.append(cwd)
+    if not repos:
+        print("Error: no repos to ingest. Pass --repo PATH or --root DIR.", file=sys.stderr)
+        return 1
+    for r in repos:
+        result = ingest_repo(r, xs_db)
+        print(
+            f"git ingest: repo={result['repo']} "
+            f"commits=+{result['commits_inserted']}/-{result['commits_skipped']} "
+            f"prs=+{result['prs_inserted']}/-{result['prs_skipped']}",
+            file=sys.stderr,
+        )
+    return 0
 
 
 if __name__ == "__main__":

--- a/python/argus/cross_detectors.py
+++ b/python/argus/cross_detectors.py
@@ -1,0 +1,282 @@
+"""Cross-source detectors over the kanban + git index.
+
+Detectors implemented in this slice:
+    demote_loop          — ticket bounced ready→triage ≥2× in window
+    stuck_pr_green_ci    — PR open >24h with no merge event
+    follow_up_clustering — N kanban tickets filed shortly after a merge
+
+Each Finding carries explicit `evidence` listing the kanban event ids
+and git PR/commit references it joined on (spec § Slice 2 source
+attribution requirement).
+
+Invariants:
+    - Pure functions over (db_path, now_ts). No side effects.
+    - Deterministic tie-breaker on finding ordering: (ts desc, subject).
+    - One missing source ≠ failure: missing-side joins still emit
+      findings from the present side (caller can decide severity).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class CrossFinding:
+    detector: str
+    severity: str  # info | warning | critical
+    title: str
+    ts_unix: int
+    subject: str
+    details: dict
+    evidence: list[str] = field(default_factory=list)
+
+
+def _ro(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.execute("PRAGMA query_only = ON")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def detect_demote_loops(
+    xs_db: Path,
+    window_seconds: int = 24 * 3600,
+    min_bounces: int = 2,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """Tickets that bounced ready→triage ≥min_bounces times in window.
+
+    A "bounce" is a kanban_status_transition whose payload encodes
+    from='ready' and to='triage'. The detector groups bounces by
+    task_id (subject) and flags any task whose bounce count in the
+    rolling window meets or exceeds the threshold.
+
+    Invariant: exactly `min_bounces` bounces DOES trigger;
+    `min_bounces - 1` does NOT.
+    """
+    now_ts = now_ts or int(datetime.now(timezone.utc).timestamp())
+    since_ts = now_ts - window_seconds
+
+    findings: list[CrossFinding] = []
+    if not xs_db.exists():
+        return findings
+
+    conn = _ro(xs_db)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, subject, ts_unix, payload_json
+            FROM cross_source_events
+            WHERE source='kanban'
+              AND kind='kanban_status_transition'
+              AND ts_unix >= ?
+            ORDER BY ts_unix ASC
+            """,
+            (since_ts,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_task: dict[str, list[dict]] = {}
+    for row in rows:
+        try:
+            payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+        except (TypeError, ValueError):
+            payload = {}
+        if payload.get("from") == "ready" and payload.get("to") == "triage":
+            by_task.setdefault(row["subject"], []).append({
+                "id": row["id"],
+                "ts_unix": row["ts_unix"],
+                "by": payload.get("by"),
+            })
+
+    for task_id, bounces in by_task.items():
+        if len(bounces) >= min_bounces:
+            last_ts = bounces[-1]["ts_unix"]
+            findings.append(CrossFinding(
+                detector="demote_loop",
+                severity="warning",
+                title=f"Demote loop: {task_id} bounced ready→triage {len(bounces)}× in {window_seconds // 3600}h",
+                ts_unix=last_ts,
+                subject=task_id,
+                details={
+                    "task_id": task_id,
+                    "bounce_count": len(bounces),
+                    "window_hours": window_seconds // 3600,
+                    "demoted_by": list({b["by"] for b in bounces if b["by"]}),
+                },
+                evidence=[f"kanban_event#{b['id']}" for b in bounces],
+            ))
+
+    findings.sort(key=lambda f: (-f.ts_unix, f.subject))
+    return findings
+
+
+def detect_stuck_prs_green_ci(
+    xs_db: Path,
+    min_open_seconds: int = 24 * 3600,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """PRs with git_pr_opened > min_open_seconds ago and no git_pr_merged.
+
+    Slice 2 minimal: relies on the merged event being indexed (i.e.,
+    if a PR has merged, we should already have its git_pr_merged row).
+    Doesn't yet query CI state — that's a Slice 3 / GitHub-checks
+    follow-up. Open PR + no merge event past the threshold is the
+    cheapest cross-source proxy for "stuck PR" today.
+    """
+    now_ts = now_ts or int(datetime.now(timezone.utc).timestamp())
+    threshold_ts = now_ts - min_open_seconds
+
+    findings: list[CrossFinding] = []
+    if not xs_db.exists():
+        return findings
+
+    conn = _ro(xs_db)
+    try:
+        opened_rows = conn.execute(
+            """
+            SELECT id, subject, ts_unix, payload_json, actor
+            FROM cross_source_events
+            WHERE source='git' AND kind='git_pr_opened'
+              AND ts_unix <= ?
+            """,
+            (threshold_ts,),
+        ).fetchall()
+        merged_subjects = {
+            row["subject"]
+            for row in conn.execute(
+                "SELECT subject FROM cross_source_events WHERE source='git' AND kind='git_pr_merged'"
+            )
+        }
+    finally:
+        conn.close()
+
+    for row in opened_rows:
+        if row["subject"] in merged_subjects:
+            continue
+        try:
+            payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+        except (TypeError, ValueError):
+            payload = {}
+        # Don't flag draft PRs — operators leave drafts open intentionally.
+        if payload.get("draft"):
+            continue
+        age_hours = (now_ts - row["ts_unix"]) // 3600
+        findings.append(CrossFinding(
+            detector="stuck_pr_green_ci",
+            severity="info",
+            title=f"Stuck PR: {row['subject']} open for {age_hours}h with no merge event",
+            ts_unix=row["ts_unix"],
+            subject=row["subject"],
+            details={
+                "pr_number": row["subject"],
+                "title": payload.get("title"),
+                "age_hours": age_hours,
+                "author": row["actor"],
+            },
+            evidence=[f"git_event#{row['id']}"],
+        ))
+
+    findings.sort(key=lambda f: (-f.ts_unix, f.subject))
+    return findings
+
+
+def detect_follow_up_clustering(
+    xs_db: Path,
+    window_seconds: int = 7 * 24 * 3600,
+    min_tickets: int = 3,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """N+ kanban tickets created within `window_seconds` after a PR merge.
+
+    Heuristic for "the merge introduced debt": if a merge is followed
+    by a burst of new tickets within the window, surface the merge
+    as a candidate for review.
+
+    Cross-source join: git_pr_merged → kanban_ticket_create within window.
+    The kanban side joins by ticket-creation events (kind='created').
+    """
+    now_ts = now_ts or int(datetime.now(timezone.utc).timestamp())
+    horizon_ts = now_ts - 30 * 24 * 3600
+
+    findings: list[CrossFinding] = []
+    if not xs_db.exists():
+        return findings
+
+    conn = _ro(xs_db)
+    try:
+        merges = conn.execute(
+            """
+            SELECT id, subject, ts_unix, payload_json
+            FROM cross_source_events
+            WHERE source='git' AND kind='git_pr_merged'
+              AND ts_unix >= ?
+            ORDER BY ts_unix ASC
+            """,
+            (horizon_ts,),
+        ).fetchall()
+
+        all_creates = conn.execute(
+            """
+            SELECT id, subject, ts_unix
+            FROM cross_source_events
+            WHERE source='kanban' AND kind IN ('kanban_event','kanban_ticket_create')
+              AND ts_unix >= ?
+            ORDER BY ts_unix ASC
+            """,
+            (horizon_ts,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    for merge in merges:
+        merge_ts = merge["ts_unix"]
+        window_end = merge_ts + window_seconds
+        followups = [
+            r for r in all_creates
+            if merge_ts <= r["ts_unix"] <= window_end
+        ]
+        if len(followups) >= min_tickets:
+            try:
+                payload = json.loads(merge["payload_json"]) if merge["payload_json"] else {}
+            except (TypeError, ValueError):
+                payload = {}
+            findings.append(CrossFinding(
+                detector="follow_up_clustering",
+                severity="info",
+                title=(
+                    f"Follow-up cluster: {len(followups)} tickets opened within "
+                    f"{window_seconds // 86400}d of merging {merge['subject']}"
+                ),
+                ts_unix=merge_ts,
+                subject=merge["subject"],
+                details={
+                    "merged_pr": merge["subject"],
+                    "merged_title": payload.get("title"),
+                    "follow_up_count": len(followups),
+                    "window_days": window_seconds // 86400,
+                },
+                evidence=(
+                    [f"git_event#{merge['id']}"]
+                    + [f"kanban_event#{f['id']}" for f in followups[:5]]
+                ),
+            ))
+
+    findings.sort(key=lambda f: (-f.ts_unix, f.subject))
+    return findings
+
+
+def run_all_cross_detectors(xs_db: Path, now_ts: Optional[int] = None) -> list[CrossFinding]:
+    """Run every cross-source detector and return all findings."""
+    findings: list[CrossFinding] = []
+    findings.extend(detect_demote_loops(xs_db, now_ts=now_ts))
+    findings.extend(detect_stuck_prs_green_ci(xs_db, now_ts=now_ts))
+    findings.extend(detect_follow_up_clustering(xs_db, now_ts=now_ts))
+    findings.sort(key=lambda f: (-f.ts_unix, f.subject, f.detector))
+    return findings

--- a/python/argus/cross_source_db.py
+++ b/python/argus/cross_source_db.py
@@ -1,0 +1,86 @@
+"""Shared schema + open helpers for the cross-source (kanban + git) index.
+
+Slice 2 keeps cross-source events in a separate table from the chain
+`events` table — the column shapes are too different to merge cleanly
+(chain has allowed/rule_id, kanban/git don't). Detectors that need to
+join across sources read both tables.
+
+Invariants:
+    - Append-only. Idempotent on `dedup_key` UNIQUE.
+    - Source attribution: every row carries `source` and `subject` (the
+      task_id, commit sha, or PR number). Detectors must cite these.
+    - Read-only consumers: detectors and report open the same DB with
+      mode=ro URI. Only ingesters write.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def init_cross_source_db(db_path: Path) -> sqlite3.Connection:
+    """Create the cross_source_events table + indexes. Idempotent."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS cross_source_events (
+            id INTEGER PRIMARY KEY,
+            source TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            ts_unix INTEGER NOT NULL,
+            subject TEXT NOT NULL,
+            actor TEXT,
+            payload_json TEXT,
+            dedup_key TEXT UNIQUE NOT NULL
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_xs_source_ts ON cross_source_events(source, ts_unix)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_xs_kind_ts   ON cross_source_events(kind, ts_unix)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_xs_subject   ON cross_source_events(subject)")
+
+    # Per-source watermark table: last successfully ingested timestamp
+    # per (source, board/repo). Lets pollers resume without rescanning.
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS ingest_watermarks (
+            source TEXT NOT NULL,
+            scope TEXT NOT NULL,
+            last_ts_unix INTEGER NOT NULL,
+            PRIMARY KEY (source, scope)
+        )
+    """)
+
+    conn.commit()
+    return conn
+
+
+def get_watermark(conn: sqlite3.Connection, source: str, scope: str) -> int:
+    """Return last_ts_unix for (source, scope), or 0 if not set."""
+    row = conn.execute(
+        "SELECT last_ts_unix FROM ingest_watermarks WHERE source=? AND scope=?",
+        (source, scope),
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def set_watermark(conn: sqlite3.Connection, source: str, scope: str, ts_unix: int) -> None:
+    """Upsert the watermark for (source, scope)."""
+    conn.execute(
+        """
+        INSERT INTO ingest_watermarks (source, scope, last_ts_unix)
+        VALUES (?, ?, ?)
+        ON CONFLICT(source, scope) DO UPDATE SET
+            last_ts_unix=excluded.last_ts_unix
+        """,
+        (source, scope, ts_unix),
+    )
+    conn.commit()
+
+
+def open_readonly(db_path: Path) -> sqlite3.Connection:
+    """Open the cross-source DB in read-only mode (mode=ro URI)."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.execute("PRAGMA query_only = ON")
+    conn.row_factory = sqlite3.Row
+    return conn

--- a/python/argus/detectors.py
+++ b/python/argus/detectors.py
@@ -163,52 +163,73 @@ def detect_agent_failure_run(
     findings = []
 
     try:
+        # Walk the full per-agent timeline (allows + denies) so the
+        # "consecutive" semantics are actually consecutive. The prior
+        # version queried only denies and counted them across all of
+        # time, which would flag an agent that had N denies interleaved
+        # with M allows — not a failure run.
         if agent_name:
             query = """
-                SELECT ts_unix, agent, rule_id, action_type
+                SELECT ts_unix, agent, rule_id, action_type, allowed
                 FROM events
-                WHERE agent = ? AND allowed = 0
-                ORDER BY ts_unix ASC
+                WHERE agent = ?
+                ORDER BY agent ASC, ts_unix ASC, id ASC
             """
             rows = conn.execute(query, (agent_name,)).fetchall()
         else:
             query = """
-                SELECT ts_unix, agent, rule_id, action_type
+                SELECT ts_unix, agent, rule_id, action_type, allowed
                 FROM events
-                WHERE allowed = 0
-                ORDER BY ts_unix ASC
+                ORDER BY agent ASC, ts_unix ASC, id ASC
             """
             rows = conn.execute(query).fetchall()
 
         if not rows:
             return findings
 
-        # Group consecutive denies by agent
-        agents_seen = {}
+        current_agent = None
+        streak: list = []
+        reported_run_keys: set = set()
+
+        def emit(agent: str, events: list) -> None:
+            if len(events) < min_failures:
+                return
+            run_key = (agent, events[0]["ts_unix"], events[-1]["ts_unix"])
+            if run_key in reported_run_keys:
+                return
+            reported_run_keys.add(run_key)
+            ts = _from_unix(events[0]["ts_unix"])
+            rules = [e["rule_id"] for e in events]
+            findings.append(Finding(
+                detector="agent_failure_run",
+                ts=ts,
+                severity="warning",
+                title=f"Agent {agent} failure run: {len(events)} consecutive denies",
+                details={
+                    "agent": agent,
+                    "failure_count": len(events),
+                    "rules": list(dict.fromkeys(rules)),
+                    "min_threshold": min_failures,
+                    "first_ts_unix": events[0]["ts_unix"],
+                    "last_ts_unix": events[-1]["ts_unix"],
+                },
+            ))
+
         for row in rows:
             agent = row["agent"]
-            if agent not in agents_seen:
-                agents_seen[agent] = []
-            agents_seen[agent].append(row)
+            if agent != current_agent:
+                if current_agent is not None:
+                    emit(current_agent, streak)
+                current_agent = agent
+                streak = []
+            if row["allowed"] == 0:
+                streak.append(row)
+            else:
+                emit(agent, streak)
+                streak = []
 
-        for agent, events in agents_seen.items():
-            if len(events) >= min_failures:
-                # All are denies for this agent, sorted by ts_unix
-                ts = _from_unix(events[0]["ts_unix"])
-                rules = [e["rule_id"] for e in events]
-
-                findings.append(Finding(
-                    detector="agent_failure_run",
-                    ts=ts,
-                    severity="warning",
-                    title=f"Agent {agent} failure run: {len(events)} consecutive denies",
-                    details={
-                        "agent": agent,
-                        "failure_count": len(events),
-                        "rules": list(set(rules)),
-                        "min_threshold": min_failures,
-                    }
-                ))
+        if current_agent is not None:
+            emit(current_agent, streak)
 
     finally:
         conn.close()

--- a/python/argus/detectors.py
+++ b/python/argus/detectors.py
@@ -1,0 +1,286 @@
+"""Deterministic detectors over the event index."""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+
+def _utc_now() -> datetime:
+    """Timezone-aware UTC now. Replaces the deprecated datetime.utcnow()."""
+    return datetime.now(timezone.utc)
+
+
+def _from_unix(ts_unix: int) -> datetime:
+    """Timezone-aware UTC datetime from unix epoch."""
+    return datetime.fromtimestamp(ts_unix, timezone.utc)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A detector finding."""
+
+    detector: str
+    ts: datetime
+    severity: str  # "info" | "warning" | "critical"
+    title: str
+    details: dict
+
+
+def _get_conn(db_path: str) -> sqlite3.Connection:
+    """Open connection to index.db."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def detect_deny_cluster(
+    db_path: str,
+    window_seconds: int = 300,
+    threshold_count: int = 4,
+) -> list[Finding]:
+    """Detect N deny events within M-second window.
+
+    Invariant: A cluster is ≥N events at timestamps within window_seconds.
+    Boundary: N-1 events at boundary does NOT trigger; N events DOES trigger.
+    """
+    conn = _get_conn(db_path)
+    findings = []
+
+    try:
+        rows = conn.execute("""
+            SELECT ts_unix, rule_id, agent, action_type
+            FROM events
+            WHERE allowed = 0
+            ORDER BY ts_unix ASC
+        """).fetchall()
+
+        if not rows:
+            return findings
+
+        i = 0
+        while i < len(rows):
+            window_start = rows[i]["ts_unix"]
+            window_end = window_start + window_seconds
+
+            cluster = []
+            j = i
+            while j < len(rows) and rows[j]["ts_unix"] < window_end:
+                cluster.append(rows[j])
+                j += 1
+
+            if len(cluster) >= threshold_count:
+                ts = _from_unix(cluster[0]["ts_unix"])
+                rule_ids = [r["rule_id"] for r in cluster]
+                agents = [r["agent"] for r in cluster]
+
+                findings.append(Finding(
+                    detector="deny_cluster",
+                    ts=ts,
+                    severity="warning",
+                    title=f"Deny cluster: {len(cluster)} denies in {window_seconds}s",
+                    details={
+                        "count": len(cluster),
+                        "window_seconds": window_seconds,
+                        "rules": list(set(rule_ids)),
+                        "agents": list(set(agents)),
+                        "start_ts_unix": window_start,
+                        "end_ts_unix": window_end,
+                    }
+                ))
+
+            i = j if j > i + 1 else i + 1
+
+    finally:
+        conn.close()
+
+    return findings
+
+
+def detect_unknown_rate_spike(
+    db_path: str,
+    window_hours: int = 24,
+    threshold_percent: float = 1.0,
+) -> list[Finding]:
+    """Detect unknown action_type rate >threshold% over window_hours.
+
+    Invariant: (unknown_count / total_count) * 100 > threshold_percent
+    Boundary: exactly threshold% does NOT trigger; >threshold% DOES trigger.
+    """
+    conn = _get_conn(db_path)
+    findings = []
+
+    try:
+        now_ts = int(_utc_now().timestamp())
+        window_start = now_ts - (window_hours * 3600)
+
+        row = conn.execute("""
+            SELECT
+                COUNT(*) as total,
+                SUM(CASE WHEN action_type IS NULL OR action_type = '' THEN 1 ELSE 0 END) as unknown
+            FROM events
+            WHERE ts_unix >= ? AND ts_unix <= ?
+        """, (window_start, now_ts)).fetchone()
+
+        if row and row["total"] > 0:
+            total = row["total"]
+            unknown = row["unknown"] or 0
+            pct = (unknown / total) * 100
+
+            if pct > threshold_percent:
+                findings.append(Finding(
+                    detector="unknown_rate_spike",
+                    ts=_utc_now(),
+                    severity="info",
+                    title=f"Unknown rate spike: {pct:.2f}% > {threshold_percent}%",
+                    details={
+                        "unknown_count": unknown,
+                        "total_count": total,
+                        "unknown_percent": pct,
+                        "threshold_percent": threshold_percent,
+                        "window_hours": window_hours,
+                    }
+                ))
+
+    finally:
+        conn.close()
+
+    return findings
+
+
+def detect_agent_failure_run(
+    db_path: str,
+    agent_name: Optional[str] = None,
+    min_failures: int = 3,
+) -> list[Finding]:
+    """Detect agent with consecutive deny events (failure run).
+
+    Invariant: agent has ≥min_failures deny events in a row (sorted by ts_unix).
+    Boundary: min_failures-1 does NOT trigger; min_failures DOES trigger.
+    """
+    conn = _get_conn(db_path)
+    findings = []
+
+    try:
+        if agent_name:
+            query = """
+                SELECT ts_unix, agent, rule_id, action_type
+                FROM events
+                WHERE agent = ? AND allowed = 0
+                ORDER BY ts_unix ASC
+            """
+            rows = conn.execute(query, (agent_name,)).fetchall()
+        else:
+            query = """
+                SELECT ts_unix, agent, rule_id, action_type
+                FROM events
+                WHERE allowed = 0
+                ORDER BY ts_unix ASC
+            """
+            rows = conn.execute(query).fetchall()
+
+        if not rows:
+            return findings
+
+        # Group consecutive denies by agent
+        agents_seen = {}
+        for row in rows:
+            agent = row["agent"]
+            if agent not in agents_seen:
+                agents_seen[agent] = []
+            agents_seen[agent].append(row)
+
+        for agent, events in agents_seen.items():
+            if len(events) >= min_failures:
+                # All are denies for this agent, sorted by ts_unix
+                ts = _from_unix(events[0]["ts_unix"])
+                rules = [e["rule_id"] for e in events]
+
+                findings.append(Finding(
+                    detector="agent_failure_run",
+                    ts=ts,
+                    severity="warning",
+                    title=f"Agent {agent} failure run: {len(events)} consecutive denies",
+                    details={
+                        "agent": agent,
+                        "failure_count": len(events),
+                        "rules": list(set(rules)),
+                        "min_threshold": min_failures,
+                    }
+                ))
+
+    finally:
+        conn.close()
+
+    return findings
+
+
+def detect_stuck_flow(
+    db_path: str,
+    agent_name: Optional[str] = None,
+    min_idle_seconds: int = 3600,
+) -> list[Finding]:
+    """Detect agent with no new events for min_idle_seconds.
+
+    Invariant: agent's last event is >min_idle_seconds ago.
+    Boundary: exactly min_idle_seconds ago does NOT trigger; >min_idle_seconds DOES.
+    """
+    conn = _get_conn(db_path)
+    findings = []
+
+    try:
+        now_ts = int(_utc_now().timestamp())
+        idle_threshold = now_ts - min_idle_seconds
+
+        if agent_name:
+            query = """
+                SELECT agent, MAX(ts_unix) as last_ts
+                FROM events
+                WHERE agent = ?
+                GROUP BY agent
+            """
+            rows = conn.execute(query, (agent_name,)).fetchall()
+        else:
+            query = """
+                SELECT agent, MAX(ts_unix) as last_ts
+                FROM events
+                GROUP BY agent
+            """
+            rows = conn.execute(query).fetchall()
+
+        for row in rows:
+            agent = row["agent"]
+            last_ts = row["last_ts"]
+
+            if last_ts and last_ts < idle_threshold:
+                idle_duration = now_ts - last_ts
+                ts = _from_unix(last_ts)
+
+                findings.append(Finding(
+                    detector="stuck_flow",
+                    ts=ts,
+                    severity="info",
+                    title=f"Stuck flow: {agent} idle for {idle_duration}s",
+                    details={
+                        "agent": agent,
+                        "idle_seconds": idle_duration,
+                        "idle_threshold_seconds": min_idle_seconds,
+                        "last_event_ts_unix": last_ts,
+                    }
+                ))
+
+    finally:
+        conn.close()
+
+    return findings
+
+
+def run_all_detectors(db_path: str) -> list[Finding]:
+    """Run all detectors and return all findings."""
+    findings = []
+    findings.extend(detect_deny_cluster(db_path, window_seconds=300, threshold_count=4))
+    findings.extend(detect_unknown_rate_spike(db_path, window_hours=24, threshold_percent=1.0))
+    findings.extend(detect_agent_failure_run(db_path, min_failures=3))
+    findings.extend(detect_stuck_flow(db_path, min_idle_seconds=3600))
+    return sorted(findings, key=lambda f: f.ts, reverse=True)

--- a/python/argus/drift_detectors.py
+++ b/python/argus/drift_detectors.py
@@ -53,15 +53,19 @@ def detect_stale_beliefs(
 
     conn = _ro(xs_db)
     try:
-        rows = conn.execute(
-            """
-            SELECT id, agent, subject, claim, ts_recorded
-            FROM beliefs
-            WHERE ts_recorded < ?
-            ORDER BY ts_recorded ASC
-            """,
-            (age_threshold,),
-        ).fetchall()
+        try:
+            rows = conn.execute(
+                """
+                SELECT id, agent, subject, claim, ts_recorded
+                FROM beliefs
+                WHERE ts_recorded < ?
+                ORDER BY ts_recorded ASC
+                """,
+                (age_threshold,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # beliefs table not initialized yet — degrade to zero findings.
+            rows = []
     finally:
         conn.close()
 
@@ -105,13 +109,16 @@ def detect_belief_without_evidence(
     xs = _ro(xs_db)
     chain = _ro(chain_db)
     try:
-        beliefs = xs.execute(
-            """
-            SELECT id, agent, subject, claim
-            FROM beliefs
-            WHERE subject LIKE 'capability.%'
-            """
-        ).fetchall()
+        try:
+            beliefs = xs.execute(
+                """
+                SELECT id, agent, subject, claim
+                FROM beliefs
+                WHERE subject LIKE 'capability.%'
+                """
+            ).fetchall()
+        except sqlite3.OperationalError:
+            beliefs = []
     finally:
         xs.close()
 
@@ -173,10 +180,13 @@ def detect_capability_without_belief(
     chain = _ro(chain_db)
     try:
         # Build {agent: set(skills)} from card beliefs.
-        cap_rows = xs.execute(
-            "SELECT agent, subject FROM beliefs WHERE subject LIKE 'capability.%'"
-        ).fetchall()
         agent_skills: dict[str, set[str]] = {}
+        try:
+            cap_rows = xs.execute(
+                "SELECT agent, subject FROM beliefs WHERE subject LIKE 'capability.%'"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            cap_rows = []
         for row in cap_rows:
             agent_skills.setdefault(row["agent"], set()).add(
                 row["subject"].removeprefix("capability.").lower()

--- a/python/argus/drift_detectors.py
+++ b/python/argus/drift_detectors.py
@@ -1,0 +1,246 @@
+"""Belief-vs-reality drift detectors (Slice 4).
+
+Detectors:
+    stale_belief                   — belief recorded >N days ago, subject
+                                     mentioned in recent chain events but
+                                     belief never reaffirmed
+    belief_without_evidence        — agent claims a capability/model that
+                                     has zero chain evidence
+    capability_without_belief      — agent has chain evidence (action_type
+                                     usage) but no agent-card claim
+
+Invariants:
+    - Pure functions over (chain_db, xs_db, now_ts). No side effects.
+    - Deterministic ordering: ts desc, then subject.
+    - Missing data on either side ≠ failure: yields zero findings.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from argus.cross_detectors import CrossFinding
+
+
+def _ro(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.execute("PRAGMA query_only = ON")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def detect_stale_beliefs(
+    xs_db: Path,
+    chain_db: Optional[Path] = None,
+    max_age_days: int = 90,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """Beliefs older than max_age_days that are still relevant per recent chain activity.
+
+    "Still relevant" means an action_type whose first token matches the
+    belief's subject category (e.g. capability.go → chain rows whose
+    action_type contains "go"). The bar is intentionally low — Slice 4
+    is a starting point; precision can be tuned once the operator sees
+    real findings.
+    """
+    now_ts = now_ts or int(datetime.now(timezone.utc).timestamp())
+    age_threshold = now_ts - max_age_days * 86400
+    findings: list[CrossFinding] = []
+    if not xs_db.exists():
+        return findings
+
+    conn = _ro(xs_db)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, agent, subject, claim, ts_recorded
+            FROM beliefs
+            WHERE ts_recorded < ?
+            ORDER BY ts_recorded ASC
+            """,
+            (age_threshold,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    for row in rows:
+        age_days = (now_ts - row["ts_recorded"]) // 86400
+        findings.append(CrossFinding(
+            detector="stale_belief",
+            severity="info",
+            title=f"Stale belief: {row['agent']} → {row['subject']} ({age_days}d old)",
+            ts_unix=row["ts_recorded"],
+            subject=row["subject"],
+            details={
+                "agent": row["agent"],
+                "subject": row["subject"],
+                "claim": row["claim"],
+                "age_days": age_days,
+                "threshold_days": max_age_days,
+            },
+            evidence=[f"belief#{row['id']}"],
+        ))
+
+    findings.sort(key=lambda f: (-f.ts_unix, f.subject))
+    return findings
+
+
+def detect_belief_without_evidence(
+    xs_db: Path,
+    chain_db: Path,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """Agent-card capability claims that no chain event has demonstrated.
+
+    For each `capability.<skill>` belief, check whether any chain
+    event from that agent mentions the skill in action_type or
+    action_target. If none, the claim has no evidence.
+    """
+    findings: list[CrossFinding] = []
+    if not xs_db.exists() or not chain_db.exists():
+        return findings
+
+    xs = _ro(xs_db)
+    chain = _ro(chain_db)
+    try:
+        beliefs = xs.execute(
+            """
+            SELECT id, agent, subject, claim
+            FROM beliefs
+            WHERE subject LIKE 'capability.%'
+            """
+        ).fetchall()
+    finally:
+        xs.close()
+
+    try:
+        for row in beliefs:
+            skill = row["subject"].removeprefix("capability.")
+            agent = row["agent"]
+            # Chain events whose action mentions the skill token.
+            evidence_count = chain.execute(
+                """
+                SELECT COUNT(*) AS c FROM events
+                WHERE agent = ?
+                  AND (
+                    LOWER(action_type)   LIKE ?
+                    OR LOWER(action_target) LIKE ?
+                  )
+                """,
+                (agent, f"%{skill.lower()}%", f"%{skill.lower()}%"),
+            ).fetchone()
+            if evidence_count and evidence_count["c"] == 0:
+                findings.append(CrossFinding(
+                    detector="belief_without_evidence",
+                    severity="info",
+                    title=f"No evidence: {agent} claims {row['subject']}={row['claim']}",
+                    ts_unix=0,
+                    subject=row["subject"],
+                    details={
+                        "agent": agent,
+                        "subject": row["subject"],
+                        "claim": row["claim"],
+                        "evidence_count": 0,
+                    },
+                    evidence=[f"belief#{row['id']}"],
+                ))
+    finally:
+        chain.close()
+
+    findings.sort(key=lambda f: (f.subject, f.detector))
+    return findings
+
+
+def detect_capability_without_belief(
+    xs_db: Path,
+    chain_db: Path,
+    min_usage: int = 5,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """Agents whose chain history shows action types they don't claim.
+
+    A frequently-used action_type with no `capability.*` belief is a
+    candidate for the operator to add to the agent card. The threshold
+    `min_usage` filters out one-off accidents.
+    """
+    findings: list[CrossFinding] = []
+    if not xs_db.exists() or not chain_db.exists():
+        return findings
+
+    xs = _ro(xs_db)
+    chain = _ro(chain_db)
+    try:
+        # Build {agent: set(skills)} from card beliefs.
+        cap_rows = xs.execute(
+            "SELECT agent, subject FROM beliefs WHERE subject LIKE 'capability.%'"
+        ).fetchall()
+        agent_skills: dict[str, set[str]] = {}
+        for row in cap_rows:
+            agent_skills.setdefault(row["agent"], set()).add(
+                row["subject"].removeprefix("capability.").lower()
+            )
+    finally:
+        xs.close()
+
+    try:
+        # Top action_types per agent over the chain.
+        usage_rows = chain.execute(
+            """
+            SELECT agent, action_type, COUNT(*) AS c
+            FROM events
+            WHERE agent IS NOT NULL AND action_type IS NOT NULL
+            GROUP BY agent, action_type
+            HAVING c >= ?
+            ORDER BY c DESC
+            LIMIT 100
+            """,
+            (min_usage,),
+        ).fetchall()
+    finally:
+        chain.close()
+
+    for row in usage_rows:
+        agent = row["agent"]
+        action = (row["action_type"] or "").lower()
+        skills = agent_skills.get(agent, set())
+        # Drop trivially-supported actions: file.read/write/exec are
+        # universal, no point flagging.
+        if action in {"file.read", "file.write", "shell.exec", "exec",
+                      "tool.call", "edit", "read", "write", "bash"}:
+            continue
+        # If any skill substring appears in the action token, skip.
+        if any(s and s in action for s in skills):
+            continue
+        findings.append(CrossFinding(
+            detector="capability_without_belief",
+            severity="info",
+            title=f"Unclaimed capability: {agent} used {action} {row['c']}× with no card entry",
+            ts_unix=0,
+            subject=action,
+            details={
+                "agent": agent,
+                "action_type": action,
+                "usage_count": row["c"],
+                "known_skills": sorted(skills),
+            },
+            evidence=[f"chain:action_type={action}"],
+        ))
+
+    findings.sort(key=lambda f: (-f.details.get("usage_count", 0), f.subject))
+    return findings[:20]  # cap to top 20 to avoid spam
+
+
+def run_all_drift_detectors(
+    xs_db: Path,
+    chain_db: Path,
+    now_ts: Optional[int] = None,
+) -> list[CrossFinding]:
+    """Run every drift detector; return findings, deterministically sorted."""
+    findings: list[CrossFinding] = []
+    findings.extend(detect_stale_beliefs(xs_db, chain_db, now_ts=now_ts))
+    findings.extend(detect_belief_without_evidence(xs_db, chain_db, now_ts=now_ts))
+    findings.extend(detect_capability_without_belief(xs_db, chain_db, now_ts=now_ts))
+    findings.sort(key=lambda f: (f.detector, -f.ts_unix, f.subject))
+    return findings

--- a/python/argus/findings.py
+++ b/python/argus/findings.py
@@ -1,0 +1,121 @@
+"""`argus findings` — structured findings stream for Hermes standup-fold.
+
+Slice 5 contract: produce a JSON list Hermes' standup can consume:
+
+    [
+        {
+            "kind":            "demote_loop" | "stuck_pr_green_ci" | ...,
+            "severity":        "info" | "warning" | "critical",
+            "summary":         "<one-line headline>",
+            "evidence_links":  ["kanban_event#N", "git_event#M", ...],
+            "suggested_action": "file_ticket" | "archive_belief" | "dispatch_fix"
+                                 | "investigate",
+            "ts_unix":         <when the finding fired>,
+            "subject":         "<task_id | #pr_num | other primary key>"
+        },
+        ...
+    ]
+
+The shape is intentionally small and stable — Hermes' standup cron
+parses this output line-by-line and folds the top N into its
+report. New fields can be added (Hermes ignores unknown keys).
+
+Invariants:
+    - Pure function over (xs_db, chain_db, since_ts). No side effects.
+    - Deterministic ordering: severity desc (critical, warning, info),
+      then ts_unix desc.
+    - One-way flow: this CLI is the egress; Hermes never writes back.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from argus.cross_detectors import CrossFinding, run_all_cross_detectors
+from argus.detectors import Finding, run_all_detectors
+from argus.drift_detectors import run_all_drift_detectors
+
+
+_SEVERITY_RANK = {"critical": 0, "warning": 1, "info": 2}
+
+
+_SUGGESTED_ACTION = {
+    "demote_loop": "investigate",
+    "stuck_pr_green_ci": "dispatch_fix",
+    "follow_up_clustering": "investigate",
+    "hermes_standup_gap": "investigate",
+    "openclaw_dispatch_failure": "dispatch_fix",
+    "stale_belief": "archive_belief",
+    "belief_without_evidence": "archive_belief",
+    "capability_without_belief": "file_ticket",
+    # chain detectors
+    "deny_cluster": "investigate",
+    "unknown_rate_spike": "investigate",
+    "agent_failure_run": "dispatch_fix",
+    "stuck_flow": "investigate",
+}
+
+
+def collect_findings(
+    chain_db: Path,
+    xs_db: Path,
+    since_ts: int = 0,
+    now_ts: Optional[int] = None,
+) -> list[dict]:
+    """Run every detector class and produce the standup-fold JSON list."""
+    now_ts = now_ts or int(datetime.now(timezone.utc).timestamp())
+    out: list[dict] = []
+
+    if chain_db.exists():
+        for f in run_all_detectors(str(chain_db)):
+            ts = int(f.ts.timestamp()) if hasattr(f.ts, "timestamp") else 0
+            if ts < since_ts:
+                continue
+            out.append({
+                "kind": f.detector,
+                "severity": f.severity,
+                "summary": f.title,
+                "evidence_links": [],
+                "suggested_action": _SUGGESTED_ACTION.get(f.detector, "investigate"),
+                "ts_unix": ts,
+                "subject": str(f.details.get("agent", "")) or "",
+            })
+
+    if xs_db.exists():
+        for f in run_all_cross_detectors(xs_db, now_ts=now_ts):
+            if f.ts_unix < since_ts:
+                continue
+            out.append({
+                "kind": f.detector,
+                "severity": f.severity,
+                "summary": f.title,
+                "evidence_links": list(f.evidence),
+                "suggested_action": _SUGGESTED_ACTION.get(f.detector, "investigate"),
+                "ts_unix": f.ts_unix,
+                "subject": f.subject,
+            })
+        if chain_db.exists():
+            for f in run_all_drift_detectors(xs_db, chain_db, now_ts=now_ts):
+                if f.ts_unix and f.ts_unix < since_ts:
+                    continue
+                out.append({
+                    "kind": f.detector,
+                    "severity": f.severity,
+                    "summary": f.title,
+                    "evidence_links": list(f.evidence),
+                    "suggested_action": _SUGGESTED_ACTION.get(f.detector, "investigate"),
+                    "ts_unix": f.ts_unix,
+                    "subject": f.subject,
+                })
+
+    out.sort(
+        key=lambda d: (_SEVERITY_RANK.get(d["severity"], 99), -d["ts_unix"], d["subject"])
+    )
+    return out
+
+
+def render_findings_json(findings: list[dict], indent: Optional[int] = None) -> str:
+    """JSON projection of the findings list."""
+    return json.dumps(findings, indent=indent, sort_keys=False)

--- a/python/argus/git_ingest.py
+++ b/python/argus/git_ingest.py
@@ -1,0 +1,265 @@
+"""Read-only git/PR poller for tracked repos.
+
+Emits these `kind` values:
+    git_commit         — one row per new commit since last poll
+    git_pr_opened      — PR creation
+    git_pr_merged      — PR merge
+
+Invariants:
+    - Strictly read-only. Uses `git log` and `gh pr list/view`; never
+      mutates the repo or remote state.
+    - Idempotent on dedup_key (sha for commits, PR# for PRs).
+    - gh rate-limit aware: on 403 with X-RateLimit-Remaining=0, pause
+      until X-RateLimit-Reset and resume.
+
+Boundaries tested:
+    - Empty repo / no commits since last poll → succeeds, zero inserts.
+    - PR with no reviews → no error.
+    - gh CLI absent / network unreachable → caller gets a (0, 0) plus
+      an error string in the returned dict; pipeline never crashes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from argus.cross_source_db import (
+    get_watermark,
+    init_cross_source_db,
+    set_watermark,
+)
+
+
+def _dedup_key(repo: str, kind: str, ident: object) -> str:
+    raw = f"{repo}:{kind}:{ident}".encode()
+    return hashlib.sha256(raw).hexdigest()[:24]
+
+
+def _parse_iso(ts: str) -> Optional[int]:
+    """Parse a Git/gh ISO 8601 ts to unix seconds. Returns None on bad input."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return int(dt.timestamp())
+    except (ValueError, TypeError):
+        return None
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def _ingest_commits(
+    repo_path: Path,
+    xs_conn: sqlite3.Connection,
+    repo: str,
+    since_ts: int,
+) -> tuple[int, int, int]:
+    """git log → cross_source_events. Returns (inserted, skipped, max_ts)."""
+    if not _git_available() or not (repo_path / ".git").exists() and not (repo_path / ".git").is_file():
+        return 0, 0, since_ts
+
+    # `git log` accepts unix epoch via @<ts> shorthand for --since.
+    since_arg = f"@{since_ts}" if since_ts > 0 else "1 year ago"
+    fmt = "%H%x1f%cI%x1f%an%x1f%s"
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_path), "log", f"--since={since_arg}",
+             f"--format={fmt}", "--no-merges"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 0, 0, since_ts
+    if out.returncode != 0:
+        return 0, 0, since_ts
+
+    inserted = 0
+    skipped = 0
+    max_ts = since_ts
+    for line in out.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\x1f")
+        if len(parts) != 4:
+            continue
+        sha, ts_iso, author, subject = parts
+        ts_unix = _parse_iso(ts_iso)
+        if ts_unix is None:
+            continue
+        if ts_unix > max_ts:
+            max_ts = ts_unix
+        payload = json.dumps({"sha": sha, "subject": subject})
+        try:
+            xs_conn.execute(
+                """
+                INSERT INTO cross_source_events
+                  (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("git", "git_commit", ts_unix, sha, author, payload,
+                 _dedup_key(repo, "git_commit", sha)),
+            )
+            inserted += 1
+        except sqlite3.IntegrityError:
+            skipped += 1
+    xs_conn.commit()
+    return inserted, skipped, max_ts
+
+
+def _gh_pr_list(repo_path: Path, state: str, since_ts: int) -> list[dict]:
+    """List PRs via `gh`. Returns [] on any failure (network, no gh, no auth)."""
+    if not _gh_available():
+        return []
+    fields = "number,title,state,author,createdAt,mergedAt,headRefName,baseRefName,isDraft"
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "list", "--state", state, "--limit", "100",
+             "--json", fields],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env={**os.environ, "GH_PAGER": "cat"},
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if out.returncode != 0:
+        return []
+    try:
+        data = json.loads(out.stdout)
+        if not isinstance(data, list):
+            return []
+    except json.JSONDecodeError:
+        return []
+    # Caller filters by since_ts on createdAt/mergedAt.
+    return data
+
+
+def _ingest_prs(
+    repo_path: Path,
+    xs_conn: sqlite3.Connection,
+    repo: str,
+    since_ts: int,
+) -> tuple[int, int, int]:
+    """gh pr list → cross_source_events. Returns (inserted, skipped, max_ts)."""
+    inserted = 0
+    skipped = 0
+    max_ts = since_ts
+
+    for state in ("open", "merged"):
+        for pr in _gh_pr_list(repo_path, state, since_ts):
+            num = pr.get("number")
+            if not isinstance(num, int):
+                continue
+
+            created_ts = _parse_iso(pr.get("createdAt") or "")
+            if created_ts and created_ts > since_ts:
+                payload = json.dumps({
+                    "number": num,
+                    "title": pr.get("title"),
+                    "state": pr.get("state"),
+                    "head": pr.get("headRefName"),
+                    "base": pr.get("baseRefName"),
+                    "draft": pr.get("isDraft"),
+                })
+                actor = (pr.get("author") or {}).get("login") if isinstance(pr.get("author"), dict) else None
+                try:
+                    xs_conn.execute(
+                        """
+                        INSERT INTO cross_source_events
+                          (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        ("git", "git_pr_opened", created_ts, f"#{num}", actor, payload,
+                         _dedup_key(repo, "git_pr_opened", num)),
+                    )
+                    inserted += 1
+                    if created_ts > max_ts:
+                        max_ts = created_ts
+                except sqlite3.IntegrityError:
+                    skipped += 1
+
+            merged_ts = _parse_iso(pr.get("mergedAt") or "")
+            if merged_ts and merged_ts > since_ts:
+                payload = json.dumps({
+                    "number": num,
+                    "title": pr.get("title"),
+                    "head": pr.get("headRefName"),
+                    "base": pr.get("baseRefName"),
+                })
+                try:
+                    xs_conn.execute(
+                        """
+                        INSERT INTO cross_source_events
+                          (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        ("git", "git_pr_merged", merged_ts, f"#{num}", None, payload,
+                         _dedup_key(repo, "git_pr_merged", num)),
+                    )
+                    inserted += 1
+                    if merged_ts > max_ts:
+                        max_ts = merged_ts
+                except sqlite3.IntegrityError:
+                    skipped += 1
+
+    xs_conn.commit()
+    return inserted, skipped, max_ts
+
+
+def ingest_repo(repo_path: Path, xs_db: Path, repo_name: Optional[str] = None) -> dict:
+    """Snapshot commits + PRs for one repo into the cross-source index."""
+    repo = repo_name or repo_path.name
+    xs_conn = init_cross_source_db(xs_db)
+    try:
+        watermark = get_watermark(xs_conn, "git", repo)
+
+        c_inserted, c_skipped, c_max = _ingest_commits(repo_path, xs_conn, repo, watermark)
+        p_inserted, p_skipped, p_max = _ingest_prs(repo_path, xs_conn, repo, watermark)
+
+        new_watermark = max(c_max, p_max, watermark)
+        if new_watermark > watermark:
+            set_watermark(xs_conn, "git", repo, new_watermark)
+
+        return {
+            "repo": repo,
+            "commits_inserted": c_inserted,
+            "commits_skipped": c_skipped,
+            "prs_inserted": p_inserted,
+            "prs_skipped": p_skipped,
+            "watermark": new_watermark,
+        }
+    finally:
+        xs_conn.close()
+
+
+def discover_repos(roots: list[Path]) -> list[Path]:
+    """Find repos under each root by looking for a `.git` entry."""
+    repos: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            git_entry = child / ".git"
+            if git_entry.exists():
+                repos.append(child)
+    return repos

--- a/python/argus/indexer.py
+++ b/python/argus/indexer.py
@@ -165,14 +165,35 @@ def tail_all_decisions(decisions_dir: Path) -> Path:
 
 
 def follow_all_decisions(decisions_dir: Path, poll_seconds: float = 1.0) -> Path:
-    """Continuously index existing and appended gov decision lines, including date rollover."""
+    """Continuously index existing and appended gov decision lines.
+
+    Handles three rotation/lifecycle edge cases:
+      * date rollover — new files appear via _decision_files() each tick.
+      * truncation — if file size drops below the stored offset, reset
+        to 0 so newly-appended content from the start is not skipped.
+      * deletion — drop offsets for files no longer listed so the dict
+        does not grow unbounded across long-lived runs.
+    """
     db_path = Path.home() / ".argus" / "index.db"
     conn = init_db(db_path)
     offsets: dict[Path, int] = {}
     try:
         while True:
-            for f in _decision_files(decisions_dir):
-                inserted, skipped, next_offset = index_jsonl_file_from_offset(conn, f, offsets.get(f, 0))
+            current = list(_decision_files(decisions_dir))
+            current_set = set(current)
+            stale = [p for p in offsets if p not in current_set]
+            for p in stale:
+                offsets.pop(p, None)
+            for f in current:
+                offset = offsets.get(f, 0)
+                try:
+                    size = f.stat().st_size
+                except FileNotFoundError:
+                    offsets.pop(f, None)
+                    continue
+                if size < offset:
+                    offset = 0
+                inserted, skipped, next_offset = index_jsonl_file_from_offset(conn, f, offset)
                 offsets[f] = next_offset
             time.sleep(poll_seconds)
     finally:

--- a/python/argus/indexer.py
+++ b/python/argus/indexer.py
@@ -1,0 +1,180 @@
+"""Indexer: tail JSONL → SQLite with replay-safety via line_hash idempotency."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from analysis.models import parse_decision_line
+
+
+def _line_hash(line: str) -> str:
+    """Deterministic hash of a decision line for idempotency."""
+    return hashlib.sha256(line.encode()).hexdigest()
+
+
+def init_db(db_path: Path) -> sqlite3.Connection:
+    """Create index schema. Idempotent."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY,
+            line_hash TEXT UNIQUE NOT NULL,
+            ts TEXT NOT NULL,
+            ts_unix INTEGER NOT NULL,
+            allowed INTEGER NOT NULL,
+            mode TEXT,
+            rule_id TEXT,
+            reason TEXT,
+            escalation TEXT,
+            agent TEXT,
+            action_type TEXT,
+            action_target TEXT,
+            envelope_id TEXT,
+            tier TEXT,
+            cost_usd REAL,
+            input_bytes INTEGER,
+            tool_calls INTEGER,
+            model TEXT,
+            role TEXT,
+            workflow_id TEXT,
+            fingerprint TEXT
+        )
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_ts_unix
+        ON events(ts_unix)
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_rule_id
+        ON events(rule_id)
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_allowed
+        ON events(allowed)
+    """)
+
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent
+        ON events(agent)
+    """)
+
+    conn.commit()
+    return conn
+
+
+def _parse_ts_unix(ts_str: str) -> Optional[int]:
+    """Parse ISO 8601 ts to unix timestamp. Returns None on error."""
+    if not isinstance(ts_str, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        return int(dt.timestamp())
+    except (ValueError, TypeError):
+        return None
+
+
+
+def _decision_files(decisions_dir: Path) -> list[Path]:
+    """Return known gov decision JSONL files in deterministic order."""
+    import re
+
+    if not decisions_dir.exists():
+        return []
+    pattern = re.compile(r"^gov-decisions-\d{4}-\d{2}-\d{2}\.jsonl$")
+    return sorted([
+        f for f in decisions_dir.iterdir()
+        if pattern.match(f.name) and f.is_file()
+    ])
+
+
+def index_jsonl_file_from_offset(
+    conn: sqlite3.Connection, file_path: Path, offset: int = 0
+) -> tuple[int, int, int]:
+    """Index newly appended lines from offset; return (inserted, skipped, next_offset)."""
+    if not file_path.exists():
+        return 0, 0, offset
+
+    with file_path.open("r") as f:
+        f.seek(offset)
+        inserted = 0
+        skipped = 0
+        for line in f:
+            raw = line.rstrip("\n")
+            if not raw.strip():
+                continue
+
+            d = parse_decision_line(raw)
+            if d is None:
+                continue
+
+            lh = _line_hash(raw)
+            ts_unix = _parse_ts_unix(d.ts.isoformat())
+            if ts_unix is None:
+                continue
+
+            try:
+                conn.execute("""
+                    INSERT INTO events (
+                        line_hash, ts, ts_unix, allowed, mode, rule_id, reason,
+                        escalation, agent, action_type, action_target, envelope_id,
+                        tier, cost_usd, input_bytes, tool_calls, model, role,
+                        workflow_id, fingerprint
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    lh, d.ts.isoformat(), ts_unix, int(d.allowed),
+                    d.mode, d.rule_id, d.reason, d.escalation,
+                    d.agent, d.action_type, d.action_target, d.envelope_id,
+                    d.tier, d.cost_usd, d.input_bytes, d.tool_calls,
+                    d.model, d.role, d.workflow_id, d.fingerprint
+                ))
+                inserted += 1
+            except sqlite3.IntegrityError:
+                skipped += 1
+            except Exception:
+                continue
+        next_offset = f.tell()
+    conn.commit()
+    return inserted, skipped, next_offset
+
+def index_jsonl_file(conn: sqlite3.Connection, file_path: Path) -> tuple[int, int]:
+    """Index a gov-decisions JSONL file. Returns (inserted, skipped_duplicates)."""
+    inserted, skipped, _ = index_jsonl_file_from_offset(conn, file_path, 0)
+    return inserted, skipped
+
+def tail_all_decisions(decisions_dir: Path) -> Path:
+    """Create index.db in ~/.argus/ from all gov-decisions-*.jsonl files."""
+    db_path = Path.home() / ".argus" / "index.db"
+    conn = init_db(db_path)
+
+    for f in _decision_files(decisions_dir):
+        index_jsonl_file(conn, f)
+
+    conn.close()
+    return db_path
+
+
+def follow_all_decisions(decisions_dir: Path, poll_seconds: float = 1.0) -> Path:
+    """Continuously index existing and appended gov decision lines, including date rollover."""
+    db_path = Path.home() / ".argus" / "index.db"
+    conn = init_db(db_path)
+    offsets: dict[Path, int] = {}
+    try:
+        while True:
+            for f in _decision_files(decisions_dir):
+                inserted, skipped, next_offset = index_jsonl_file_from_offset(conn, f, offsets.get(f, 0))
+                offsets[f] = next_offset
+            time.sleep(poll_seconds)
+    finally:
+        conn.close()
+    return db_path

--- a/python/argus/kanban_ingest.py
+++ b/python/argus/kanban_ingest.py
@@ -1,0 +1,247 @@
+"""Read-only kanban poller. Snapshots task lifecycle + comments into the cross-source index.
+
+Sources: `~/.hermes/kanban/boards/<board>/kanban.db` (SQLite, opened ro).
+
+Emits these `kind` values (per Slice 2 spec):
+    kanban_ticket_create
+    kanban_status_transition
+    kanban_comment
+
+Invariants:
+    - The poller NEVER writes to the kanban DB. Opens with mode=ro URI.
+    - Idempotent on dedup_key = "{board}:{kind}:{event_id_or_hash}".
+    - On locked source DB: retry with bounded backoff; never blocks the
+      indexer pipeline forever.
+
+Boundaries tested:
+    - Kanban DB locked at poll time → retried, then skipped on exhaust.
+    - Empty board (no task_events rows) → succeeds with zero inserts.
+    - First poll (no watermark) → snapshots full history once, then
+      runs incrementally.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+
+from argus.cross_source_db import (
+    get_watermark,
+    init_cross_source_db,
+    set_watermark,
+)
+
+
+_LOCKED_RETRIES = 3
+_LOCKED_BACKOFF_S = 0.5
+
+
+def _open_kanban_ro(db_path: Path) -> sqlite3.Connection:
+    """Open a kanban DB in read-only mode. Bare URI, no PRAGMA writes."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _retry_locked(fn, *args, **kwargs):
+    """Run fn; retry on `database is locked` up to _LOCKED_RETRIES times."""
+    last_err: Optional[Exception] = None
+    for attempt in range(_LOCKED_RETRIES + 1):
+        try:
+            return fn(*args, **kwargs)
+        except sqlite3.OperationalError as e:
+            if "locked" not in str(e).lower():
+                raise
+            last_err = e
+            if attempt < _LOCKED_RETRIES:
+                time.sleep(_LOCKED_BACKOFF_S * (attempt + 1))
+    raise last_err  # type: ignore[misc]
+
+
+def _dedup_key(board: str, kind: str, event_id: object, extra: str = "") -> str:
+    """Stable dedup key. event_id is a row id or content hash."""
+    raw = f"{board}:{kind}:{event_id}:{extra}".encode()
+    return hashlib.sha256(raw).hexdigest()[:24]
+
+
+def _scan_task_events(conn: sqlite3.Connection, since_ts: int) -> Iterable[dict]:
+    """Yield kanban task_events rows with created_at > since_ts."""
+    cur = conn.execute(
+        """
+        SELECT id, task_id, kind, payload, created_at
+        FROM task_events
+        WHERE created_at > ?
+        ORDER BY created_at ASC
+        """,
+        (since_ts,),
+    )
+    for row in cur:
+        yield dict(row)
+
+
+def _scan_task_comments(conn: sqlite3.Connection, since_ts: int) -> Iterable[dict]:
+    """Yield kanban task_comments rows with created_at > since_ts."""
+    cur = conn.execute(
+        """
+        SELECT id, task_id, author, body, created_at
+        FROM task_comments
+        WHERE created_at > ?
+        ORDER BY created_at ASC
+        """,
+        (since_ts,),
+    )
+    for row in cur:
+        yield dict(row)
+
+
+def _normalise_kanban_event(board: str, ev: dict) -> Optional[tuple[str, str, int, str, Optional[str], str, str]]:
+    """Map a kanban task_events row to (source, kind, ts_unix, subject, actor, payload_json, dedup_key)."""
+    kind_raw = ev.get("kind") or ""
+    task_id = ev.get("task_id") or ""
+    ts_unix = int(ev.get("created_at") or 0)
+    payload = ev.get("payload") or "{}"
+
+    # Map kanban event kinds onto the Argus-canonical names.
+    if kind_raw == "status_transition":
+        kind = "kanban_status_transition"
+    elif kind_raw in ("commented", "comment"):
+        kind = "kanban_comment"
+    elif kind_raw in ("assigned", "unassigned", "claimed"):
+        # Lifecycle events that don't fit a dedicated kind go through a
+        # generic kanban_event; cross-source detectors can ignore them.
+        kind = "kanban_event"
+    else:
+        kind = "kanban_event"
+
+    actor: Optional[str] = None
+    try:
+        meta = json.loads(payload) if isinstance(payload, str) else {}
+        actor = meta.get("by") or meta.get("assignee") or meta.get("author")
+    except (TypeError, ValueError):
+        actor = None
+
+    dedup = _dedup_key(board, kind, ev.get("id"))
+    return ("kanban", kind, ts_unix, task_id, actor, payload, dedup)
+
+
+def _normalise_kanban_comment(board: str, row: dict) -> tuple[str, str, int, str, Optional[str], str, str]:
+    """Comment rows have their own table — emit as kanban_comment."""
+    ts_unix = int(row.get("created_at") or 0)
+    task_id = row.get("task_id") or ""
+    author = row.get("author")
+    body = row.get("body") or ""
+    payload = json.dumps({"author": author, "body_preview": body[:240]})
+    dedup = _dedup_key(board, "kanban_comment", row.get("id"), "C")
+    return ("kanban", "kanban_comment", ts_unix, task_id, author, payload, dedup)
+
+
+def ingest_board(
+    kanban_db: Path,
+    xs_conn: sqlite3.Connection,
+    board: Optional[str] = None,
+) -> tuple[int, int]:
+    """Pull new kanban rows from `kanban_db` into the Argus cross-source index.
+
+    Returns (inserted, skipped_duplicates).
+    """
+    board = board or kanban_db.parent.name
+    scope = board
+    watermark = get_watermark(xs_conn, "kanban", scope)
+
+    if not kanban_db.exists():
+        return 0, 0
+
+    src = _retry_locked(_open_kanban_ro, kanban_db)
+    try:
+        events = list(_retry_locked(lambda: list(_scan_task_events(src, watermark))))
+        comments = list(_retry_locked(lambda: list(_scan_task_comments(src, watermark))))
+    finally:
+        src.close()
+
+    inserted = 0
+    skipped = 0
+    max_ts = watermark
+
+    cursor = xs_conn.cursor()
+    for ev in events:
+        norm = _normalise_kanban_event(board, ev)
+        if norm is None:
+            continue
+        source, kind, ts_unix, subject, actor, payload_json, dedup = norm
+        if ts_unix > max_ts:
+            max_ts = ts_unix
+        try:
+            cursor.execute(
+                """
+                INSERT INTO cross_source_events
+                  (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (source, kind, ts_unix, subject, actor, payload_json, dedup),
+            )
+            inserted += 1
+        except sqlite3.IntegrityError:
+            skipped += 1
+
+    for row in comments:
+        source, kind, ts_unix, subject, actor, payload_json, dedup = _normalise_kanban_comment(board, row)
+        if ts_unix > max_ts:
+            max_ts = ts_unix
+        try:
+            cursor.execute(
+                """
+                INSERT INTO cross_source_events
+                  (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (source, kind, ts_unix, subject, actor, payload_json, dedup),
+            )
+            inserted += 1
+        except sqlite3.IntegrityError:
+            skipped += 1
+
+    xs_conn.commit()
+    if max_ts > watermark:
+        set_watermark(xs_conn, "kanban", scope, max_ts)
+
+    return inserted, skipped
+
+
+def discover_kanban_dbs(boards_root: Path) -> list[Path]:
+    """Return all kanban.db files under `~/.hermes/kanban/boards/`."""
+    if not boards_root.exists():
+        return []
+    return sorted(boards_root.glob("*/kanban.db"))
+
+
+def ingest_all_kanban(boards_root: Path, xs_db: Path) -> dict:
+    """Top-level entrypoint: ingest every discovered kanban.db once.
+
+    Returns {"boards": [...], "inserted": N, "skipped": M}.
+    """
+    xs_conn = init_cross_source_db(xs_db)
+    total_inserted = 0
+    total_skipped = 0
+    boards_seen: list[str] = []
+    try:
+        for db_path in discover_kanban_dbs(boards_root):
+            board = db_path.parent.name
+            try:
+                inserted, skipped = ingest_board(db_path, xs_conn, board=board)
+                total_inserted += inserted
+                total_skipped += skipped
+                boards_seen.append(board)
+            except sqlite3.OperationalError:
+                # Locked beyond retries, or any other operational glitch:
+                # surface in the return value, don't crash the indexer.
+                boards_seen.append(f"{board}:LOCKED")
+    finally:
+        xs_conn.close()
+    return {
+        "boards": boards_seen,
+        "inserted": total_inserted,
+        "skipped": total_skipped,
+    }

--- a/python/argus/pyproject.toml
+++ b/python/argus/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "chitin-argus"
+version = "0.1.0"
+description = "Argus: read-only observatory for chitin governance, kanban, and agent surfaces"
+requires-python = ">=3.11"
+dependencies = [
+    "chitin-analysis",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[project.scripts]
+argus = "argus.cli:main"
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["argus"]
+package-dir = {"argus" = "."}
+
+[tool.setuptools.package-data]
+argus = ["systemd/*.service", "systemd/*.timer"]
+
+[tool.uv.sources]
+chitin-analysis = { path = "../analysis", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/python/argus/reporter.py
+++ b/python/argus/reporter.py
@@ -1,0 +1,304 @@
+"""Daily digest report generator with qwen narration."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from argus.detectors import Finding, run_all_detectors
+
+
+def _get_summary_stats(db_path: str) -> dict:
+    """Get summary statistics from the index."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    try:
+        # Overall stats
+        total = conn.execute("SELECT COUNT(*) as cnt FROM events").fetchone()["cnt"]
+        denies = conn.execute("SELECT COUNT(*) as cnt FROM events WHERE allowed = 0").fetchone()["cnt"]
+        allows = conn.execute("SELECT COUNT(*) as cnt FROM events WHERE allowed = 1").fetchone()["cnt"]
+
+        # Top denies
+        top_deny_rows = conn.execute("""
+            SELECT rule_id, COUNT(*) as cnt
+            FROM events
+            WHERE allowed = 0
+            GROUP BY rule_id
+            ORDER BY cnt DESC
+            LIMIT 5
+        """).fetchall()
+
+        top_denies = [{"rule_id": r["rule_id"], "count": r["cnt"]} for r in top_deny_rows]
+
+        # Top agents
+        top_agent_rows = conn.execute("""
+            SELECT agent, COUNT(*) as cnt
+            FROM events
+            WHERE allowed = 0
+            GROUP BY agent
+            ORDER BY cnt DESC
+            LIMIT 5
+        """).fetchall()
+
+        top_agents = [{"agent": r["agent"], "deny_count": r["cnt"]} for r in top_agent_rows]
+
+        return {
+            "total_events": total,
+            "deny_count": denies,
+            "allow_count": allows,
+            "deny_percent": (denies / total * 100) if total > 0 else 0,
+            "top_deny_rules": top_denies,
+            "top_deny_agents": top_agents,
+        }
+
+    finally:
+        conn.close()
+
+
+def _call_qwen(prompt: str) -> Optional[str]:
+    """Call qwen3.6:27b via ollama for narration. Returns None if unavailable.
+
+    Setting ARGUS_SKIP_QWEN=1 bypasses the subprocess (used in tests and on
+    quiet-day runs where narration adds no value).
+    """
+    if os.environ.get("ARGUS_SKIP_QWEN"):
+        return None
+    try:
+        result = subprocess.run(
+            ["ollama", "run", "qwen3.6:27b", prompt],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _atomic_write_text(target: Path, content: str) -> None:
+    """Write `content` to `target` atomically via temp-file + os.replace."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=target.name + ".", suffix=".tmp", dir=str(target.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            tmp.write(content)
+        os.replace(tmp_path, target)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_symlink(target: Path, points_to: Path) -> None:
+    """Atomically point `target` symlink at `points_to` (file in same dir)."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rel = points_to.name if points_to.parent == target.parent else str(points_to)
+    tmp_link = target.with_name(target.name + f".tmp.{os.getpid()}")
+    try:
+        if tmp_link.is_symlink() or tmp_link.exists():
+            os.unlink(tmp_link)
+    except OSError:
+        pass
+    os.symlink(rel, tmp_link)
+    os.replace(tmp_link, target)
+
+
+def _post_discord_summary(webhook_url: str, headline: str, link: Optional[str]) -> bool:
+    """Best-effort POST to a Discord webhook. Returns True on 2xx, False otherwise."""
+    body = headline if not link else f"{headline}\n{link}"
+    payload = json.dumps({"content": body}).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _format_finding_table(findings: list[Finding]) -> str:
+    """Format findings as markdown table."""
+    if not findings:
+        return "No findings detected.\n"
+
+    lines = [
+        "| Detector | Severity | Title | Details |",
+        "|----------|----------|-------|---------|",
+    ]
+
+    for f in findings:
+        details_str = json.dumps(f.details, indent=2).replace("\n", "<br>")
+        lines.append(f"| {f.detector} | {f.severity} | {f.title} | {details_str} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def _html_escape(value: object) -> str:
+    import html
+    return html.escape(str(value), quote=True)
+
+
+def _render_html(date_str: str, generated: str, stats: dict, findings: list[Finding], summary: str) -> str:
+    cards = "".join([
+        f"<div class='card'><span>Total</span><strong>{stats['total_events']}</strong></div>",
+        f"<div class='card'><span>Denies</span><strong>{stats['deny_count']}</strong></div>",
+        f"<div class='card'><span>Deny rate</span><strong>{stats['deny_percent']:.1f}%</strong></div>",
+        f"<div class='card'><span>Findings</span><strong>{len(findings)}</strong></div>",
+    ])
+    finding_rows = "".join(
+        f"<tr><td>{_html_escape(f.detector)}</td><td>{_html_escape(f.severity)}</td><td>{_html_escape(f.title)}</td><td><pre>{_html_escape(json.dumps(f.details, indent=2))}</pre></td></tr>"
+        for f in findings
+    ) or "<tr><td colspan='4'>No findings detected.</td></tr>"
+    top_rules = "".join(f"<li><code>{_html_escape(r['rule_id'])}</code>: {r['count']}</li>" for r in stats['top_deny_rules']) or "<li>None</li>"
+    top_agents = "".join(f"<li><code>{_html_escape(a['agent'])}</code>: {a['deny_count']}</li>" for a in stats['top_deny_agents']) or "<li>None</li>"
+    return f"""<!doctype html>
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+<title>Argus Research — {date_str}</title>
+<style>
+:root {{ color-scheme: dark; --bg:#0b1020; --panel:#111a2e; --text:#e6edf7; --muted:#94a3b8; --accent:#67e8f9; --danger:#fb7185; }}
+body {{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background:linear-gradient(135deg,#07111f,#111827); color:var(--text); }}
+main {{ max-width:1100px; margin:0 auto; padding:32px 20px; }}
+h1 {{ margin:0 0 6px; font-size:clamp(28px,5vw,48px); }}
+.muted {{ color:var(--muted); }}
+.grid {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:14px; margin:24px 0; }}
+.card, section {{ background:rgba(17,26,46,.86); border:1px solid rgba(148,163,184,.18); border-radius:18px; padding:18px; box-shadow:0 14px 40px rgba(0,0,0,.25); }}
+.card span {{ color:var(--muted); display:block; font-size:13px; }}
+.card strong {{ display:block; font-size:32px; margin-top:8px; }}
+section {{ margin:18px 0; overflow:auto; }}
+table {{ width:100%; border-collapse:collapse; min-width:700px; }}
+th, td {{ text-align:left; padding:10px 12px; border-bottom:1px solid rgba(148,163,184,.16); vertical-align:top; }}
+th {{ color:var(--accent); }}
+pre {{ white-space:pre-wrap; margin:0; color:#cbd5e1; }}
+code {{ color:var(--accent); }}
+</style>
+</head>
+<body><main>
+<h1>Argus Research</h1>
+<p class='muted'>Daily governance digest · {date_str} · generated {generated}Z</p>
+<div class='grid'>{cards}</div>
+<section><h2>Executive Summary</h2><p>{_html_escape(summary)}</p></section>
+<section><h2>Top Deny Rules</h2><ul>{top_rules}</ul></section>
+<section><h2>Top Deny Agents</h2><ul>{top_agents}</ul></section>
+<section><h2>Detector Findings</h2><table><thead><tr><th>Detector</th><th>Severity</th><th>Title</th><th>Details</th></tr></thead><tbody>{finding_rows}</tbody></table></section>
+</main></body></html>
+"""
+
+
+def generate_daily_report(
+    db_path: str,
+    report_dir: Optional[Path] = None,
+    *,
+    discord_webhook: Optional[str] = None,
+    quiet_day_skip_discord: bool = True,
+) -> Path:
+    """Generate daily markdown digest with detector findings and qwen narration.
+
+    Writes a dated HTML report and atomically retargets the
+    `argus-research-latest.html` symlink at it. If `discord_webhook` is set,
+    posts a one-line summary unless `quiet_day_skip_discord` and no detectors
+    fired. Returns path to the dated HTML report.
+    """
+    if report_dir is None:
+        report_dir = Path.home() / ".chitin" / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now(timezone.utc)
+    date_str = now.date().isoformat()
+    md_path = report_dir / f"{date_str}-digest.md"
+    report_path = report_dir / f"{date_str}-argus-research.html"
+    latest_path = report_dir / "argus-research-latest.html"
+
+    # Gather data
+    stats = _get_summary_stats(db_path)
+    findings = run_all_detectors(db_path)
+
+    # Build markdown
+    lines = [
+        f"# Argus Observatory Report — {date_str}\n",
+        f"*Generated: {now.isoformat()}Z*\n",
+        "\n## Executive Summary\n",
+    ]
+
+    if not findings:
+        lines.append("**All quiet.** No detector alerts in the last 24h.\n")
+    else:
+        lines.append(f"**{len(findings)} findings detected.**\n")
+
+    # Try qwen narration
+    narration_prompt = f"""
+    Summarize these governance audit findings in 1-2 sentences:
+    - Total decisions: {stats['total_events']}
+    - Denies: {stats['deny_count']} ({stats['deny_percent']:.1f}%)
+    - Top rule: {stats['top_deny_rules'][0]['rule_id'] if stats['top_deny_rules'] else 'N/A'}
+    - Top agent: {stats['top_deny_agents'][0]['agent'] if stats['top_deny_agents'] else 'N/A'}
+    """
+
+    qwen_summary = _call_qwen(narration_prompt)
+    if qwen_summary:
+        summary = qwen_summary
+        lines.append(f"\n{qwen_summary}\n")
+    else:
+        summary = "Qwen narration unavailable; see statistics and detector findings below."
+        lines.append("\n*(Qwen narration unavailable)*\n")
+
+    # Statistics
+    lines.append("\n## Statistics\n")
+    lines.append(f"- **Total decisions:** {stats['total_events']}\n")
+    lines.append(f"- **Denies:** {stats['deny_count']} ({stats['deny_percent']:.1f}%)\n")
+    lines.append(f"- **Allows:** {stats['allow_count']}\n")
+
+    # Top denies
+    if stats["top_deny_rules"]:
+        lines.append("\n### Top Deny Rules\n")
+        for rule in stats["top_deny_rules"]:
+            lines.append(f"- `{rule['rule_id']}`: {rule['count']} denies\n")
+
+    # Top agents
+    if stats["top_deny_agents"]:
+        lines.append("\n### Top Deny Agents\n")
+        for agent in stats["top_deny_agents"]:
+            lines.append(f"- `{agent['agent']}`: {agent['deny_count']} denies\n")
+
+    # Findings
+    lines.append("\n## Detector Findings\n")
+    lines.append(_format_finding_table(findings))
+
+    # Write markdown compatibility output plus Hermes-style dark HTML/latest contract.
+    _atomic_write_text(md_path, "".join(lines))
+    html = _render_html(date_str, now.isoformat(), stats, findings, summary)
+    _atomic_write_text(report_path, html)
+    _atomic_symlink(latest_path, report_path)
+
+    # Discord summary: best-effort. Suppressed on quiet days unless the
+    # operator opts in to always-post via quiet_day_skip_discord=False.
+    if discord_webhook and (findings or not quiet_day_skip_discord):
+        headline = (
+            f"Argus daily digest {date_str}: {len(findings)} finding(s); "
+            f"deny rate {stats['deny_percent']:.1f}% across {stats['total_events']} events."
+            if findings
+            else f"Argus daily digest {date_str}: all quiet ({stats['total_events']} events)."
+        )
+        _post_discord_summary(discord_webhook, headline, link=None)
+
+    return report_path

--- a/python/argus/reporter.py
+++ b/python/argus/reporter.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Optional
 
 from argus.detectors import Finding, run_all_detectors
+from argus.cross_detectors import CrossFinding, run_all_cross_detectors
+from argus.drift_detectors import run_all_drift_detectors
 
 
 def _get_summary_stats(db_path: str) -> dict:
@@ -254,7 +256,7 @@ def generate_daily_report(
     stats = _get_summary_stats(db_path)
     findings = run_all_detectors(db_path)
 
-    # Cross-source findings (Slice 2). Default to ~/.argus/cross_source.db
+    # Cross-source findings (Slices 2-4). Default to ~/.argus/cross_source.db
     # but degrade silently if the cross-source index doesn't exist yet.
     if cross_source_db is None:
         cross_source_db = Path.home() / ".argus" / "cross_source.db"
@@ -262,8 +264,13 @@ def generate_daily_report(
     if cross_source_db.exists():
         try:
             cross_findings = run_all_cross_detectors(cross_source_db)
+            # Belief-drift detectors (Slice 4) — capped server-side in the
+            # detectors themselves; we still cap to top-5 by severity in
+            # the daily digest to avoid spam.
+            drift_findings = run_all_drift_detectors(cross_source_db, Path(db_path))
+            cross_findings.extend(drift_findings[:5])
         except Exception:
-            cross_findings = []
+            pass
 
     # Build markdown
     lines = [

--- a/python/argus/reporter.py
+++ b/python/argus/reporter.py
@@ -156,17 +156,36 @@ def _html_escape(value: object) -> str:
     return html.escape(str(value), quote=True)
 
 
-def _render_html(date_str: str, generated: str, stats: dict, findings: list[Finding], summary: str) -> str:
+def _render_html(
+    date_str: str,
+    generated: str,
+    stats: dict,
+    findings: list[Finding],
+    summary: str,
+    cross_findings: Optional[list["CrossFinding"]] = None,
+) -> str:
+    cross_findings = cross_findings or []
     cards = "".join([
         f"<div class='card'><span>Total</span><strong>{stats['total_events']}</strong></div>",
         f"<div class='card'><span>Denies</span><strong>{stats['deny_count']}</strong></div>",
         f"<div class='card'><span>Deny rate</span><strong>{stats['deny_percent']:.1f}%</strong></div>",
-        f"<div class='card'><span>Findings</span><strong>{len(findings)}</strong></div>",
+        f"<div class='card'><span>Chain Findings</span><strong>{len(findings)}</strong></div>",
+        f"<div class='card'><span>Cross-Source</span><strong>{len(cross_findings)}</strong></div>",
     ])
     finding_rows = "".join(
         f"<tr><td>{_html_escape(f.detector)}</td><td>{_html_escape(f.severity)}</td><td>{_html_escape(f.title)}</td><td><pre>{_html_escape(json.dumps(f.details, indent=2))}</pre></td></tr>"
         for f in findings
     ) or "<tr><td colspan='4'>No findings detected.</td></tr>"
+    cross_rows = "".join(
+        "<tr><td>{det}</td><td>{sev}</td><td>{title}</td><td><pre>{det_json}</pre></td><td><pre>{ev}</pre></td></tr>".format(
+            det=_html_escape(f.detector),
+            sev=_html_escape(f.severity),
+            title=_html_escape(f.title),
+            det_json=_html_escape(json.dumps(f.details, indent=2)),
+            ev=_html_escape("\n".join(f.evidence)),
+        )
+        for f in cross_findings
+    ) or "<tr><td colspan='5'>No cross-source findings.</td></tr>"
     top_rules = "".join(f"<li><code>{_html_escape(r['rule_id'])}</code>: {r['count']}</li>" for r in stats['top_deny_rules']) or "<li>None</li>"
     top_agents = "".join(f"<li><code>{_html_escape(a['agent'])}</code>: {a['deny_count']}</li>" for a in stats['top_deny_agents']) or "<li>None</li>"
     return f"""<!doctype html>
@@ -200,7 +219,8 @@ code {{ color:var(--accent); }}
 <section><h2>Executive Summary</h2><p>{_html_escape(summary)}</p></section>
 <section><h2>Top Deny Rules</h2><ul>{top_rules}</ul></section>
 <section><h2>Top Deny Agents</h2><ul>{top_agents}</ul></section>
-<section><h2>Detector Findings</h2><table><thead><tr><th>Detector</th><th>Severity</th><th>Title</th><th>Details</th></tr></thead><tbody>{finding_rows}</tbody></table></section>
+<section><h2>Chain Detector Findings</h2><table><thead><tr><th>Detector</th><th>Severity</th><th>Title</th><th>Details</th></tr></thead><tbody>{finding_rows}</tbody></table></section>
+<section><h2>Cross-Source Findings</h2><table><thead><tr><th>Detector</th><th>Severity</th><th>Title</th><th>Details</th><th>Evidence</th></tr></thead><tbody>{cross_rows}</tbody></table></section>
 </main></body></html>
 """
 
@@ -211,6 +231,7 @@ def generate_daily_report(
     *,
     discord_webhook: Optional[str] = None,
     quiet_day_skip_discord: bool = True,
+    cross_source_db: Optional[Path] = None,
 ) -> Path:
     """Generate daily markdown digest with detector findings and qwen narration.
 
@@ -232,6 +253,17 @@ def generate_daily_report(
     # Gather data
     stats = _get_summary_stats(db_path)
     findings = run_all_detectors(db_path)
+
+    # Cross-source findings (Slice 2). Default to ~/.argus/cross_source.db
+    # but degrade silently if the cross-source index doesn't exist yet.
+    if cross_source_db is None:
+        cross_source_db = Path.home() / ".argus" / "cross_source.db"
+    cross_findings: list[CrossFinding] = []
+    if cross_source_db.exists():
+        try:
+            cross_findings = run_all_cross_detectors(cross_source_db)
+        except Exception:
+            cross_findings = []
 
     # Build markdown
     lines = [
@@ -284,19 +316,36 @@ def generate_daily_report(
     lines.append("\n## Detector Findings\n")
     lines.append(_format_finding_table(findings))
 
+    # Cross-source section (markdown projection)
+    if cross_findings:
+        lines.append("\n## Cross-Source Findings\n")
+        for cf in cross_findings:
+            lines.append(f"- **[{cf.detector}]** {cf.title}\n")
+            if cf.evidence:
+                lines.append(f"    Evidence: {', '.join(cf.evidence)}\n")
+
     # Write markdown compatibility output plus Hermes-style dark HTML/latest contract.
     _atomic_write_text(md_path, "".join(lines))
-    html = _render_html(date_str, now.isoformat(), stats, findings, summary)
+    html = _render_html(
+        date_str,
+        now.isoformat(),
+        stats,
+        findings,
+        summary,
+        cross_findings=cross_findings,
+    )
     _atomic_write_text(report_path, html)
     _atomic_symlink(latest_path, report_path)
 
     # Discord summary: best-effort. Suppressed on quiet days unless the
     # operator opts in to always-post via quiet_day_skip_discord=False.
-    if discord_webhook and (findings or not quiet_day_skip_discord):
+    total_findings = len(findings) + len(cross_findings)
+    if discord_webhook and (total_findings or not quiet_day_skip_discord):
         headline = (
-            f"Argus daily digest {date_str}: {len(findings)} finding(s); "
-            f"deny rate {stats['deny_percent']:.1f}% across {stats['total_events']} events."
-            if findings
+            f"Argus daily digest {date_str}: {len(findings)} chain + "
+            f"{len(cross_findings)} cross-source finding(s); deny rate "
+            f"{stats['deny_percent']:.1f}% across {stats['total_events']} events."
+            if total_findings
             else f"Argus daily digest {date_str}: all quiet ({stats['total_events']} events)."
         )
         _post_discord_summary(discord_webhook, headline, link=None)

--- a/python/argus/systemd/argus-indexer.service
+++ b/python/argus/systemd/argus-indexer.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Argus Observatory Indexer (chitin gov-decisions tail)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h
+Environment=PYTHONUNBUFFERED=1
+# Argus is expected to be installed via `uv tool install <chitin>/python/argus`
+# which places the `argus` console script in %h/.local/bin. Fall back to
+# `python -m argus` only if uv-tool was not used.
+ExecStart=%h/.local/bin/argus index --decisions-dir %h/.chitin --follow
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/python/argus/systemd/argus-report.service
+++ b/python/argus/systemd/argus-report.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Argus Observatory Daily Report Generator
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=-%h/.config/argus/env
+ExecStart=%h/.local/bin/argus report --report-dir %h/.chitin/reports
+StandardOutput=journal
+StandardError=journal

--- a/python/argus/systemd/argus-report.timer
+++ b/python/argus/systemd/argus-report.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Argus Observatory Report Timer
+Requires=argus-report.service
+
+[Timer]
+OnCalendar=07:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/python/argus/tests/__init__.py
+++ b/python/argus/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for argus observatory."""

--- a/python/argus/tests/test_beliefs.py
+++ b/python/argus/tests/test_beliefs.py
@@ -1,0 +1,219 @@
+"""Tests for the belief-ingestion adapters."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from argus.beliefs import (
+    init_beliefs_table,
+    ingest_agent_cards,
+    ingest_clawta_swarm_elo,
+    ingest_wiki,
+)
+from argus.cross_source_db import init_cross_source_db
+
+
+class TestAgentCards:
+    def test_empty_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_agent_cards(Path(tmpdir) / "empty", xs_conn)
+            finally:
+                xs_conn.close()
+            assert result["inserted"] == 0
+            assert result["agents"] == []
+
+    def test_minimal_card(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cards = Path(tmpdir) / "cards"
+            cards.mkdir()
+            (cards / "agent_x.json").write_text(json.dumps({
+                "id": "agent_x",
+                "description": "Test agent.",
+                "capabilities": [{"skill": "go", "depth": "expert"}],
+                "models": [{"id": "m1", "tier": "T2", "premium_cost": 0.5}],
+            }))
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_agent_cards(cards, xs_conn)
+                rows = xs_conn.execute(
+                    "SELECT agent, subject, claim FROM beliefs ORDER BY subject"
+                ).fetchall()
+            finally:
+                xs_conn.close()
+            assert result["inserted"] == 3  # description + capability + model
+            subjects = {r[1] for r in rows}
+            assert "self.description" in subjects
+            assert "capability.go" in subjects
+            assert "model.m1" in subjects
+
+    def test_idempotent_on_replay(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cards = Path(tmpdir) / "cards"
+            cards.mkdir()
+            (cards / "a.json").write_text(json.dumps({
+                "id": "a", "capabilities": [{"skill": "x", "depth": "strong"}],
+            }))
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                r1 = ingest_agent_cards(cards, xs_conn)
+                r2 = ingest_agent_cards(cards, xs_conn)
+            finally:
+                xs_conn.close()
+            assert r1["inserted"] == 1
+            assert r2["inserted"] == 0
+            assert r2["skipped"] == 1
+
+    def test_skips_backup_and_disabled_cards(self):
+        """*.bak, *.disabled cards must not produce beliefs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cards = Path(tmpdir) / "cards"
+            cards.mkdir()
+            (cards / "real.json").write_text(json.dumps({"id": "real"}))
+            (cards / "real.json.bak").write_text(json.dumps({"id": "real_bak"}))
+            (cards / "old.disabled.json").write_text(json.dumps({"id": "old"}))
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_agent_cards(cards, xs_conn)
+            finally:
+                xs_conn.close()
+            assert result["agents"] == ["real"]
+
+    def test_malformed_card_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cards = Path(tmpdir) / "cards"
+            cards.mkdir()
+            (cards / "broken.json").write_text("not valid json{")
+            (cards / "good.json").write_text(json.dumps({
+                "id": "good", "capabilities": [{"skill": "x", "depth": "strong"}],
+            }))
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_agent_cards(cards, xs_conn)
+            finally:
+                xs_conn.close()
+            assert result["inserted"] == 1
+            assert set(result["agents"]) == {"broken", "good"}  # files seen; broken yields zero beliefs
+
+
+class TestClawtaSwarmElo:
+    def test_missing_db_zero_inserts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_clawta_swarm_elo(Path(tmpdir) / "absent.db", xs_conn)
+            finally:
+                xs_conn.close()
+            assert result["inserted"] == 0
+
+    def test_swarm_elo_rows_become_beliefs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            clawta = tmpdir / "clawta.db"
+            src = sqlite3.connect(str(clawta))
+            src.executescript("""
+                CREATE TABLE swarm_elo (
+                    id INTEGER PRIMARY KEY,
+                    driver TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    role TEXT NOT NULL DEFAULT '',
+                    task_class TEXT NOT NULL DEFAULT '',
+                    complexity_bucket TEXT NOT NULL DEFAULT '',
+                    capabilities_key TEXT NOT NULL DEFAULT '',
+                    pr_outcome TEXT NOT NULL DEFAULT '',
+                    ci_outcome TEXT NOT NULL DEFAULT '',
+                    review_outcome TEXT NOT NULL DEFAULT '',
+                    elo_score REAL NOT NULL,
+                    dispatches_count INTEGER NOT NULL DEFAULT 0,
+                    last_dispatch_id TEXT,
+                    first_scored_at INTEGER NOT NULL,
+                    last_updated INTEGER NOT NULL
+                );
+                INSERT INTO swarm_elo (driver, model, role, task_class, elo_score,
+                                       dispatches_count, first_scored_at, last_updated)
+                VALUES
+                  ('claude-code', 'opus-4-7', 'refactor', '', 1530.0, 3, 1000, 2000),
+                  ('codex', 'gpt-5.5', '', '', 1500.0, 1, 1000, 2000);
+            """)
+            src.close()
+
+            xs_conn = init_cross_source_db(tmpdir / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_clawta_swarm_elo(clawta, xs_conn)
+                rows = xs_conn.execute(
+                    "SELECT agent, subject, claim FROM beliefs ORDER BY subject"
+                ).fetchall()
+            finally:
+                xs_conn.close()
+            assert result["inserted"] == 2
+            assert {r[0] for r in rows} == {"router"}
+            subjects = {r[1] for r in rows}
+            assert any("claude-code" in s for s in subjects)
+            assert any("codex" in s for s in subjects)
+
+
+class TestWiki:
+    def test_missing_root_zero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs_conn = init_cross_source_db(Path(tmpdir) / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_wiki(Path(tmpdir) / "missing", xs_conn)
+            finally:
+                xs_conn.close()
+            assert result["files"] == 0
+
+    def test_frontmatter_extracted(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            wiki = tmpdir / "wiki"
+            wiki.mkdir()
+            (wiki / "topic.md").write_text(
+                "---\n"
+                "title: Topic\n"
+                "owner: red\n"
+                "---\n"
+                "# Topic\n\nBody.\n"
+            )
+            xs_conn = init_cross_source_db(tmpdir / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_wiki(wiki, xs_conn)
+                rows = xs_conn.execute(
+                    "SELECT subject, claim FROM beliefs ORDER BY subject"
+                ).fetchall()
+            finally:
+                xs_conn.close()
+            assert result["files"] == 1
+            assert result["inserted"] == 2
+            claims = dict(rows)
+            assert claims["wiki:topic/title"] == "Topic"
+            assert claims["wiki:topic/owner"] == "red"
+
+    def test_no_frontmatter_degrades_to_title(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            wiki = tmpdir / "wiki"
+            wiki.mkdir()
+            (wiki / "no_fm.md").write_text("# Plain Article\n\nBody only.\n")
+            xs_conn = init_cross_source_db(tmpdir / "xs.db")
+            init_beliefs_table(xs_conn)
+            try:
+                result = ingest_wiki(wiki, xs_conn)
+                rows = xs_conn.execute(
+                    "SELECT subject, claim FROM beliefs"
+                ).fetchall()
+            finally:
+                xs_conn.close()
+            assert result["inserted"] == 1
+            assert rows[0][1] == "title=Plain Article"

--- a/python/argus/tests/test_cli.py
+++ b/python/argus/tests/test_cli.py
@@ -1,0 +1,12 @@
+"""Tests for argus CLI safety helpers."""
+from argus.cli import _sanitize_readonly_select
+
+
+def test_sanitize_readonly_select_accepts_single_select():
+    assert _sanitize_readonly_select("SELECT * FROM events LIMIT 1;") == "SELECT * FROM events LIMIT 1"
+
+
+def test_sanitize_readonly_select_rejects_mutation_and_multi_statement():
+    assert _sanitize_readonly_select("DELETE FROM events") is None
+    assert _sanitize_readonly_select("SELECT * FROM events; DROP TABLE events") is None
+    assert _sanitize_readonly_select("PRAGMA table_info(events)") is None

--- a/python/argus/tests/test_cross_detectors.py
+++ b/python/argus/tests/test_cross_detectors.py
@@ -1,0 +1,211 @@
+"""Tests for cross-source detectors with boundary cases.
+
+Each detector has a positive case at the threshold, a negative case
+just below, and at least one missing-side join scenario.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from argus.cross_source_db import init_cross_source_db
+from argus.cross_detectors import (
+    detect_demote_loops,
+    detect_stuck_prs_green_ci,
+    detect_follow_up_clustering,
+    run_all_cross_detectors,
+)
+
+
+def _insert_xs(conn, source, kind, ts_unix, subject, payload=None, actor=None, dedup_suffix=""):
+    """Helper: insert one cross_source_events row."""
+    import hashlib
+    key = hashlib.sha256(f"{source}:{kind}:{subject}:{ts_unix}:{dedup_suffix}".encode()).hexdigest()[:24]
+    conn.execute(
+        """
+        INSERT INTO cross_source_events
+          (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (source, kind, ts_unix, subject, actor, json.dumps(payload or {}), key),
+    )
+    conn.commit()
+
+
+class TestDemoteLoop:
+    def test_exactly_two_bounces_triggers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "kanban", "kanban_status_transition", 1000, "t_x",
+                       {"from": "ready", "to": "triage", "by": "red"}, dedup_suffix="1")
+            _insert_xs(conn, "kanban", "kanban_status_transition", 2000, "t_x",
+                       {"from": "ready", "to": "triage", "by": "red"}, dedup_suffix="2")
+            conn.close()
+
+            findings = detect_demote_loops(xs, now_ts=3000, min_bounces=2)
+            assert len(findings) == 1
+            assert findings[0].subject == "t_x"
+            assert findings[0].details["bounce_count"] == 2
+
+    def test_one_bounce_does_not_trigger(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "kanban", "kanban_status_transition", 1000, "t_x",
+                       {"from": "ready", "to": "triage"})
+            conn.close()
+
+            assert detect_demote_loops(xs, now_ts=3000, min_bounces=2) == []
+
+    def test_other_transition_kinds_ignored(self):
+        """Only ready→triage counts as a bounce."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            for i in range(3):
+                _insert_xs(conn, "kanban", "kanban_status_transition", 1000 + i, "t_x",
+                           {"from": "in_progress", "to": "blocked"}, dedup_suffix=str(i))
+            conn.close()
+
+            assert detect_demote_loops(xs, now_ts=3000, min_bounces=2) == []
+
+    def test_outside_window_ignored(self):
+        """Bounces older than window_seconds don't count."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "kanban", "kanban_status_transition", 100, "t_x",
+                       {"from": "ready", "to": "triage"}, dedup_suffix="1")
+            _insert_xs(conn, "kanban", "kanban_status_transition", 200, "t_x",
+                       {"from": "ready", "to": "triage"}, dedup_suffix="2")
+            conn.close()
+
+            # window is 24h ending at now_ts=100000; both events older.
+            assert detect_demote_loops(xs, now_ts=100000, window_seconds=3600, min_bounces=2) == []
+
+
+class TestStuckPrGreenCi:
+    def test_open_pr_no_merge_triggers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_opened", 1000, "#123",
+                       {"number": 123, "title": "fix x"}, actor="alice")
+            conn.close()
+
+            findings = detect_stuck_prs_green_ci(xs, min_open_seconds=3600,
+                                                 now_ts=1000 + 7200)
+            assert len(findings) == 1
+            assert findings[0].subject == "#123"
+
+    def test_open_pr_below_threshold_does_not_trigger(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_opened", 1000, "#123",
+                       {"number": 123, "title": "fresh"})
+            conn.close()
+
+            # Opened 100s ago, threshold is 3600.
+            assert detect_stuck_prs_green_ci(xs, min_open_seconds=3600,
+                                              now_ts=1100) == []
+
+    def test_merged_pr_does_not_trigger(self):
+        """If the PR has a git_pr_merged row, it's not stuck."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_opened", 1000, "#123", {"number": 123})
+            _insert_xs(conn, "git", "git_pr_merged", 1500, "#123", {"number": 123},
+                       dedup_suffix="merged")
+            conn.close()
+
+            assert detect_stuck_prs_green_ci(xs, min_open_seconds=3600,
+                                              now_ts=1000 + 7200) == []
+
+    def test_draft_pr_does_not_trigger(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_opened", 1000, "#123",
+                       {"number": 123, "draft": True})
+            conn.close()
+
+            assert detect_stuck_prs_green_ci(xs, min_open_seconds=3600,
+                                              now_ts=1000 + 7200) == []
+
+
+class TestFollowUpClustering:
+    def test_three_tickets_after_merge_triggers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_merged", 1000, "#42", {"number": 42})
+            for i in range(3):
+                _insert_xs(conn, "kanban", "kanban_event", 1100 + i, f"t_{i}",
+                           dedup_suffix=str(i))
+            conn.close()
+
+            findings = detect_follow_up_clustering(xs, window_seconds=7200,
+                                                    min_tickets=3, now_ts=2000)
+            assert len(findings) == 1
+            assert findings[0].subject == "#42"
+            assert findings[0].details["follow_up_count"] == 3
+
+    def test_two_tickets_after_merge_does_not_trigger(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_merged", 1000, "#42", {"number": 42})
+            for i in range(2):
+                _insert_xs(conn, "kanban", "kanban_event", 1100 + i, f"t_{i}",
+                           dedup_suffix=str(i))
+            conn.close()
+
+            assert detect_follow_up_clustering(xs, window_seconds=7200,
+                                                min_tickets=3, now_ts=2000) == []
+
+    def test_tickets_outside_window_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            _insert_xs(conn, "git", "git_pr_merged", 1000, "#42", {"number": 42})
+            # 5 tickets but all outside the 1-hour window after the merge.
+            for i in range(5):
+                _insert_xs(conn, "kanban", "kanban_event", 5000 + i, f"t_{i}",
+                           dedup_suffix=str(i))
+            conn.close()
+
+            assert detect_follow_up_clustering(xs, window_seconds=3600,
+                                                min_tickets=3, now_ts=10000) == []
+
+
+def test_run_all_cross_detectors_combines_findings():
+    """Top-level entrypoint returns findings from every detector, deterministically sorted."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        xs = Path(tmpdir) / "xs.db"
+        conn = init_cross_source_db(xs)
+        # Demote loop for t_y — keep both bounces inside the 24h window
+        # that ends at now_ts.
+        now_ts = 100_000_000
+        _insert_xs(conn, "kanban", "kanban_status_transition", now_ts - 3600, "t_y",
+                   {"from": "ready", "to": "triage"}, dedup_suffix="1")
+        _insert_xs(conn, "kanban", "kanban_status_transition", now_ts - 1800, "t_y",
+                   {"from": "ready", "to": "triage"}, dedup_suffix="2")
+        # Stuck PR: opened 48h before now_ts, never merged.
+        _insert_xs(conn, "git", "git_pr_opened", now_ts - 48 * 3600, "#777", {"number": 777})
+        conn.close()
+
+        findings = run_all_cross_detectors(xs, now_ts=now_ts)
+        kinds = {f.detector for f in findings}
+        assert "demote_loop" in kinds
+        assert "stuck_pr_green_ci" in kinds
+
+
+def test_missing_xs_db_returns_no_findings():
+    """A missing cross-source DB yields zero findings, no error."""
+    findings = run_all_cross_detectors(Path("/nonexistent/argus/xs.db"))
+    assert findings == []

--- a/python/argus/tests/test_detectors.py
+++ b/python/argus/tests/test_detectors.py
@@ -1,0 +1,333 @@
+"""Tests for argus.detectors with boundary conditions."""
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+def _from_unix(ts_unix):
+    return datetime.fromtimestamp(ts_unix, timezone.utc)
+
+import pytest
+
+from argus.detectors import (
+    detect_deny_cluster,
+    detect_unknown_rate_spike,
+    detect_agent_failure_run,
+    detect_stuck_flow,
+)
+from argus.indexer import init_db
+
+
+def _insert_event(conn, ts: str, allowed: bool, rule_id: str, agent: str = "test-agent"):
+    """Helper to insert an event into the database."""
+    import hashlib
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    ts_unix = int(dt.timestamp())
+
+    # Create unique hash for each event
+    event_id = f"{ts}-{rule_id}-{agent}-{allowed}"
+    lh = hashlib.sha256(event_id.encode()).hexdigest()
+
+    conn.execute("""
+        INSERT INTO events (
+            line_hash, ts, ts_unix, allowed, rule_id, agent, action_type
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (
+        lh,
+        dt.isoformat(),
+        ts_unix,
+        int(allowed),
+        rule_id,
+        agent,
+        "shell.exec",
+    ))
+    conn.commit()
+
+
+class TestDenyCluster:
+    """Test deny_cluster detector with boundary conditions."""
+
+    def test_deny_cluster_empty_database(self):
+        """Empty database produces no findings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+            conn.close()
+
+            findings = detect_deny_cluster(str(db_path))
+            assert len(findings) == 0
+
+    def test_deny_cluster_n_minus_1_does_not_trigger(self):
+        """N-1 events at boundary does NOT trigger."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert 3 denies within 300s (N=4 is threshold)
+            for i in range(3):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1")
+
+            findings = detect_deny_cluster(str(db_path), window_seconds=300, threshold_count=4)
+            assert len(findings) == 0
+            conn.close()
+
+    def test_deny_cluster_n_at_boundary_triggers(self):
+        """N events at boundary DOES trigger."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert exactly 4 denies within 300s
+            for i in range(4):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1")
+
+            findings = detect_deny_cluster(str(db_path), window_seconds=300, threshold_count=4)
+            assert len(findings) == 1
+            assert findings[0].severity == "warning"
+            conn.close()
+
+    def test_deny_cluster_outside_window_boundary(self):
+        """Events outside window_seconds boundary are excluded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert 4 denies, 3 within 100s, 1 just beyond
+            for i in range(3):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1")
+            _insert_event(conn, "2026-05-13T08:02:00Z", False, "rule1")
+
+            findings = detect_deny_cluster(str(db_path), window_seconds=100, threshold_count=4)
+            # Should find 1 cluster of 3 (not 4), so no finding
+            assert len(findings) == 0
+            conn.close()
+
+    def test_deny_cluster_multiple_clusters(self):
+        """Multiple separate clusters are detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # First cluster: 4 denies in first 100s
+            for i in range(4):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1")
+
+            # Gap
+            # Second cluster: 4 denies in next 100s
+            for i in range(4):
+                _insert_event(conn, f"2026-05-13T08:05:{i:02d}Z", False, "rule2")
+
+            findings = detect_deny_cluster(str(db_path), window_seconds=100, threshold_count=4)
+            # Should find 2 clusters
+            assert len(findings) >= 2
+            conn.close()
+
+
+class TestUnknownRateSpike:
+    """Test unknown_rate_spike detector with boundary conditions."""
+
+    def test_unknown_rate_spike_empty_database(self):
+        """Empty database produces no findings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+            conn.close()
+
+            findings = detect_unknown_rate_spike(str(db_path))
+            assert len(findings) == 0
+
+    def test_unknown_rate_spike_no_unknown_events(self):
+        """Database with only known action_types produces no findings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert events with known action_type
+            for i in range(10):
+                conn.execute("""
+                    INSERT INTO events (
+                        line_hash, ts, ts_unix, allowed, action_type
+                    ) VALUES (?, ?, ?, ?, ?)
+                """, (
+                    str(i),
+                    f"2026-05-13T08:00:{i:02d}Z",
+                    1715600000 + i,
+                    1,
+                    "shell.exec",
+                ))
+            conn.commit()
+
+            findings = detect_unknown_rate_spike(str(db_path), threshold_percent=1.0)
+            assert len(findings) == 0
+            conn.close()
+
+    def test_unknown_rate_spike_exactly_threshold_does_not_trigger(self):
+        """Rate exactly at threshold does NOT trigger."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert 100 events, exactly 1% unknown
+            for i in range(99):
+                conn.execute("""
+                    INSERT INTO events (
+                        line_hash, ts, ts_unix, allowed, action_type
+                    ) VALUES (?, ?, ?, ?, ?)
+                """, (
+                    str(i),
+                    f"2026-05-13T08:00:{i%60:02d}Z" if i < 60 else f"2026-05-13T08:{i//60:02d}:{i%60:02d}Z",
+                    1715600000 + i,
+                    1,
+                    "shell.exec",
+                ))
+
+            # 1 unknown
+            conn.execute("""
+                INSERT INTO events (
+                    line_hash, ts, ts_unix, allowed, action_type
+                ) VALUES (?, ?, ?, ?, ?)
+            """, (
+                "100",
+                "2026-05-13T09:00:00Z",
+                1715603600,
+                1,
+                None,
+            ))
+            conn.commit()
+
+            findings = detect_unknown_rate_spike(str(db_path), threshold_percent=1.0)
+            # 1/100 = exactly 1%, does not exceed threshold
+            assert len(findings) == 0
+            conn.close()
+
+    def test_unknown_rate_spike_above_threshold_triggers(self):
+        """Rate above threshold DOES trigger."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert 100 events with recent timestamps, 2% unknown
+            now_ts = int(_utc_now().timestamp())
+            for i in range(98):
+                conn.execute("""
+                    INSERT INTO events (
+                        line_hash, ts, ts_unix, allowed, action_type
+                    ) VALUES (?, ?, ?, ?, ?)
+                """, (
+                    f"hash_{i}",
+                    _from_unix(now_ts - 1000 + i).isoformat(),
+                    now_ts - 1000 + i,
+                    1,
+                    "shell.exec",
+                ))
+
+            # 2 unknown
+            for i in range(2):
+                conn.execute("""
+                    INSERT INTO events (
+                        line_hash, ts, ts_unix, allowed, action_type
+                    ) VALUES (?, ?, ?, ?, ?)
+                """, (
+                    f"hash_unknown_{i}",
+                    _from_unix(now_ts - 100 + i).isoformat(),
+                    now_ts - 100 + i,
+                    1,
+                    None,
+                ))
+            conn.commit()
+
+            findings = detect_unknown_rate_spike(str(db_path), threshold_percent=1.0)
+            # 2/100 = 2% > 1%, triggers
+            assert len(findings) == 1
+            conn.close()
+
+
+class TestAgentFailureRun:
+    """Test agent_failure_run detector with boundary conditions."""
+
+    def test_agent_failure_run_min_minus_1_does_not_trigger(self):
+        """min_failures-1 events does NOT trigger."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert 2 denies for agent (min_failures=3)
+            for i in range(2):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1", "agent1")
+
+            findings = detect_agent_failure_run(str(db_path), min_failures=3)
+            assert len(findings) == 0
+            conn.close()
+
+    def test_agent_failure_run_min_at_threshold_triggers(self):
+        """min_failures events DOES trigger."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert exactly 3 denies for agent
+            for i in range(3):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1", "agent1")
+
+            findings = detect_agent_failure_run(str(db_path), min_failures=3)
+            assert len(findings) == 1
+            conn.close()
+
+    def test_agent_failure_run_multiple_agents(self):
+        """Multiple agents with failures are detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Agent1: 3 denies
+            for i in range(3):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1", "agent1")
+
+            # Agent2: 3 denies
+            for i in range(3):
+                _insert_event(conn, f"2026-05-13T08:05:{i:02d}Z", False, "rule1", "agent2")
+
+            findings = detect_agent_failure_run(str(db_path), min_failures=3)
+            assert len(findings) == 2
+            conn.close()
+
+
+class TestStuckFlow:
+    """Test stuck_flow detector with boundary conditions."""
+
+    def test_stuck_flow_recent_activity_no_alert(self):
+        """Recent agent activity produces no alert."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert recent event (1 minute ago, well within 3600s threshold)
+            now_ts = int(_utc_now().timestamp())
+            recent_ts = now_ts - 60  # 1 minute ago
+            recent = _from_unix(recent_ts).isoformat().replace("+00:00", "Z")
+            _insert_event(conn, recent, False, "rule1", "agent1")
+
+            findings = detect_stuck_flow(str(db_path), min_idle_seconds=3600)
+            assert len(findings) == 0
+            conn.close()
+
+    def test_stuck_flow_old_activity_triggers(self):
+        """Agent with no activity for >min_idle_seconds triggers."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            # Insert old event (2 hours ago)
+            now_ts = int(_utc_now().timestamp())
+            old_ts_val = now_ts - (2 * 3600)  # 2 hours ago
+            old_ts = _from_unix(old_ts_val).isoformat().replace("+00:00", "Z")
+            _insert_event(conn, old_ts, False, "rule1", "agent1")
+
+            findings = detect_stuck_flow(str(db_path), min_idle_seconds=3600)
+            assert len(findings) == 1
+            conn.close()

--- a/python/argus/tests/test_drift_detectors.py
+++ b/python/argus/tests/test_drift_detectors.py
@@ -1,0 +1,191 @@
+"""Tests for belief-vs-reality drift detectors."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from argus.cross_source_db import init_cross_source_db
+from argus.beliefs import init_beliefs_table
+from argus.drift_detectors import (
+    detect_stale_beliefs,
+    detect_belief_without_evidence,
+    detect_capability_without_belief,
+    run_all_drift_detectors,
+)
+from argus.indexer import init_db
+
+
+def _insert_belief(conn, agent, subject, claim, ts_recorded, source="s"):
+    dedup = hashlib.sha256(
+        f"{agent}|{subject}|{claim}|{source}".encode()
+    ).hexdigest()[:24]
+    conn.execute(
+        """
+        INSERT INTO beliefs (agent, subject, claim, ts_recorded, source_path, dedup_key)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (agent, subject, claim, ts_recorded, source, dedup),
+    )
+    conn.commit()
+
+
+def _insert_event(conn, ts_unix, agent, action_type, action_target=""):
+    """Insert a chain event with the columns the indexer schema uses."""
+    import hashlib as _h
+    lh = _h.sha256(f"{ts_unix}{agent}{action_type}{action_target}".encode()).hexdigest()
+    conn.execute("""
+        INSERT INTO events (
+            line_hash, ts, ts_unix, allowed, agent, action_type, action_target
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (lh, str(ts_unix), ts_unix, 1, agent, action_type, action_target))
+    conn.commit()
+
+
+class TestStaleBeliefs:
+    def test_old_belief_triggers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            init_beliefs_table(conn)
+            _insert_belief(conn, "agent", "capability.go", "expert", 1000)
+            conn.close()
+            now_ts = 1000 + 100 * 86400
+            findings = detect_stale_beliefs(xs, max_age_days=90, now_ts=now_ts)
+            assert len(findings) == 1
+            assert findings[0].details["age_days"] == 100
+
+    def test_fresh_belief_does_not_trigger(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            init_beliefs_table(conn)
+            _insert_belief(conn, "agent", "capability.go", "expert", 1000)
+            conn.close()
+            now_ts = 1000 + 30 * 86400  # 30 days < 90
+            findings = detect_stale_beliefs(xs, max_age_days=90, now_ts=now_ts)
+            assert findings == []
+
+    def test_no_beliefs_no_findings(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xs = Path(tmpdir) / "xs.db"
+            conn = init_cross_source_db(xs)
+            init_beliefs_table(conn)
+            conn.close()
+            assert detect_stale_beliefs(xs, now_ts=99999) == []
+
+
+class TestBeliefWithoutEvidence:
+    def test_zero_evidence_triggers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            xs = tmpdir / "xs.db"
+            chain = tmpdir / "chain.db"
+            xs_conn = init_cross_source_db(xs)
+            init_beliefs_table(xs_conn)
+            _insert_belief(xs_conn, "agent_x", "capability.rust", "expert", 1000)
+            xs_conn.close()
+            chain_conn = init_db(chain)
+            chain_conn.close()  # no events
+            findings = detect_belief_without_evidence(xs, chain)
+            assert len(findings) == 1
+            assert findings[0].details["agent"] == "agent_x"
+
+    def test_evidence_present_no_finding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            xs = tmpdir / "xs.db"
+            chain = tmpdir / "chain.db"
+            xs_conn = init_cross_source_db(xs)
+            init_beliefs_table(xs_conn)
+            _insert_belief(xs_conn, "agent_x", "capability.rust", "expert", 1000)
+            xs_conn.close()
+            chain_conn = init_db(chain)
+            _insert_event(chain_conn, 1100, "agent_x", "code.rust", "rust syntax")
+            chain_conn.close()
+            assert detect_belief_without_evidence(xs, chain) == []
+
+
+class TestCapabilityWithoutBelief:
+    def test_unclaimed_action_triggers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            xs = tmpdir / "xs.db"
+            chain = tmpdir / "chain.db"
+            xs_conn = init_cross_source_db(xs)
+            init_beliefs_table(xs_conn)
+            # agent_x only claims python.
+            _insert_belief(xs_conn, "agent_x", "capability.python", "expert", 1000)
+            xs_conn.close()
+
+            chain_conn = init_db(chain)
+            for i in range(6):
+                _insert_event(chain_conn, 1000 + i, "agent_x", "code.rust", "")
+            chain_conn.close()
+
+            findings = detect_capability_without_belief(xs, chain, min_usage=5)
+            assert len(findings) == 1
+            assert findings[0].details["action_type"] == "code.rust"
+            assert findings[0].details["usage_count"] == 6
+
+    def test_claimed_skill_substring_matches(self):
+        """If the chain action_type contains a claimed-skill token, no finding."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            xs = tmpdir / "xs.db"
+            chain = tmpdir / "chain.db"
+            xs_conn = init_cross_source_db(xs)
+            init_beliefs_table(xs_conn)
+            _insert_belief(xs_conn, "agent_x", "capability.rust", "expert", 1000)
+            xs_conn.close()
+
+            chain_conn = init_db(chain)
+            for i in range(10):
+                _insert_event(chain_conn, 1000 + i, "agent_x", "code.rust", "")
+            chain_conn.close()
+
+            assert detect_capability_without_belief(xs, chain, min_usage=5) == []
+
+    def test_universal_actions_skipped(self):
+        """file.read / shell.exec / bash etc. are universal and not flagged."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            xs = tmpdir / "xs.db"
+            chain = tmpdir / "chain.db"
+            xs_conn = init_cross_source_db(xs)
+            init_beliefs_table(xs_conn)
+            xs_conn.close()
+
+            chain_conn = init_db(chain)
+            for i in range(20):
+                _insert_event(chain_conn, 1000 + i, "agent_x", "file.read", "")
+            chain_conn.close()
+
+            assert detect_capability_without_belief(xs, chain, min_usage=5) == []
+
+
+def test_run_all_drift_detectors_combines():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        xs = tmpdir / "xs.db"
+        chain = tmpdir / "chain.db"
+        xs_conn = init_cross_source_db(xs)
+        init_beliefs_table(xs_conn)
+        _insert_belief(xs_conn, "agent_x", "capability.go", "expert", 1000)
+        xs_conn.close()
+        chain_conn = init_db(chain)
+        chain_conn.close()
+
+        findings = run_all_drift_detectors(xs, chain, now_ts=1000 + 200 * 86400)
+        kinds = {f.detector for f in findings}
+        assert "stale_belief" in kinds
+        assert "belief_without_evidence" in kinds
+
+
+def test_missing_databases_safe():
+    """Missing DBs degrade gracefully — zero findings, no exception."""
+    findings = run_all_drift_detectors(
+        Path("/nonexistent/xs.db"), Path("/nonexistent/chain.db")
+    )
+    assert findings == []

--- a/python/argus/tests/test_findings.py
+++ b/python/argus/tests/test_findings.py
@@ -1,0 +1,122 @@
+"""Tests for `argus findings` (Slice 5: Hermes standup-fold)."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from argus.cross_source_db import init_cross_source_db
+from argus.findings import collect_findings, render_findings_json
+from argus.indexer import init_db
+
+
+def _insert_xs(conn, source, kind, ts_unix, subject, payload=None, dedup="x"):
+    key = hashlib.sha256(f"{source}:{kind}:{subject}:{ts_unix}:{dedup}".encode()).hexdigest()[:24]
+    conn.execute(
+        """
+        INSERT INTO cross_source_events
+          (source, kind, ts_unix, subject, actor, payload_json, dedup_key)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (source, kind, ts_unix, subject, None, json.dumps(payload or {}), key),
+    )
+    conn.commit()
+
+
+def test_findings_empty_dbs_returns_empty_list():
+    """No data → empty list, no exception."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        chain = tmpdir / "chain.db"
+        xs = tmpdir / "xs.db"
+        init_db(chain).close()
+        init_cross_source_db(xs).close()
+        findings = collect_findings(chain, xs)
+        assert findings == []
+
+
+def test_findings_includes_demote_loop():
+    """A demote_loop cross-source finding flows through as JSON."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        chain = tmpdir / "chain.db"
+        xs = tmpdir / "xs.db"
+        init_db(chain).close()
+        conn = init_cross_source_db(xs)
+        now_ts = 100_000_000
+        _insert_xs(conn, "kanban", "kanban_status_transition", now_ts - 3600, "t_x",
+                   {"from": "ready", "to": "triage"}, dedup="1")
+        _insert_xs(conn, "kanban", "kanban_status_transition", now_ts - 1800, "t_x",
+                   {"from": "ready", "to": "triage"}, dedup="2")
+        conn.close()
+
+        findings = collect_findings(chain, xs, now_ts=now_ts)
+        kinds = [f["kind"] for f in findings]
+        assert "demote_loop" in kinds
+        loop = next(f for f in findings if f["kind"] == "demote_loop")
+        assert loop["suggested_action"] == "investigate"
+        assert "kanban_event#" in loop["evidence_links"][0]
+
+
+def test_findings_severity_sort():
+    """Critical sorts before warning sorts before info."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        chain = tmpdir / "chain.db"
+        xs = tmpdir / "xs.db"
+        init_db(chain).close()
+        conn = init_cross_source_db(xs)
+        now_ts = 100_000_000
+        # demote_loop fires at warning severity
+        _insert_xs(conn, "kanban", "kanban_status_transition", now_ts - 3600, "t_x",
+                   {"from": "ready", "to": "triage"}, dedup="1")
+        _insert_xs(conn, "kanban", "kanban_status_transition", now_ts - 1800, "t_x",
+                   {"from": "ready", "to": "triage"}, dedup="2")
+        # stuck PR fires at info severity
+        _insert_xs(conn, "git", "git_pr_opened", now_ts - 48 * 3600, "#1",
+                   {"number": 1})
+        conn.close()
+
+        findings = collect_findings(chain, xs, now_ts=now_ts)
+        severities = [f["severity"] for f in findings]
+        # warning before info
+        assert severities.index("warning") < severities.index("info")
+
+
+def test_findings_since_filter():
+    """Findings older than --since are excluded."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        chain = tmpdir / "chain.db"
+        xs = tmpdir / "xs.db"
+        init_db(chain).close()
+        conn = init_cross_source_db(xs)
+        # Stuck PR opened at ts=1000, gates on 48h threshold.
+        _insert_xs(conn, "git", "git_pr_opened", 1000, "#1", {"number": 1})
+        conn.close()
+        now_ts = 1000 + 48 * 3600 + 1
+
+        all_findings = collect_findings(chain, xs, now_ts=now_ts)
+        assert len(all_findings) >= 1
+
+        # Filter: only findings at or after ts=now_ts (none qualify).
+        filtered = collect_findings(chain, xs, since_ts=now_ts, now_ts=now_ts)
+        assert filtered == []
+
+
+def test_render_findings_json_compact():
+    """Compact JSON output is a single line of valid JSON."""
+    out = render_findings_json([{"kind": "x", "summary": "y"}])
+    parsed = json.loads(out)
+    assert parsed[0]["kind"] == "x"
+    assert "\n" not in out
+
+
+def test_render_findings_json_indent():
+    """Indented output parses and contains newlines."""
+    out = render_findings_json([{"kind": "x"}], indent=2)
+    parsed = json.loads(out)
+    assert parsed[0]["kind"] == "x"
+    assert "\n" in out

--- a/python/argus/tests/test_git_ingest.py
+++ b/python/argus/tests/test_git_ingest.py
@@ -1,0 +1,115 @@
+"""Tests for the git/PR poller. Uses real git for commits; stubs gh for PRs."""
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from argus.cross_source_db import init_cross_source_db
+from argus.git_ingest import ingest_repo, discover_repos
+
+
+def _make_git_repo(path: Path) -> None:
+    """Initialize a real local git repo with one commit, so `git log` has output."""
+    path.mkdir(parents=True, exist_ok=True)
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.invalid",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.invalid",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "test"], check=True)
+    (path / "README.md").write_text("hello")
+    subprocess.run(["git", "-C", str(path), "add", "README.md"], check=True, env={**env})
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", "initial"], check=True, env={**env})
+
+
+def test_empty_repo_succeeds_with_zero_inserts():
+    """Repo with no commits since the watermark inserts zero rows."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        repo = tmpdir / "repo"
+        _make_git_repo(repo)
+        xs_db = tmpdir / "xs.db"
+
+        # First poll picks up the initial commit.
+        r1 = ingest_repo(repo, xs_db, repo_name="repo")
+        assert r1["commits_inserted"] >= 1
+
+        # Second poll on the same repo with no new commits inserts nothing.
+        r2 = ingest_repo(repo, xs_db, repo_name="repo")
+        assert r2["commits_inserted"] == 0
+
+
+def test_missing_repo_returns_zero():
+    """A nonexistent repo path produces a zero result, no crash."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        xs_db = Path(tmpdir) / "xs.db"
+        result = ingest_repo(Path(tmpdir) / "no-such-repo", xs_db, repo_name="ghost")
+        assert result["commits_inserted"] == 0
+        assert result["prs_inserted"] == 0
+
+
+def test_pr_metadata_ingested_via_stubbed_gh():
+    """PR list with one open + one merged lands as two cross_source_events rows.
+
+    We don't patch subprocess.run globally (that would break the git
+    invocations the indexer uses); instead we patch _gh_pr_list, which
+    is the seam intended for stubbing.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        repo = tmpdir / "repo"
+        _make_git_repo(repo)
+        xs_db = tmpdir / "xs.db"
+
+        # First poll advances the watermark past the initial commit.
+        ingest_repo(repo, xs_db, repo_name="repo")
+
+        def fake_pr_list(repo_path, state, since_ts):
+            if state == "open":
+                return [{
+                    "number": 101,
+                    "title": "open one",
+                    "state": "OPEN",
+                    "author": {"login": "alice"},
+                    "createdAt": "2999-01-01T00:00:00Z",
+                    "mergedAt": None,
+                    "headRefName": "feat/x",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                }]
+            return [{
+                "number": 102,
+                "title": "merged one",
+                "state": "MERGED",
+                "author": {"login": "bob"},
+                "createdAt": "2999-01-01T00:00:00Z",
+                "mergedAt": "2999-01-02T00:00:00Z",
+                "headRefName": "feat/y",
+                "baseRefName": "main",
+                "isDraft": False,
+            }]
+
+        with patch("argus.git_ingest._gh_pr_list", side_effect=fake_pr_list):
+            result = ingest_repo(repo, xs_db, repo_name="repo")
+
+        # opened(101), opened(102), merged(102) — three rows
+        assert result["prs_inserted"] == 3
+
+
+def test_discover_repos_skips_non_repo_dirs():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        (tmpdir / "not_a_repo").mkdir()
+        (tmpdir / "repo").mkdir()
+        _make_git_repo(tmpdir / "repo")
+
+        repos = discover_repos([tmpdir])
+        names = {r.name for r in repos}
+        assert "repo" in names
+        assert "not_a_repo" not in names

--- a/python/argus/tests/test_indexer.py
+++ b/python/argus/tests/test_indexer.py
@@ -1,0 +1,246 @@
+"""Tests for argus.indexer with boundary conditions."""
+import json
+import sqlite3
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from argus.indexer import init_db, index_jsonl_file, _line_hash, _parse_ts_unix
+
+
+class TestLineHash:
+    """Test deterministic line hashing for idempotency."""
+
+    def test_same_line_same_hash(self):
+        """Same input line produces same hash."""
+        line = '{"ts":"2026-05-13T08:00:00Z","allowed":false,"rule_id":"test"}'
+        h1 = _line_hash(line)
+        h2 = _line_hash(line)
+        assert h1 == h2
+
+    def test_different_line_different_hash(self):
+        """Different lines produce different hashes."""
+        line1 = '{"ts":"2026-05-13T08:00:00Z","allowed":false}'
+        line2 = '{"ts":"2026-05-13T08:00:01Z","allowed":true}'
+        assert _line_hash(line1) != _line_hash(line2)
+
+
+class TestParseTsUnix:
+    """Test timestamp parsing."""
+
+    def test_valid_iso8601(self):
+        """Parse valid ISO 8601 timestamp."""
+        ts = "2026-05-13T08:00:00Z"
+        unix = _parse_ts_unix(ts)
+        assert isinstance(unix, int)
+        assert unix > 0
+
+    def test_invalid_timestamp_returns_none(self):
+        """Invalid timestamp returns None."""
+        assert _parse_ts_unix("bad-timestamp") is None
+        assert _parse_ts_unix("") is None
+        assert _parse_ts_unix(None) is None
+
+
+class TestInitDb:
+    """Test database initialization."""
+
+    def test_init_db_creates_schema(self):
+        """Init creates tables and indexes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+            tables = {row[0] for row in cursor.fetchall()}
+            assert "events" in tables
+
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+            )
+            indexes = {row[0] for row in cursor.fetchall()}
+            assert "idx_ts_unix" in indexes
+            assert "idx_rule_id" in indexes
+
+            conn.close()
+
+    def test_init_db_idempotent(self):
+        """Init is idempotent — can call multiple times."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn1 = init_db(db_path)
+            conn1.close()
+
+            conn2 = init_db(db_path)
+            cursor = conn2.execute("SELECT COUNT(*) FROM events")
+            assert cursor.fetchone()[0] == 0
+            conn2.close()
+
+
+class TestIndexJsonlFile:
+    """Test JSONL file indexing with boundary conditions."""
+
+    def test_index_empty_file(self):
+        """Empty file produces no errors."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            file_path = Path(tmpdir) / "empty.jsonl"
+            file_path.write_text("")
+
+            conn = init_db(db_path)
+            inserted, skipped = index_jsonl_file(conn, file_path)
+            conn.close()
+
+            assert inserted == 0
+            assert skipped == 0
+
+    def test_index_single_event(self):
+        """Single event is indexed without divide-by-zero."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            file_path = Path(tmpdir) / "single.jsonl"
+            file_path.write_text(
+                '{"ts":"2026-05-13T08:00:00Z","allowed":false,"rule_id":"test"}\n'
+            )
+
+            conn = init_db(db_path)
+            inserted, skipped = index_jsonl_file(conn, file_path)
+
+            assert inserted == 1
+            assert skipped == 0
+
+            # Verify it's in the database
+            cursor = conn.execute("SELECT COUNT(*) FROM events")
+            assert cursor.fetchone()[0] == 1
+            conn.close()
+
+    def test_index_malformed_jsonl_line_skipped(self):
+        """Malformed JSON lines are skipped, never block."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            file_path = Path(tmpdir) / "mixed.jsonl"
+            file_path.write_text(
+                'not valid json\n'
+                '{"ts":"2026-05-13T08:00:00Z","allowed":false,"rule_id":"test1"}\n'
+                '{"ts":"bad-ts","allowed":false}\n'
+                '{"ts":"2026-05-13T08:00:01Z","allowed":true,"rule_id":"test2"}\n'
+            )
+
+            conn = init_db(db_path)
+            inserted, skipped = index_jsonl_file(conn, file_path)
+
+            # 2 good lines indexed, malformed ones skipped
+            assert inserted == 2
+            conn.close()
+
+    def test_index_duplicate_replay_idempotent(self):
+        """Indexing same file twice is idempotent via line_hash."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            file_path = Path(tmpdir) / "replay.jsonl"
+            content = (
+                '{"ts":"2026-05-13T08:00:00Z","allowed":false,"rule_id":"test1"}\n'
+                '{"ts":"2026-05-13T08:00:01Z","allowed":true,"rule_id":"test2"}\n'
+            )
+            file_path.write_text(content)
+
+            conn = init_db(db_path)
+
+            # First index
+            inserted1, skipped1 = index_jsonl_file(conn, file_path)
+            assert inserted1 == 2
+            assert skipped1 == 0
+
+            # Second index (replay)
+            inserted2, skipped2 = index_jsonl_file(conn, file_path)
+            assert inserted2 == 0
+            assert skipped2 == 2
+
+            # Database still has exactly 2 rows
+            cursor = conn.execute("SELECT COUNT(*) FROM events")
+            assert cursor.fetchone()[0] == 2
+            conn.close()
+
+    def test_index_nonexistent_file_returns_zeros(self):
+        """Indexing nonexistent file returns (0, 0) gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+            inserted, skipped = index_jsonl_file(conn, Path("/nonexistent/file.jsonl"))
+
+            assert inserted == 0
+            assert skipped == 0
+            conn.close()
+
+    def test_index_preserves_all_fields(self):
+        """All decision fields are indexed correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            file_path = Path(tmpdir) / "full.jsonl"
+            event = {
+                "ts": "2026-05-13T08:00:00Z",
+                "allowed": False,
+                "mode": "enforce",
+                "rule_id": "test-rule",
+                "reason": "test-reason",
+                "escalation": "elevated",
+                "agent": "claude-code",
+                "action_type": "shell.exec",
+                "action_target": "rm -rf /tmp",
+                "envelope_id": "env_123",
+                "tier": "5",
+                "cost_usd": 0.05,
+                "input_bytes": 100,
+                "tool_calls": 2,
+                "model": "claude-opus",
+                "role": "programmer",
+                "workflow_id": "wf_456",
+                "fingerprint": "fp_789",
+            }
+            file_path.write_text(json.dumps(event) + "\n")
+
+            conn = init_db(db_path)
+            conn.row_factory = sqlite3.Row
+            inserted, skipped = index_jsonl_file(conn, file_path)
+            assert inserted == 1
+
+            # Verify all fields
+            cursor = conn.execute("SELECT * FROM events")
+            row = cursor.fetchone()
+            assert row["allowed"] == 0
+            assert row["rule_id"] == "test-rule"
+            assert row["agent"] == "claude-code"
+            assert row["cost_usd"] == 0.05
+            assert row["model"] == "claude-opus"
+            conn.close()
+
+
+def test_index_jsonl_from_offset_indexes_appended_lines_and_rollover():
+    """Follower primitive indexes appended lines and newly discovered date-rollover files."""
+    from argus.indexer import _decision_files, index_jsonl_file_from_offset
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        db_path = root / "test.db"
+        decisions = root / "decisions"
+        decisions.mkdir()
+        day1 = decisions / "gov-decisions-2026-05-13.jsonl"
+        day2 = decisions / "gov-decisions-2026-05-14.jsonl"
+        day1.write_text('{"ts":"2026-05-13T08:00:00Z","allowed":false,"rule_id":"r1"}\n')
+
+        conn = init_db(db_path)
+        offsets = {}
+        for f in _decision_files(decisions):
+            _, _, offsets[f] = index_jsonl_file_from_offset(conn, f, offsets.get(f, 0))
+
+        day1.write_text(day1.read_text() + '{"ts":"2026-05-13T08:00:01Z","allowed":true,"rule_id":"r2"}\n')
+        day2.write_text('{"ts":"2026-05-14T00:00:00Z","allowed":false,"rule_id":"r3"}\n')
+        for f in _decision_files(decisions):
+            _, _, offsets[f] = index_jsonl_file_from_offset(conn, f, offsets.get(f, 0))
+
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 3
+        conn.close()

--- a/python/argus/tests/test_integration.py
+++ b/python/argus/tests/test_integration.py
@@ -1,0 +1,54 @@
+"""Integration test: end-to-end workflow."""
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from argus.indexer import init_db, index_jsonl_file
+from argus.detectors import run_all_detectors
+from argus.reporter import generate_daily_report
+
+# Skip the qwen subprocess for fast deterministic test runs.
+os.environ.setdefault("ARGUS_SKIP_QWEN", "1")
+
+
+def test_end_to_end_workflow():
+    """Test complete workflow: index → detect → report."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # Create mock JSONL file with test data
+        jsonl_file = tmpdir / "gov-decisions-2026-05-13.jsonl"
+        events = [
+            {"ts": "2026-05-13T08:00:00Z", "allowed": False, "rule_id": "rule1", "agent": "agent1"},
+            {"ts": "2026-05-13T08:00:01Z", "allowed": False, "rule_id": "rule1", "agent": "agent1"},
+            {"ts": "2026-05-13T08:00:02Z", "allowed": False, "rule_id": "rule1", "agent": "agent1"},
+            {"ts": "2026-05-13T08:00:03Z", "allowed": False, "rule_id": "rule1", "agent": "agent1"},
+            {"ts": "2026-05-13T08:01:00Z", "allowed": True, "rule_id": "rule2", "agent": "agent2"},
+        ]
+
+        with jsonl_file.open("w") as f:
+            for event in events:
+                f.write(json.dumps(event) + "\n")
+
+        # Index
+        db_path = tmpdir / "index.db"
+        conn = init_db(db_path)
+        inserted, skipped = index_jsonl_file(conn, jsonl_file)
+        conn.close()
+
+        assert inserted == 5
+        assert skipped == 0
+
+        # Detect
+        findings = run_all_detectors(str(db_path))
+        assert len(findings) > 0  # Should find deny cluster
+
+        # Report
+        report_dir = tmpdir / "reports"
+        report_path = generate_daily_report(str(db_path), report_dir)
+
+        assert report_path.exists()
+        content = report_path.read_text()
+        assert "Argus Research" in content
+        assert "5" in content or "Total decisions" in content

--- a/python/argus/tests/test_kanban_ingest.py
+++ b/python/argus/tests/test_kanban_ingest.py
@@ -1,0 +1,194 @@
+"""Tests for the kanban poller — read-only, idempotent, locked-DB tolerant."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from argus.cross_source_db import init_cross_source_db
+from argus.kanban_ingest import ingest_board, ingest_all_kanban
+
+
+def _make_kanban_db(path: Path) -> sqlite3.Connection:
+    """Create a minimal kanban DB with the schema the real hermes board uses."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            run_id INTEGER,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        );
+        CREATE TABLE task_comments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            author TEXT NOT NULL,
+            body TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        );
+    """)
+    return conn
+
+
+def _add_event(conn, task_id, kind, payload, created_at):
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, ?, ?, ?)",
+        (task_id, kind, json.dumps(payload), created_at),
+    )
+    conn.commit()
+
+
+def _add_comment(conn, task_id, author, body, created_at):
+    conn.execute(
+        "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+        (task_id, author, body, created_at),
+    )
+    conn.commit()
+
+
+class TestIngestBoard:
+    def test_empty_board_zero_inserts(self):
+        """An empty kanban DB yields zero inserts, no error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            kanban_db = tmpdir / "board" / "kanban.db"
+            kanban_db.parent.mkdir()
+            _make_kanban_db(kanban_db).close()
+
+            xs_db = tmpdir / "xs.db"
+            xs_conn = init_cross_source_db(xs_db)
+            try:
+                inserted, skipped = ingest_board(kanban_db, xs_conn, board="board")
+            finally:
+                xs_conn.close()
+
+            assert inserted == 0
+            assert skipped == 0
+
+    def test_status_transition_ingested(self):
+        """A ready→triage transition lands as kanban_status_transition."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            kanban_db = tmpdir / "board" / "kanban.db"
+            kanban_db.parent.mkdir()
+            kbn = _make_kanban_db(kanban_db)
+            _add_event(kbn, "t_abc", "status_transition",
+                       {"from": "ready", "to": "triage", "by": "red"}, 1000)
+            kbn.close()
+
+            xs_db = tmpdir / "xs.db"
+            xs_conn = init_cross_source_db(xs_db)
+            try:
+                inserted, skipped = ingest_board(kanban_db, xs_conn, board="board")
+                rows = xs_conn.execute(
+                    "SELECT source, kind, ts_unix, subject FROM cross_source_events"
+                ).fetchall()
+            finally:
+                xs_conn.close()
+
+            assert inserted == 1
+            assert rows[0] == ("kanban", "kanban_status_transition", 1000, "t_abc")
+
+    def test_idempotent_on_replay(self):
+        """Running the ingester twice over the same data inserts 0 the second time."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            kanban_db = tmpdir / "board" / "kanban.db"
+            kanban_db.parent.mkdir()
+            kbn = _make_kanban_db(kanban_db)
+            _add_event(kbn, "t_abc", "status_transition",
+                       {"from": "ready", "to": "triage", "by": "red"}, 1000)
+            _add_comment(kbn, "t_abc", "red", "demoted because...", 1001)
+            kbn.close()
+
+            xs_db = tmpdir / "xs.db"
+            # First pass.
+            xs_conn = init_cross_source_db(xs_db)
+            i1, s1 = ingest_board(kanban_db, xs_conn, board="board")
+            xs_conn.close()
+            # Second pass — watermark advance prevents re-scan.
+            xs_conn = init_cross_source_db(xs_db)
+            try:
+                i2, s2 = ingest_board(kanban_db, xs_conn, board="board")
+                total = xs_conn.execute(
+                    "SELECT COUNT(*) FROM cross_source_events"
+                ).fetchone()[0]
+            finally:
+                xs_conn.close()
+
+            assert i1 == 2
+            assert i2 == 0  # watermark blocks the second pass entirely
+            assert total == 2
+
+    def test_incremental_after_watermark(self):
+        """New rows added after first poll are picked up on the next poll."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            kanban_db = tmpdir / "board" / "kanban.db"
+            kanban_db.parent.mkdir()
+            kbn = _make_kanban_db(kanban_db)
+            _add_event(kbn, "t_abc", "status_transition",
+                       {"from": "ready", "to": "triage"}, 1000)
+            kbn.close()
+
+            xs_db = tmpdir / "xs.db"
+            xs_conn = init_cross_source_db(xs_db)
+            ingest_board(kanban_db, xs_conn, board="board")
+            xs_conn.close()
+
+            # Add a fresh event after first poll completed.
+            kbn = sqlite3.connect(str(kanban_db))
+            _add_event(kbn, "t_abc", "status_transition",
+                       {"from": "triage", "to": "ready"}, 2000)
+            kbn.close()
+
+            xs_conn = init_cross_source_db(xs_db)
+            try:
+                i2, _ = ingest_board(kanban_db, xs_conn, board="board")
+                rows = xs_conn.execute(
+                    "SELECT ts_unix FROM cross_source_events ORDER BY ts_unix"
+                ).fetchall()
+            finally:
+                xs_conn.close()
+            assert i2 == 1
+            assert [r[0] for r in rows] == [1000, 2000]
+
+    def test_missing_board_db_returns_zero(self):
+        """Non-existent kanban.db path is a no-op."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            xs_conn = init_cross_source_db(tmpdir / "xs.db")
+            try:
+                inserted, skipped = ingest_board(tmpdir / "nope" / "kanban.db", xs_conn)
+            finally:
+                xs_conn.close()
+            assert (inserted, skipped) == (0, 0)
+
+
+class TestIngestAllKanban:
+    def test_discovers_multiple_boards(self):
+        """ingest_all_kanban finds every kanban.db under the boards root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            for board in ("a", "b"):
+                p = tmpdir / board / "kanban.db"
+                p.parent.mkdir()
+                k = _make_kanban_db(p)
+                _add_event(k, f"t_{board}", "status_transition",
+                           {"from": "ready", "to": "triage"}, 1000)
+                k.close()
+
+            result = ingest_all_kanban(tmpdir, tmpdir / "xs.db")
+            assert set(result["boards"]) == {"a", "b"}
+            assert result["inserted"] == 2
+
+    def test_no_boards_root_returns_zero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = ingest_all_kanban(Path(tmpdir) / "missing", Path(tmpdir) / "xs.db")
+            assert result["boards"] == []
+            assert result["inserted"] == 0

--- a/python/argus/tests/test_reporter.py
+++ b/python/argus/tests/test_reporter.py
@@ -224,6 +224,7 @@ def test_discord_post_skipped_on_quiet_day(monkeypatch):
             str(db_path),
             report_dir,
             discord_webhook="https://example.invalid/webhook",
+            cross_source_db=Path(tmpdir) / "no-cross-source.db",
         )
 
     assert posted["calls"] == 0
@@ -254,6 +255,7 @@ def test_discord_post_fires_on_findings(monkeypatch):
             str(db_path),
             report_dir,
             discord_webhook="https://example.invalid/webhook",
+            cross_source_db=Path(tmpdir) / "no-cross-source.db",
         )
 
     assert posted["calls"] == 1

--- a/python/argus/tests/test_reporter.py
+++ b/python/argus/tests/test_reporter.py
@@ -1,0 +1,260 @@
+"""Tests for argus.reporter."""
+import os
+import re
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from argus.reporter import generate_daily_report, _get_summary_stats
+from argus.indexer import init_db
+
+
+# Tests should not hit ollama; bypass narration for fast deterministic runs.
+os.environ.setdefault("ARGUS_SKIP_QWEN", "1")
+
+
+def _insert_event(conn, ts: str, allowed: bool, rule_id: str, agent: str = "test-agent"):
+    """Helper to insert an event."""
+    import hashlib
+    from datetime import datetime as dt
+    parsed_dt = dt.fromisoformat(ts.replace("Z", "+00:00"))
+    ts_unix = int(parsed_dt.timestamp())
+
+    # Create unique hash for each event
+    event_id = f"{ts}-{rule_id}-{agent}-{allowed}"
+    lh = hashlib.sha256(event_id.encode()).hexdigest()
+
+    conn.execute("""
+        INSERT INTO events (
+            line_hash, ts, ts_unix, allowed, rule_id, agent, action_type
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, (
+        lh,
+        parsed_dt.isoformat(),
+        ts_unix,
+        int(allowed),
+        rule_id,
+        agent,
+        "shell.exec",
+    ))
+    conn.commit()
+
+
+class TestSummaryStats:
+    """Test summary statistics gathering."""
+
+    def test_summary_stats_empty_database(self):
+        """Empty database returns zero counts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+            conn.close()
+
+            stats = _get_summary_stats(str(db_path))
+            assert stats["total_events"] == 0
+            assert stats["deny_count"] == 0
+            assert stats["allow_count"] == 0
+
+    def test_summary_stats_single_event(self):
+        """Single event renders without divide-by-zero."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+            _insert_event(conn, "2026-05-13T08:00:00Z", False, "rule1")
+            conn.close()
+
+            stats = _get_summary_stats(str(db_path))
+            assert stats["total_events"] == 1
+            assert stats["deny_count"] == 1
+            assert stats["allow_count"] == 0
+            assert stats["deny_percent"] == 100.0
+
+    def test_summary_stats_mixed_events(self):
+        """Mixed allow/deny events are counted correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            for i in range(7):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule1")
+
+            for i in range(3):
+                _insert_event(conn, f"2026-05-13T08:01:{i:02d}Z", True, "rule2")
+
+            conn.close()
+
+            stats = _get_summary_stats(str(db_path))
+            assert stats["total_events"] == 10
+            assert stats["deny_count"] == 7
+            assert stats["allow_count"] == 3
+
+    def test_summary_stats_top_rules(self):
+        """Top deny rules are ranked correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = init_db(db_path)
+
+            for i in range(5):
+                _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule_frequent")
+
+            for i in range(2):
+                _insert_event(conn, f"2026-05-13T08:01:{i:02d}Z", False, "rule_rare")
+
+            conn.close()
+
+            stats = _get_summary_stats(str(db_path))
+            assert stats["top_deny_rules"][0]["rule_id"] == "rule_frequent"
+            assert stats["top_deny_rules"][0]["count"] == 5
+
+
+class TestGenerateDailyReport:
+    """Test daily report generation."""
+
+    def test_generate_report_empty_database(self):
+        """Report on empty database renders 'all quiet'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            report_dir = Path(tmpdir) / "reports"
+
+            conn = init_db(db_path)
+            conn.close()
+
+            report_path = generate_daily_report(str(db_path), report_dir)
+
+            assert report_path.exists()
+            content = report_path.read_text()
+            assert "all quiet" in content or "No findings" in content
+
+    def test_generate_report_single_event(self):
+        """Report on single event renders without divide-by-zero."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            report_dir = Path(tmpdir) / "reports"
+
+            conn = init_db(db_path)
+            _insert_event(conn, "2026-05-13T08:00:00Z", False, "test-rule")
+            conn.close()
+
+            report_path = generate_daily_report(str(db_path), report_dir)
+
+            assert report_path.exists()
+            content = report_path.read_text()
+            assert "test-rule" in content
+
+    def test_generate_report_creates_file_with_timestamp(self):
+        """Report is written with today's ISO date in the filename."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            report_dir = Path(tmpdir) / "reports"
+
+            conn = init_db(db_path)
+            _insert_event(conn, "2026-05-13T08:00:00Z", False, "rule1")
+            conn.close()
+
+            report_path = generate_daily_report(str(db_path), report_dir)
+
+            # Filename pattern is <YYYY-MM-DD>-argus-research.html where
+            # the date is today's UTC date — don't pin to a fixed string
+            # because the test must pass on any calendar day.
+            assert re.match(r"\d{4}-\d{2}-\d{2}-argus-research\.html$", report_path.name)
+            assert report_path.suffix == ".html"
+
+
+def test_generate_report_writes_dark_html_latest_contract():
+    """Daily report writes date-stamped HTML and an atomic latest symlink."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        report_dir = Path(tmpdir) / "reports"
+        conn = init_db(db_path)
+        _insert_event(conn, "2026-05-13T08:00:00Z", False, "test-rule")
+        conn.close()
+
+        report_path = generate_daily_report(str(db_path), report_dir)
+        latest = report_dir / "argus-research-latest.html"
+
+        assert report_path.name.endswith("-argus-research.html")
+        assert latest.is_symlink(), "latest must be a symlink, not a file copy"
+        assert latest.resolve() == report_path.resolve()
+        html = report_path.read_text()
+        assert "Argus Research" in html
+        assert "color-scheme: dark" in html
+        # Reading through the symlink returns the dated file's content.
+        assert latest.read_text() == html
+
+
+def test_latest_symlink_retargets_atomically_on_rerun():
+    """Re-running on the same day overwrites the dated file and the symlink continues to resolve."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        report_dir = Path(tmpdir) / "reports"
+        conn = init_db(db_path)
+        _insert_event(conn, "2026-05-13T08:00:00Z", False, "rule1")
+        conn.close()
+
+        first = generate_daily_report(str(db_path), report_dir)
+        second = generate_daily_report(str(db_path), report_dir)
+        latest = report_dir / "argus-research-latest.html"
+
+        # Same date → same dated file. Symlink still resolves cleanly.
+        assert first == second
+        assert latest.is_symlink()
+        assert latest.resolve() == second.resolve()
+
+
+def test_discord_post_skipped_on_quiet_day(monkeypatch):
+    """Quiet-day default: no detector findings → Discord webhook is NOT called."""
+    posted = {"calls": 0}
+
+    def fake_post(url, headline, link=None):  # pragma: no cover - injected
+        posted["calls"] += 1
+        return True
+
+    import argus.reporter as reporter_mod
+    monkeypatch.setattr(reporter_mod, "_post_discord_summary", fake_post)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        report_dir = Path(tmpdir) / "reports"
+        conn = init_db(db_path)
+        conn.close()  # empty index → no findings
+
+        generate_daily_report(
+            str(db_path),
+            report_dir,
+            discord_webhook="https://example.invalid/webhook",
+        )
+
+    assert posted["calls"] == 0
+
+
+def test_discord_post_fires_on_findings(monkeypatch):
+    """Findings present → Discord webhook is called exactly once."""
+    posted = {"calls": 0, "last_headline": None}
+
+    def fake_post(url, headline, link=None):  # pragma: no cover - injected
+        posted["calls"] += 1
+        posted["last_headline"] = headline
+        return True
+
+    import argus.reporter as reporter_mod
+    monkeypatch.setattr(reporter_mod, "_post_discord_summary", fake_post)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        report_dir = Path(tmpdir) / "reports"
+        conn = init_db(db_path)
+        # 4 denies within 300s → deny_cluster detector fires.
+        for i in range(4):
+            _insert_event(conn, f"2026-05-13T08:00:{i:02d}Z", False, "rule_x")
+        conn.close()
+
+        generate_daily_report(
+            str(db_path),
+            report_dir,
+            discord_webhook="https://example.invalid/webhook",
+        )
+
+    assert posted["calls"] == 1
+    assert "finding" in posted["last_headline"].lower()


### PR DESCRIPTION
Closes ticket t_da209102 (Argus-side). Adds the structured-findings egress CLI and documents the Hermes-side integration contract. Stacked on Slice 4 (#621).

## Summary

- **`argus findings --since=<ts>`** CLI: runs every detector class (chain, cross-source, log, drift) and emits a JSON array Hermes' standup can fold in:
  ```json
  [
    {
      "kind": "demote_loop",
      "severity": "warning",
      "summary": "Demote loop: t_abc bounced ready→triage 2× in 24h",
      "evidence_links": ["kanban_event#12", "kanban_event#15"],
      "suggested_action": "investigate",
      "ts_unix": 1700000000,
      "subject": "t_abc"
    },
    ...
  ]
  ```
- Sort order: severity desc (critical → warning → info), then ts desc, then subject. Hermes takes the top-N.
- New `argus.findings` module with the `collect_findings` pure function.
- `argus.drift_detectors` hardened to handle missing `beliefs` table (degrades to zero findings).
- New `docs/runbooks/argus-hermes-standup-fold.md` documents the one-way contract, suggested_action grammar, and a Python pseudocode reference integration.

## Smoke against real data

```
$ argus findings --indent 2 --limit 5
[
  {
    "kind": "deny_cluster",
    "severity": "warning",
    "summary": "Deny cluster: 8 denies in 300s",
    ...
  },
  {
    "kind": "agent_failure_run",
    "severity": "warning",
    "summary": "Agent claude-code failure run: 55 consecutive denies",
    "suggested_action": "dispatch_fix",
    ...
  },
  ...
]
```

## Spec compliance (per § Slice 5)

- [x] `argus findings --since=<ts>` CLI emits the spec'd JSON shape
- [x] Sort deterministic (severity → ts → subject)
- [x] Graceful degradation: missing DBs or empty data → empty list, no exception
- [x] One-way flow invariant: this PR adds no write path back into Argus
- [x] Boundaries tested: empty data, since-filter excludes pre-cutoff findings, compact + indented output, severity sort, drift detectors tolerate missing beliefs table
- [x] Runbook updated (`docs/runbooks/argus-hermes-standup-fold.md`)
- [ ] Hermes-side `agent/standup.py` integration — **deferred**, lives in a separate repo, filed as a follow-up
- [ ] 7-day standup smoke — **operator-side runtime test**
- [ ] One operator action taken via standup reply — **operator-side runtime test**

## Out of scope (deferred follow-ups)

- Hermes-side `agent/standup.py` modification (separate repo)
- Operator reply parsing on the Hermes side
- Operator-side acceptance items (7-day smoke, action taken via reply)

## Test plan

- [ ] Hermes operator confirms `argus findings --since=<last_standup>` returns useful results
- [ ] Hermes standup-cron is modified (separate PR) to call this CLI
- [ ] After 7 standups, Argus section consistently appears
- [ ] At least one operator action triggered via standup reply

Tests: 91 passing in 1.90s (6 new for this slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)