### PR TITLE
fix(swarm): resolve repo root for installed watchdog

### DIFF
--- a/swarm/bin/clawta-stale-worker-watchdog
+++ b/swarm/bin/clawta-stale-worker-watchdog
@@ -46,7 +46,22 @@ KANBAN_DB = Path(
         str(Path.home() / ".hermes/kanban/boards/chitin/kanban.db"),
     )
 )
-REPO_ROOT = Path(os.environ.get("CHITIN_REPO", Path(__file__).resolve().parents[2]))
+def resolve_repo_root() -> Path:
+    """Find the Chitin repo root from both repo and installed script paths."""
+    env_root = os.environ.get("CHITIN_REPO")
+    candidates: list[Path] = []
+    if env_root:
+        candidates.append(Path(env_root))
+    here = Path(__file__).resolve()
+    candidates.extend(here.parents)
+    candidates.append(Path.home() / "workspace" / "chitin")
+    for candidate in candidates:
+        if (candidate / "scripts" / "kanban-flow").exists() and (candidate / "swarm").exists():
+            return candidate
+    return here.parents[2]
+
+
+REPO_ROOT = resolve_repo_root()
 KANBAN_FLOW_BIN = Path(
     os.environ.get("KANBAN_FLOW_BIN", str(REPO_ROOT / "scripts" / "kanban-flow"))
 )

--- a/swarm/bin/clawta-stale-worker-watchdog
+++ b/swarm/bin/clawta-stale-worker-watchdog
@@ -46,15 +46,16 @@ KANBAN_DB = Path(
         str(Path.home() / ".hermes/kanban/boards/chitin/kanban.db"),
     )
 )
-def resolve_repo_root() -> Path:
+def resolve_repo_root(script_path: Path | None = None, home: Path | None = None) -> Path:
     """Find the Chitin repo root from both repo and installed script paths."""
     env_root = os.environ.get("CHITIN_REPO")
     candidates: list[Path] = []
     if env_root:
         candidates.append(Path(env_root))
-    here = Path(__file__).resolve()
+    here = (script_path or Path(__file__)).resolve()
+    home = home or Path.home()
     candidates.extend(here.parents)
-    candidates.append(Path.home() / "workspace" / "chitin")
+    candidates.append(home / "workspace" / "chitin")
     for candidate in candidates:
         if (candidate / "scripts" / "kanban-flow").exists() and (candidate / "swarm").exists():
             return candidate

--- a/swarm/tests/test_clawta_stale_worker_watchdog.py
+++ b/swarm/tests/test_clawta_stale_worker_watchdog.py
@@ -409,3 +409,14 @@ class TestDryRun:
         assert checked == []
         assert retried == []
         assert escalated == []
+
+class TestRepoRootResolution:
+    def test_resolve_repo_root_prefers_env_when_valid(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "swarm").mkdir()
+        (repo / "scripts" / "kanban-flow").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("CHITIN_REPO", str(repo))
+        wd = _load_module()
+
+        assert wd.resolve_repo_root() == repo

--- a/swarm/tests/test_clawta_stale_worker_watchdog.py
+++ b/swarm/tests/test_clawta_stale_worker_watchdog.py
@@ -420,3 +420,16 @@ class TestRepoRootResolution:
         wd = _load_module()
 
         assert wd.resolve_repo_root() == repo
+
+    def test_resolve_repo_root_falls_back_to_home_workspace(self, tmp_path, monkeypatch):
+        installed_script = tmp_path / ".openclaw" / "bin" / "clawta-stale-worker-watchdog"
+        installed_script.parent.mkdir(parents=True)
+        installed_script.write_text("#!/usr/bin/env python3\n")
+        repo = tmp_path / "workspace" / "chitin"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "swarm").mkdir()
+        (repo / "scripts" / "kanban-flow").write_text("#!/bin/sh\n")
+        monkeypatch.delenv("CHITIN_REPO", raising=False)
+        wd = _load_module()
+
+        assert wd.resolve_repo_root(script_path=installed_script, home=tmp_path) == repo


### PR DESCRIPTION
## Summary
- add robust Chitin repo-root discovery for `clawta-stale-worker-watchdog`
- preserve `CHITIN_REPO` override
- support installed `~/.openclaw/bin` runtime by falling back to `~/workspace/chitin` when valid
- add regression coverage for env-backed root discovery

## Validation
- `python3 -m py_compile swarm/bin/clawta-stale-worker-watchdog`
- `pytest -q swarm/tests/test_clawta_stale_worker_watchdog.py`

Refs t_4b2a4a43