### PR TITLE
feat(swarm): cron-driven judge backfill + durable dispatch metadata

### DIFF
--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -311,6 +311,9 @@ steps:
         echo "spawn_worker: selected model $MODEL is not present on driver=$DRIVER card" >&2
         exit 1
       fi
+      ROLE="${ROLE:-programmer}"
+      hermes kanban --board chitin comment "$TICKET_ID" --author clawta \
+        "dispatch driver=$DRIVER model=$MODEL role=$ROLE" 2>/dev/null || true
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
       ARGS_JSON=$(jq -c --arg model "$MODEL" \
         '.invocation.args | map(if . == "{model}" then $model else . end)' \

--- a/infra/systemd/clawta-judge-backfill.service
+++ b/infra/systemd/clawta-judge-backfill.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Clawta swarm judge backfill
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=red
+WorkingDirectory=/home/red/workspace/chitin
+Environment=PATH=/home/red/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/python3 /home/red/workspace/chitin/swarm/workflows/judge_backfill.py

--- a/infra/systemd/clawta-judge-backfill.timer
+++ b/infra/systemd/clawta-judge-backfill.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Clawta swarm judge backfill every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+AccuracySec=1min
+Persistent=true
+Unit=clawta-judge-backfill.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install-clawta-judge-backfill.sh
+++ b/scripts/install-clawta-judge-backfill.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SERVICE_SRC="$ROOT/infra/systemd/clawta-judge-backfill.service"
+TIMER_SRC="$ROOT/infra/systemd/clawta-judge-backfill.timer"
+SERVICE_DST="/etc/systemd/system/clawta-judge-backfill.service"
+TIMER_DST="/etc/systemd/system/clawta-judge-backfill.timer"
+
+install -m 0644 "$SERVICE_SRC" "$SERVICE_DST"
+install -m 0644 "$TIMER_SRC" "$TIMER_DST"
+systemctl daemon-reload
+systemctl enable --now clawta-judge-backfill.timer
+systemctl list-timers --all clawta-judge-backfill.timer

--- a/swarm/tests/test_judge_backfill.py
+++ b/swarm/tests/test_judge_backfill.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKFILL = ROOT / "workflows" / "judge_backfill.py"
+ELO = ROOT / "workflows" / "_swarm_elo.py"
+
+
+def load_elo_module():
+    spec = importlib.util.spec_from_loader("test_backfill_elo", SourceFileLoader("test_backfill_elo", str(ELO)))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_backfill_module():
+    sys.modules["_swarm_elo"] = load_elo_module()
+    spec = importlib.util.spec_from_loader("judge_backfill_module", SourceFileLoader("judge_backfill_module", str(BACKFILL)))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["judge_backfill_module"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class JudgeBackfillTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backfill = load_backfill_module()
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("CREATE TABLE swarm_dispatch_scores (pr_url TEXT)")
+
+    def test_pr_without_ticket_skips(self) -> None:
+        stats = self.backfill.process_prs(
+            [{"number": 1, "url": "https://github.com/chitinhq/chitin/pull/1", "body": "no ticket", "headRefName": "feature/no-ticket"}],
+            conn=self.conn,
+        )
+        self.assertEqual(stats["skipped_no_ticket"], 1)
+        self.assertEqual(stats["scored"], 0)
+
+    def test_already_scored_skips(self) -> None:
+        self.conn.execute("INSERT INTO swarm_dispatch_scores (pr_url) VALUES (?)", ("https://github.com/chitinhq/chitin/pull/2",))
+        stats = self.backfill.process_prs(
+            [{"number": 2, "url": "https://github.com/chitinhq/chitin/pull/2", "body": "Closes t_1234abcd", "headRefName": "swarm/codex-1234abcd"}],
+            conn=self.conn,
+        )
+        self.assertEqual(stats["skipped_existing"], 1)
+        self.assertEqual(stats["scored"], 0)
+
+    def test_inferred_default_path(self) -> None:
+        calls = []
+
+        def fake_run(ticket_id, pr_url, meta, *, dry_run=False):
+            calls.append((ticket_id, pr_url, meta, dry_run))
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+        with mock.patch.object(self.backfill, "fetch_ticket_json", return_value={"comments": []}), \
+             mock.patch.object(self.backfill, "run_judge", side_effect=fake_run):
+            stats = self.backfill.process_prs(
+                [{"number": 3, "url": "https://github.com/chitinhq/chitin/pull/3", "body": "Fixes t_deadbeef", "headRefName": "swarm/codex-deadbeef"}],
+                conn=self.conn,
+            )
+        self.assertEqual(stats["scored"], 1)
+        meta = calls[0][2]
+        self.assertEqual((meta.driver, meta.model, meta.role), ("clawta", "gpt-5.5", "programmer"))
+        self.assertTrue(meta.inferred)
+
+    def test_comment_parse_path(self) -> None:
+        ticket_json = {"comments": [{"body": "dispatch driver=codex model=gpt-5.4 role=programmer"}]}
+        meta = self.backfill.parse_dispatch_meta_from_comments(ticket_json)
+        self.assertIsNotNone(meta)
+        assert meta is not None
+        self.assertEqual((meta.driver, meta.model, meta.role, meta.inferred), ("codex", "gpt-5.4", "programmer", False))
+
+    def test_error_isolation_between_prs(self) -> None:
+        def fake_run(ticket_id, pr_url, meta, *, dry_run=False):
+            if ticket_id == "t_badbad00":
+                return mock.Mock(returncode=3, stdout="", stderr="judge failed")
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+
+        with mock.patch.object(self.backfill, "fetch_ticket_json", return_value={"comments": []}), \
+             mock.patch.object(self.backfill, "run_judge", side_effect=fake_run):
+            stats = self.backfill.process_prs(
+                [
+                    {"number": 4, "url": "https://github.com/chitinhq/chitin/pull/4", "body": "t_badbad00", "headRefName": "swarm/codex-badbad00"},
+                    {"number": 5, "url": "https://github.com/chitinhq/chitin/pull/5", "body": "t_cafebabe", "headRefName": "swarm/codex-cafebabe"},
+                ],
+                conn=self.conn,
+            )
+        self.assertEqual(stats["failed"], 1)
+        self.assertEqual(stats["scored"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/swarm/workflows/_swarm_elo.py
+++ b/swarm/workflows/_swarm_elo.py
@@ -164,6 +164,7 @@ def _migrate_dispatch_scores(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "swarm_dispatch_scores", "pr_created_at", "INTEGER")
     _ensure_column(conn, "swarm_dispatch_scores", "pr_updated_at", "INTEGER")
     _ensure_column(conn, "swarm_dispatch_scores", "pr_merged_at", "INTEGER")
+    _ensure_column(conn, "swarm_dispatch_scores", "inferred", "INTEGER NOT NULL DEFAULT 0")
     conn.execute("UPDATE swarm_dispatch_scores SET task_class = '' WHERE task_class IS NULL")
 
 
@@ -214,6 +215,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             total_score INTEGER,
             judge_model TEXT NOT NULL,
             judge_reasoning TEXT,
+            inferred INTEGER NOT NULL DEFAULT 0,
             pr_created_at INTEGER,
             pr_updated_at INTEGER,
             pr_merged_at INTEGER,
@@ -297,6 +299,7 @@ def record_score(
     pr_updated_at: int | None = None,
     pr_merged_at: int | None = None,
     scored_at: int | None = None,
+    inferred: bool = False,
 ) -> int:
     """Insert one row in swarm_dispatch_scores. Returns the new row id."""
     total = sum(
@@ -329,9 +332,9 @@ def record_score(
             pr_outcome, ci_outcome, review_outcome,
             code_quality, test_coverage, scope_adherence,
             efficiency, review_friendliness, total_score,
-            judge_model, judge_reasoning,
+            judge_model, judge_reasoning, inferred,
             pr_created_at, pr_updated_at, pr_merged_at, scored_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             ticket_id,
@@ -354,6 +357,7 @@ def record_score(
             total,
             judge_model,
             reasoning,
+            1 if inferred else 0,
             pr_created_at,
             pr_updated_at,
             pr_merged_at,
@@ -529,7 +533,7 @@ def recent_scores(conn: sqlite3.Connection, limit: int = 20) -> list[dict]:
         SELECT ticket_id, pr_url, driver, model, role, task_class,
                complexity_bucket, capabilities_json, capabilities_key,
                pr_outcome, ci_outcome, review_outcome,
-               total_score, judge_model, judge_reasoning,
+               total_score, judge_model, judge_reasoning, inferred,
                pr_created_at, pr_updated_at, pr_merged_at, scored_at
           FROM swarm_dispatch_scores
          ORDER BY id DESC

--- a/swarm/workflows/judge.py
+++ b/swarm/workflows/judge.py
@@ -9,13 +9,16 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import datetime
 
-sys.path.insert(0, os.path.expanduser("~/.openclaw/workflows"))
+sys.path.insert(0, os.path.dirname(__file__))
+# Runtime deployments may still keep the shared library in ~/.openclaw/workflows.
+sys.path.append(os.path.expanduser("~/.openclaw/workflows"))
 import _swarm_elo as elo  # noqa: E402
 
 
-DEFAULT_JUDGE = "clawta-glm-5.1"
+DEFAULT_JUDGE = "clawta-gpt-5.5"
 TASK_CLASS_HEURISTICS = [
     (r"refactor|cleanup|reorganize|consolidat", "refactor"),
     (r"\b(bug|fix|broken|fails?|crash|error)\b", "bugfix"),
@@ -279,9 +282,17 @@ Reply with ONLY a JSON object (no prose, no markdown):
 
 def call_judge(prompt: str, judge_model: str, timeout_seconds: int = 240) -> dict | None:
     """Call the judge LLM. Returns parsed dict or None on failure."""
+    prompt_path = None
     try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", prefix="clawta-judge-", suffix=".txt", delete=False) as fh:
+            fh.write(prompt)
+            prompt_path = fh.name
+        message = (
+            "Read the complete post-PR judge prompt from "
+            f"{prompt_path}. Reply with ONLY the JSON object requested in that file."
+        )
         result = subprocess.run(
-            ["clawta", "--text", prompt],
+            ["clawta", "--text", message],
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
@@ -289,6 +300,12 @@ def call_judge(prompt: str, judge_model: str, timeout_seconds: int = 240) -> dic
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
         print(f"judge: clawta call failed: {e}", file=sys.stderr)
         return None
+    finally:
+        if prompt_path:
+            try:
+                os.unlink(prompt_path)
+            except OSError:
+                pass
 
     if result.returncode != 0:
         print(f"judge: clawta returned {result.returncode}", file=sys.stderr)
@@ -325,6 +342,7 @@ def main() -> int:
     ap.add_argument("--role", default="programmer", help="Worker role that produced the PR")
     ap.add_argument("--task-class", default=None, help="Override task class (auto-inferred if absent)")
     ap.add_argument("--judge-model", default=DEFAULT_JUDGE, help=f"Judge LLM (default: {DEFAULT_JUDGE})")
+    ap.add_argument("--inferred", action="store_true", help="Mark dispatch metadata as inferred/backfilled")
     ap.add_argument("--dry-run", action="store_true", help="Print prompt + scores; do not write to DB")
     args = ap.parse_args()
 
@@ -375,6 +393,7 @@ def main() -> int:
         pr_created_at=metadata["pr_created_at"],
         pr_updated_at=metadata["pr_updated_at"],
         pr_merged_at=metadata["pr_merged_at"],
+        inferred=args.inferred,
     )
     new_elo = elo.update_elo(
         conn, args.driver, args.model, task_class, total,
@@ -403,6 +422,7 @@ def main() -> int:
         "total": total,
         "new_elo": round(new_elo, 1),
         "reasoning": reasoning,
+        "inferred": bool(args.inferred),
     }, indent=2))
     return 0
 

--- a/swarm/workflows/judge_backfill.py
+++ b/swarm/workflows/judge_backfill.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Cron-driven post-PR judge backfill for merged swarm PRs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import _swarm_elo as elo  # noqa: E402
+
+LOG_PATH = Path(os.path.expanduser("~/.openclaw/logs/judge_backfill.log"))
+TICKET_RE = re.compile(r"t_[a-f0-9]{8}")
+DISPATCH_META_RE = re.compile(
+    r"\bdispatch\s+driver=(?P<driver>\S+)\s+model=(?P<model>\S+)\s+role=(?P<role>\S+)",
+    re.IGNORECASE,
+)
+DEFAULT_DRIVER = "clawta"
+DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_ROLE = "programmer"
+
+
+@dataclass(frozen=True)
+class DispatchMeta:
+    driver: str
+    model: str
+    role: str
+    inferred: bool = False
+
+
+def log(message: str, *, log_path: Path = LOG_PATH) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    line = f"{ts} {message}"
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+    print(line)
+
+
+def cutoff_iso(hours: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def query_merged_prs(hours: int = 48) -> list[dict]:
+    search = f"merged:>={cutoff_iso(hours)}"
+    result = subprocess.run(
+        [
+            "gh", "pr", "list",
+            "--repo", "chitinhq/chitin",
+            "--state", "merged",
+            "--search", search,
+            "--json", "number,url,headRefName,body,title,mergedAt",
+            "--limit", "100",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed rc={result.returncode}: {result.stderr.strip()[:300]}")
+    return json.loads(result.stdout or "[]")
+
+
+def ticket_from_pr(pr: dict) -> str | None:
+    parts = [
+        str(pr.get("body") or ""),
+        str(pr.get("headRefName") or ""),
+        str(pr.get("title") or ""),
+    ]
+    for text in parts:
+        match = TICKET_RE.search(text)
+        if match:
+            return match.group(0)
+    return None
+
+
+def score_exists(conn: sqlite3.Connection, pr_url: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM swarm_dispatch_scores WHERE pr_url = ? LIMIT 1",
+        (pr_url,),
+    ).fetchone()
+    return row is not None
+
+
+def _comment_bodies(ticket_json: dict) -> Iterable[str]:
+    candidates = []
+    if isinstance(ticket_json, dict):
+        candidates.extend(ticket_json.get("comments") or [])
+        candidates.extend(ticket_json.get("task_comments") or [])
+        task = ticket_json.get("task")
+        if isinstance(task, dict):
+            candidates.extend(task.get("comments") or [])
+    for item in candidates:
+        if isinstance(item, str):
+            yield item
+        elif isinstance(item, dict):
+            body = item.get("body") or item.get("text") or item.get("comment")
+            if body:
+                yield str(body)
+
+
+def parse_dispatch_meta_from_comments(ticket_json: dict) -> DispatchMeta | None:
+    # Last matching comment wins so retries can update model/role.
+    found: DispatchMeta | None = None
+    for body in _comment_bodies(ticket_json):
+        match = DISPATCH_META_RE.search(body)
+        if match:
+            found = DispatchMeta(
+                driver=match.group("driver"),
+                model=match.group("model"),
+                role=match.group("role"),
+                inferred=False,
+            )
+    return found
+
+
+def fetch_ticket_json(ticket_id: str) -> dict:
+    result = subprocess.run(
+        ["hermes", "kanban", "--board", "chitin", "show", ticket_id, "--json"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"hermes show {ticket_id} failed rc={result.returncode}: {result.stderr.strip()[:200]}")
+    return json.loads(result.stdout or "{}")
+
+
+def recover_dispatch_meta(ticket_id: str) -> DispatchMeta:
+    try:
+        meta = parse_dispatch_meta_from_comments(fetch_ticket_json(ticket_id))
+        if meta:
+            return meta
+        log(f"{ticket_id}: dispatch metadata absent; using inferred default")
+    except Exception as exc:  # noqa: BLE001 - log and fall back for backfill robustness
+        log(f"{ticket_id}: metadata recovery failed: {exc}; using inferred default")
+    return DispatchMeta(DEFAULT_DRIVER, DEFAULT_MODEL, DEFAULT_ROLE, inferred=True)
+
+
+def run_judge(ticket_id: str, pr_url: str, meta: DispatchMeta, *, dry_run: bool = False) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "judge.py"),
+        "--ticket", ticket_id,
+        "--pr-url", pr_url,
+        "--driver", meta.driver,
+        "--model", meta.model,
+        "--role", meta.role,
+    ]
+    if meta.inferred:
+        cmd.append("--inferred")
+    if dry_run:
+        cmd.append("--dry-run")
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=360)
+
+
+def process_prs(prs: list[dict], *, conn: sqlite3.Connection, dry_run: bool = False) -> dict:
+    stats = {"considered": 0, "scored": 0, "skipped_no_ticket": 0, "skipped_existing": 0, "failed": 0}
+    for pr in prs:
+        stats["considered"] += 1
+        pr_url = str(pr.get("url") or "")
+        pr_num = pr.get("number") or pr_url.rsplit("/", 1)[-1]
+        ticket_id = ticket_from_pr(pr)
+        if not ticket_id:
+            stats["skipped_no_ticket"] += 1
+            log(f"PR #{pr_num}: skip no ticket id")
+            continue
+        if pr_url and score_exists(conn, pr_url):
+            stats["skipped_existing"] += 1
+            log(f"PR #{pr_num} {ticket_id}: skip already scored")
+            continue
+        meta = recover_dispatch_meta(ticket_id)
+        try:
+            result = run_judge(ticket_id, pr_url, meta, dry_run=dry_run)
+        except Exception as exc:  # noqa: BLE001
+            stats["failed"] += 1
+            log(f"PR #{pr_num} {ticket_id}: judge failed to start: {exc}")
+            continue
+        if result.returncode == 0:
+            stats["scored"] += 1
+            log(f"PR #{pr_num} {ticket_id}: scored driver={meta.driver} model={meta.model} role={meta.role} inferred={int(meta.inferred)}")
+            if result.stdout.strip():
+                log(f"PR #{pr_num} judge stdout: {result.stdout.strip()[:500]}")
+        else:
+            stats["failed"] += 1
+            log(f"PR #{pr_num} {ticket_id}: judge rc={result.returncode} stderr={result.stderr.strip()[:500]}")
+    return stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--hours", type=int, default=48, help="Look back this many hours for merged PRs")
+    ap.add_argument("--limit", type=int, default=0, help="Optional max PRs to consider this run (0 = no limit)")
+    ap.add_argument("--dry-run", action="store_true", help="Run discovery/judge prompt only; do not write scores")
+    args = ap.parse_args()
+
+    conn = elo.open_db()
+    try:
+        prs = query_merged_prs(args.hours)
+        if args.limit > 0:
+            prs = prs[: args.limit]
+        stats = process_prs(prs, conn=conn, dry_run=args.dry_run)
+        log("summary " + json.dumps(stats, sort_keys=True))
+        return 0 if stats["failed"] == 0 else 1
+    except Exception as exc:  # noqa: BLE001
+        log(f"fatal: {exc}")
+        return 2
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -311,6 +311,9 @@ steps:
         echo "spawn_worker: selected model $MODEL is not present on driver=$DRIVER card" >&2
         exit 1
       fi
+      ROLE="${ROLE:-programmer}"
+      hermes kanban --board chitin comment "$TICKET_ID" --author clawta \
+        "dispatch driver=$DRIVER model=$MODEL role=$ROLE" 2>/dev/null || true
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
       ARGS_JSON=$(jq -c --arg model "$MODEL" \
         '.invocation.args | map(if . == "{model}" then $model else . end)' \


### PR DESCRIPTION
## Summary
- persist dispatch driver/model/role metadata on kanban tickets for later scoring
- add cron-friendly judge_backfill.py for merged PRs, with idempotent score skips and per-PR failure isolation
- add inferred dispatch metadata support to judge/ELO schema and fix the judge model label to clawta-gpt-5.5
- add systemd service/timer units plus installer for 15-minute backfill runs

## Verification
- python3 -m unittest swarm/tests/test_judge.py swarm/tests/test_judge_backfill.py swarm/tests/test_swarm_elo.py
- python3 -m py_compile swarm/workflows/judge.py swarm/workflows/_swarm_elo.py swarm/workflows/judge_backfill.py
- python3 swarm/workflows/judge_backfill.py --hours 72 --limit 3
  - produced new score rows for PR #618 and #617 (new total rows: 5)
- ./swarm/bin/swarm-elo leaderboard

## Notes
- Did not install the systemd timer on the host from this PR branch; installer is included for operator/merge-time activation.