### PR TITLE
test(clawta-poller): lock in singular Boundary: + plural Boundaries: invariants gate

### DIFF
--- a/swarm/tests/test_clawta_poller.py
+++ b/swarm/tests/test_clawta_poller.py
@@ -324,6 +324,23 @@ class ClawtaPollerDependencyTests(unittest.TestCase):
         demote_cmd = next(cmd for cmd in seen if cmd[0] == module.KANBAN_FLOW_BIN)
         self.assertIn("missing explicit boundary list", demote_cmd[3])
 
+    def test_missing_invariants_reason_accepts_singular_and_plural_boundary(self) -> None:
+        # Locks in: the gate accepts both `Boundary:` (singular) and
+        # `Boundaries:` (plural) so author choice never traps a ticket
+        # in a promote-demote loop. Closes t_b8e4f138.
+        module = load_module()
+        for form in ("Boundary: empty, max", "Boundaries: empty, max"):
+            with self.subTest(form=form):
+                body = (
+                    "invariants_and_boundaries:\n"
+                    "  Invariant: parser never returns an empty action.\n"
+                    f"  {form}\n"
+                )
+                self.assertIsNone(
+                    module.missing_invariants_reason({"body": body}),
+                    f"gate should accept '{form}' form",
+                )
+
     def test_tick_blocks_unmerged_pr_before_routing(self) -> None:
         module = load_module()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- Add a unit test on `missing_invariants_reason` asserting both `Boundary:` (singular) and `Boundaries:` (plural) satisfy the invariants gate.
- The boundary-extractor regex `\bboundar(?:y|ies)\s*:\s*(.+)` (clawta-poller line 151) already accepts both forms — this test pins the behavior so a future tightening can't silently re-introduce the promote-demote loop.

## Why

Closes kanban ticket **t_b8e4f138**. The watchdog has been escalating a 40+-cycle promote-demote loop on multiple chitin tickets, naming this ticket as the root cause. Inspection showed the regex was already correct — only the regression test was missing.

## Test plan
- [x] `python3 -m unittest swarm.tests.test_clawta_poller` — all 15 pass locally
- [x] New test passes for both `Boundary: empty, max` and `Boundaries: empty, max`
- [x] Negative tests (`test_tick_demotes_ticket_missing_invariants_and_boundaries`, `test_tick_demotes_ticket_with_invariant_but_no_boundaries`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)