### PR TITLE
feat(swarm): surface controller projections

### DIFF
--- a/swarm/bin/clawta-poller-safe-tick
+++ b/swarm/bin/clawta-poller-safe-tick
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG=${CLAWTA_POLLER_SAFE_TICK_LOG:-/home/red/.openclaw/logs/clawta-poller-safe-tick.log}
+mkdir -p "$(dirname "$LOG")"
+ts() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log() { echo "$(ts) $*" | tee -a "$LOG"; }
+
+MAX_ACTIVE_WORKERS=${CLAWTA_MAX_ACTIVE_WORKERS:-1}
+MAX_LOAD=${CLAWTA_MAX_LOAD:-12}
+MAX_DISPATCH=${CLAWTA_MAX_DISPATCH:-1}
+TERMINAL_LANES=${TERMINAL_LANES:-codex,copilot,gemini}
+CLAWTA_POLLER_BIN=${CLAWTA_POLLER_BIN:-/home/red/.local/bin/clawta-poller}
+
+# Count active dispatch roots by ticket id; avoid counting child codex/vendor processes twice.
+# There are two valid active shapes:
+# - lobster workflow roots while orchestration is still running (`--args-json {"ticket_id":...}`)
+# - long-lived `clawta dispatch ticket t_xxx to DRIVER` roots while the worker subprocess runs
+# Empty pgrep/grep output is capacity-available, not failure.
+active_matches=$(
+  {
+    (pgrep -af 'lobster run --mode tool --file /home/red/.openclaw/workflows/kanban-dispatch.lobster' 2>/dev/null || true) \
+      | grep -oE '"ticket_id":"t_[0-9a-f]+"' \
+      | sed -E 's/.*"(t_[0-9a-f]+)".*/\1/' || true
+    (pgrep -af '/home/red/.local/bin/clawta dispatch ticket t_[0-9a-f]+ to ' 2>/dev/null || true) \
+      | grep -oE 'dispatch ticket t_[0-9a-f]+' \
+      | awk '{print $3}' || true
+  } || true
+)
+active_tickets=$(printf '%s\n' "$active_matches" | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
+active_tickets=${active_tickets:-0}
+
+load1=$(awk '{print $1}' /proc/loadavg)
+load_high=$(awk -v l="$load1" -v m="$MAX_LOAD" 'BEGIN { print (l > m) ? 1 : 0 }')
+
+if [ "$active_tickets" -ge "$MAX_ACTIVE_WORKERS" ]; then
+  log "skip: active_dispatch_tickets=$active_tickets >= max=$MAX_ACTIVE_WORKERS load1=$load1"
+  exit 0
+fi
+
+if [ "$load_high" = "1" ]; then
+  log "skip: load1=$load1 > max=$MAX_LOAD active_dispatch_tickets=$active_tickets"
+  exit 0
+fi
+
+log "run: active_dispatch_tickets=$active_tickets load1=$load1 max_dispatch=$MAX_DISPATCH lanes=$TERMINAL_LANES"
+exec env TERMINAL_LANES="$TERMINAL_LANES" CLAWTA_ROUTER_MODE="${CLAWTA_ROUTER_MODE:-deterministic}" "$CLAWTA_POLLER_BIN" --once --max-dispatch "$MAX_DISPATCH"

--- a/swarm/bin/clawta-poller-safe-tick
+++ b/swarm/bin/clawta-poller-safe-tick
@@ -20,7 +20,7 @@ CLAWTA_POLLER_BIN=${CLAWTA_POLLER_BIN:-/home/red/.local/bin/clawta-poller}
 active_matches=$(
   {
     (pgrep -af 'lobster run --mode tool --file /home/red/.openclaw/workflows/kanban-dispatch.lobster' 2>/dev/null || true) \
-      | grep -oE '"ticket_id":"t_[0-9a-f]+"' \
+      | grep -oE '"ticket_id":[[:space:]]*"t_[0-9a-f]+"' \
       | sed -E 's/.*"(t_[0-9a-f]+)".*/\1/' || true
     (pgrep -af '/home/red/.local/bin/clawta dispatch ticket t_[0-9a-f]+ to ' 2>/dev/null || true) \
       | grep -oE 'dispatch ticket t_[0-9a-f]+' \

--- a/swarm/bin/clawta-report
+++ b/swarm/bin/clawta-report
@@ -145,7 +145,11 @@ def active_dispatch_tickets():
     ticket ...` roots. Child vendor CLIs are intentionally ignored so one
     worker is counted once.
     """
-    code, out = sh("""{ (pgrep -af 'lobster run --mode tool --file /home/red/.openclaw/workflows/kanban-dispatch.lobster' 2>/dev/null || true) | grep -oE '"ticket_id":"t_[0-9a-f]+"' | sed -E 's/.*"(t_[0-9a-f]+)".*/\1/' || true; (pgrep -af '/home/red/.local/bin/clawta dispatch ticket t_[0-9a-f]+ to ' 2>/dev/null || true) | grep -oE 'dispatch ticket t_[0-9a-f]+' | awk '{print $3}' || true; } | sed '/^$/d' | sort -u""", 20)
+    # NOTE: raw string — the sed backreference \1 must reach sed intact. A
+    # plain "" string turns \1 into the octal escape \x01, which silently
+    # breaks ticket extraction (every row gets filtered out below).
+    # The [[:space:]]* after the colon tolerates spaced --args-json JSON.
+    code, out = sh(r"""{ (pgrep -af 'lobster run --mode tool --file /home/red/.openclaw/workflows/kanban-dispatch.lobster' 2>/dev/null || true) | grep -oE '"ticket_id":[[:space:]]*"t_[0-9a-f]+"' | sed -E 's/.*"(t_[0-9a-f]+)".*/\1/' || true; (pgrep -af '/home/red/.local/bin/clawta dispatch ticket t_[0-9a-f]+ to ' 2>/dev/null || true) | grep -oE 'dispatch ticket t_[0-9a-f]+' | awk '{print $3}' || true; } | sed '/^$/d' | sort -u""", 20)
     if code != 0:
         return []
     tickets = [line.strip() for line in out.splitlines() if re.match(r'^t_[0-9a-f]+$', line.strip())]
@@ -169,7 +173,11 @@ def runtime_lane_cards():
 def projection_scenarios(queue_depth, active_count, max_active=1):
     remaining = max(queue_depth, 0)
     capacity = max(max_active, 1)
-    waves = (remaining + capacity - 1) // capacity
+    # Workers already mid-flight occupy a lane for the first wave before the
+    # queue can use it, so they flow through the same `capacity` lanes as
+    # queued work. With active_count=0 this reduces to ceil(remaining/cap).
+    in_flight = max(active_count, 0)
+    waves = (remaining + in_flight + capacity - 1) // capacity
     scenarios = []
     for label, minutes in [("fast", 45), ("expected", 90), ("slow/sticky", 180)]:
         total_minutes = waves * minutes

--- a/swarm/bin/clawta-report
+++ b/swarm/bin/clawta-report
@@ -11,6 +11,8 @@ ELO_DB = os.path.expanduser("~/.openclaw/data/clawta.db")
 BASE_ELO = 1500.0
 BASE_K = 32.0
 K_DECAY_AT_N = 50  # keep in sync with swarm/workflows/_swarm_elo.py
+TERMINAL_LANES = {"codex", "copilot", "gemini", "claude-code"}
+ROUTING_LANE = "clawta"
 
 REPORT_CARDS = [
     {
@@ -136,6 +138,48 @@ def pill(text, tone=""):
     cls = f"pill {tone}".strip()
     return f"<span class='{cls}'>{html.escape(text)}</span>"
 
+def active_dispatch_tickets():
+    """Return unique ticket ids currently owned by dispatch roots/workers.
+
+    Counts both early lobster workflow roots and long-lived `clawta dispatch
+    ticket ...` roots. Child vendor CLIs are intentionally ignored so one
+    worker is counted once.
+    """
+    code, out = sh("""{ (pgrep -af 'lobster run --mode tool --file /home/red/.openclaw/workflows/kanban-dispatch.lobster' 2>/dev/null || true) | grep -oE '"ticket_id":"t_[0-9a-f]+"' | sed -E 's/.*"(t_[0-9a-f]+)".*/\1/' || true; (pgrep -af '/home/red/.local/bin/clawta dispatch ticket t_[0-9a-f]+ to ' 2>/dev/null || true) | grep -oE 'dispatch ticket t_[0-9a-f]+' | awk '{print $3}' || true; } | sed '/^$/d' | sort -u""", 20)
+    if code != 0:
+        return []
+    tickets = [line.strip() for line in out.splitlines() if re.match(r'^t_[0-9a-f]+$', line.strip())]
+    return sorted(set(tickets))
+
+def runtime_lane_cards():
+    root = os.path.expanduser("~/.openclaw/data/agent-cards")
+    lanes = {}
+    for lane in sorted(TERMINAL_LANES):
+        path = os.path.join(root, f"{lane}.json")
+        if os.path.exists(path):
+            try:
+                data = json.load(open(path))
+            except Exception:
+                data = {}
+            lanes[lane] = {"active": True, "models": [m.get("id", "?") for m in data.get("models", [])]}
+        else:
+            lanes[lane] = {"active": False, "models": []}
+    return lanes
+
+def projection_scenarios(queue_depth, active_count, max_active=1):
+    remaining = max(queue_depth, 0)
+    capacity = max(max_active, 1)
+    waves = (remaining + capacity - 1) // capacity
+    scenarios = []
+    for label, minutes in [("fast", 45), ("expected", 90), ("slow/sticky", 180)]:
+        total_minutes = waves * minutes
+        scenarios.append({
+            "label": label,
+            "worker_minutes": minutes,
+            "eta_seconds": total_minutes * 60,
+        })
+    return scenarios
+
 def board_conn():
     conn = sqlite3.connect(BOARD_DB)
     conn.row_factory = sqlite3.Row
@@ -171,6 +215,36 @@ def pr_check_summary(pr):
     else:
         tone, label = "good", "clean"
     return {"failing": failing, "pending": pending, "success": success, "tone": tone, "label": label}
+
+def lifecycle_snapshot():
+    code, raw = sh("cd /home/red/workspace/chitin && ./swarm/bin/clawta-pr-lifecycle --auto-merge --escalate-to red", 240)
+    if code != 0:
+        return {"items": [], "error": raw[:1000]}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"items": [], "error": raw[:1000]}
+
+def merge_blockers(item):
+    blockers = []
+    if item.get("state") != "OPEN":
+        return ["not open"]
+    if item.get("ticket") is None:
+        blockers.append("unmapped ticket")
+    elif item.get("ticket_status") != "in_progress":
+        blockers.append(f"ticket {item.get('ticket_status') or 'unknown'}")
+    if item.get("mergeable") not in ("MERGEABLE", "CLEAN"):
+        blockers.append(f"merge {item.get('mergeable') or 'unknown'}")
+    if item.get("checks") != "pass":
+        blockers.append(f"checks {item.get('checks') or 'unknown'}")
+    review = item.get("review") or "none"
+    if review != "APPROVE":
+        blockers.append(f"review {review}")
+    if not item.get("review_current_head"):
+        blockers.append("review not current-head")
+    if not blockers and not item.get("auto_merge_ready"):
+        blockers.append(item.get("action") or "not lifecycle-ready")
+    return blockers or ["ready"]
 
 def load_board_state():
     conn = board_conn()
@@ -350,6 +424,38 @@ def load_swarm_health():
     elo_rows = compute_complexity_elo(score_rows, complexity_map_from_comments(comments))
     elo_conn.close()
 
+    runtime_lanes = runtime_lane_cards()
+    enabled_lanes = {lane for lane, meta in runtime_lanes.items() if meta["active"]}
+    dispatchable = [
+        task for task in tasks
+        if task["status"] in ("ready", "todo")
+        and (task["assignee"] or "") in enabled_lanes.union({ROUTING_LANE})
+    ]
+    active_tickets = active_dispatch_tickets()
+    # Current OpenClaw cron is intentionally conservative; keep the report honest
+    # even if no env is available inside the static report runner.
+    max_active = int(os.environ.get("CLAWTA_MAX_ACTIVE_WORKERS", "1"))
+    projections = projection_scenarios(len(dispatchable), len(active_tickets), max_active=max_active)
+
+    lifecycle = lifecycle_snapshot()
+    merge_blocker_rows = []
+    for item in lifecycle.get("items", []):
+        if item.get("state") != "OPEN":
+            continue
+        blockers = merge_blockers(item)
+        merge_blocker_rows.append({
+            "pr": item.get("pr"),
+            "url": item.get("url"),
+            "ticket": item.get("ticket") or "—",
+            "ticket_status": item.get("ticket_status") or "—",
+            "checks": item.get("checks") or "unknown",
+            "review": item.get("review") or "none",
+            "mergeable": item.get("mergeable") or "unknown",
+            "action": item.get("action") or "wait",
+            "blockers": blockers,
+        })
+    merge_blocker_rows.sort(key=lambda row: (row["blockers"] == ["ready"], int(row["pr"] or 0)), reverse=True)
+
     return {
         "tasks": tasks,
         "dispatched_today": dispatched_today,
@@ -358,6 +464,13 @@ def load_swarm_health():
         "blocked_red": blocked_red,
         "pr_lifecycle": pr_lifecycle,
         "elo_rows": elo_rows,
+        "dispatchable_queue": dispatchable,
+        "active_dispatch_tickets": active_tickets,
+        "runtime_lanes": runtime_lanes,
+        "max_active_workers": max_active,
+        "projections": projections,
+        "merge_blockers": merge_blocker_rows,
+        "lifecycle_error": lifecycle.get("error", ""),
     }
 
 def parse_stats(txt):
@@ -461,6 +574,13 @@ def swarm_health():
     blocked_red = data["blocked_red"]
     prs = data["pr_lifecycle"]
     elo_rows = data["elo_rows"][:12]
+    dispatchable_queue = data["dispatchable_queue"]
+    active_dispatch = data["active_dispatch_tickets"]
+    runtime_lanes = data["runtime_lanes"]
+    projections = data["projections"]
+    max_active_workers = data["max_active_workers"]
+    merge_blockers = data["merge_blockers"]
+    lifecycle_error = data.get("lifecycle_error", "")
 
     status_counts = Counter(task["status"] for task in tasks)
     pr_status = Counter(row["checks"]["label"] for row in prs)
@@ -473,7 +593,7 @@ def swarm_health():
     hero = (
         "<section class='hero'>"
         "<div class='section-head'><div><div class='k'>Swarm Dashboard</div><div class='v'>Autopilot health across board, PRs, and judged outcomes</div></div>"
-        f"<div class='inline-stats'><span>{len(dispatched)} unique tickets dispatched today</span><span>{len(dispatch_attempts)} dispatch attempts</span><span>{len(stuck)} stuck in-progress</span><span>{len(blocked_red)} blocked on red</span><span>{len(prs)} open PRs</span></div></div>"
+        f"<div class='inline-stats'><span>{len(dispatched)} unique tickets dispatched today</span><span>{len(dispatch_attempts)} dispatch attempts</span><span>{len(dispatchable_queue)} dispatchable queued</span><span>{len(active_dispatch)}/{max_active_workers} active workers</span><span>{len(stuck)} stuck in-progress</span><span>{len(blocked_red)} blocked on red</span><span>{len(prs)} open PRs</span></div></div>"
         f"{status_pills}"
         "<p class='small muted'>ELO is replayed locally from judged dispatch scores and joined with dispatch-time complexity comments from Hermes so the breakdown stays faithful to operator-local data.</p>"
         "</section>"
@@ -505,24 +625,50 @@ def swarm_health():
         for row in prs[:14]
     ) or "<tr><td colspan='7'>No open PRs returned by GitHub.</td></tr>"
 
+    blocker_rows = ''.join(
+        f"<tr><td><a href='{html.escape(row['url'] or '#')}'>#{html.escape(str(row['pr']))}</a></td><td class='mono'>{html.escape(row['ticket'])}</td><td>{html.escape(row['ticket_status'])}</td><td>{pill(row['checks'], 'good' if row['checks']=='pass' else 'bad' if row['checks']=='fail' else 'warn')}</td><td>{pill(row['review'], 'good' if row['review']=='APPROVE' else 'bad' if row['review']=='REQUEST_CHANGES' else 'warn')}</td><td>{html.escape(row['mergeable'])}</td><td>{html.escape(', '.join(row['blockers']))}</td><td>{html.escape(row['action'])}</td></tr>"
+        for row in merge_blockers[:16]
+    ) or "<tr><td colspan='8'>No open lifecycle-managed PRs returned by Clawta lifecycle.</td></tr>"
+    if lifecycle_error:
+        blocker_rows += f"<tr><td colspan='8'><span class='bad'>Lifecycle snapshot failed:</span> {html.escape(lifecycle_error[:400])}</td></tr>"
+
     elo_table = ''.join(
         f"<tr><td>{html.escape(row['driver'])}</td><td>{html.escape(row['model'])}</td><td>{pill(row['complexity'], 'good' if row['complexity']=='low' else 'warn' if row['complexity']=='med' else 'bad' if row['complexity']=='high' else '')}</td><td>{row['elo_score']:.1f}</td><td>{row['dispatches_count']}</td><td>{row['avg_score']:.1f}</td><td class='mono'>{html.escape(row['last_ticket_id'])}</td></tr>"
         for row in elo_rows
     ) or "<tr><td colspan='7'>No judged dispatches in local ELO yet.</td></tr>"
 
+    projection_rows = ''.join(
+        f"<tr><td>{html.escape(row['label'])}</td><td>{row['worker_minutes']}m</td><td>{age_human(row['eta_seconds'])}</td></tr>"
+        for row in projections
+    )
+    lane_rows = ''.join(
+        f"<tr><td>{html.escape(lane)}</td><td>{pill('active', 'good') if meta['active'] else pill('disabled', 'bad')}</td><td>{html.escape(', '.join(meta['models']) or '—')}</td></tr>"
+        for lane, meta in sorted(runtime_lanes.items())
+    )
+    queue_rows = ''.join(
+        f"<tr><td class='mono'>{html.escape(row['id'])}</td><td>{html.escape(row['status'])}</td><td>{html.escape(row['assignee'] or '(unassigned)')}</td><td>{html.escape(row['title'])}</td></tr>"
+        for row in dispatchable_queue[:14]
+    ) or "<tr><td colspan='4'>No dispatchable ready/todo tickets for active lanes.</td></tr>"
+
     body = (
         hero
         + "<section class='grid'>"
+        + f"<div class='card'><div class='k'>Dispatchable Queue</div><div class='v'>{len(dispatchable_queue)}</div><div class='small muted'>ready/todo tickets assigned to Clawta or active terminal lanes</div></div>"
+        + f"<div class='card'><div class='k'>Active Workers</div><div class='v'>{len(active_dispatch)}/{max_active_workers}</div><div class='small muted'>{html.escape(', '.join(active_dispatch) or 'none')} currently counted by dispatch roots</div></div>"
         + f"<div class='card'><div class='k'>Dispatched Today</div><div class='v'>{len(dispatched)}</div><div class='small muted'>{len(dispatch_attempts)} transitions to <span class='mono'>in_progress</span> since local midnight</div></div>"
         + f"<div class='card'><div class='k'>Stuck Tickets</div><div class='v bad'>{len(stuck)}</div><div class='small muted'>idle for 90m+ or explicitly watchdog-flagged</div></div>"
         + f"<div class='card'><div class='k'>Blocked Red Queue</div><div class='v warn'>{len(blocked_red)}</div><div class='small muted'>blocked tickets assigned to red</div></div>"
         + f"<div class='card'><div class='k'>Open PR Lifecycle</div><div class='v'>{len(prs)}</div><div class='small muted'>{pr_status.get('failing', 0)} failing · {pr_status.get('pending', 0)} pending · {pr_status.get('clean', 0)} clean</div></div>"
         + "</section>"
         + "<section class='grid-2'>"
+        + f"<div class='card'><div class='section-head'><h2>Queue Projection</h2><span class='small muted'>current cap: {max_active_workers} active worker(s)</span></div><table><tr><th>Scenario</th><th>Avg worker runtime</th><th>Estimated drain time</th></tr>{projection_rows}</table><p class='small muted'>Projection counts dispatch/PR creation only; clean PR lifecycle normally adds check/review time.</p></div>"
+        + f"<div class='card'><div class='section-head'><h2>Lane Health</h2><span class='small muted'>runtime agent-card presence</span></div><table><tr><th>Lane</th><th>Status</th><th>Models</th></tr>{lane_rows}</table></div>"
+        + f"<div class='card'><div class='section-head'><h2>Dispatchable Queue</h2><span class='small muted'>first 14</span></div><table><tr><th>Ticket</th><th>Status</th><th>Assignee</th><th>Title</th></tr>{queue_rows}</table></div>"
         + f"<div class='card'><div class='section-head'><h2>Dispatched Today</h2><a href='{BASE}/clawta-swarm-health-latest.html'>latest asset</a></div><table><tr><th>Ticket</th><th>Title</th><th>Lane</th><th>Dispatched</th><th>PR</th></tr>{dispatched_rows}</table></div>"
         + f"<div class='card'><div class='section-head'><h2>Stuck Tickets</h2><span class='small muted'>watchdog + idle heuristic</span></div><ul class='list'>{stuck_items}</ul></div>"
         + "</section>"
         + f"<div class='card'><div class='section-head'><h2>Blocked Red Queue</h2><span class='small muted'>sorted by priority then age</span></div><table><tr><th>Ticket</th><th>Title</th><th>Priority</th><th>Blocked At</th><th>Age</th></tr>{blocked_rows}</table></div>"
+        + f"<div class='card'><div class='section-head'><h2>Why PRs Are Not Auto-Merging</h2><span class='small muted'>strict lifecycle gate blockers</span></div><table><tr><th>PR</th><th>Ticket</th><th>Ticket Status</th><th>Checks</th><th>Review</th><th>Merge</th><th>Blockers</th><th>Lifecycle Action</th></tr>{blocker_rows}</table></div>"
         + f"<div class='card'><div class='section-head'><h2>Open PR Lifecycle</h2><span class='small muted'>GitHub state + check rollups</span></div><table><tr><th>PR</th><th>Ticket</th><th>Head</th><th>Checks</th><th>Merge</th><th>Pass</th><th>Title</th></tr>{pr_rows}</table></div>"
         + f"<div class='card'><div class='section-head'><h2>Model-Aware ELO</h2><span class='small muted'>driver + model + complexity replayed from local score history</span></div><table><tr><th>Driver</th><th>Model</th><th>Complexity</th><th>ELO</th><th>Dispatches</th><th>Avg Score</th><th>Last Ticket</th></tr>{elo_table}</table></div>"
     )

--- a/swarm/bin/clawta-swarm-pr-owner-cron
+++ b/swarm/bin/clawta-swarm-pr-owner-cron
@@ -6,6 +6,8 @@ git pull --ff-only origin main >/tmp/clawta-pr-owner-pull.log 2>&1
 pull_rc=$?
 ./swarm/bin/clawta-pr-reviewer --max-prs 3 >/tmp/clawta-pr-owner-reviewer.json 2>/tmp/clawta-pr-owner-reviewer.err
 review_rc=$?
+./swarm/bin/clawta-pr-fix-dispatcher --max-prs "${CLAWTA_PR_FIX_MAX_PRS:-1}" >/tmp/clawta-pr-owner-fix-dispatcher.json 2>/tmp/clawta-pr-owner-fix-dispatcher.err
+fix_rc=$?
 if ./swarm/bin/clawta-pr-lifecycle --help 2>&1 | grep -q -- '--escalate-to'; then
   ./swarm/bin/clawta-pr-lifecycle --apply --auto-merge --escalate-to red >/tmp/clawta-pr-owner-lifecycle.json 2>/tmp/clawta-pr-owner-lifecycle.err
 else
@@ -13,10 +15,11 @@ else
 fi
 life_rc=$?
 
-PULL_RC=$pull_rc REVIEW_RC=$review_rc LIFE_RC=$life_rc python3 - <<'PY'
+PULL_RC=$pull_rc REVIEW_RC=$review_rc FIX_RC=$fix_rc LIFE_RC=$life_rc python3 - <<'PY'
 import json, os, pathlib
 pull_rc = int(os.environ.get('PULL_RC', '1'))
 review_rc = int(os.environ.get('REVIEW_RC', '1'))
+fix_rc = int(os.environ.get('FIX_RC', '1'))
 life_rc = int(os.environ.get('LIFE_RC', '1'))
 print('🦞 swarm PR owner cron')
 if pull_rc:
@@ -30,6 +33,18 @@ try:
         print(f'- reviewer failed rc={review_rc}: ' + pathlib.Path('/tmp/clawta-pr-owner-reviewer.err').read_text(errors='ignore')[-300:].replace('\n',' '))
 except Exception as e:
     print(f'- reviewer summary unavailable: {e}')
+try:
+    f=json.load(open('/tmp/clawta-pr-owner-fix-dispatcher.json'))
+    dispatched=f.get('dispatched') or []
+    skipped=f.get('skipped') or []
+    if dispatched:
+        print('- fix-dispatcher: dispatched ' + ', '.join('#'+str(x.get('pr','?')) for x in dispatched[:8]))
+    elif fix_rc:
+        print(f'- fix-dispatcher failed rc={fix_rc}: ' + pathlib.Path('/tmp/clawta-pr-owner-fix-dispatcher.err').read_text(errors='ignore')[-300:].replace('\n',' '))
+    else:
+        print(f'- fix-dispatcher: no dispatches ({len(skipped)} skipped)')
+except Exception as e:
+    print(f'- fix-dispatcher summary unavailable: {e}')
 try:
     l=json.load(open('/tmp/clawta-pr-owner-lifecycle.json'))
     actions=[]

--- a/swarm/bin/clawta-worker-failure-sentinel
+++ b/swarm/bin/clawta-worker-failure-sentinel
@@ -12,7 +12,6 @@ from pathlib import Path
 
 DB = Path("/home/red/.hermes/kanban/boards/chitin/kanban.db")
 STATE = Path("/home/red/.openclaw/state/clawta-worker-failure-sentinel.json")
-STATE.parent.mkdir(parents=True, exist_ok=True)
 CHANNEL = "channel:1503439202719760405"
 LOOKBACK_SECONDS = int(os.environ.get("CLAWTA_FAILURE_LOOKBACK_SECONDS", "86400"))
 QUARANTINE_THRESHOLD = int(os.environ.get("CLAWTA_FAILURE_QUARANTINE_THRESHOLD", "3"))
@@ -48,6 +47,9 @@ def load_state() -> dict:
 
 
 def save_state(state: dict) -> None:
+    # Create the state dir lazily here, not at import time — importing this
+    # module for tests must not touch /home/red/.openclaw on CI/dev machines.
+    STATE.parent.mkdir(parents=True, exist_ok=True)
     tmp = STATE.with_suffix(".tmp")
     tmp.write_text(json.dumps(state, indent=2, sort_keys=True))
     tmp.replace(STATE)

--- a/swarm/bin/clawta-worker-failure-sentinel
+++ b/swarm/bin/clawta-worker-failure-sentinel
@@ -17,6 +17,10 @@ CHANNEL = "channel:1503439202719760405"
 LOOKBACK_SECONDS = int(os.environ.get("CLAWTA_FAILURE_LOOKBACK_SECONDS", "86400"))
 QUARANTINE_THRESHOLD = int(os.environ.get("CLAWTA_FAILURE_QUARANTINE_THRESHOLD", "3"))
 QUARANTINE_WINDOW = int(os.environ.get("CLAWTA_FAILURE_QUARANTINE_WINDOW", "7200"))
+# If Copilot is manually restored and smoke-tested, set this state timestamp.
+# The quarantine counter must ignore failures older than that restore point,
+# otherwise stale failure comments can immediately quarantine a healthy card again.
+COPILOT_HEALTHY_AFTER_KEY = "copilot_healthy_after"
 PATTERNS = [
     re.compile(r"gh pr create failed", re.I),
     re.compile(r"worker failed", re.I),
@@ -107,6 +111,17 @@ def quarantine_copilot() -> bool:
     return True
 
 
+def copilot_quarantine_since(now: int, state: dict) -> int:
+    """Return earliest comment timestamp that may count toward quarantine.
+
+    A manual restore + smoke test records `copilot_healthy_after` in state.
+    Failures before that checkpoint are stale evidence and must not immediately
+    re-quarantine the restored card.
+    """
+    copilot_healthy_after = int(state.get(COPILOT_HEALTHY_AFTER_KEY, 0) or 0)
+    return max(now - QUARANTINE_WINDOW, copilot_healthy_after)
+
+
 def main() -> int:
     state = load_state()
     last = int(state.get("last_comment_id", 0))
@@ -157,13 +172,15 @@ def main() -> int:
                 lines.append(f"  - `{f['task']}` — {f['title']} — {snippet}")
 
         # Quarantine Copilot automatically if repeated recent failures are observed.
+        # Honor a manual restore/smoke checkpoint: only failures after that point count.
+        quarantine_since = copilot_quarantine_since(now, state)
         recent_copilot = conn.execute(
             """
-            SELECT c.id, c.body FROM task_comments c
+            SELECT c.id, c.body, c.created_at FROM task_comments c
             WHERE c.created_at >= ? AND (c.body LIKE '%swarm/copilot-%' OR c.body LIKE '%Starting dispatch to copilot%' OR c.body LIKE '%dispatching to copilot%' OR c.body LIKE '%-> copilot%')
             ORDER BY c.id DESC
             """,
-            (now - QUARANTINE_WINDOW,),
+            (quarantine_since,),
         ).fetchall()
         copilot_fail_count = sum(1 for r in recent_copilot if any(p.search(r["body"] or "") for p in PATTERNS))
         quarantined = set(state.get("quarantined", []))
@@ -171,8 +188,9 @@ def main() -> int:
             moved = quarantine_copilot()
             quarantined.add("copilot")
             state["quarantined"] = sorted(quarantined)
-            lines.append(f"- **copilot quarantine:** {copilot_fail_count} failures in the last {QUARANTINE_WINDOW//60}m; runtime card {'moved out of routing' if moved else 'already absent'}.")
-            lines.append("- Poller should run with `TERMINAL_LANES=codex,claude-code,gemini` until cleared.")
+            window_min = max(0, (now - quarantine_since) // 60)
+            lines.append(f"- **copilot quarantine:** {copilot_fail_count} failures since last healthy checkpoint ({window_min}m window); runtime card {'moved out of routing' if moved else 'already absent'}.")
+            lines.append("- Poller should run with `TERMINAL_LANES=codex,gemini` until cleared and re-smoked.")
 
         send_discord("\n".join(lines))
 

--- a/swarm/bin/install-clawta-poller.sh
+++ b/swarm/bin/install-clawta-poller.sh
@@ -35,7 +35,7 @@ case "${mode}" in
 esac
 
 mkdir -p "$LOCAL_BIN"
-for tool in clawta-poller clawta-blocked-escalator clawta-stale-worker-watchdog; do
+for tool in clawta-poller clawta-poller-safe-tick clawta-blocked-escalator clawta-stale-worker-watchdog clawta-worker-failure-sentinel; do
   ln -sfn "$REPO_ROOT/swarm/bin/$tool" "$LOCAL_BIN/$tool"
   echo "linked: $LOCAL_BIN/$tool → $REPO_ROOT/swarm/bin/$tool"
 done
@@ -88,7 +88,7 @@ install_openclaw_cron() {
     "clawta-kanban-poller" \
     "2m" \
     "Autonomous kanban dispatch tick. Reads ready terminal-lane tickets, sequences via LLM, dispatches top-N via lobster. See chitin swarm/bin/clawta-poller." \
-    "clawta-poller --once --max-dispatch 2"
+    "TERMINAL_LANES=codex,copilot,gemini CLAWTA_MAX_ACTIVE_WORKERS=1 CLAWTA_MAX_LOAD=12 CLAWTA_MAX_DISPATCH=1 CLAWTA_ROUTER_MODE=deterministic flock -n /tmp/clawta-kanban-poller.lock clawta-poller-safe-tick"
   ensure_openclaw_cron_job \
     "clawta-blocked-escalator" \
     "10m" \

--- a/swarm/tests/test_clawta_controller_observability.py
+++ b/swarm/tests/test_clawta_controller_observability.py
@@ -31,6 +31,16 @@ class ControllerProjectionTests(unittest.TestCase):
         # 5 queued tickets at cap 2 drains in 3 waves. Expected scenario is 90m/wave.
         self.assertEqual(rows[1]["eta_seconds"], 3 * 90 * 60)
 
+    def test_projection_accounts_for_active_workers(self) -> None:
+        module = load_module(REPORT, "clawta_report_projection_active")
+        # 5 queued + 2 mid-flight workers through 2 lanes: the active pair
+        # occupies wave 1, so the queue needs 4 waves total (ceil(7/2)).
+        rows = module.projection_scenarios(queue_depth=5, active_count=2, max_active=2)
+        self.assertEqual(rows[1]["eta_seconds"], 4 * 90 * 60)
+        # active_count=0 must still reduce to the plain ceil(queue/cap).
+        rows0 = module.projection_scenarios(queue_depth=5, active_count=0, max_active=2)
+        self.assertEqual(rows0[1]["eta_seconds"], 3 * 90 * 60)
+
     def test_active_dispatch_tickets_counts_lobster_and_long_lived_roots(self) -> None:
         module = load_module(REPORT, "clawta_report_active_dispatch")
         sample = "\n".join(["t_aaaabbbb", "t_ccccdddd", "t_ccccdddd"])

--- a/swarm/tests/test_clawta_controller_observability.py
+++ b/swarm/tests/test_clawta_controller_observability.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT = REPO_ROOT / "swarm" / "bin" / "clawta-report"
+SENTINEL = REPO_ROOT / "swarm" / "bin" / "clawta-worker-failure-sentinel"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_loader(name, SourceFileLoader(name, str(path)))
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ControllerProjectionTests(unittest.TestCase):
+    def test_projection_uses_active_worker_cap(self) -> None:
+        module = load_module(REPORT, "clawta_report_projection")
+        rows = module.projection_scenarios(queue_depth=5, active_count=0, max_active=2)
+        self.assertEqual([row["label"] for row in rows], ["fast", "expected", "slow/sticky"])
+        # 5 queued tickets at cap 2 drains in 3 waves. Expected scenario is 90m/wave.
+        self.assertEqual(rows[1]["eta_seconds"], 3 * 90 * 60)
+
+    def test_active_dispatch_tickets_counts_lobster_and_long_lived_roots(self) -> None:
+        module = load_module(REPORT, "clawta_report_active_dispatch")
+        sample = "\n".join(["t_aaaabbbb", "t_ccccdddd", "t_ccccdddd"])
+        with mock.patch.object(module, "sh", return_value=(0, sample)):
+            self.assertEqual(module.active_dispatch_tickets(), ["t_aaaabbbb", "t_ccccdddd"])
+
+
+class CopilotSentinelTests(unittest.TestCase):
+    def test_quarantine_since_honors_healthy_checkpoint(self) -> None:
+        module = load_module(SENTINEL, "clawta_worker_failure_sentinel_checkpoint")
+        with mock.patch.object(module, "QUARANTINE_WINDOW", 7200):
+            self.assertEqual(module.copilot_quarantine_since(10_000, {}), 2_800)
+            self.assertEqual(
+                module.copilot_quarantine_since(10_000, {module.COPILOT_HEALTHY_AFTER_KEY: 9_500}),
+                9_500,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add queue-depth ETA projections and runtime lane-health cards to Clawta swarm-health report
- harden Copilot failure sentinel with a `copilot_healthy_after` checkpoint so stale pre-restore failures cannot immediately re-quarantine a smoked card
- add repo-backed `clawta-poller-safe-tick` wrapper and install wiring for resource-governed dispatch ticks

## Validation
- `python3 -m unittest swarm.tests.test_clawta_controller_observability swarm.tests.test_clawta_runtime_guards`
- `bash -n swarm/bin/clawta-poller-safe-tick swarm/bin/install-clawta-poller.sh`
- `CLAWTA_POLLER_BIN=/bin/true CLAWTA_MAX_ACTIVE_WORKERS=99 CLAWTA_MAX_LOAD=999 CLAWTA_POLLER_SAFE_TICK_LOG=/tmp/chitin-safe-tick-test.log ./swarm/bin/clawta-poller-safe-tick`
- `./swarm/bin/clawta-report swarm-health`

Refs t_379ffdce