### PR TITLE
fix(swarm): retry silent dispatch failures

### DIFF
--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -389,6 +389,49 @@ steps:
       bash -c "$(cat <<'BASH_SCRIPT'
       set -uo pipefail  # NOT -e: each step below is best-effort
       DRIVER='$pick_driver.json.driver'
+      CHITIN_REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+      FAILURE_POLICY="$CHITIN_REPO/swarm/lib/dispatch_failure_policy.py"
+
+      plan_dispatch_failure() {
+        local mode="$1"
+        local failure_class="$2"
+        local reason="$3"
+        local details_json="${4:-\{\}}"
+        python3 "$FAILURE_POLICY" "$mode" \
+          --db-path "${KANBAN_DB:-$HOME/.hermes/kanban/boards/chitin/kanban.db}" \
+          --ticket-id "${ticket_id}" \
+          --failure-class "$failure_class" \
+          --reason "$reason" \
+          --details-json "$details_json" 2>/dev/null || echo ""
+      }
+
+      apply_retryable_failure() {
+        local failure_class="$1"
+        local reason="$2"
+        local details_json="${3:-\{\}}"
+        local plan
+        plan=$(plan_dispatch_failure retryable "$failure_class" "$reason" "$details_json")
+        if [[ -z "$plan" ]]; then
+          kanban-flow block ${ticket_id} "$reason" --author clawta 2>/dev/null || true
+          hermes kanban --board chitin comment ${ticket_id} --author clawta "$reason" 2>/dev/null || true
+          openclaw message send --channel discord --account default --text "🦞 ${ticket_id}: $reason" 2>/dev/null || true
+          exit 0
+        fi
+        local action count comment block_reason
+        action=$(echo "$plan" | jq -r '.action // "escalate"')
+        count=$(echo "$plan" | jq -r '.dispatch_failure_count // 0')
+        comment=$(echo "$plan" | jq -r '.comment // empty')
+        block_reason=$(echo "$plan" | jq -r '.block_reason // empty')
+        if [[ "$action" == "retry" ]]; then
+          kanban-flow retry-dispatch ${ticket_id} "$comment" --author clawta 2>/dev/null || true
+          hermes kanban --board chitin comment ${ticket_id} --author clawta "🦞 ${ticket_id}: retry-eligible dispatch failure ${count}/3. Reset for fresh dispatch." 2>/dev/null || true
+          exit 0
+        fi
+        kanban-flow block ${ticket_id} "$block_reason" --author clawta 2>/dev/null || true
+        hermes kanban --board chitin comment ${ticket_id} --author clawta "$comment" 2>/dev/null || true
+        openclaw message send --channel discord --account default --text "$comment" 2>/dev/null || true
+        exit 0
+      }
 
       # Check worker result from spawn_worker step
       RESULT_FILE="/tmp/dispatch-worker-result-${ticket_id}.json"
@@ -396,6 +439,7 @@ steps:
         WORKER_RESULT=$(cat "$RESULT_FILE")
         WORKER_STATUS=$(echo "$WORKER_RESULT" | jq -r '.status // "unknown"')
         WORKER_ERROR=$(echo "$WORKER_RESULT" | jq -r '.error // ""')
+        WORKER_RETURNCODE=$(echo "$WORKER_RESULT" | jq -r '.returncode // -1')
 
         case "$WORKER_STATUS" in
           timeout)
@@ -407,8 +451,9 @@ steps:
             ;;
           failed)
             MSG="🦞 ${ticket_id}: worker failed: $WORKER_ERROR"
+            plan_dispatch_failure explicit "worker_nonzero_exit" "$MSG" "{\"driver\":\"$DRIVER\",\"returncode\":$WORKER_RETURNCODE}" >/dev/null
             hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
-            kanban-flow block ${ticket_id} "worker failed" --author clawta 2>/dev/null || true
+            kanban-flow block ${ticket_id} "$MSG" --author clawta 2>/dev/null || true
             openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
             exit 0
             ;;
@@ -447,11 +492,7 @@ steps:
       BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
         MSG="🦞 ${ticket_id}: worker finished but no feature branch checked out (HEAD=$BRANCH). No PR opened."
-        hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
-        # Slice D: failure path — block, don't leave in_progress with no PR.
-        kanban-flow block ${ticket_id} "no feature branch checked out at end of run (HEAD=$BRANCH)" --author clawta 2>/dev/null || true
-        openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
-        exit 0
+        apply_retryable_failure "empty_branch" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
       fi
       # Push (idempotent — git push on already-up-to-date is fine).
       git push -u origin "$BRANCH" 2>&1 | tail -3 || true
@@ -468,8 +509,7 @@ steps:
       fi
       if [[ -z "$PR_URL" ]]; then
         MSG="🦞 ${ticket_id}: branch $BRANCH pushed, but gh pr create failed. Manual PR open needed."
-        # Slice D: PR failed — block so it gets human attention.
-        kanban-flow block ${ticket_id} "branch $BRANCH pushed but gh pr create failed" --author clawta 2>/dev/null || true
+        apply_retryable_failure "gh_pr_create_failed" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
       else
         MSG="🦞 ${ticket_id}: PR opened; ticket remains in_progress for review/merge. Branch: $BRANCH. PR: $PR_URL"
         # PR opened — record the URL on the ticket. Ticket stays in

--- a/docs/governance-setup-extras/kanban-dispatch.lobster
+++ b/docs/governance-setup-extras/kanban-dispatch.lobster
@@ -392,6 +392,18 @@ steps:
       CHITIN_REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
       FAILURE_POLICY="$CHITIN_REPO/swarm/lib/dispatch_failure_policy.py"
 
+      dispatch_details() {
+        jq -cn \
+          --arg driver "${1:-}" \
+          --arg branch "${2:-}" \
+          --arg returncode "${3:-}" \
+          '{
+            driver: $driver
+          }
+          + (if $branch != "" then {branch: $branch} else {} end)
+          + (if $returncode != "" then {returncode: ($returncode | tonumber)} else {} end)'
+      }
+
       plan_dispatch_failure() {
         local mode="$1"
         local failure_class="$2"
@@ -451,7 +463,8 @@ steps:
             ;;
           failed)
             MSG="🦞 ${ticket_id}: worker failed: $WORKER_ERROR"
-            plan_dispatch_failure explicit "worker_nonzero_exit" "$MSG" "{\"driver\":\"$DRIVER\",\"returncode\":$WORKER_RETURNCODE}" >/dev/null
+            DETAILS=$(dispatch_details "$DRIVER" "" "$WORKER_RETURNCODE")
+            plan_dispatch_failure explicit "worker_nonzero_exit" "$MSG" "$DETAILS" >/dev/null
             hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
             kanban-flow block ${ticket_id} "$MSG" --author clawta 2>/dev/null || true
             openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
@@ -476,11 +489,8 @@ steps:
       WORKTREE=$(ls -td "$HOME"/.cache/chitin/swarm-worktrees/swarm-*-${ticket_id}*/ 2>/dev/null | head -1)
       if [[ -z "$WORKTREE" || ! -d "$WORKTREE" ]]; then
         MSG="🦞 spawn_worker completed but no worktree found for ${ticket_id} — worker may have failed before committing."
-        hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
-        # Slice D: failure path — block the ticket so it isn't silently lost.
-        kanban-flow block ${ticket_id} "worker completed but produced no worktree" --author clawta 2>/dev/null || true
-        openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
-        exit 0
+        DETAILS=$(dispatch_details "$DRIVER")
+        apply_retryable_failure "missing_worktree" "$MSG" "$DETAILS"
       fi
       if ! cd "$WORKTREE"; then
         MSG="🦞 ${ticket_id}: worker worktree exists but could not be entered: $WORKTREE"
@@ -492,7 +502,8 @@ steps:
       BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
         MSG="🦞 ${ticket_id}: worker finished but no feature branch checked out (HEAD=$BRANCH). No PR opened."
-        apply_retryable_failure "empty_branch" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
+        DETAILS=$(dispatch_details "$DRIVER" "$BRANCH")
+        apply_retryable_failure "empty_branch" "$MSG" "$DETAILS"
       fi
       # Push (idempotent — git push on already-up-to-date is fine).
       git push -u origin "$BRANCH" 2>&1 | tail -3 || true
@@ -509,7 +520,8 @@ steps:
       fi
       if [[ -z "$PR_URL" ]]; then
         MSG="🦞 ${ticket_id}: branch $BRANCH pushed, but gh pr create failed. Manual PR open needed."
-        apply_retryable_failure "gh_pr_create_failed" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
+        DETAILS=$(dispatch_details "$DRIVER" "$BRANCH")
+        apply_retryable_failure "gh_pr_create_failed" "$MSG" "$DETAILS"
       else
         MSG="🦞 ${ticket_id}: PR opened; ticket remains in_progress for review/merge. Branch: $BRANCH. PR: $PR_URL"
         # PR opened — record the URL on the ticket. Ticket stays in

--- a/scripts/kanban-flow
+++ b/scripts/kanban-flow
@@ -37,6 +37,10 @@
 #       ready|todo → triage. Comments with reason. Used by clawta when a
 #       ticket isn't actually ready to dispatch.
 #
+#   kanban-flow retry-dispatch <id> <reason...> [--author NAME] [--assignee NAME]
+#       in_progress → triage → ready. Used for retry-eligible dispatch
+#       infrastructure failures so the poller can pick the ticket up again.
+#
 #   kanban-flow done <id> --result "<summary>" [--author NAME]
 #       in_progress → done. Comments with result.
 #
@@ -206,6 +210,26 @@ case "$cmd" in
     sqlite3 "$DB" "UPDATE tasks SET assignee='clawta' WHERE id='$id'"
     emit_transition "$id" "$from" triage "$author"
     echo "$id: $from → triage ($reason)"
+    ;;
+  retry-dispatch)
+    parse_flags "$@"
+    id="${REST[0]:-}"; require_id "$id"
+    reason="${REST[*]:1}"
+    [[ -n "$reason" ]] || die "missing reason"
+    assert_status "$id" in_progress
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Retrying dispatch after infrastructure failure: $reason" >/dev/null
+    flip_status "$id" triage 0 0
+    sqlite3 "$DB" "UPDATE tasks SET assignee='clawta' WHERE id='$id'"
+    emit_transition "$id" in_progress triage "$author" '{"retry_dispatch":true}'
+    hermes kanban --board "$BOARD" comment "$id" --author "$author" "Marked ready for redispatch at $(date -Iseconds)" >/dev/null
+    flip_status "$id" ready 0 0
+    if [[ -z "$assignee_override" ]]; then
+      sqlite3 "$DB" "UPDATE tasks SET assignee='clawta' WHERE id='$id'"
+    else
+      sqlite3 "$DB" "UPDATE tasks SET assignee='$assignee_override' WHERE id='$id'"
+    fi
+    emit_transition "$id" triage ready "$author" '{"retry_dispatch":true}'
+    echo "$id: in_progress → triage → ready ($reason)"
     ;;
   ready)
     parse_flags "$@"

--- a/swarm/bin/clawta-stale-worker-watchdog
+++ b/swarm/bin/clawta-stale-worker-watchdog
@@ -11,6 +11,7 @@ Thresholds:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import sqlite3
@@ -36,6 +37,7 @@ KANBAN_DB = Path(
     )
 )
 REPO_ROOT = Path(os.environ.get("CHITIN_REPO", Path(__file__).resolve().parents[2]))
+POLICY_HELPER = REPO_ROOT / "swarm" / "lib" / "dispatch_failure_policy.py"
 KANBAN_FLOW_BIN = Path(
     os.environ.get("KANBAN_FLOW_BIN", str(REPO_ROOT / "scripts" / "kanban-flow"))
 )
@@ -44,6 +46,20 @@ OPENCLAW_LOG_DIR = Path(
 )
 STALE_AFTER = int(os.environ.get("CLAWTA_STALE_AFTER_SECONDS", "2700"))
 QUIET_AFTER = int(os.environ.get("CLAWTA_QUIET_AFTER_SECONDS", "1200"))
+RETRY_LIMIT = int(os.environ.get("CLAWTA_DISPATCH_RETRY_LIMIT", "3"))
+
+
+def load_policy_helper():
+    spec = importlib.util.spec_from_file_location("dispatch_failure_policy", POLICY_HELPER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load dispatch failure helper: {POLICY_HELPER}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+dispatch_failure_policy = load_policy_helper()
 
 
 @dataclass
@@ -176,9 +192,9 @@ def find_stale_candidates(now: int | None = None) -> tuple[list[InProgressTicket
     return checked, stale
 
 
-def block_ticket(escalation: Escalation) -> None:
+def block_ticket(escalation: Escalation, decision) -> None:
     run(
-        [str(KANBAN_FLOW_BIN), "block", escalation.id, escalation.reason, "--author", AUTHOR],
+        [str(KANBAN_FLOW_BIN), "block", escalation.id, decision.block_reason, "--author", AUTHOR],
         check=True,
         timeout=45,
     )
@@ -196,10 +212,45 @@ def block_ticket(escalation: Escalation) -> None:
             escalation.id,
             "--author",
             AUTHOR,
-            f"Stale-worker watchdog escalated to red: {escalation.reason}",
+            decision.comment,
         ],
         check=True,
     )
+
+
+def retry_ticket(escalation: Escalation, decision) -> None:
+    run(
+        [
+            str(KANBAN_FLOW_BIN),
+            "retry-dispatch",
+            escalation.id,
+            decision.comment,
+            "--author",
+            AUTHOR,
+        ],
+        check=True,
+        timeout=45,
+    )
+
+
+def handle_escalation(escalation: Escalation):
+    decision = dispatch_failure_policy.plan_retryable_failure(
+        KANBAN_DB,
+        ticket_id=escalation.id,
+        failure_class="silent_worker_death",
+        reason=escalation.reason,
+        details={
+            "assignee": escalation.assignee,
+            "age_seconds": escalation.age_seconds,
+            "quiet_seconds": escalation.quiet_seconds,
+        },
+        retry_limit=RETRY_LIMIT,
+    )
+    if decision.action == "retry":
+        retry_ticket(escalation, decision)
+    else:
+        block_ticket(escalation, decision)
+    return decision
 
 
 def notify(changed: Sequence[Escalation]) -> None:
@@ -240,14 +291,17 @@ def main() -> int:
     args = parse_args()
     checked, stale = find_stale_candidates()
     changed: list[Escalation] = []
+    escalated: list[Escalation] = []
     if not args.dry_run:
         for item in stale:
             try:
-                block_ticket(item)
+                decision = handle_escalation(item)
                 changed.append(item)
+                if decision.action == "escalate":
+                    escalated.append(item)
             except subprocess.CalledProcessError as exc:
                 print(f"{item.id}: watchdog failed: {exc.stderr[-300:]}", file=sys.stderr)
-        notify(changed)
+        notify(escalated)
     else:
         changed = stale
 

--- a/swarm/lib/dispatch_failure_policy.py
+++ b/swarm/lib/dispatch_failure_policy.py
@@ -184,6 +184,9 @@ def _history_summary(record: DispatchFailureRecord) -> str:
     if record.failure_class == "silent_worker_death":
         quiet = details.get("quiet_seconds")
         return f"silent at {quiet}s" if quiet is not None else "silent"
+    if record.failure_class == "missing_worktree":
+        worktree = details.get("worktree")
+        return f"no worktree ({worktree})" if worktree else "no worktree"
     if record.failure_class == "empty_branch":
         branch = details.get("branch") or "unknown"
         return f"empty branch ({branch})"
@@ -240,9 +243,9 @@ def _escalation_comment(
 ) -> str:
     history = format_history(db_path, ticket_id, records)
     if records and all(record.failure_class == "silent_worker_death" for record in records):
-        header = f"Watchdog: ticket bounced {retry_limit}x with silent worker death."
+        header = f"Watchdog: ticket bounced {retry_limit}× with silent worker death."
     else:
-        header = f"Dispatch watchdog: ticket bounced {retry_limit}x on retry-eligible infrastructure failures."
+        header = f"Dispatch watchdog: ticket bounced {retry_limit}× on retry-eligible infrastructure failures."
     lines = [header, "Dispatch history:"]
     lines.extend(f"  {item['time']} {item['driver']} -> {item['summary']}" for item in history)
     lines.append(

--- a/swarm/lib/dispatch_failure_policy.py
+++ b/swarm/lib/dispatch_failure_policy.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Shared dispatch failure policy for clawta watchdog/finalize paths."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+DB_PATH = Path(
+    os.environ.get(
+        "KANBAN_DB",
+        str(Path.home() / ".hermes/kanban/boards/chitin/kanban.db"),
+    )
+)
+RETRY_LIMIT = int(os.environ.get("CLAWTA_DISPATCH_RETRY_LIMIT", "3"))
+EVENT_KIND = "dispatch_failure"
+DISPATCH_PATTERNS = (
+    re.compile(r"Starting dispatch to ([a-z0-9-]+)", re.I),
+    re.compile(r"dispatching to ([a-z0-9-]+)", re.I),
+    re.compile(r"Routed by clawta-poller: [^>]+ -> ([a-z0-9-]+)", re.I),
+)
+
+
+@dataclass
+class DispatchFailureRecord:
+    task_id: str
+    failure_class: str
+    reason: str
+    retry_eligible: bool
+    dispatch_failure_count: int
+    created_at: int
+    details: dict[str, Any]
+
+
+@dataclass
+class DispatchFailureDecision:
+    action: str
+    ticket_id: str
+    failure_class: str
+    retry_eligible: bool
+    dispatch_failure_count: int
+    retry_limit: int
+    block_reason: str
+    comment: str
+    history: list[dict[str, Any]]
+    recorded_failure: dict[str, Any]
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(db_path)
+
+
+def _fetch_rows(db_path: Path, ticket_id: str) -> list[sqlite3.Row]:
+    with _connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return conn.execute(
+            """
+            SELECT payload, created_at
+              FROM task_events
+             WHERE task_id = ?
+               AND kind = ?
+             ORDER BY created_at ASC, id ASC
+            """,
+            (ticket_id, EVENT_KIND),
+        ).fetchall()
+
+
+def list_failures(db_path: Path, ticket_id: str) -> list[DispatchFailureRecord]:
+    records: list[DispatchFailureRecord] = []
+    for row in _fetch_rows(db_path, ticket_id):
+        try:
+            payload = json.loads(row["payload"] or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        records.append(
+            DispatchFailureRecord(
+                task_id=ticket_id,
+                failure_class=str(payload.get("failure_class", "unknown")),
+                reason=str(payload.get("reason", "")),
+                retry_eligible=bool(payload.get("retry_eligible")),
+                dispatch_failure_count=int(payload.get("dispatch_failure_count", 0)),
+                created_at=int(row["created_at"] or 0),
+                details=dict(payload.get("details") or {}),
+            )
+        )
+    return records
+
+
+def retry_failures(db_path: Path, ticket_id: str) -> list[DispatchFailureRecord]:
+    return [record for record in list_failures(db_path, ticket_id) if record.retry_eligible]
+
+
+def _insert_failure(
+    db_path: Path,
+    *,
+    ticket_id: str,
+    failure_class: str,
+    reason: str,
+    retry_eligible: bool,
+    details: dict[str, Any] | None,
+    now: int | None = None,
+) -> DispatchFailureRecord:
+    now = int(time.time()) if now is None else now
+    previous_retry_count = len(retry_failures(db_path, ticket_id))
+    current_count = previous_retry_count + (1 if retry_eligible else 0)
+    details = dict(details or {})
+    payload = {
+        "failure_class": failure_class,
+        "reason": reason,
+        "retry_eligible": retry_eligible,
+        "dispatch_failure_count": current_count,
+        "details": details,
+    }
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO task_events(task_id, kind, payload, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (ticket_id, EVENT_KIND, json.dumps(payload, sort_keys=True), now),
+        )
+        conn.commit()
+    return DispatchFailureRecord(
+        task_id=ticket_id,
+        failure_class=failure_class,
+        reason=reason,
+        retry_eligible=retry_eligible,
+        dispatch_failure_count=current_count,
+        created_at=now,
+        details=details,
+    )
+
+
+def _load_dispatch_comments(db_path: Path, ticket_id: str) -> list[tuple[int, str, str]]:
+    try:
+        with _connect(db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT created_at, body
+                  FROM task_comments
+                 WHERE task_id = ?
+                 ORDER BY created_at ASC, id ASC
+                """,
+                (ticket_id,),
+            ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    comments: list[tuple[int, str, str]] = []
+    for created_at, body in rows:
+        text = str(body or "")
+        driver = ""
+        for pattern in DISPATCH_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                driver = match.group(1).lower()
+                comments.append((int(created_at or 0), driver, text))
+                break
+    return comments
+
+
+def _history_driver(comments: list[tuple[int, str, str]], record: DispatchFailureRecord) -> tuple[str, int]:
+    chosen_driver = str(record.details.get("assignee") or "unknown").lower()
+    chosen_at = record.created_at
+    for created_at, driver, _ in comments:
+        if created_at <= record.created_at:
+            chosen_driver = driver
+            chosen_at = created_at
+        else:
+            break
+    return chosen_driver or "unknown", chosen_at
+
+
+def _history_summary(record: DispatchFailureRecord) -> str:
+    details = record.details
+    if record.failure_class == "silent_worker_death":
+        quiet = details.get("quiet_seconds")
+        return f"silent at {quiet}s" if quiet is not None else "silent"
+    if record.failure_class == "empty_branch":
+        branch = details.get("branch") or "unknown"
+        return f"empty branch ({branch})"
+    if record.failure_class == "gh_pr_create_failed":
+        branch = details.get("branch") or "unknown"
+        return f"gh pr create failed ({branch})"
+    if record.failure_class == "worker_nonzero_exit":
+        return f"worker failed ({record.reason})"
+    return record.reason or record.failure_class.replace("_", " ")
+
+
+def format_history(db_path: Path, ticket_id: str, records: list[DispatchFailureRecord]) -> list[dict[str, Any]]:
+    comments = _load_dispatch_comments(db_path, ticket_id)
+    history: list[dict[str, Any]] = []
+    for record in records:
+        driver, started_at = _history_driver(comments, record)
+        history.append(
+            {
+                "time": datetime.fromtimestamp(started_at).strftime("%H:%M"),
+                "driver": driver,
+                "summary": _history_summary(record),
+                "failure_class": record.failure_class,
+                "created_at": record.created_at,
+            }
+        )
+    return history
+
+
+def _retry_comment(record: DispatchFailureRecord, retry_limit: int) -> str:
+    count = record.dispatch_failure_count
+    if record.failure_class == "silent_worker_death":
+        return (
+            f"Watchdog auto-retry {count}/{retry_limit}: silent worker death. "
+            f"Resetting to ready for a fresh dispatch. {record.reason}"
+        )
+    return (
+        f"Retry-eligible dispatch failure {count}/{retry_limit}: "
+        f"{record.reason}. Resetting to ready for a fresh dispatch."
+    )
+
+
+def _escalation_reason(records: list[DispatchFailureRecord]) -> str:
+    count = len(records)
+    if records and all(record.failure_class == "silent_worker_death" for record in records):
+        return f"{count} silent worker deaths; the ticket spec or the swarm infra needs operator review"
+    return f"{count} retry-eligible dispatch failures; the ticket spec or the swarm infra needs operator review"
+
+
+def _escalation_comment(
+    db_path: Path,
+    ticket_id: str,
+    records: list[DispatchFailureRecord],
+    retry_limit: int,
+) -> str:
+    history = format_history(db_path, ticket_id, records)
+    if records and all(record.failure_class == "silent_worker_death" for record in records):
+        header = f"Watchdog: ticket bounced {retry_limit}x with silent worker death."
+    else:
+        header = f"Dispatch watchdog: ticket bounced {retry_limit}x on retry-eligible infrastructure failures."
+    lines = [header, "Dispatch history:"]
+    lines.extend(f"  {item['time']} {item['driver']} -> {item['summary']}" for item in history)
+    lines.append(
+        "Recommend: (a) check copilot/codex wrapper health, or (b) ticket is too vague for the current model and needs re-spec."
+    )
+    return "\n".join(lines)
+
+
+def plan_retryable_failure(
+    db_path: Path,
+    *,
+    ticket_id: str,
+    failure_class: str,
+    reason: str,
+    details: dict[str, Any] | None = None,
+    retry_limit: int = RETRY_LIMIT,
+    now: int | None = None,
+) -> DispatchFailureDecision:
+    recorded = _insert_failure(
+        db_path,
+        ticket_id=ticket_id,
+        failure_class=failure_class,
+        reason=reason,
+        retry_eligible=True,
+        details=details,
+        now=now,
+    )
+    retry_history = retry_failures(db_path, ticket_id)
+    if recorded.dispatch_failure_count < retry_limit:
+        history = format_history(db_path, ticket_id, retry_history)
+        return DispatchFailureDecision(
+            action="retry",
+            ticket_id=ticket_id,
+            failure_class=failure_class,
+            retry_eligible=True,
+            dispatch_failure_count=recorded.dispatch_failure_count,
+            retry_limit=retry_limit,
+            block_reason="",
+            comment=_retry_comment(recorded, retry_limit),
+            history=history,
+            recorded_failure=asdict(recorded),
+        )
+    history = format_history(db_path, ticket_id, retry_history)
+    return DispatchFailureDecision(
+        action="escalate",
+        ticket_id=ticket_id,
+        failure_class=failure_class,
+        retry_eligible=True,
+        dispatch_failure_count=recorded.dispatch_failure_count,
+        retry_limit=retry_limit,
+        block_reason=_escalation_reason(retry_history),
+        comment=_escalation_comment(db_path, ticket_id, retry_history, retry_limit),
+        history=history,
+        recorded_failure=asdict(recorded),
+    )
+
+
+def plan_explicit_failure(
+    db_path: Path,
+    *,
+    ticket_id: str,
+    failure_class: str,
+    reason: str,
+    details: dict[str, Any] | None = None,
+    retry_limit: int = RETRY_LIMIT,
+    now: int | None = None,
+) -> DispatchFailureDecision:
+    recorded = _insert_failure(
+        db_path,
+        ticket_id=ticket_id,
+        failure_class=failure_class,
+        reason=reason,
+        retry_eligible=False,
+        details=details,
+        now=now,
+    )
+    history = format_history(db_path, ticket_id, retry_failures(db_path, ticket_id))
+    return DispatchFailureDecision(
+        action="escalate",
+        ticket_id=ticket_id,
+        failure_class=failure_class,
+        retry_eligible=False,
+        dispatch_failure_count=len(retry_failures(db_path, ticket_id)),
+        retry_limit=retry_limit,
+        block_reason=reason,
+        comment=reason,
+        history=history,
+        recorded_failure=asdict(recorded),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("retryable", "explicit"))
+    parser.add_argument("--ticket-id", required=True)
+    parser.add_argument("--failure-class", required=True)
+    parser.add_argument("--reason", required=True)
+    parser.add_argument("--details-json", default="{}")
+    parser.add_argument("--db-path", default=str(DB_PATH))
+    parser.add_argument("--retry-limit", type=int, default=RETRY_LIMIT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        details = json.loads(args.details_json or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid --details-json: {exc}")
+    db_path = Path(args.db_path)
+    if args.mode == "retryable":
+        decision = plan_retryable_failure(
+            db_path,
+            ticket_id=args.ticket_id,
+            failure_class=args.failure_class,
+            reason=args.reason,
+            details=details,
+            retry_limit=args.retry_limit,
+        )
+    else:
+        decision = plan_explicit_failure(
+            db_path,
+            ticket_id=args.ticket_id,
+            failure_class=args.failure_class,
+            reason=args.reason,
+            details=details,
+            retry_limit=args.retry_limit,
+        )
+    print(json.dumps(asdict(decision), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swarm/tests/test_clawta_runtime_guards.py
+++ b/swarm/tests/test_clawta_runtime_guards.py
@@ -44,7 +44,15 @@ def make_db(root: Path) -> Path:
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           task_id TEXT NOT NULL,
           kind TEXT NOT NULL,
-          payload TEXT
+          payload TEXT,
+          created_at INTEGER
+        );
+        CREATE TABLE task_comments (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id TEXT NOT NULL,
+          author TEXT,
+          body TEXT,
+          created_at INTEGER
         );
         """
     )
@@ -190,11 +198,19 @@ class StaleWatchdogTests(unittest.TestCase):
             quiet_seconds=1500,
             reason="stale in_progress without PR or active worker after 3000s; dispatch log quiet 1500s",
         )
+        decision = type(
+            "Decision",
+            (),
+            {
+                "block_reason": "3 silent worker deaths; the ticket spec or the swarm infra needs operator review",
+                "comment": "Watchdog: ticket bounced 3x with silent worker death.\nDispatch history:\n  17:36 codex -> silent at 3136s",
+            },
+        )()
         with mock.patch.object(module, "run", side_effect=fake_run):
-            module.block_ticket(escalation)
+            module.block_ticket(escalation, decision)
 
         self.assertEqual(seen[0][0], str(module.KANBAN_FLOW_BIN))
-        self.assertEqual(seen[0][1:5], ["block", "t_2", escalation.reason, "--author"])
+        self.assertEqual(seen[0][1:5], ["block", "t_2", decision.block_reason, "--author"])
         self.assertEqual(
             seen[1],
             [
@@ -207,7 +223,70 @@ class StaleWatchdogTests(unittest.TestCase):
                 module.RED_ASSIGNEE,
             ],
         )
-        self.assertIn("Stale-worker watchdog escalated to red:", seen[2][-1])
+        self.assertIn("Watchdog: ticket bounced 3x with silent worker death.", seen[2][-1])
+
+    def test_retries_first_two_silent_failures_then_escalates_on_third(self) -> None:
+        module = load_module(STALE_WATCHDOG, "clawta_stale_watchdog_retry")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            db_path = make_db(root)
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                """
+                INSERT INTO tasks(id, status, assignee, title, priority, created_at, started_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("t_retry", "in_progress", "codex", "retry me", 10, 1_000, 1_100),
+            )
+            conn.executemany(
+                """
+                INSERT INTO task_comments(task_id, author, body, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                [
+                    ("t_retry", "clawta", "clawta-poller dispatching to codex. Sequence reason: first", 1_200),
+                    ("t_retry", "clawta", "clawta-poller dispatching to codex. Sequence reason: second", 1_500),
+                    ("t_retry", "clawta", "clawta-poller dispatching to codex. Sequence reason: third", 1_800),
+                ],
+            )
+            conn.commit()
+            conn.close()
+
+            seen: list[list[str]] = []
+
+            def fake_run(cmd, **kwargs):
+                seen.append(list(cmd))
+                return None
+
+            escalation = module.Escalation(
+                id="t_retry",
+                assignee="codex",
+                title="retry me",
+                age_seconds=3000,
+                quiet_seconds=3136,
+                reason="stale in_progress without PR or active worker after 3000s; dispatch log quiet 3136s",
+            )
+
+            with mock.patch.object(module, "KANBAN_DB", db_path), mock.patch.object(
+                module, "run", side_effect=fake_run
+            ), mock.patch.object(module, "RETRY_LIMIT", 3):
+                first = module.handle_escalation(escalation)
+                escalation.quiet_seconds = 3210
+                escalation.reason = "stale in_progress without PR or active worker after 3200s; dispatch log quiet 3210s"
+                second = module.handle_escalation(escalation)
+                escalation.quiet_seconds = 1788
+                escalation.reason = "stale in_progress without PR or active worker after 1800s; dispatch log quiet 1788s"
+                third = module.handle_escalation(escalation)
+
+        self.assertEqual(first.action, "retry")
+        self.assertEqual(second.action, "retry")
+        self.assertEqual(third.action, "escalate")
+        self.assertEqual(seen[0][0:2], [str(module.KANBAN_FLOW_BIN), "retry-dispatch"])
+        self.assertEqual(seen[1][0:2], [str(module.KANBAN_FLOW_BIN), "retry-dispatch"])
+        self.assertEqual(seen[2][0:2], [str(module.KANBAN_FLOW_BIN), "block"])
+        self.assertIn("3 silent worker deaths", seen[2][3])
+        self.assertEqual(seen[3][0:6], [module.HERMES_BIN, "kanban", "--board", module.BOARD, "assign", "t_retry"])
+        self.assertIn("Watchdog: ticket bounced 3x with silent worker death.", seen[4][-1])
 
 
 if __name__ == "__main__":

--- a/swarm/tests/test_dispatch_failure_policy.py
+++ b/swarm/tests/test_dispatch_failure_policy.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sqlite3
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -98,7 +100,7 @@ class DispatchFailurePolicyTests(unittest.TestCase):
         self.assertEqual(second.action, "retry")
         self.assertEqual(third.action, "escalate")
         self.assertEqual(third.dispatch_failure_count, 3)
-        self.assertIn("Watchdog: ticket bounced 3x with silent worker death.", third.comment)
+        self.assertIn("Watchdog: ticket bounced 3× with silent worker death.", third.comment)
         self.assertIn("Dispatch history:", third.comment)
         self.assertIn("codex -> silent at 3136s", third.comment)
         self.assertIn("codex -> silent at 3210s", third.comment)
@@ -134,3 +136,104 @@ class DispatchFailurePolicyTests(unittest.TestCase):
         self.assertEqual(explicit.dispatch_failure_count, 1)
         self.assertEqual(explicit.block_reason, "worker failed: exit code 23: pytest exploded")
         self.assertEqual(explicit.comment, "worker failed: exit code 23: pytest exploded")
+
+    def test_mixed_retryable_failures_use_generic_escalation_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+
+            first = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="missing_worktree",
+                reason="spawn_worker completed but no worktree found",
+                details={"assignee": "codex"},
+                retry_limit=2,
+                now=2_000,
+            )
+            second = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="gh_pr_create_failed",
+                reason="branch pushed, but gh pr create failed",
+                details={"assignee": "codex", "branch": "swarm/codex-t_retry"},
+                retry_limit=2,
+                now=2_100,
+            )
+
+        self.assertEqual(first.action, "retry")
+        self.assertEqual(second.action, "escalate")
+        self.assertIn(
+            "Dispatch watchdog: ticket bounced 2× on retry-eligible infrastructure failures.",
+            second.comment,
+        )
+        self.assertIn("codex -> no worktree", second.comment)
+        self.assertIn("codex -> gh pr create failed (swarm/codex-t_retry)", second.comment)
+        self.assertIn("2 retry-eligible dispatch failures", second.block_reason)
+
+    def test_boundary_empty_branch_records_unknown_branch_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+
+            decision = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="empty_branch",
+                reason="worker finished but no feature branch checked out",
+                details={"assignee": "codex", "branch": ""},
+                retry_limit=1,
+                now=2_000,
+            )
+
+        self.assertEqual(decision.action, "escalate")
+        self.assertIn("empty branch (unknown)", decision.comment)
+
+    def test_boundary_max_retry_limit_escalates_at_exact_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+
+            first = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="silent_worker_death",
+                reason="first silent failure",
+                details={"assignee": "codex"},
+                retry_limit=2,
+                now=2_000,
+            )
+            second = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="silent_worker_death",
+                reason="second silent failure",
+                details={"assignee": "codex"},
+                retry_limit=2,
+                now=2_100,
+            )
+
+        self.assertEqual(first.action, "retry")
+        self.assertEqual(second.action, "escalate")
+        self.assertEqual(second.dispatch_failure_count, 2)
+        self.assertIn("Watchdog: ticket bounced 2× with silent worker death.", second.comment)
+
+    def test_boundary_error_rejects_invalid_details_json(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(Path(policy.__file__)),
+                "retryable",
+                "--ticket-id",
+                "t_retry",
+                "--failure-class",
+                "empty_branch",
+                "--reason",
+                "bad json",
+                "--details-json",
+                '{"branch":',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid --details-json", result.stderr)

--- a/swarm/tests/test_dispatch_failure_policy.py
+++ b/swarm/tests/test_dispatch_failure_policy.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from swarm.lib import dispatch_failure_policy as policy
+
+
+def make_db(root: Path) -> Path:
+    db_path = root / "kanban.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT NOT NULL,
+          assignee TEXT,
+          title TEXT NOT NULL,
+          priority INTEGER DEFAULT 0,
+          created_at INTEGER NOT NULL,
+          started_at INTEGER
+        );
+        CREATE TABLE task_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          payload TEXT,
+          created_at INTEGER
+        );
+        CREATE TABLE task_comments (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id TEXT NOT NULL,
+          author TEXT,
+          body TEXT,
+          created_at INTEGER
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO tasks(id, status, assignee, title, priority, created_at, started_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("t_retry", "in_progress", "codex", "retry me", 10, 1_000, 1_100),
+    )
+    conn.executemany(
+        """
+        INSERT INTO task_comments(task_id, author, body, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        [
+            ("t_retry", "clawta", "clawta-poller dispatching to codex. Sequence reason: first", 1_200),
+            ("t_retry", "clawta", "clawta-poller dispatching to codex. Sequence reason: second", 1_500),
+            ("t_retry", "clawta", "clawta-poller dispatching to codex. Sequence reason: third", 1_800),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class DispatchFailurePolicyTests(unittest.TestCase):
+    def test_third_silent_failure_escalates_with_structured_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+
+            first = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="silent_worker_death",
+                reason="stale in_progress without PR or active worker after 3000s; dispatch log quiet 3136s",
+                details={"assignee": "codex", "quiet_seconds": 3136},
+                retry_limit=3,
+                now=2_000,
+            )
+            second = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="silent_worker_death",
+                reason="stale in_progress without PR or active worker after 3200s; dispatch log quiet 3210s",
+                details={"assignee": "codex", "quiet_seconds": 3210},
+                retry_limit=3,
+                now=2_100,
+            )
+            third = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="silent_worker_death",
+                reason="stale in_progress without PR or active worker after 1800s; dispatch log quiet 1788s",
+                details={"assignee": "codex", "quiet_seconds": 1788},
+                retry_limit=3,
+                now=2_200,
+            )
+
+        self.assertEqual(first.action, "retry")
+        self.assertEqual(second.action, "retry")
+        self.assertEqual(third.action, "escalate")
+        self.assertEqual(third.dispatch_failure_count, 3)
+        self.assertIn("Watchdog: ticket bounced 3x with silent worker death.", third.comment)
+        self.assertIn("Dispatch history:", third.comment)
+        self.assertIn("codex -> silent at 3136s", third.comment)
+        self.assertIn("codex -> silent at 3210s", third.comment)
+        self.assertIn("codex -> silent at 1788s", third.comment)
+        self.assertIn("3 silent worker deaths", third.block_reason)
+
+    def test_explicit_failure_escalates_immediately_after_silent_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+
+            silent = policy.plan_retryable_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="silent_worker_death",
+                reason="stale in_progress without PR or active worker after 3000s; dispatch log quiet 3136s",
+                details={"assignee": "codex", "quiet_seconds": 3136},
+                retry_limit=3,
+                now=2_000,
+            )
+            explicit = policy.plan_explicit_failure(
+                db_path,
+                ticket_id="t_retry",
+                failure_class="worker_nonzero_exit",
+                reason="worker failed: exit code 23: pytest exploded",
+                details={"assignee": "codex", "returncode": 23},
+                retry_limit=3,
+                now=2_100,
+            )
+
+        self.assertEqual(silent.action, "retry")
+        self.assertEqual(explicit.action, "escalate")
+        self.assertFalse(explicit.retry_eligible)
+        self.assertEqual(explicit.dispatch_failure_count, 1)
+        self.assertEqual(explicit.block_reason, "worker failed: exit code 23: pytest exploded")
+        self.assertEqual(explicit.comment, "worker failed: exit code 23: pytest exploded")

--- a/swarm/tests/test_kanban_dispatch_workflow.py
+++ b/swarm/tests/test_kanban_dispatch_workflow.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_WORKFLOW = REPO_ROOT / "swarm" / "workflows" / "kanban-dispatch.lobster"
+MIRROR_WORKFLOW = REPO_ROOT / "docs" / "governance-setup-extras" / "kanban-dispatch.lobster"
+
+
+class KanbanDispatchWorkflowTests(unittest.TestCase):
+    def test_missing_worktree_uses_retryable_dispatch_failure_path(self) -> None:
+        workflow = CANONICAL_WORKFLOW.read_text()
+
+        self.assertIn(
+            'DETAILS=$(dispatch_details "$DRIVER")',
+            workflow,
+        )
+        self.assertIn('apply_retryable_failure "missing_worktree" "$MSG" "$DETAILS"', workflow)
+        self.assertNotIn(
+            'kanban-flow block ${ticket_id} "worker completed but produced no worktree"',
+            workflow,
+        )
+
+    def test_docs_mirror_stays_in_sync_for_missing_worktree_handling(self) -> None:
+        canonical = CANONICAL_WORKFLOW.read_text()
+        mirror = MIRROR_WORKFLOW.read_text()
+
+        needle = 'apply_retryable_failure "missing_worktree" "$MSG" "$DETAILS"'
+        self.assertIn(needle, canonical)
+        self.assertIn(needle, mirror)
+
+    def test_boundary_empty_branch_details_are_built_with_jq(self) -> None:
+        workflow = CANONICAL_WORKFLOW.read_text()
+
+        self.assertIn('dispatch_details() {', workflow)
+        self.assertIn('DETAILS=$(dispatch_details "$DRIVER" "$BRANCH")', workflow)
+        self.assertIn('apply_retryable_failure "empty_branch" "$MSG" "$DETAILS"', workflow)
+        self.assertNotIn(
+            'apply_retryable_failure "empty_branch" "$MSG" "{\\"driver\\":\\"$DRIVER\\",\\"branch\\":\\"$BRANCH\\"}"',
+            workflow,
+        )
+
+    def test_boundary_error_pr_create_details_are_built_with_jq(self) -> None:
+        workflow = CANONICAL_WORKFLOW.read_text()
+
+        self.assertIn('apply_retryable_failure "gh_pr_create_failed" "$MSG" "$DETAILS"', workflow)
+        self.assertNotIn(
+            'apply_retryable_failure "gh_pr_create_failed" "$MSG" "{\\"driver\\":\\"$DRIVER\\",\\"branch\\":\\"$BRANCH\\"}"',
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -389,6 +389,49 @@ steps:
       bash -c "$(cat <<'BASH_SCRIPT'
       set -uo pipefail  # NOT -e: each step below is best-effort
       DRIVER='$pick_driver.json.driver'
+      CHITIN_REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
+      FAILURE_POLICY="$CHITIN_REPO/swarm/lib/dispatch_failure_policy.py"
+
+      plan_dispatch_failure() {
+        local mode="$1"
+        local failure_class="$2"
+        local reason="$3"
+        local details_json="${4:-\{\}}"
+        python3 "$FAILURE_POLICY" "$mode" \
+          --db-path "${KANBAN_DB:-$HOME/.hermes/kanban/boards/chitin/kanban.db}" \
+          --ticket-id "${ticket_id}" \
+          --failure-class "$failure_class" \
+          --reason "$reason" \
+          --details-json "$details_json" 2>/dev/null || echo ""
+      }
+
+      apply_retryable_failure() {
+        local failure_class="$1"
+        local reason="$2"
+        local details_json="${3:-\{\}}"
+        local plan
+        plan=$(plan_dispatch_failure retryable "$failure_class" "$reason" "$details_json")
+        if [[ -z "$plan" ]]; then
+          kanban-flow block ${ticket_id} "$reason" --author clawta 2>/dev/null || true
+          hermes kanban --board chitin comment ${ticket_id} --author clawta "$reason" 2>/dev/null || true
+          openclaw message send --channel discord --account default --text "🦞 ${ticket_id}: $reason" 2>/dev/null || true
+          exit 0
+        fi
+        local action count comment block_reason
+        action=$(echo "$plan" | jq -r '.action // "escalate"')
+        count=$(echo "$plan" | jq -r '.dispatch_failure_count // 0')
+        comment=$(echo "$plan" | jq -r '.comment // empty')
+        block_reason=$(echo "$plan" | jq -r '.block_reason // empty')
+        if [[ "$action" == "retry" ]]; then
+          kanban-flow retry-dispatch ${ticket_id} "$comment" --author clawta 2>/dev/null || true
+          hermes kanban --board chitin comment ${ticket_id} --author clawta "🦞 ${ticket_id}: retry-eligible dispatch failure ${count}/3. Reset for fresh dispatch." 2>/dev/null || true
+          exit 0
+        fi
+        kanban-flow block ${ticket_id} "$block_reason" --author clawta 2>/dev/null || true
+        hermes kanban --board chitin comment ${ticket_id} --author clawta "$comment" 2>/dev/null || true
+        openclaw message send --channel discord --account default --text "$comment" 2>/dev/null || true
+        exit 0
+      }
 
       # Check worker result from spawn_worker step
       RESULT_FILE="/tmp/dispatch-worker-result-${ticket_id}.json"
@@ -396,6 +439,7 @@ steps:
         WORKER_RESULT=$(cat "$RESULT_FILE")
         WORKER_STATUS=$(echo "$WORKER_RESULT" | jq -r '.status // "unknown"')
         WORKER_ERROR=$(echo "$WORKER_RESULT" | jq -r '.error // ""')
+        WORKER_RETURNCODE=$(echo "$WORKER_RESULT" | jq -r '.returncode // -1')
 
         case "$WORKER_STATUS" in
           timeout)
@@ -407,8 +451,9 @@ steps:
             ;;
           failed)
             MSG="🦞 ${ticket_id}: worker failed: $WORKER_ERROR"
+            plan_dispatch_failure explicit "worker_nonzero_exit" "$MSG" "{\"driver\":\"$DRIVER\",\"returncode\":$WORKER_RETURNCODE}" >/dev/null
             hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
-            kanban-flow block ${ticket_id} "worker failed" --author clawta 2>/dev/null || true
+            kanban-flow block ${ticket_id} "$MSG" --author clawta 2>/dev/null || true
             openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
             exit 0
             ;;
@@ -447,11 +492,7 @@ steps:
       BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
         MSG="🦞 ${ticket_id}: worker finished but no feature branch checked out (HEAD=$BRANCH). No PR opened."
-        hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
-        # Slice D: failure path — block, don't leave in_progress with no PR.
-        kanban-flow block ${ticket_id} "no feature branch checked out at end of run (HEAD=$BRANCH)" --author clawta 2>/dev/null || true
-        openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
-        exit 0
+        apply_retryable_failure "empty_branch" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
       fi
       # Push (idempotent — git push on already-up-to-date is fine).
       git push -u origin "$BRANCH" 2>&1 | tail -3 || true
@@ -468,8 +509,7 @@ steps:
       fi
       if [[ -z "$PR_URL" ]]; then
         MSG="🦞 ${ticket_id}: branch $BRANCH pushed, but gh pr create failed. Manual PR open needed."
-        # Slice D: PR failed — block so it gets human attention.
-        kanban-flow block ${ticket_id} "branch $BRANCH pushed but gh pr create failed" --author clawta 2>/dev/null || true
+        apply_retryable_failure "gh_pr_create_failed" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
       else
         MSG="🦞 ${ticket_id}: PR opened; ticket remains in_progress for review/merge. Branch: $BRANCH. PR: $PR_URL"
         # PR opened — record the URL on the ticket. Ticket stays in

--- a/swarm/workflows/kanban-dispatch.lobster
+++ b/swarm/workflows/kanban-dispatch.lobster
@@ -392,6 +392,18 @@ steps:
       CHITIN_REPO="${CHITIN_REPO:-$HOME/workspace/chitin}"
       FAILURE_POLICY="$CHITIN_REPO/swarm/lib/dispatch_failure_policy.py"
 
+      dispatch_details() {
+        jq -cn \
+          --arg driver "${1:-}" \
+          --arg branch "${2:-}" \
+          --arg returncode "${3:-}" \
+          '{
+            driver: $driver
+          }
+          + (if $branch != "" then {branch: $branch} else {} end)
+          + (if $returncode != "" then {returncode: ($returncode | tonumber)} else {} end)'
+      }
+
       plan_dispatch_failure() {
         local mode="$1"
         local failure_class="$2"
@@ -451,7 +463,8 @@ steps:
             ;;
           failed)
             MSG="🦞 ${ticket_id}: worker failed: $WORKER_ERROR"
-            plan_dispatch_failure explicit "worker_nonzero_exit" "$MSG" "{\"driver\":\"$DRIVER\",\"returncode\":$WORKER_RETURNCODE}" >/dev/null
+            DETAILS=$(dispatch_details "$DRIVER" "" "$WORKER_RETURNCODE")
+            plan_dispatch_failure explicit "worker_nonzero_exit" "$MSG" "$DETAILS" >/dev/null
             hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
             kanban-flow block ${ticket_id} "$MSG" --author clawta 2>/dev/null || true
             openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
@@ -476,11 +489,8 @@ steps:
       WORKTREE=$(ls -td "$HOME"/.cache/chitin/swarm-worktrees/swarm-*-${ticket_id}*/ 2>/dev/null | head -1)
       if [[ -z "$WORKTREE" || ! -d "$WORKTREE" ]]; then
         MSG="🦞 spawn_worker completed but no worktree found for ${ticket_id} — worker may have failed before committing."
-        hermes kanban --board chitin comment ${ticket_id} --author clawta "$MSG" 2>/dev/null || true
-        # Slice D: failure path — block the ticket so it isn't silently lost.
-        kanban-flow block ${ticket_id} "worker completed but produced no worktree" --author clawta 2>/dev/null || true
-        openclaw message send --channel discord --account default --text "$MSG" 2>/dev/null || true
-        exit 0
+        DETAILS=$(dispatch_details "$DRIVER")
+        apply_retryable_failure "missing_worktree" "$MSG" "$DETAILS"
       fi
       if ! cd "$WORKTREE"; then
         MSG="🦞 ${ticket_id}: worker worktree exists but could not be entered: $WORKTREE"
@@ -492,7 +502,8 @@ steps:
       BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       if [[ -z "$BRANCH" || "$BRANCH" == "main" || "$BRANCH" == "HEAD" ]]; then
         MSG="🦞 ${ticket_id}: worker finished but no feature branch checked out (HEAD=$BRANCH). No PR opened."
-        apply_retryable_failure "empty_branch" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
+        DETAILS=$(dispatch_details "$DRIVER" "$BRANCH")
+        apply_retryable_failure "empty_branch" "$MSG" "$DETAILS"
       fi
       # Push (idempotent — git push on already-up-to-date is fine).
       git push -u origin "$BRANCH" 2>&1 | tail -3 || true
@@ -509,7 +520,8 @@ steps:
       fi
       if [[ -z "$PR_URL" ]]; then
         MSG="🦞 ${ticket_id}: branch $BRANCH pushed, but gh pr create failed. Manual PR open needed."
-        apply_retryable_failure "gh_pr_create_failed" "$MSG" "{\"driver\":\"$DRIVER\",\"branch\":\"$BRANCH\"}"
+        DETAILS=$(dispatch_details "$DRIVER" "$BRANCH")
+        apply_retryable_failure "gh_pr_create_failed" "$MSG" "$DETAILS"
       else
         MSG="🦞 ${ticket_id}: PR opened; ticket remains in_progress for review/merge. Branch: $BRANCH. PR: $PR_URL"
         # PR opened — record the URL on the ticket. Ticket stays in


### PR DESCRIPTION
Closes ticket t_66471c5d (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-66471c5d.