### PR TITLE
fix(swarm): keep worker prompts out of argv

### DIFF
--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -328,13 +328,17 @@ steps:
       # Spawn worker as subprocess with output capture instead of exec.
       # This enables: output capture, result observation, and parent-child
       # session tracking via parent_chain_id in chain ledger.
-      SPAWN_CONFIG=$(jq -n \
+      #
+      # The prompt is fed to jq over stdin (--rawfile /dev/stdin), not as
+      # --arg, so the full ticket body never lands in jq's argv / ps output
+      # or risks ARG_MAX. Everything else passed to jq is small + non-sensitive.
+      SPAWN_CONFIG=$(printf '%s' "$PROMPT" | jq -n \
         --arg driver "$DRIVER" \
         --arg model "$MODEL" \
         --arg worktree "$WORKTREE_DIR" \
         --arg branch "$BRANCH" \
         --arg cmd "$CMD" \
-        --arg prompt "$PROMPT" \
+        --rawfile prompt /dev/stdin \
         --argjson args "$(echo "$ARGS_JSON" | jq -c '.')" \
         '{
           driver: $driver,

--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -201,8 +201,9 @@ steps:
   #
   # Reads ~/.openclaw/data/agent-cards/<driver>.json and honors the
   # model selected by _pick_driver.py (complexity-aware and ELO-ready).
-  # substitutes {model} and {prompt} into card.invocation.args, execs
-  # the leaf CLI. The exec is gated by chitin under driver=clawta (the
+  # substitutes {model} into card.invocation.args and passes the full
+  # prompt via stdin inside the subprocess helper so long ticket bodies
+  # stay out of argv / ps output. The leaf CLI exec is gated by chitin under driver=clawta (the
   # spawning surface); the leaf CLI's own PreToolUse/BeforeTool hook
   # handles inner-hop chain events with driver=<cli>.
   #
@@ -311,11 +312,9 @@ steps:
         exit 1
       fi
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
-      ARGS_JSON=$(jq -c --arg model "$MODEL" --arg prompt "$PROMPT" \
-        '.invocation.args | map(if . == "{model}" then $model elif . == "{prompt}" then $prompt else . end)' \
+      ARGS_JSON=$(jq -c --arg model "$MODEL" \
+        '.invocation.args | map(if . == "{model}" then $model else . end)' \
         "$CARD_PATH")
-      # NUL-delimit so multi-line prompts survive intact; -r would split on \n.
-      mapfile -d '' -t ARGV < <(echo "$ARGS_JSON" | jq -j '.[] | . + "\u0000"')
       # Per-dispatch envelope: each worker gets its own spent_calls
       # counter. Without this, the worker inherits the parent's
       # CHITIN_BUDGET_ENVELOPE (which beats the ~/.chitin/current-envelope
@@ -323,7 +322,8 @@ steps:
       # agent dispatched under the same parent — one cap hit locks
       # whichever agent calls next.
       NEW_ENV=$(chitin-kernel envelope create --calls=10000 --bytes=33554432 --usd=2.0)
-      echo "spawn_worker: spawning $CMD ${ARGV[*]} (envelope=$NEW_ENV)" >&2
+      PROMPT_BYTES=$(printf '%s' "$PROMPT" | wc -c | tr -d ' ')
+      echo "spawn_worker: spawning driver=$DRIVER model=$MODEL cmd=$CMD prompt_bytes=$PROMPT_BYTES envelope=$NEW_ENV" >&2
 
       # Spawn worker as subprocess with output capture instead of exec.
       # This enables: output capture, result observation, and parent-child
@@ -334,6 +334,7 @@ steps:
         --arg worktree "$WORKTREE_DIR" \
         --arg branch "$BRANCH" \
         --arg cmd "$CMD" \
+        --arg prompt "$PROMPT" \
         --argjson args "$(echo "$ARGS_JSON" | jq -c '.')" \
         '{
           driver: $driver,
@@ -341,6 +342,7 @@ steps:
           worktree: $worktree,
           branch: $branch,
           cmd: $cmd,
+          prompt: $prompt,
           args: $args,
           env: {
             "CHITIN_DRIVER": "clawta",

--- a/docs/runbooks/swarm-runtime-guards.md
+++ b/docs/runbooks/swarm-runtime-guards.md
@@ -85,3 +85,16 @@ The installer registers these jobs:
 
 Each cron job is idempotent and responds with a closing `ok` token so OpenClaw
 records the run as successful.
+
+## Diagnostics
+
+For live worker/process inspection, prefer the narrow process view:
+
+```bash
+ps -o pid,ppid,stat,rss,etime,command -C codex -C gemini -C chitin-kernel -C lobster
+```
+
+This keeps diagnostics readable and avoids dumping long ticket or diff text by
+default. Worker launchers now pass large prompts through stdin where the driver
+supports it; if deeper inspection is needed, check the relevant log file rather
+than relying on full argv snapshots.

--- a/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
+++ b/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
@@ -78,6 +78,15 @@ func resolveCopilotPrompt(args []string, interactive bool, stdin io.Reader) (str
 		return "", nil
 	}
 
+	// If stdin is an interactive terminal (not a pipe or file), no prompt is
+	// coming — return the usage error immediately instead of blocking on
+	// ReadAll waiting for an EOF the operator has no way to send.
+	if f, ok := stdin.(*os.File); ok {
+		if stat, statErr := f.Stat(); statErr == nil && stat.Mode()&os.ModeCharDevice != 0 {
+			return "", fmt.Errorf("prompt required unless --interactive")
+		}
+	}
+
 	data, err := io.ReadAll(stdin)
 	if err != nil {
 		return "", fmt.Errorf("read stdin: %w", err)

--- a/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
+++ b/go/execution-kernel/cmd/chitin-kernel/drive_copilot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -49,16 +50,14 @@ func cmdDriveCopilot(args []string) int {
 		return 0
 	}
 
-	var prompt string
-	if fs.NArg() > 0 {
-		prompt = strings.Join(fs.Args(), " ")
-	} else if !*interactive {
-		fmt.Fprintln(os.Stderr, "error: prompt required unless --interactive")
+	prompt, err := resolveCopilotPrompt(fs.Args(), *interactive, os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
 		return 2
 	}
 
 	ctx := context.Background()
-	err := copilot.Run(ctx, prompt, copilot.RunOpts{
+	err = copilot.Run(ctx, prompt, copilot.RunOpts{
 		Cwd:         *cwd,
 		Interactive: *interactive,
 		Verbose:     *verbose,
@@ -69,4 +68,22 @@ func cmdDriveCopilot(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+func resolveCopilotPrompt(args []string, interactive bool, stdin io.Reader) (string, error) {
+	if len(args) > 0 {
+		return strings.Join(args, " "), nil
+	}
+	if interactive {
+		return "", nil
+	}
+
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return "", fmt.Errorf("prompt required unless --interactive")
+	}
+	return string(data), nil
 }

--- a/go/execution-kernel/cmd/chitin-kernel/drive_copilot_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/drive_copilot_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveCopilotPrompt_UsesArgsWhenPresent(t *testing.T) {
+	prompt, err := resolveCopilotPrompt([]string{"fix", "the", "bug"}, false, strings.NewReader("ignored"))
+	if err != nil {
+		t.Fatalf("resolveCopilotPrompt returned error: %v", err)
+	}
+	if prompt != "fix the bug" {
+		t.Fatalf("got %q, want joined argv prompt", prompt)
+	}
+}
+
+func TestResolveCopilotPrompt_ReadsStdinWhenArgMissing(t *testing.T) {
+	prompt, err := resolveCopilotPrompt(nil, false, strings.NewReader("stdin prompt"))
+	if err != nil {
+		t.Fatalf("resolveCopilotPrompt returned error: %v", err)
+	}
+	if prompt != "stdin prompt" {
+		t.Fatalf("got %q, want stdin prompt", prompt)
+	}
+}
+
+func TestResolveCopilotPrompt_RejectsEmptyNonInteractivePrompt(t *testing.T) {
+	_, err := resolveCopilotPrompt(nil, false, strings.NewReader("   \n"))
+	if err == nil {
+		t.Fatal("expected empty stdin to be rejected")
+	}
+}
+
+func TestResolveCopilotPrompt_AllowsInteractiveWithoutPrompt(t *testing.T) {
+	prompt, err := resolveCopilotPrompt(nil, true, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("resolveCopilotPrompt returned error: %v", err)
+	}
+	if prompt != "" {
+		t.Fatalf("got %q, want empty interactive prompt", prompt)
+	}
+}

--- a/swarm/bin/clawta-pr-fix-dispatcher
+++ b/swarm/bin/clawta-pr-fix-dispatcher
@@ -20,6 +20,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -181,13 +182,20 @@ def dispatch_worker(pr: dict[str, Any], review_body: str, dry_run: bool) -> str:
     wt = ensure_worktree(branch, pr_number)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     with log_path.open("a") as out:
+        prompt_file = tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False)
+        prompt_file.write(prompt)
+        prompt_file.flush()
+        prompt_file.seek(0)
         proc = subprocess.Popen(
-            ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--model", CODEX_MODEL, prompt],
+            ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--model", CODEX_MODEL],
             cwd=str(wt),
+            stdin=prompt_file,
             stdout=out,
             stderr=out,
             start_new_session=True,
         )
+    os.unlink(prompt_file.name)
+    prompt_file.close()
     log(f"dispatched codex fix worker for PR #{pr_number} pid={proc.pid} log={log_path}")
     return str(log_path)
 

--- a/swarm/bin/clawta-pr-fix-dispatcher
+++ b/swarm/bin/clawta-pr-fix-dispatcher
@@ -183,19 +183,24 @@ def dispatch_worker(pr: dict[str, Any], review_body: str, dry_run: bool) -> str:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     with log_path.open("a") as out:
         prompt_file = tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False)
-        prompt_file.write(prompt)
-        prompt_file.flush()
-        prompt_file.seek(0)
-        proc = subprocess.Popen(
-            ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--model", CODEX_MODEL],
-            cwd=str(wt),
-            stdin=prompt_file,
-            stdout=out,
-            stderr=out,
-            start_new_session=True,
-        )
-    os.unlink(prompt_file.name)
-    prompt_file.close()
+        try:
+            prompt_file.write(prompt)
+            prompt_file.flush()
+            prompt_file.seek(0)
+            proc = subprocess.Popen(
+                ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--model", CODEX_MODEL],
+                cwd=str(wt),
+                stdin=prompt_file,
+                stdout=out,
+                stderr=out,
+                start_new_session=True,
+            )
+        finally:
+            # Always clean up the prompt file — even if Popen raises — so the
+            # ticket body never lingers on disk. The child has already dup'd
+            # the fd by the time Popen returns, so unlinking here is safe.
+            prompt_file.close()
+            os.unlink(prompt_file.name)
     log(f"dispatched codex fix worker for PR #{pr_number} pid={proc.pid} log={log_path}")
     return str(log_path)
 

--- a/swarm/tests/test_clawta_pr_fix_dispatcher.py
+++ b/swarm/tests/test_clawta_pr_fix_dispatcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -107,6 +108,37 @@ class FixDispatcherTests(unittest.TestCase):
         stdin_text = stdin_payloads[0]
         self.assertIn("Review comment:", stdin_text)
         self.assertIn(review, stdin_text)
+
+    def test_dispatch_worker_cleans_up_prompt_file_when_popen_errors(self):
+        # Boundary: error. If Popen raises, the temp prompt file — which holds
+        # the review/ticket body — must still be removed, not leaked to disk.
+        module = load_module()
+        created_files = []
+        real_named_tmp = tempfile.NamedTemporaryFile
+
+        def recording_named_tmp(*args, **kwargs):
+            handle = real_named_tmp(*args, **kwargs)
+            created_files.append(handle.name)
+            return handle
+
+        pr = {"number": 88, "title": "x", "headRefName": "swarm/codex-fix", "url": "https://example/pr/88"}
+        review = "Review body."
+
+        with tempfile.TemporaryDirectory() as tmp:
+            worktree = Path(tmp) / "pr-88"
+            worktree.mkdir()
+            with mock.patch.object(module, "WORKTREE_ROOT", Path(tmp)), \
+                 mock.patch.object(module, "ensure_worktree", return_value=worktree), \
+                 mock.patch.object(module.tempfile, "NamedTemporaryFile", side_effect=recording_named_tmp), \
+                 mock.patch.object(module.subprocess, "Popen", side_effect=FileNotFoundError("codex")):
+                with self.assertRaises(FileNotFoundError):
+                    module.dispatch_worker(pr, review, dry_run=False)
+
+        self.assertEqual(len(created_files), 1)
+        self.assertFalse(
+            os.path.exists(created_files[0]),
+            "temp prompt file leaked to disk after Popen error",
+        )
 
 
 if __name__ == "__main__":

--- a/swarm/tests/test_clawta_pr_fix_dispatcher.py
+++ b/swarm/tests/test_clawta_pr_fix_dispatcher.py
@@ -73,6 +73,41 @@ class FixDispatcherTests(unittest.TestCase):
             calls,
         )
 
+    def test_dispatch_worker_pipes_prompt_over_stdin_instead_of_argv(self):
+        module = load_module()
+        popen_calls = []
+        stdin_payloads = []
+
+        class FakePopen:
+            def __init__(self, cmd, **kwargs):
+                popen_calls.append((cmd, kwargs))
+                handle = kwargs["stdin"]
+                handle.seek(0)
+                stdin_payloads.append(handle.read())
+                self.pid = 4321
+
+        pr = {"number": 77, "title": "Fix lint", "headRefName": "swarm/codex-fix", "url": "https://example/pr/77"}
+        review = "Review body with actionable changes."
+
+        with tempfile.TemporaryDirectory() as tmp:
+            worktree = Path(tmp) / "pr-77"
+            worktree.mkdir()
+            with mock.patch.object(module, "WORKTREE_ROOT", Path(tmp)), \
+                 mock.patch.object(module, "ensure_worktree", return_value=worktree), \
+                 mock.patch.object(module.subprocess, "Popen", FakePopen):
+                module.dispatch_worker(pr, review, dry_run=False)
+
+        self.assertEqual(len(popen_calls), 1)
+        cmd, kwargs = popen_calls[0]
+        self.assertEqual(
+            cmd,
+            ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--model", module.CODEX_MODEL],
+        )
+        self.assertNotIn(review, cmd)
+        stdin_text = stdin_payloads[0]
+        self.assertIn("Review comment:", stdin_text)
+        self.assertIn(review, stdin_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/tests/test_spawn_worker_subprocess.py
+++ b/swarm/tests/test_spawn_worker_subprocess.py
@@ -1,0 +1,70 @@
+"""Unit tests for spawn_worker_subprocess prompt transport."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "workflows" / "spawn_worker_subprocess.py"
+
+
+def load_module():
+    loader = importlib.machinery.SourceFileLoader("spawn_worker_subprocess", str(SCRIPT))
+    spec = importlib.util.spec_from_loader("spawn_worker_subprocess", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class SpawnWorkerSubprocessTests(unittest.TestCase):
+    def test_prepare_worker_command_codex_uses_stdin_not_prompt_argv(self):
+        module = load_module()
+        argv, stdin_text = module.prepare_worker_command(
+            {
+                "driver": "codex",
+                "cmd": "codex",
+                "model": "gpt-5.5",
+                "prompt": "ticket body here",
+                "args": ["exec", "--model", "{model}", "{prompt}"],
+            }
+        )
+
+        self.assertEqual(argv, ["codex", "exec", "--model", "gpt-5.5"])
+        self.assertEqual(stdin_text, "ticket body here")
+
+    def test_prepare_worker_command_gemini_uses_empty_prompt_flag_plus_stdin(self):
+        module = load_module()
+        argv, stdin_text = module.prepare_worker_command(
+            {
+                "driver": "gemini",
+                "cmd": "gemini",
+                "model": "gemini-2.5-flash",
+                "prompt": "ticket body here",
+                "args": ["-y", "-p", "{prompt}", "--model", "{model}"],
+            }
+        )
+
+        self.assertEqual(argv, ["gemini", "-y", "-p", "", "--model", "gemini-2.5-flash"])
+        self.assertEqual(stdin_text, "ticket body here")
+
+    def test_prepare_worker_command_copilot_uses_stdin_not_prompt_argv(self):
+        module = load_module()
+        argv, stdin_text = module.prepare_worker_command(
+            {
+                "driver": "copilot",
+                "cmd": "chitin-kernel",
+                "model": "gpt-4.1",
+                "prompt": "ticket body here",
+                "args": ["drive", "copilot", "--model", "{model}", "--cwd", ".", "{prompt}"],
+            }
+        )
+
+        self.assertEqual(argv, ["chitin-kernel", "drive", "copilot", "--model", "gpt-4.1", "--cwd", "."])
+        self.assertEqual(stdin_text, "ticket body here")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/swarm/tests/test_spawn_worker_subprocess.py
+++ b/swarm/tests/test_spawn_worker_subprocess.py
@@ -65,6 +65,41 @@ class SpawnWorkerSubprocessTests(unittest.TestCase):
         self.assertEqual(argv, ["chitin-kernel", "drive", "copilot", "--model", "gpt-4.1", "--cwd", "."])
         self.assertEqual(stdin_text, "ticket body here")
 
+    def test_prepare_worker_command_max_size_prompt_stays_off_argv(self):
+        # Boundary: max. A very large ticket body must travel via stdin_text,
+        # never argv — that is the whole point of the change (ps visibility +
+        # ARG_MAX). Check every stdin-routed driver.
+        module = load_module()
+        huge_prompt = "x" * 500_000
+        for driver, cmd in (("codex", "codex"), ("copilot", "chitin-kernel"), ("gemini", "gemini")):
+            argv, stdin_text = module.prepare_worker_command(
+                {
+                    "driver": driver,
+                    "cmd": cmd,
+                    "model": "m",
+                    "prompt": huge_prompt,
+                    "args": ["--model", "{model}", "{prompt}"],
+                }
+            )
+            self.assertEqual(stdin_text, huge_prompt, msg=driver)
+            self.assertNotIn(huge_prompt, argv, msg=driver)
+
+    def test_prepare_worker_command_missing_prompt_does_not_crash(self):
+        # Boundary: error. A config with no "prompt" key must not raise — the
+        # helper falls back to an empty prompt, still routed via stdin so the
+        # {prompt} placeholder never becomes a literal argv entry.
+        module = load_module()
+        argv, stdin_text = module.prepare_worker_command(
+            {
+                "driver": "codex",
+                "cmd": "codex",
+                "model": "gpt-5.5",
+                "args": ["exec", "--model", "{model}", "{prompt}"],
+            }
+        )
+        self.assertEqual(argv, ["codex", "exec", "--model", "gpt-5.5"])
+        self.assertEqual(stdin_text, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -328,13 +328,17 @@ steps:
       # Spawn worker as subprocess with output capture instead of exec.
       # This enables: output capture, result observation, and parent-child
       # session tracking via parent_chain_id in chain ledger.
-      SPAWN_CONFIG=$(jq -n \
+      #
+      # The prompt is fed to jq over stdin (--rawfile /dev/stdin), not as
+      # --arg, so the full ticket body never lands in jq's argv / ps output
+      # or risks ARG_MAX. Everything else passed to jq is small + non-sensitive.
+      SPAWN_CONFIG=$(printf '%s' "$PROMPT" | jq -n \
         --arg driver "$DRIVER" \
         --arg model "$MODEL" \
         --arg worktree "$WORKTREE_DIR" \
         --arg branch "$BRANCH" \
         --arg cmd "$CMD" \
-        --arg prompt "$PROMPT" \
+        --rawfile prompt /dev/stdin \
         --argjson args "$(echo "$ARGS_JSON" | jq -c '.')" \
         '{
           driver: $driver,

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -201,8 +201,9 @@ steps:
   #
   # Reads ~/.openclaw/data/agent-cards/<driver>.json and honors the
   # model selected by _pick_driver.py (complexity-aware and ELO-ready).
-  # substitutes {model} and {prompt} into card.invocation.args, execs
-  # the leaf CLI. The exec is gated by chitin under driver=clawta (the
+  # substitutes {model} into card.invocation.args and passes the full
+  # prompt via stdin inside the subprocess helper so long ticket bodies
+  # stay out of argv / ps output. The leaf CLI exec is gated by chitin under driver=clawta (the
   # spawning surface); the leaf CLI's own PreToolUse/BeforeTool hook
   # handles inner-hop chain events with driver=<cli>.
   #
@@ -311,11 +312,9 @@ steps:
         exit 1
       fi
       CMD=$(jq -r '.invocation.cmd' "$CARD_PATH")
-      ARGS_JSON=$(jq -c --arg model "$MODEL" --arg prompt "$PROMPT" \
-        '.invocation.args | map(if . == "{model}" then $model elif . == "{prompt}" then $prompt else . end)' \
+      ARGS_JSON=$(jq -c --arg model "$MODEL" \
+        '.invocation.args | map(if . == "{model}" then $model else . end)' \
         "$CARD_PATH")
-      # NUL-delimit so multi-line prompts survive intact; -r would split on \n.
-      mapfile -d '' -t ARGV < <(echo "$ARGS_JSON" | jq -j '.[] | . + "\u0000"')
       # Per-dispatch envelope: each worker gets its own spent_calls
       # counter. Without this, the worker inherits the parent's
       # CHITIN_BUDGET_ENVELOPE (which beats the ~/.chitin/current-envelope
@@ -323,7 +322,8 @@ steps:
       # agent dispatched under the same parent — one cap hit locks
       # whichever agent calls next.
       NEW_ENV=$(chitin-kernel envelope create --calls=10000 --bytes=33554432 --usd=2.0)
-      echo "spawn_worker: spawning $CMD ${ARGV[*]} (envelope=$NEW_ENV)" >&2
+      PROMPT_BYTES=$(printf '%s' "$PROMPT" | wc -c | tr -d ' ')
+      echo "spawn_worker: spawning driver=$DRIVER model=$MODEL cmd=$CMD prompt_bytes=$PROMPT_BYTES envelope=$NEW_ENV" >&2
 
       # Spawn worker as subprocess with output capture instead of exec.
       # This enables: output capture, result observation, and parent-child
@@ -334,6 +334,7 @@ steps:
         --arg worktree "$WORKTREE_DIR" \
         --arg branch "$BRANCH" \
         --arg cmd "$CMD" \
+        --arg prompt "$PROMPT" \
         --argjson args "$(echo "$ARGS_JSON" | jq -c '.')" \
         '{
           driver: $driver,
@@ -341,6 +342,7 @@ steps:
           worktree: $worktree,
           branch: $branch,
           cmd: $cmd,
+          prompt: $prompt,
           args: $args,
           env: {
             "CHITIN_DRIVER": "clawta",

--- a/swarm/workflows/spawn_worker_subprocess.py
+++ b/swarm/workflows/spawn_worker_subprocess.py
@@ -62,6 +62,10 @@ def prepare_worker_command(config: dict) -> tuple[list[str], str | None]:
                 stdin_text = prompt
                 continue
             if driver == "gemini":
+                # gemini CLI: `-p ""` selects non-interactive mode while
+                # leaving the prompt body to be read from stdin. The empty
+                # argv slot is the flag value, not the prompt — the real
+                # prompt travels via stdin_text so it stays off argv.
                 argv.append("")
                 stdin_text = prompt
                 continue
@@ -71,6 +75,8 @@ def prepare_worker_command(config: dict) -> tuple[list[str], str | None]:
         argv.append(arg)
 
     if prompt and driver == "gemini" and "{prompt}" not in args_template:
+        # Card has no {prompt} placeholder: append `-p ""` ourselves so the
+        # gemini CLI still runs non-interactively and consumes stdin_text.
         argv.extend(["-p", ""])
         stdin_text = prompt
 

--- a/swarm/workflows/spawn_worker_subprocess.py
+++ b/swarm/workflows/spawn_worker_subprocess.py
@@ -36,7 +36,45 @@ import json
 import subprocess
 import sys
 import os
-from pathlib import Path
+
+
+def prepare_worker_command(config: dict) -> tuple[list[str], str | None]:
+    """Build a worker command line while keeping long prompts out of argv.
+
+    Returns (argv, stdin_text). The caller is responsible for feeding
+    stdin_text to the subprocess when non-None.
+    """
+    driver = config.get("driver", "unknown")
+    model = config.get("model", "")
+    prompt = config.get("prompt", "")
+    args_template = config.get("args", [])
+
+    argv: list[str] = [config.get("cmd", "")]
+    stdin_text: str | None = None
+
+    for arg in args_template:
+        if arg == "{model}":
+            argv.append(model)
+            continue
+
+        if arg == "{prompt}":
+            if driver in {"codex", "copilot"}:
+                stdin_text = prompt
+                continue
+            if driver == "gemini":
+                argv.append("")
+                stdin_text = prompt
+                continue
+            argv.append(prompt)
+            continue
+
+        argv.append(arg)
+
+    if prompt and driver == "gemini" and "{prompt}" not in args_template:
+        argv.extend(["-p", ""])
+        stdin_text = prompt
+
+    return argv, stdin_text
 
 def main():
     try:
@@ -46,7 +84,6 @@ def main():
 
         driver = config.get("driver", "unknown")
         cmd = config.get("cmd", "")
-        args = config.get("args", [])
         worktree = config.get("worktree", "")
         env_vars = config.get("env", {})
 
@@ -76,8 +113,9 @@ def main():
             }))
             return 1
 
-        # Spawn worker process
-        full_cmd = [cmd] + args
+        # Spawn worker process. Driver-specific prompt handling keeps
+        # large ticket bodies off argv where possible.
+        full_cmd, stdin_text = prepare_worker_command(config)
         try:
             result = subprocess.run(
                 full_cmd,
@@ -85,6 +123,7 @@ def main():
                 env=env,
                 capture_output=True,
                 text=True,
+                input=stdin_text,
                 timeout=3600  # 1 hour timeout, same as before
             )
 


### PR DESCRIPTION
Closes ticket t_c02c8528 (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-c02c8528.