### PR TITLE
skills: invariant layer — /invariant, /gate, /verdict

### DIFF
--- a/.claude/commands/gate.md
+++ b/.claude/commands/gate.md
@@ -1,0 +1,86 @@
+# /gate — Run the adversarial review before PR open, not after
+
+Codify a recurring finding as a permanent, typed check — a lint rule,
+a CI check, or a pre-PR hook — so the adversarial review runs *before*
+the PR exists instead of as a comment after. Every gate is a finding
+that can never be filed again.
+
+## Usage
+
+```
+/gate "<finding>"               — Promote a described finding into a gate
+/gate from invariant <prim>     — Enforce that a /invariant primitive is used
+/gate preflight                 — Run all active gates against the current branch
+/gate list                      — Show active gates + what each one catches
+```
+
+## What a gate is
+
+A gate is **specific and typed, not regex mush** (the sentinel
+promotion rule). It takes one of three forms:
+
+| Form | Runs | Example |
+|---|---|---|
+| Lint rule | On save / pre-commit | "no raw `json.Unmarshal` on event payloads — use `hashNormalized`" |
+| CI check | On push | "every `chitin.yaml` change ships a regression test in the same PR" |
+| Pre-PR hook | `/gate preflight` | "no `delegate_task(acp_command=copilot)` — route through clawta" |
+
+`/gate preflight` is the adversarial pass itself: run it before
+`/land` or `gh pr create` and it catches the findings that would
+otherwise come back as review comments.
+
+## Promotion rule
+
+Promote a finding into a gate only when **all** hold (mirrors the
+sentinel role's promotion rule — do not invent policy from weak
+evidence):
+
+1. The pattern repeats — it is a class, not a one-off.
+2. The check is specific and typed — it names the exact shape.
+3. The predicted false-positive rate is bounded and acceptable.
+4. You can prove the gate with a test: one fixture it catches, one it
+   correctly passes.
+
+If the finding is real but not yet repeating, leave it as a `/verdict`
+note on the PR — don't gate it yet.
+
+## The contract (in order)
+
+1. **Name the finding** as a one-line claim: *"PRs that touch
+   `internal/gov` without a paired test are unsafe to merge."*
+2. **Pick the form** — lint / CI / pre-PR — by where it can fire
+   *earliest* and still be cheap.
+3. **Write the gate + its two-fixture test** (one caught, one passed).
+4. **Register it** so `/gate list` and `/gate preflight` pick it up.
+5. **Backfill once**: run the new gate against open branches and file
+   the hits as `/verdict rework` notes — don't silently break them.
+
+## Chains with
+
+- **Input** ← `/invariant` (a primitive exists → gate enforces its
+  use) or `/mine` (a deny rule repeats → gate stops the action shape).
+- **Runs before** → `/land` and `gh pr create`: `/gate preflight` is
+  the pre-open adversarial review.
+- **Output** → `/verdict`: preflight hits become `rework` dispositions
+  with the gate name as the must-fix reason.
+
+Goal-runner form: `/goal "make <finding> impossible to ship"` →
+`/gate "<finding>"` → `/gate preflight` on every branch after.
+
+## Anti-patterns
+
+- **No broad allow/deny from weak evidence.** One occurrence is a
+  `/verdict` note, not a gate.
+- **No bulk-tuning.** One gate per finding, each independently
+  testable and removable.
+- **Don't gate what `/invariant` should kill.** If the class can be
+  made structurally impossible by a primitive, do that first — a gate
+  is for what *can't* be designed out.
+
+## Why this exists
+
+Remote-control interview, 2026-05-14: "turn the Clawta findings
+taxonomy into actual lint/CI gates so the adversarial review runs
+before PR open, not after." Accountability for PR quality without the
+authority to set merge gates is review with partial leverage. This is
+the gate-setting half.

--- a/.claude/commands/invariant.md
+++ b/.claude/commands/invariant.md
@@ -2,7 +2,7 @@
 
 Turn a **recurring** finding into a shared, tested primitive plus an
 invariant test that makes the whole class structurally impossible.
-The unit of work is the *class*, not the instance: "bugs classes
+The unit of work is the *class*, not the instance: "bug classes
 eliminated," not "PRs touched."
 
 This is the upstream half of review. `/land` and adversarial review

--- a/.claude/commands/invariant.md
+++ b/.claude/commands/invariant.md
@@ -1,0 +1,94 @@
+# /invariant — Eliminate a bug class, don't fix a bug
+
+Turn a **recurring** finding into a shared, tested primitive plus an
+invariant test that makes the whole class structurally impossible.
+The unit of work is the *class*, not the instance: "bugs classes
+eliminated," not "PRs touched."
+
+This is the upstream half of review. `/land` and adversarial review
+find the same bug five times across five PRs; `/invariant` finds it
+once and ends it.
+
+## Usage
+
+```
+/invariant "<pattern>"        — Census + extract + prove for a described class
+/invariant from <finding>     — Seed from a /mine row or a Clawta finding id
+/invariant audit              — Scan the repo for the known recurring classes
+/invariant list               — Show primitives already extracted + their gate
+```
+
+## The contract (in order)
+
+**State the invariant in one sentence before any code.** If you can't,
+the class isn't understood yet — stop and read more. Example:
+*"Every event hash is computed over the schema-normalized form, so
+stripping unknown keys can never change the hash."*
+
+1. **Census.** Find *every* occurrence of the class, not the one in
+   front of you. `rtk grep` the shape across the repo; list each
+   call-site with `file:line`. The census is the scope — a class with
+   one occurrence is not a class, it's a bug (go fix it directly).
+
+2. **Extract.** Pull the defense into one named primitive. Refuse
+   vague names — `validate`, `normalize`, `check` are names of things
+   not yet understood. The honest name (`hashOverNormalizedForm`,
+   `freezeManifestSnapshot`) usually collapses the function by half.
+
+3. **Prove.** Write the invariant test as a claim over *branches*,
+   not a single happy-path run. Walk the boundaries: empty, single,
+   N-equal, max value, out-of-order, same-timestamp. A passing test is
+   evidence; an invariant that holds across all inputs is the proof.
+
+4. **Migrate.** Replace every call-site from the census with the
+   primitive. The diff should show the ad-hoc defense *deleted*, not
+   left beside the new one.
+
+5. **Evidence.** The PR body states the invariant sentence, the
+   census count ("9 call-sites → 1 primitive"), and the boundary
+   cases the test covers. Title: `harden(<class>): <invariant sentence>`.
+
+## Known recurring classes (audit targets)
+
+| Class | Invariant | Primitive shape |
+|---|---|---|
+| hash-before-parse | Hash is computed over the schema-normalized form | `hashNormalized(raw)` |
+| pointer aliasing | Manifest snapshots are immutable after capture | `freezeSnapshot` / JSON round-trip |
+| finalization lifecycle | No event appends after a terminal event | emitter rejects post-`session_end` |
+| schema-column defense | Missing columns degrade, never panic | `taskField(row, col)` with default |
+| event-chain on timeout | Partial work on timeout captures the real chain hash | `chainHashOrDetect()`, never hard null |
+
+`/invariant audit` greps for each shape and reports which still have
+ad-hoc, un-primitived occurrences.
+
+## Chains with
+
+- **Input** ← `/mine` (a deny rule or PR-failure pattern that repeats)
+  or a Clawta/Copilot finding that has shown up on more than one PR.
+- **Output** → `/gate`: once the primitive exists, `/gate` makes its
+  use enforceable so the class can't quietly come back.
+- **Output** → `/verdict`: record the disposition of any PR this
+  supersedes (`rework` → now `merge-ready` or closed).
+
+Goal-runner form: `/goal "kill the <class> bug class"` → `/invariant`
+→ `/gate from invariant <primitive>`.
+
+## When to use
+
+- A finding has appeared on **2+ PRs** or fires as a repeated deny.
+- A `/mine` run surfaces the same rule or failure shape repeatedly.
+- Adversarial review keeps writing the same comment.
+
+## When NOT to use
+
+- A genuinely one-off bug — fix it in its own PR, don't manufacture a
+  primitive for a class of one.
+- A finding you can't state as a one-sentence invariant — it's not
+  ready; understand it first.
+
+## Why this exists
+
+Remote-control interview, 2026-05-14: "The same classes of bug keep
+recurring across PRs… I find the same bug 5 times instead of once."
+Sixty-bugs-fixed sessions are partly a symptom of a missing prevention
+layer. This skill is that layer's entrypoint.

--- a/.claude/commands/verdict.md
+++ b/.claude/commands/verdict.md
@@ -1,0 +1,106 @@
+# /verdict — Durable disposition state for PRs and tickets
+
+Record a disposition **once**, with a reason and a scope, into an
+append-only ledger. `/queue` reads the ledger instead of re-deriving
+state every run. Triage becomes O(new) — only items whose state
+actually moved — instead of O(all).
+
+A verdict is durable: it stays authoritative until the underlying
+thing changes (a PR's head moves) or someone explicitly reopens it.
+
+## Usage
+
+```
+/verdict <pr|ticket-id> <disposition> "<reason>"   — Record a disposition
+/verdict show <id>                                 — Show current verdict + history
+/verdict list [stale]                              — All verdicts; `stale` = head moved past verdict
+/verdict reopen <id> "<why>"                        — Invalidate a verdict, send back to triage
+```
+
+## Disposition vocabulary
+
+Standardized values — `/queue` keys its display and skip logic off
+these (parallels the `block_reason` vocabulary in `docs/hermes-role.md`):
+
+| Disposition | Meaning | /queue behaviour |
+|---|---|---|
+| `merge-ready` | CI green, reviewed, no blockers | surfaced in `merge all green` batch |
+| `rework` | Real must-fix items; reason lists them | shown with must-fix count, skipped from re-review |
+| `blocked-environmental` | Non-code blocker (token scope, infra) | shown once, not re-triaged until reopened |
+| `defer` | Low-priority + stale; archive candidate | folded into `defer` batch |
+| `wont-merge` | Superseded / rejected by design | hidden from default view |
+
+## The ledger
+
+Append-only JSONL at `~/.hermes/verdicts/<board>.jsonl`. One line per
+record:
+
+```json
+{
+  "id": "pr-628",
+  "disposition": "blocked-environmental",
+  "reason": "merge blocked: OAuth token missing workflow scope; needs token refresh or web-UI merge",
+  "scope": "no code work required",
+  "head_sha": "a1b2c3d",
+  "recorded_at": "2026-05-14T20:00:00-04:00",
+  "recorded_by": "claude-code",
+  "reopened": false
+}
+```
+
+`head_sha` is the disposition's anchor. For a PR, capture it with
+`gh pr view <n> --json headRefOid -q .headRefOid` at record time.
+
+## Staleness — the O(new) mechanism
+
+A verdict is **current** while the PR head still equals `head_sha`.
+When new commits land, the verdict goes **stale**: `/queue` and
+`/verdict list stale` flag it for re-triage, and only those items get
+a fresh deep-dive. Everything with a current verdict is read, not
+re-derived.
+
+Tickets (no head SHA) use the kanban `updated_at` instead: a verdict
+goes stale if the ticket changed after `recorded_at`.
+
+## Contract with /queue
+
+`/queue` consults `~/.hermes/verdicts/<board>.jsonl` before its PR
+section:
+
+- PR with a **current** verdict → one line: `#628 [verdict:
+  blocked-environmental] "needs token refresh"` — no deep re-triage.
+- PR with a **stale** verdict → re-triaged normally; a new `/verdict`
+  supersedes the old line.
+- PR with **no** verdict → triaged normally (this is the "new" in
+  O(new)).
+
+`/verdict reopen` is the only way to re-triage a still-current
+verdict — disposition decisions don't get silently re-litigated.
+
+## Chains with
+
+- **Input** ← terminal step of `/land` (per-PR review outcome),
+  `/gate preflight` (hits → `rework` with gate names as must-fix),
+  `/invariant` (a superseding PR → old PR `wont-merge` or `merge-ready`),
+  or adversarial review.
+- **Reader** → `/queue`: the whole point. Verdicts are what make the
+  queue cheap.
+
+Goal-runner form: any `/goal` that dispositions PRs ends each item
+with a `/verdict` write so the next run starts from state, not from
+scratch.
+
+## When to use
+
+- End of every `/land` or `/queue` deep-dive — record the call you
+  just made so it sticks.
+- Any PR that's blocked for a reason that won't change on its own
+  (environmental blockers especially — record once, stop rediscovering).
+
+## Why this exists
+
+Remote-control interview, 2026-05-14: sessions S174–S178 — five
+"queue status check" runs in ~3 hours, each re-deriving the same
+state from scratch. "The disposition state should be a fact the queue
+reads, not something I rediscover." Disposition decisions should be
+durable unless explicitly reopened.

--- a/.claude/commands/verdict.md
+++ b/.claude/commands/verdict.md
@@ -1,9 +1,10 @@
 # /verdict — Durable disposition state for PRs and tickets
 
 Record a disposition **once**, with a reason and a scope, into an
-append-only ledger. `/queue` reads the ledger instead of re-deriving
-state every run. Triage becomes O(new) — only items whose state
-actually moved — instead of O(all).
+append-only ledger. `/queue` is designed to read the ledger instead of
+re-deriving state every run (ledger integration is a planned follow-up).
+Triage becomes O(new) — only items whose state actually moved — instead
+of O(all).
 
 A verdict is durable: it stays authoritative until the underlying
 thing changes (a PR's head moves) or someone explicitly reopens it.
@@ -20,7 +21,7 @@ thing changes (a PR's head moves) or someone explicitly reopens it.
 ## Disposition vocabulary
 
 Standardized values — `/queue` keys its display and skip logic off
-these (parallels the `block_reason` vocabulary in `docs/hermes-role.md`):
+these (parallels the `block_reason` vocabulary used by Hermes):
 
 | Disposition | Meaning | /queue behaviour |
 |---|---|---|


### PR DESCRIPTION
Adds the **prevention pipeline** as three composable operator slash commands in `.claude/commands/`, alongside the existing `/queue` command. They move work upstream — from reactive PR triage to bug-class elimination.

## Skills

| Skill | Does | Chains |
|---|---|---|
| **`/invariant`** | Kills a bug *class*: census every occurrence → extract a named shared primitive → prove with a boundary-walking invariant test | ← `/mine` · → `/gate` |
| **`/gate`** | Promotes a recurring finding into a typed lint/CI/pre-PR check; `/gate preflight` is the adversarial pass before PR open | ← `/invariant` · runs before `/land` / `gh pr create` |
| **`/verdict`** | Append-only PR/ticket disposition ledger keyed to head SHA; `/queue` reads it → triage is O(new), not O(all) | terminal step · `/queue` is the reader |

## How they compose

Full chain: `/mine` (find recurring signal) → `/invariant` (kill the class) → `/gate` (make it permanent) → `/verdict` (record the disposition). Each skill is also independently invokable from `/goal` — every one declares its inputs/outputs and a "Chains with" section so a goal-runner can compose them.

`/verdict`'s ledger (`~/.hermes/verdicts/<board>.jsonl`) is designed for `/queue` to consult before its PR section, so dispositions stop being re-derived every run.

## Why

From a role-design conversation: the same bug classes recur across PRs (hash-before-parse, pointer aliasing, finalization lifecycle, schema-column defense, event-chain-on-timeout), the adversarial review runs *after* PR open instead of as a gate before it, and `/queue` re-derives the same disposition state every run. These three skills are the prevention layer that addresses each.

Follow-up (not in this PR): `/queue` could be updated to read the `/verdict` ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)