### PR TITLE
fix(swarm): install shared runtime helpers

### DIFF
--- a/scripts/check-swarm-deployed-sync.sh
+++ b/scripts/check-swarm-deployed-sync.sh
@@ -70,11 +70,13 @@ if [ -d "$CARDS_SRC" ]; then
         ! -name '*.bak*' 2>/dev/null)
 fi
 
-# Operator scripts (clawta-* cron helpers under swarm/bin/)
+# Operator scripts (clawta-* cron helpers under swarm/bin/) and shared
+# helper modules they import at runtime.
 if [ -d "$BIN_SRC" ] && [ -d "$BIN_DST" ]; then
     while IFS= read -r src; do
         check_pair "$src" "$BIN_DST/$(basename "$src")"
-    done < <(find "$BIN_SRC" -maxdepth 1 -type f -name 'clawta-*' \
+    done < <(find "$BIN_SRC" -maxdepth 1 -type f \
+        \( -name 'clawta-*' -o -name 'board_resolver.py' \) \
         ! -name '*.bak*' 2>/dev/null)
 fi
 

--- a/scripts/install-swarm.sh
+++ b/scripts/install-swarm.sh
@@ -78,12 +78,13 @@ find "$CARDS_SRC" -maxdepth 1 -type f -name '*.json' \
     install_file "$src" "$CARDS_DST/$(basename "$src")"
 done
 
-# clawta-* operator cron + helper scripts. The poller (~/.local/bin/...)
-# is a separate install path managed by the operator; this set covers
-# the openclaw-cron-resident scripts (pool guard, failure sentinel,
-# escalator, etc.) that live under ~/.openclaw/bin/.
+# clawta-* operator cron scripts plus shared helper modules they import.
+# The poller (~/.local/bin/...) is a separate install path managed by the
+# operator; this set covers the openclaw-cron-resident scripts (pool guard,
+# failure sentinel, escalator, etc.) that live under ~/.openclaw/bin/.
 echo "Installing swarm operator scripts into $BIN_DST"
-find "$BIN_SRC" -maxdepth 1 -type f -name 'clawta-*' \
+find "$BIN_SRC" -maxdepth 1 -type f \
+    \( -name 'clawta-*' -o -name 'board_resolver.py' \) \
     ! -name '*.bak*' \
     -print 2>/dev/null \
 | while IFS= read -r src; do
@@ -113,7 +114,7 @@ done
 # survive. Recount the destination tree against the source as a final
 # summary.
 src_count=$(find "$WORKFLOWS_SRC" "$CARDS_SRC" "$BIN_SRC" -maxdepth 1 -type f \
-    \( -name '*.lobster' -o -name '*.py' -o -name '*.md' -o -name '*.json' -o -name 'clawta-*' \) \
+    \( -name '*.lobster' -o -name '*.py' -o -name '*.md' -o -name '*.json' -o -name 'clawta-*' -o -name 'board_resolver.py' \) \
     ! -name '*.bak*' 2>/dev/null | wc -l)
 src_count=$((src_count + $(find "$ROLES_SRC" -type f -name '*.md' ! -name '*.bak*' 2>/dev/null | wc -l)))
 

--- a/swarm/bin/clawta-report
+++ b/swarm/bin/clawta-report
@@ -2,6 +2,7 @@
 import html, json, os, re, sqlite3, subprocess, sys, time, urllib.parse, urllib.request, xml.etree.ElementTree as ET
 from collections import Counter, defaultdict
 from datetime import datetime
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from board_resolver import resolve_db, resolve_board

--- a/swarm/tests/test_install_swarmsync.py
+++ b/swarm/tests/test_install_swarmsync.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL = REPO_ROOT / "scripts" / "install-swarm.sh"
+CHECK_SYNC = REPO_ROOT / "scripts" / "check-swarm-deployed-sync.sh"
+
+
+class InstallSwarmSyncTests(unittest.TestCase):
+    def test_installs_imported_helper_modules_and_import_smokes_scripts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            openclaw = Path(tmp) / "openclaw"
+            home.mkdir()
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HOME": str(home),
+                    "OPENCLAW_HOME": str(openclaw),
+                    "KANBAN_BOARDS_DIR": str(home / ".hermes" / "kanban" / "boards"),
+                    "KANBAN_DB": str(home / ".hermes" / "kanban" / "boards" / "chitin" / "kanban.db"),
+                }
+            )
+
+            subprocess.run(["bash", str(INSTALL)], cwd=REPO_ROOT, env=env, check=True, text=True, capture_output=True)
+            subprocess.run(["bash", str(CHECK_SYNC)], cwd=REPO_ROOT, env=env, check=True, text=True, capture_output=True)
+
+            self.assertTrue((openclaw / "bin" / "board_resolver.py").exists())
+
+            for script in ("clawta-report", "clawta-pr-lifecycle"):
+                deployed = openclaw / "bin" / script
+                proc = subprocess.run(
+                    ["python3", "-c", f"import runpy; runpy.run_path({str(deployed)!r}, run_name='__clawta_import_smoke__')"],
+                    cwd=REPO_ROOT,
+                    env=env,
+                    text=True,
+                    capture_output=True,
+                    timeout=20,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Install `board_resolver.py` alongside deployed `clawta-*` runtime scripts
- Include the helper in deployed-sync drift checks so future installs cannot omit it silently
- Fix `clawta-report` importing `Path` after first use
- Add an install/sync smoke test that imports deployed runtime scripts from a temp OpenClaw home

Refs t_17c29b5d.

## Validation
- python3 -m py_compile swarm/bin/clawta-report swarm/bin/clawta-pr-lifecycle swarm/bin/board_resolver.py
- python3 -m unittest swarm.tests.test_install_swarmsync
- bash scripts/install-swarm.sh
- bash scripts/check-swarm-deployed-sync.sh
- /home/red/.openclaw/bin/clawta-report swarm-health
- bash scripts/regression-gate.sh