### PR TITLE
fix(swarm): ignore parent ticket refs

### DIFF
--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -108,6 +108,9 @@ PR_SHORT_RE = re.compile(r"\bPR\s*#(?P<number>\d+)\b", re.IGNORECASE)
 PR_REPO_RE = re.compile(r"\b(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<number>\d+)\b")
 PR_URL_RE = re.compile(r"https://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<name>[A-Za-z0-9_.-]+)/pull/(?P<number>\d+)")
 TICKET_REF_RE = re.compile(r"\bt_[a-f0-9]+\b")
+PARENT_REF_PREFIX_RE = re.compile(
+    r"(?i)(?:^|[\n\s])(?:\*\*?parent(?::\*?\*?|\*?\*?)?|parent):?\s*$"
+)
 INVARIANTS_FIELD_RE = re.compile(
     r"(?ims)^invariants_and_boundaries:\s*(?P<value>.+?)(?=^[A-Za-z0-9_-]+:\s|\Z)"
 )
@@ -408,6 +411,9 @@ def extract_dependency_refs(body: str | None, *, self_ticket_id: str | None = No
         )
 
     for match in TICKET_REF_RE.finditer(body):
+        prefix = body[max(0, match.start() - 32):match.start()]
+        if PARENT_REF_PREFIX_RE.search(prefix):
+            continue
         ticket_id = match.group(0)
         if self_ticket_id and ticket_id == self_ticket_id:
             continue

--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -108,9 +108,6 @@ PR_SHORT_RE = re.compile(r"\bPR\s*#(?P<number>\d+)\b", re.IGNORECASE)
 PR_REPO_RE = re.compile(r"\b(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<number>\d+)\b")
 PR_URL_RE = re.compile(r"https://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<name>[A-Za-z0-9_.-]+)/pull/(?P<number>\d+)")
 TICKET_REF_RE = re.compile(r"\bt_[a-f0-9]+\b")
-PARENT_REF_PREFIX_RE = re.compile(
-    r"(?i)(?:^|[\n\s])(?:\*\*?parent(?::\*?\*?|\*?\*?)?|parent):?\s*$"
-)
 INVARIANTS_FIELD_RE = re.compile(
     r"(?ims)^invariants_and_boundaries:\s*(?P<value>.+?)(?=^[A-Za-z0-9_-]+:\s|\Z)"
 )
@@ -160,6 +157,11 @@ def extract_named_boundaries(field_value: str | None) -> list[str]:
         seen.add(key)
         boundaries.append(cleaned)
     return boundaries
+
+
+def is_parent_hierarchy_prefix(prefix: str) -> bool:
+    normalized = prefix.strip().replace("*", "").lower()
+    return normalized.endswith("parent:")
 
 
 def missing_invariants_reason(ticket: dict[str, Any]) -> str | None:
@@ -412,7 +414,7 @@ def extract_dependency_refs(body: str | None, *, self_ticket_id: str | None = No
 
     for match in TICKET_REF_RE.finditer(body):
         prefix = body[max(0, match.start() - 32):match.start()]
-        if PARENT_REF_PREFIX_RE.search(prefix):
+        if is_parent_hierarchy_prefix(prefix):
             continue
         ticket_id = match.group(0)
         if self_ticket_id and ticket_id == self_ticket_id:

--- a/swarm/tests/test_clawta_poller.py
+++ b/swarm/tests/test_clawta_poller.py
@@ -70,7 +70,9 @@ class ClawtaPollerDependencyTests(unittest.TestCase):
         refs = module.extract_dependency_refs(
             "\n".join(
                 [
+                    "Parent: t_abcd1234",
                     "**Parent:** t_feedface",
+                    "**parent**: t_decafbad",
                     "Depends on: t_deadbeef",
                     "Blocks: t_cafebabe",
                     "Plain mention t_8badf00d still counts.",
@@ -81,6 +83,36 @@ class ClawtaPollerDependencyTests(unittest.TestCase):
         self.assertEqual(
             [ref.ticket_id for ref in refs if ref.kind == "ticket"],
             ["t_deadbeef", "t_cafebabe", "t_8badf00d"],
+        )
+
+    def test_extract_dependency_refs_empty_boundary_returns_empty_refs(self) -> None:
+        module = load_module()
+
+        self.assertEqual(module.extract_dependency_refs(None), [])
+        self.assertEqual(module.extract_dependency_refs(""), [])
+
+    def test_extract_dependency_refs_max_boundary_deduplicates_many_refs(self) -> None:
+        module = load_module()
+
+        body = "\n".join(
+            [
+                *(f"Depends on: t_{i:08x}" for i in range(20)),
+                *(f"Blocks: t_{i:08x}" for i in range(20)),
+            ]
+        )
+
+        refs = module.extract_dependency_refs(body)
+
+        self.assertEqual(len([ref for ref in refs if ref.kind == "ticket"]), 20)
+
+    def test_extract_dependency_refs_error_boundary_treats_malformed_parent_as_plain_ref(self) -> None:
+        module = load_module()
+
+        refs = module.extract_dependency_refs("Parent t_abcd1234")
+
+        self.assertEqual(
+            [ref.ticket_id for ref in refs if ref.kind == "ticket"],
+            ["t_abcd1234"],
         )
 
     def test_tick_demotes_ticket_missing_invariants_and_boundaries(self) -> None:

--- a/swarm/tests/test_clawta_poller.py
+++ b/swarm/tests/test_clawta_poller.py
@@ -64,6 +64,25 @@ def make_db(root: Path) -> Path:
 
 
 class ClawtaPollerDependencyTests(unittest.TestCase):
+    def test_extract_dependency_refs_ignores_parent_hierarchy_refs(self) -> None:
+        module = load_module()
+
+        refs = module.extract_dependency_refs(
+            "\n".join(
+                [
+                    "**Parent:** t_feedface",
+                    "Depends on: t_deadbeef",
+                    "Blocks: t_cafebabe",
+                    "Plain mention t_8badf00d still counts.",
+                ]
+            )
+        )
+
+        self.assertEqual(
+            [ref.ticket_id for ref in refs if ref.kind == "ticket"],
+            ["t_deadbeef", "t_cafebabe", "t_8badf00d"],
+        )
+
     def test_tick_demotes_ticket_missing_invariants_and_boundaries(self) -> None:
         module = load_module()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes ticket t_520e2e24 (dispatched via clawta to codex). Auto-opened by kanban-dispatch.lobster finalize step. Branch swarm/codex-520e2e24.