### PR TITLE
fix(swarm): map lifecycle PR refs to tickets

### DIFF
--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -178,7 +178,7 @@ def infer_ticket(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> str | N
     # Explicit PR body/title references are accepted only when they look like
     # the PR's own ticket linkage, not incidental mentions in a repair summary.
     explicit = re.search(
-        r"(?i)(?:closes|fixes|resolves|ticket|task|kanban)\s*[:#-]?\s*(t_[a-f0-9]{8})",
+        r"(?i)(?:closes|fixes|resolves|refs?|references|ticket|task|kanban)\s*[:#-]?\s*(t_[a-f0-9]{8})",
         body_title,
     )
     if explicit:

--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -178,7 +178,7 @@ def infer_ticket(pr: dict[str, Any], comments_: list[dict[str, Any]]) -> str | N
     # Explicit PR body/title references are accepted only when they look like
     # the PR's own ticket linkage, not incidental mentions in a repair summary.
     explicit = re.search(
-        r"(?i)(?:closes|fixes|resolves|refs?|references|ticket|task|kanban)\s*[:#-]?\s*(t_[a-f0-9]{8})",
+        r"(?i)(?:closes|fixes|resolves|refs?|references?|ticket|task|kanban)\s*[:#-]?\s*(t_[a-f0-9]{8})",
         body_title,
     )
     if explicit:

--- a/swarm/bin/clawta-pr-lifecycle
+++ b/swarm/bin/clawta-pr-lifecycle
@@ -77,12 +77,22 @@ def run_regression_gate(pr_number: int, head: str) -> tuple[int, str]:
         for posting as a kanban comment.
     """
     workdir = tempfile.mkdtemp(prefix=f"regression-gate-pr-{pr_number}-")
+    merge_ref = f"refs/remotes/origin/pr/{pr_number}/merge"
     try:
+        # Fetch the synthetic GitHub merge ref explicitly. It is not present in
+        # ordinary clones by default, and relying on refs/pull/<n>/merge being
+        # local strands otherwise-ready PRs behind a fail-closed tool error.
+        fetched = run(
+            ["git", "fetch", "origin", f"+refs/pull/{pr_number}/merge:{merge_ref}"],
+            timeout=60,
+        )
+        if fetched.returncode != 0:
+            return (2, f"git fetch merge ref failed:\n{fetched.stderr or fetched.stdout}")
+
         # Worktree the PR's merge ref into the temp dir. --detach because
         # we don't need a branch and want to avoid name collisions.
         wt = run(
-            ["git", "worktree", "add", "--detach", workdir,
-             f"refs/pull/{pr_number}/merge"],
+            ["git", "worktree", "add", "--detach", workdir, merge_ref],
             timeout=60,
         )
         if wt.returncode != 0:

--- a/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
+++ b/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
@@ -70,6 +70,33 @@ def approve_comment(head: str = "abc1234") -> dict:
 _TICKET_INFO_PASS = {"status": "in_progress", "assignee": None}
 
 
+class RegressionGateFetchTests(unittest.TestCase):
+    def test_gate_fetches_github_merge_ref_before_worktree(self) -> None:
+        m = load_module()
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(m.tempfile, "mkdtemp", return_value="/tmp/regression-gate-pr-42"), \
+             mock.patch.object(m, "run", side_effect=fake_run), \
+             mock.patch.object(m.subprocess, "run", return_value=mock.Mock(returncode=0, stdout="ok\n", stderr="")), \
+             mock.patch.object(m.shutil, "rmtree"):
+            rc, diagnostic = m.run_regression_gate(42, "abc1234")
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(diagnostic, "ok")
+        self.assertEqual(
+            calls[0],
+            ["git", "fetch", "origin", "+refs/pull/42/merge:refs/remotes/origin/pr/42/merge"],
+        )
+        self.assertEqual(
+            calls[1],
+            ["git", "worktree", "add", "--detach", "/tmp/regression-gate-pr-42", "refs/remotes/origin/pr/42/merge"],
+        )
+
+
 class TicketInferenceTests(unittest.TestCase):
     def test_infer_ticket_accepts_explicit_refs_in_pr_body(self) -> None:
         m = load_module()

--- a/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
+++ b/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
@@ -70,6 +70,24 @@ def approve_comment(head: str = "abc1234") -> dict:
 _TICKET_INFO_PASS = {"status": "in_progress", "assignee": None}
 
 
+class TicketInferenceTests(unittest.TestCase):
+    def test_infer_ticket_accepts_explicit_refs_in_pr_body(self) -> None:
+        m = load_module()
+        pr = base_pr(
+            headRefName="clawta/lifecycle-pr-ref-mapping",
+            body="## Summary\n- lifecycle mapping fix\n\nRefs t_f2ede4a8",
+        )
+
+        self.assertEqual(m.infer_ticket(pr, []), "t_f2ede4a8")
+
+    def test_infer_ticket_ignores_arbitrary_comment_refs(self) -> None:
+        m = load_module()
+        pr = base_pr(headRefName="clawta/human-readable", body="")
+        comments = [{"body": "Refs t_badbeef1"}]
+
+        self.assertIsNone(m.infer_ticket(pr, comments))
+
+
 class GateShortCircuitTests(unittest.TestCase):
     def test_gate_skipped_when_base_gates_fail(self) -> None:
         """If (a-e) fail, gate is NOT invoked (expensive subprocess avoided)."""

--- a/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
+++ b/swarm/tests/test_clawta_pr_lifecycle_regression_gate.py
@@ -73,12 +73,20 @@ _TICKET_INFO_PASS = {"status": "in_progress", "assignee": None}
 class TicketInferenceTests(unittest.TestCase):
     def test_infer_ticket_accepts_explicit_refs_in_pr_body(self) -> None:
         m = load_module()
-        pr = base_pr(
-            headRefName="clawta/lifecycle-pr-ref-mapping",
-            body="## Summary\n- lifecycle mapping fix\n\nRefs t_f2ede4a8",
-        )
+        cases = [
+            "Refs t_f2ede4a8",
+            "Ref t_f2ede4a8",
+            "References t_f2ede4a8",
+            "Reference t_f2ede4a8",
+        ]
+        for body in cases:
+            with self.subTest(body=body):
+                pr = base_pr(
+                    headRefName="clawta/lifecycle-pr-ref-mapping",
+                    body=f"## Summary\n- lifecycle mapping fix\n\n{body}",
+                )
 
-        self.assertEqual(m.infer_ticket(pr, []), "t_f2ede4a8")
+                self.assertEqual(m.infer_ticket(pr, []), "t_f2ede4a8")
 
     def test_infer_ticket_ignores_arbitrary_comment_refs(self) -> None:
         m = load_module()


### PR DESCRIPTION
## Summary
- accept explicit `Refs t_xxxxxxxx` / `Reference(s) t_xxxxxxxx` PR body/title links in lifecycle ticket inference
- keep arbitrary comment refs ignored to avoid unsafe ticket mapping
- add regression tests for body refs and comment refs

## Validation
- `python3 -m py_compile swarm/bin/clawta-pr-lifecycle`
- `python3 -m unittest swarm.tests.test_clawta_pr_lifecycle_regression_gate`

Refs t_f2ede4a8