### PR TITLE
fix(swarm): make PR fix dispatch head-aware

### DIFF
--- a/swarm/bin/clawta-pr-fix-dispatcher
+++ b/swarm/bin/clawta-pr-fix-dispatcher
@@ -32,6 +32,7 @@ LOG_DIR = Path.home() / ".openclaw" / "logs"
 LOG_FILE = LOG_DIR / "clawta-pr-fix-dispatcher.log"
 REVIEW_MARKER_RE = re.compile(r"<!--\s*clawta-reviewer:v1(?:\s+head=[0-9a-f]+)?\s*-->")
 DISPATCH_MARKER = "<!-- clawta-fix-dispatcher:v1 -->"
+DISPATCH_MARKER_RE = re.compile(r"<!--\s*clawta-fix-dispatcher:v1(?:\s+head=([0-9a-f]+))?\s*-->")
 DEFAULT_PREFIXES = ("swarm/", "clawta/")
 CODEX_MODEL = os.environ.get("CLAWTA_FIX_CODEX_MODEL", "gpt-5.5")
 TRUSTED_REVIEW_AUTHORS = tuple(
@@ -68,7 +69,7 @@ def gh_json(cmd: list[str], *, timeout: int = 60) -> Any:
 def list_candidate_prs(prefixes: tuple[str, ...]) -> list[dict[str, Any]]:
     prs = gh_json([
         "gh", "pr", "list", "--repo", REPO, "--state", "open",
-        "--json", "number,title,headRefName,url,isDraft,updatedAt",
+        "--json", "number,title,headRefName,headRefOid,url,isDraft,updatedAt",
         "--limit", "100",
     ])
     return [p for p in prs if any(str(p.get("headRefName", "")).startswith(prefix) for prefix in prefixes)]
@@ -98,8 +99,23 @@ def latest_review_comment(comments_: list[dict[str, Any]]) -> str | None:
     return bodies[-1] if bodies else None
 
 
-def already_dispatched(comments_: list[dict[str, Any]]) -> bool:
-    return any(DISPATCH_MARKER in str(c.get("body", "")) for c in comments_)
+def already_dispatched(comments_: list[dict[str, Any]], head_oid: str | None) -> bool:
+    """Return true only when a fix worker was dispatched for this PR head.
+
+    Legacy headless markers are intentionally not enough to suppress a new
+    dispatch. They were one-shot markers and can strand PRs forever after a
+    failed/no-op fix worker. New markers include `head=<sha>` so retries are
+    naturally allowed after either a new review head or a no-op legacy attempt.
+    """
+    if not head_oid:
+        return False
+    for c in comments_:
+        body = str(c.get("body", ""))
+        for match in DISPATCH_MARKER_RE.finditer(body):
+            marker_head = match.group(1)
+            if marker_head and marker_head == head_oid:
+                return True
+    return False
 
 
 def verdict(review_body: str) -> str:
@@ -206,7 +222,9 @@ def dispatch_worker(pr: dict[str, Any], review_body: str, dry_run: bool) -> str:
 
 
 def mark_dispatched(pr: dict[str, Any], log_path: str, dry_run: bool) -> None:
-    body = f"{DISPATCH_MARKER}\n🦞 Dispatched codex fix worker for PR #{pr['number']} review findings. Log: `{log_path}`"
+    head = str(pr.get("headRefOid") or "")
+    marker = f"<!-- clawta-fix-dispatcher:v1 head={head} -->" if head else DISPATCH_MARKER
+    body = f"{marker}\n🦞 Dispatched codex fix worker for PR #{pr['number']} review findings. Log: `{log_path}`"
     if dry_run:
         print(f"--- DRY RUN DISPATCH MARKER PR #{pr['number']} ---\n{body}\n")
         return
@@ -224,7 +242,7 @@ def dispatch_once(prefixes: tuple[str, ...], max_prs: int, dry_run: bool) -> dic
         n = str(pr["number"])
         try:
             cs = comments(int(pr["number"]))
-            if already_dispatched(cs):
+            if already_dispatched(cs, str(pr.get("headRefOid") or "")):
                 skipped.append({"pr": n, "reason": "already-dispatched"})
                 continue
             review = latest_review_comment(cs)

--- a/swarm/tests/test_clawta_pr_fix_dispatcher.py
+++ b/swarm/tests/test_clawta_pr_fix_dispatcher.py
@@ -38,6 +38,32 @@ class FixDispatcherTests(unittest.TestCase):
         self.assertIsNone(module.latest_review_comment([untrusted]))
         self.assertEqual(module.latest_review_comment([untrusted, trusted]), trusted["body"])
 
+    def test_already_dispatched_is_head_aware(self):
+        module = load_module()
+        comments = [
+            {"body": "<!-- clawta-fix-dispatcher:v1 -->\nlegacy marker"},
+            {"body": "<!-- clawta-fix-dispatcher:v1 head=abc123 -->\nold head"},
+            {"body": "<!-- clawta-fix-dispatcher:v1 head=def456 -->\ncurrent head"},
+        ]
+
+        self.assertTrue(module.already_dispatched(comments, "def456"))
+        self.assertFalse(module.already_dispatched(comments, "ffff00"))
+        self.assertFalse(module.already_dispatched(comments, ""))
+
+    def test_mark_dispatched_includes_head_marker(self):
+        module = load_module()
+        seen = []
+
+        def fake_run(cmd, **kwargs):
+            seen.append(cmd)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        pr = {"number": 77, "headRefOid": "abc123", "headRefName": "swarm/codex-abc", "title": "x"}
+        with mock.patch.object(module, "run", side_effect=fake_run):
+            module.mark_dispatched(pr, "/tmp/log", dry_run=False)
+
+        self.assertIn("<!-- clawta-fix-dispatcher:v1 head=abc123 -->", seen[0][-1])
+
     def test_ensure_worktree_creates_local_branch_from_remote_branch(self):
         module = load_module()
         calls: list[list[str]] = []


### PR DESCRIPTION
## Summary
- include PR head SHA in `clawta-fix-dispatcher` markers
- only skip fix dispatch when the current head already has a matching marker
- treat legacy headless markers as stale so REQUEST_CHANGES PRs are not stranded forever

## Validation
- `python3 -m unittest swarm.tests.test_clawta_pr_fix_dispatcher`
- `./swarm/bin/clawta-pr-fix-dispatcher --dry-run --max-prs 3`

Refs t_222c42cb