### PR TITLE
feat(gov): bounds.exclude_paths for generated artifacts

### DIFF
--- a/go/execution-kernel/internal/gov/bounds.go
+++ b/go/execution-kernel/internal/gov/bounds.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
+	"path"
 	"strconv"
 	"strings"
 
@@ -12,9 +12,9 @@ import (
 )
 
 // CheckBounds fires only for push-shaped actions (git.push, github.pr.create).
-// For git.push it shells out to `git diff --stat origin/main...HEAD` in cwd.
+// For git.push it shells out to `git diff --numstat origin/main...HEAD` in cwd.
 // For github.pr.create it resolves the repo root and measures
-// `git diff --stat <base>...<head>` from the gh command line so the bounds
+// `git diff --numstat <base>...<head>` from the gh command line so the bounds
 // check matches the PR page's merge-base diff regardless of the caller's cwd.
 // Rejects if the per-action ceiling in policy.Bounds is exceeded. Fail-closed:
 // if git diff fails or returns unparseable output, treat as over-bounds.
@@ -22,6 +22,10 @@ import (
 // Per-action overrides (Bounds.PerAction[<action_type>]) close #70: doc-batch
 // pushes via git.push can be allowed a higher ceiling than code commits via
 // github.pr.create without widening either globally.
+//
+// Bounds.ExcludePaths drops generated artifacts (lockfiles, vendored trees)
+// from the files/lines totals before they are measured against the ceilings.
+// An entirely-excluded diff measures as 0 files / 0 lines and passes.
 //
 // Bounds decisions default to mode=enforce — bounds are intended as hard
 // kill-switches even when policy is in monitor — but the operator can opt
@@ -38,7 +42,7 @@ func CheckBounds(a Action, p Policy, cwd string) Decision {
 		return Decision{Allowed: true, RuleID: "bounds:no-ceiling", Action: a}
 	}
 
-	files, ins, del, err := collectDiffStats(a, cwd)
+	files, ins, del, err := collectDiffStats(a, cwd, p.Bounds.ExcludePaths)
 	if err != nil {
 		return Decision{
 			Allowed: false,
@@ -93,7 +97,7 @@ func boundsModeFor(p Policy, ruleID string) string {
 	return "enforce"
 }
 
-func collectDiffStats(a Action, cwd string) (files, ins, del int, err error) {
+func collectDiffStats(a Action, cwd string, excludePaths []string) (files, ins, del int, err error) {
 	diffRange := "origin/main...HEAD"
 	repoPath := cwd
 
@@ -115,26 +119,121 @@ func collectDiffStats(a Action, cwd string) (files, ins, del int, err error) {
 	// No silent HEAD~1 fallback: a single-commit diff doesn't tell us the
 	// PR-level blast radius, and getting bounds wrong in the permissive
 	// direction defeats the point.
-	cmd := exec.Command("git", "-C", repoPath, "diff", "--stat", diffRange)
+	//
+	// --numstat gives one machine-readable line per file:
+	//   <added>\t<deleted>\t<path>
+	// Binary files render as `-\t-\t<path>`; they count as a changed file
+	// with zero lines. This is parsed per file (not via a summary line) so
+	// ExcludePaths can drop generated artifacts before totals are summed.
+	cmd := exec.Command("git", "-C", repoPath, "diff", "--numstat", diffRange)
 	out, runErr := cmd.Output()
 	if runErr != nil {
-		return 0, 0, 0, fmt.Errorf("git diff --stat %s: %w", diffRange, runErr)
+		return 0, 0, 0, fmt.Errorf("git diff --numstat %s: %w", diffRange, runErr)
 	}
-	trimmed := strings.TrimSpace(string(out))
+	return parseNumstat(string(out), excludePaths)
+}
+
+// parseNumstat sums files/insertions/deletions over `git diff --numstat`
+// output, skipping any file whose path matches an ExcludePaths glob.
+// Empty output means no changes vs. base — all zeros, which passes
+// bounds. A line that does not have three tab-separated fields is
+// treated fail-closed: an error, not a silent skip.
+func parseNumstat(out string, excludePaths []string) (files, ins, del int, err error) {
+	trimmed := strings.TrimSpace(out)
 	if trimmed == "" {
-		// Empty diff (no changes vs. base). All zeros pass bounds.
 		return 0, 0, 0, nil
 	}
-	lines := strings.Split(trimmed, "\n")
-	last := lines[len(lines)-1]
-	f, ip, dp := parseDiffStatLine(last)
-	// Non-empty output but the summary line didn't match the expected
-	// shape — fail-closed rather than let bounds silently pass on
-	// unparseable input.
-	if f == 0 && ip == 0 && dp == 0 && !strings.Contains(last, "files changed") && !strings.Contains(last, "file changed") {
-		return 0, 0, 0, fmt.Errorf("unparseable git diff --stat summary: %q", last)
+	for _, line := range strings.Split(trimmed, "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) != 3 {
+			return 0, 0, 0, fmt.Errorf("unparseable git diff --numstat line: %q", line)
+		}
+		addStr, delStr, pathField := fields[0], fields[1], fields[2]
+		if pathMatchesAny(pathField, excludePaths) {
+			continue
+		}
+		// Binary files render added/deleted as "-"; count the file but
+		// contribute zero lines (there is no textual line count).
+		a := 0
+		if addStr != "-" {
+			a, err = strconv.Atoi(addStr)
+			if err != nil {
+				return 0, 0, 0, fmt.Errorf("unparseable added count %q in %q", addStr, line)
+			}
+		}
+		d := 0
+		if delStr != "-" {
+			d, err = strconv.Atoi(delStr)
+			if err != nil {
+				return 0, 0, 0, fmt.Errorf("unparseable deleted count %q in %q", delStr, line)
+			}
+		}
+		files++
+		ins += a
+		del += d
 	}
-	return f, ip, dp, nil
+	return files, ins, del, nil
+}
+
+// pathMatchesAny reports whether p matches any of the glob patterns.
+// The path field from `git diff --numstat` is matched as-is; rename
+// entries (which contain `=>`) will not match a clean glob and so are
+// counted — the conservative direction for a ceiling check.
+func pathMatchesAny(p string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if matchGlob(pattern, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob matches a slash-separated path against a glob pattern.
+// Each non-`**` segment is matched with path.Match (so `*` and `?`
+// work within a segment but do not cross `/`). A `**` segment matches
+// zero or more whole path segments, so `**/pnpm-lock.yaml` matches both
+// `pnpm-lock.yaml` and `apps/x/pnpm-lock.yaml`, and `vendor/**` matches
+// everything under `vendor/`.
+func matchGlob(pattern, p string) bool {
+	if pattern == "" {
+		return false
+	}
+	return matchSegments(strings.Split(pattern, "/"), strings.Split(p, "/"))
+}
+
+func matchSegments(pat, segs []string) bool {
+	if len(pat) == 0 {
+		return len(segs) == 0
+	}
+	if pat[0] == "**" {
+		// `**` matches zero or more whole segments, EXCEPT a trailing
+		// `**` (e.g. `vendor/**`) which requires at least one segment
+		// after the separator — so `vendor/**` matches `vendor/x` but
+		// not `vendor` itself. A leading/middle `**` (e.g.
+		// `**/pnpm-lock.yaml`) still matches zero segments, so the
+		// pattern also matches `pnpm-lock.yaml` at the repo root.
+		start := 0
+		if len(pat) == 1 {
+			start = 1
+		}
+		for i := start; i <= len(segs); i++ {
+			if matchSegments(pat[1:], segs[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(segs) == 0 {
+		return false
+	}
+	ok, matchErr := path.Match(pat[0], segs[0])
+	if matchErr != nil || !ok {
+		return false
+	}
+	return matchSegments(pat[1:], segs[1:])
 }
 
 func prDiffRange(a Action, repoRoot string) (string, error) {
@@ -168,27 +267,4 @@ func boundsGitOutput(repoPath string, args ...string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-// parseDiffStatLine parses the summary line printed at the bottom of
-// `git diff --stat`, e.g.:
-//
-//	" 3 files changed, 10 insertions(+), 5 deletions(-)"
-//
-// Returns (files, insertions, deletions). Any field missing returns 0
-// for that field (e.g. a diff with only insertions lacks deletions).
-func parseDiffStatLine(s string) (files, ins, del int) {
-	reFiles := regexp.MustCompile(`(\d+)\s+files?\s+changed`)
-	reIns := regexp.MustCompile(`(\d+)\s+insertions?\(\+\)`)
-	reDel := regexp.MustCompile(`(\d+)\s+deletions?\(-\)`)
-	if m := reFiles.FindStringSubmatch(s); len(m) > 1 {
-		files, _ = strconv.Atoi(m[1])
-	}
-	if m := reIns.FindStringSubmatch(s); len(m) > 1 {
-		ins, _ = strconv.Atoi(m[1])
-	}
-	if m := reDel.FindStringSubmatch(s); len(m) > 1 {
-		del, _ = strconv.Atoi(m[1])
-	}
-	return files, ins, del
 }

--- a/go/execution-kernel/internal/gov/bounds_test.go
+++ b/go/execution-kernel/internal/gov/bounds_test.go
@@ -19,31 +19,88 @@ func TestBounds_NonPushShapedSkips(t *testing.T) {
 	}
 }
 
-func TestBounds_ParseStatLine(t *testing.T) {
-	cases := []struct {
-		line    string
-		wantF   int
-		wantIns int
-		wantDel int
-	}{
-		{" 3 files changed, 10 insertions(+), 5 deletions(-)", 3, 10, 5},
-		{" 1 file changed, 1 insertion(+)", 1, 1, 0},
-		{" 60 files changed, 42 insertions(+), 8874 deletions(-)", 60, 42, 8874},
-		{" 2 files changed, 0 insertions(+), 7 deletions(-)", 2, 0, 7},
+func TestBounds_ParseNumstat(t *testing.T) {
+	out := "10\t5\tsrc/a.go\n" +
+		"3045\t42\tpnpm-lock.yaml\n" +
+		"-\t-\tassets/logo.png\n" +
+		"1\t0\tapps/x/pnpm-lock.yaml\n"
+
+	// No exclusions: every file counts; binary contributes 0 lines.
+	f, ins, del, err := parseNumstat(out, nil)
+	if err != nil {
+		t.Fatalf("parseNumstat: %v", err)
 	}
-	for _, c := range cases {
-		f, ins, del := parseDiffStatLine(c.line)
-		if f != c.wantF || ins != c.wantIns || del != c.wantDel {
-			t.Errorf("parseDiffStatLine(%q) = (%d,%d,%d) want (%d,%d,%d)",
-				c.line, f, ins, del, c.wantF, c.wantIns, c.wantDel)
-		}
+	if f != 4 || ins != 3056 || del != 47 {
+		t.Errorf("no-exclude: got (%d,%d,%d) want (4,3056,47)", f, ins, del)
+	}
+
+	// Excluding lockfiles drops both pnpm-lock.yaml files.
+	f, ins, del, err = parseNumstat(out, []string{"**/pnpm-lock.yaml"})
+	if err != nil {
+		t.Fatalf("parseNumstat exclude: %v", err)
+	}
+	if f != 2 || ins != 10 || del != 5 {
+		t.Errorf("exclude lockfiles: got (%d,%d,%d) want (2,10,5)", f, ins, del)
 	}
 }
 
-func TestBounds_ParseStatLine_Empty(t *testing.T) {
-	f, ins, del := parseDiffStatLine("")
+func TestBounds_ParseNumstat_Empty(t *testing.T) {
+	f, ins, del, err := parseNumstat("", nil)
+	if err != nil || f != 0 || ins != 0 || del != 0 {
+		t.Errorf("empty should parse to zeros with no error, got (%d,%d,%d) err=%v", f, ins, del, err)
+	}
+	f, ins, del, err = parseNumstat("   \n  ", nil)
+	if err != nil || f != 0 || ins != 0 || del != 0 {
+		t.Errorf("whitespace-only should parse to zeros, got (%d,%d,%d) err=%v", f, ins, del, err)
+	}
+}
+
+func TestBounds_ParseNumstat_AllExcludedPasses(t *testing.T) {
+	// Boundary: every changed file is excluded — measures as 0/0/0.
+	out := "9000\t9000\tpnpm-lock.yaml\n5000\t0\tvendor/big.js\n"
+	f, ins, del, err := parseNumstat(out, []string{"**/pnpm-lock.yaml", "vendor/**"})
+	if err != nil {
+		t.Fatalf("parseNumstat: %v", err)
+	}
 	if f != 0 || ins != 0 || del != 0 {
-		t.Errorf("empty should parse to zeros, got (%d,%d,%d)", f, ins, del)
+		t.Errorf("fully-excluded diff should be zeros, got (%d,%d,%d)", f, ins, del)
+	}
+}
+
+func TestBounds_ParseNumstat_Unparseable(t *testing.T) {
+	// Fail-closed: a line without three tab fields is an error, not a skip.
+	if _, _, _, err := parseNumstat("garbage line no tabs\n", nil); err == nil {
+		t.Errorf("unparseable line should error (fail-closed)")
+	}
+	// Fail-closed: a non-numeric count is an error.
+	if _, _, _, err := parseNumstat("abc\t5\tsrc/a.go\n", nil); err == nil {
+		t.Errorf("non-numeric added count should error")
+	}
+}
+
+func TestBounds_MatchGlob(t *testing.T) {
+	cases := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"**/pnpm-lock.yaml", "pnpm-lock.yaml", true},
+		{"**/pnpm-lock.yaml", "apps/x/pnpm-lock.yaml", true},
+		{"**/pnpm-lock.yaml", "apps/x/pnpm-lock.yaml.bak", false},
+		{"vendor/**", "vendor/a/b.js", true},
+		{"vendor/**", "vendor", false},
+		{"vendor/**", "src/vendor/a.js", false},
+		{"pnpm-lock.yaml", "pnpm-lock.yaml", true},
+		{"pnpm-lock.yaml", "apps/x/pnpm-lock.yaml", false},
+		{"*.lock", "Cargo.lock", true},
+		{"*.lock", "a/Cargo.lock", false},
+		{"**/*.snap", "test/__snapshots__/a.snap", true},
+		{"", "anything", false},
+	}
+	for _, c := range cases {
+		if got := matchGlob(c.pattern, c.path); got != c.want {
+			t.Errorf("matchGlob(%q, %q) = %v want %v", c.pattern, c.path, got, c.want)
+		}
 	}
 }
 
@@ -194,12 +251,44 @@ func TestCollectDiffStats_GithubPRCreateUsesHeadBranchNotCwdHead(t *testing.T) {
 	files, ins, del, err := collectDiffStats(Action{
 		Type:   ActGithubPRCreate,
 		Target: "gh pr create --base main --head feature/small",
-	}, repo)
+	}, repo, nil)
 	if err != nil {
 		t.Fatalf("collectDiffStats: %v", err)
 	}
 	if files != 1 || ins != 20 || del != 0 {
 		t.Fatalf("github.pr.create should diff main...feature/small, got files=%d ins=%d del=%d", files, ins, del)
+	}
+}
+
+// Integration: ExcludePaths drops a generated lockfile from the totals
+// measured by collectDiffStats against a real git diff.
+func TestCollectDiffStats_ExcludePathsDropsLockfile(t *testing.T) {
+	repo := initBoundsTestRepo(t)
+	writeAndCommitBoundsFile(t, repo, "pnpm-lock.yaml", strings.Repeat("dep\n", 3000), "regen lockfile")
+	writeAndCommitBoundsFile(t, repo, "app_change.go", strings.Repeat("x\n", 40), "real code change")
+
+	// Without exclusion: lockfile churn dominates the total.
+	files, ins, del, err := collectDiffStats(Action{
+		Type:   ActGitPush,
+		Target: "git push origin main",
+	}, repo, nil)
+	if err != nil {
+		t.Fatalf("collectDiffStats no-exclude: %v", err)
+	}
+	if files != 2 || ins != 3040 || del != 0 {
+		t.Fatalf("no-exclude: got files=%d ins=%d del=%d want (2,3040,0)", files, ins, del)
+	}
+
+	// With exclusion: only the real code change counts.
+	files, ins, del, err = collectDiffStats(Action{
+		Type:   ActGitPush,
+		Target: "git push origin main",
+	}, repo, []string{"**/pnpm-lock.yaml"})
+	if err != nil {
+		t.Fatalf("collectDiffStats exclude: %v", err)
+	}
+	if files != 1 || ins != 40 || del != 0 {
+		t.Fatalf("exclude lockfile: got files=%d ins=%d del=%d want (1,40,0)", files, ins, del)
 	}
 }
 
@@ -210,7 +299,7 @@ func TestCollectDiffStats_GitPushStillUsesCwdHead(t *testing.T) {
 	files, ins, del, err := collectDiffStats(Action{
 		Type:   ActGitPush,
 		Target: "git push origin main",
-	}, repo)
+	}, repo, nil)
 	if err != nil {
 		t.Fatalf("collectDiffStats: %v", err)
 	}
@@ -227,7 +316,7 @@ func TestCollectDiffStats_GithubPRCreateMissingHeadFallsBackToCwdHeadAndWarns(t 
 		files, ins, del, err := collectDiffStats(Action{
 			Type:   ActGithubPRCreate,
 			Target: "gh pr create --base main",
-		}, repo)
+		}, repo, nil)
 		if err != nil {
 			t.Fatalf("collectDiffStats: %v", err)
 		}
@@ -250,7 +339,7 @@ func TestCollectDiffStats_GithubPRCreateOmittedBaseUsesOriginHead(t *testing.T) 
 	files, ins, del, err := collectDiffStats(Action{
 		Type:   ActGithubPRCreate,
 		Target: "gh pr create --head feature/small",
-	}, repo)
+	}, repo, nil)
 	if err != nil {
 		t.Fatalf("collectDiffStats: %v", err)
 	}

--- a/go/execution-kernel/internal/gov/policy.go
+++ b/go/execution-kernel/internal/gov/policy.go
@@ -83,6 +83,14 @@ type Bounds struct {
 	MaxFilesChanged int                     `yaml:"max_files_changed"`
 	MaxLinesChanged int                     `yaml:"max_lines_changed"`
 	PerAction       map[string]ActionBounds `yaml:"per_action,omitempty"`
+	// ExcludePaths are glob patterns; a changed file whose path matches
+	// any pattern is excluded from the files/lines totals measured
+	// against the ceilings. Intended for generated artifacts (lockfiles,
+	// vendored trees, snapshots) whose churn is not reviewed line by
+	// line. `**` matches across path segments, e.g. `**/pnpm-lock.yaml`
+	// or `vendor/**`. Exclusion applies to every push-shaped action;
+	// there is no per-action exclude list.
+	ExcludePaths []string `yaml:"exclude_paths,omitempty"`
 }
 
 // ActionBounds is the per-action override for blast-radius ceilings.


### PR DESCRIPTION
## What

Adds `bounds.exclude_paths`: glob patterns whose matching files are dropped from the `files_changed` / `lines_changed` totals *before* they hit the bounds ceilings.

The blast-radius gate measured every changed line equally, so a single dependency bump (pnpm-lock.yaml regenerates wholesale) would dominate a PR's line count and trip the ceiling even when the human-reviewed code change was small. A fully excluded diff measures as 0/0 and passes.

## How

- **`collectDiffStats`** switches from `git diff --stat` summary-line parsing to `git diff --numstat` per-file parsing — machine-readable, and per-file is required to filter by path. Binary files (`-` counts) contribute a changed file with zero lines. **Fail-closed preserved**: a line without three tab fields, or a non-numeric count, is an error.
- **`matchGlob`** now supports `**` across path segments. A leading/middle `**` matches zero or more segments (`**/pnpm-lock.yaml` matches the file at repo root too); a trailing `**` requires at least one segment (`vendor/**` matches `vendor/x` but not `vendor`).
- `parseDiffStatLine` and its tests removed (dead after the `--numstat` switch).
- Wire-up in `policy.go` so `bounds.exclude_paths` parses from chitin.yaml.

## Verification

- `go test ./internal/gov/...` — **PASS** (1.286s, all bounds + matchGlob tests covered including binary files, `**` patterns, exclusion math)
- `go build ./...` — clean

## Follow-up

This PR is a precondition for the Chitin Console PR (slice 3 of the dashboard epic) — that PR adds Angular deps which regenerate pnpm-lock.yaml wholesale and currently trips the bounds gate. Once this lands, that PR can configure `bounds.exclude_paths: ["**/pnpm-lock.yaml"]` and pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)