### PR TITLE
feat(kanban): exempt tracking epics from auto-promotion + demote gates

### DIFF
--- a/scripts/kanban-flow
+++ b/scripts/kanban-flow
@@ -448,6 +448,7 @@ event_chain_hash=""
 chain_file=""
 run_status_override=""
 outcome_override=""
+force_flag=0
 parse_flags() {
   local rest=()
   while [[ $# -gt 0 ]]; do
@@ -461,10 +462,21 @@ parse_flags() {
       --chain-file) chain_file="$2"; shift 2 ;;
       --run-status) run_status_override="$2"; shift 2 ;;
       --outcome) outcome_override="$2"; shift 2 ;;
+      --force) force_flag=1; shift ;;
       *) rest+=("$1"); shift ;;
     esac
   done
   REST=("${rest[@]+"${rest[@]}"}")
+}
+
+# Tracking-epic guard: matches `Tracking-epic: true|yes|1` at start of line
+# in the ticket body, case-insensitive. Used by the `ready` subcommand to
+# refuse auto-promotion of parent containers (see ticket t_6eba6ad2).
+is_tracking_epic_id() {
+  local id="$1"
+  local body
+  body=$(sqlite3 "$DB" "SELECT COALESCE(body,'') FROM tasks WHERE id='$id'" 2>/dev/null)
+  [[ -n "$body" ]] && grep -qiE '^tracking-epic:[[:space:]]*(true|yes|1)[[:space:]]*$' <<< "$body"
 }
 
 post_cost_summary_comment() {
@@ -610,6 +622,13 @@ case "$cmd" in
     id="${REST[0]:-}"; require_id "$id"
     from="$(ticket_status "$id")"
     [[ "$from" == triage || "$from" == blocked ]] || die "$id is in '$from'; can only mark ready from triage|blocked"
+    # Refuse to auto-promote tracking epics — they intentionally lack
+    # invariants_and_boundaries + a terminal-lane assignee, and will spin
+    # in a promote-demote loop with clawta-poller. Operator can override
+    # with --force. See ticket t_6eba6ad2.
+    if (( force_flag == 0 )) && is_tracking_epic_id "$id"; then
+      die "$id is marked 'Tracking-epic: true' — auto-promotion blocked. Pass --force to override (operator-explicit promotion)."
+    fi
     hermes kanban --board "$BOARD" comment "$id" --author "$author" "Marked ready by $author at $(date -Iseconds)" >/dev/null
     flip_status "$id" ready 0 0
 

--- a/swarm/bin/clawta-poller
+++ b/swarm/bin/clawta-poller
@@ -122,6 +122,12 @@ TICKET_REF_RE = re.compile(r"\bt_[a-f0-9]+\b")
 INVARIANTS_FIELD_RE = re.compile(
     r"(?ims)^invariants_and_boundaries:\s*(?P<value>.+?)(?=^[A-Za-z0-9_-]+:\s|\Z)"
 )
+# Tracking-epic marker: a body line that opts a ticket out of auto-promotion
+# and out of the demote/stale-flag gates. Matches `Tracking-epic: true|yes|1`
+# at start of line, case-insensitive. See ticket t_6eba6ad2.
+TRACKING_EPIC_RE = re.compile(
+    r"(?im)^tracking-epic:\s*(true|yes|1)\s*$"
+)
 
 
 def log(msg: str) -> None:
@@ -168,6 +174,20 @@ def extract_named_boundaries(field_value: str | None) -> list[str]:
         seen.add(key)
         boundaries.append(cleaned)
     return boundaries
+
+
+def is_tracking_epic(body: str | None) -> bool:
+    """True when the body opts the ticket out of auto-promotion + demote gates.
+
+    The marker is a `Tracking-epic: true|yes|1` line (case-insensitive) at start
+    of line. Tracking epics intentionally lack `invariants_and_boundaries:` and
+    a terminal-lane assignee — they're parent containers, not dispatchable
+    work — so the demote and stale-flag gates must skip them or they spin in
+    a promote-demote loop forever (see t_6eba6ad2).
+    """
+    if not body:
+        return False
+    return bool(TRACKING_EPIC_RE.search(body))
 
 
 def is_parent_hierarchy_prefix(prefix: str) -> bool:
@@ -303,7 +323,7 @@ def fetch_ungroomed_ready() -> list[dict[str, Any]]:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             f"""
-            SELECT id, title, assignee, priority, created_at
+            SELECT id, title, body, assignee, priority, created_at
               FROM tasks
              WHERE status IN ({status_placeholders})
                AND (assignee IS NULL
@@ -903,6 +923,8 @@ def demote_ungroomed(dry_run: bool) -> list[str]:
     lanes = "/".join(TERMINAL_LANES)
     for t in ungroomed:
         tid = t["id"]
+        if is_tracking_epic(t.get("body")):
+            continue
         if not t["assignee"]:
             reason = (
                 f"missing assignee — grooming step must route to a terminal "
@@ -926,6 +948,8 @@ def demote_missing_invariants_and_boundaries(dry_run: bool) -> list[str]:
         return []
     demoted: list[str] = []
     for ticket in candidates:
+        if is_tracking_epic(ticket.get("body")):
+            continue
         reason = missing_invariants_reason(ticket)
         if not reason:
             continue

--- a/swarm/tests/test_clawta_poller.py
+++ b/swarm/tests/test_clawta_poller.py
@@ -324,6 +324,94 @@ class ClawtaPollerDependencyTests(unittest.TestCase):
         demote_cmd = next(cmd for cmd in seen if cmd[0] == module.KANBAN_FLOW_BIN)
         self.assertIn("missing explicit boundary list", demote_cmd[3])
 
+    def test_is_tracking_epic_recognizes_marker(self) -> None:
+        module = load_module()
+        positives = [
+            "Tracking-epic: true",
+            "tracking-epic: TRUE",
+            "Tracking-Epic:  yes",
+            "tracking-epic: 1",
+            "Header text\n\nTracking-epic: true\n\nMore text\n",
+        ]
+        for body in positives:
+            with self.subTest(case="positive", body=body[:40]):
+                self.assertTrue(module.is_tracking_epic(body))
+        negatives = [
+            "",
+            None,
+            "Goal: ship the thing",
+            "Tracking-epic: false",
+            "Tracking-epic: no",
+            "tracking-epic: maybe",
+            "Refers to Tracking-epic: true inside a sentence",
+        ]
+        for body in negatives:
+            with self.subTest(case="negative", body=str(body)[:40]):
+                self.assertFalse(module.is_tracking_epic(body))
+
+    def test_tick_skips_demote_ungroomed_for_tracking_epic(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "INSERT INTO tasks(id, title, body, status, assignee, priority, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("t_epic1", "tracking epic", "Goal: tracker.\n\nTracking-epic: true\n",
+                 "ready", None, 50, 1),
+            )
+            conn.commit(); conn.close()
+
+            seen: list[list[str]] = []
+            def fake_run(cmd, **kwargs):
+                seen.append(list(cmd))
+                if cmd[0] == module.KANBAN_FLOW_BIN and cmd[1] == "demote":
+                    return mock.Mock(returncode=0, stdout="", stderr="")
+                raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+            with mock.patch.object(module, "DB_PATH", db_path), mock.patch.object(
+                module, "run_invariant_repairs", return_value={"skipped": "test"}
+            ), mock.patch.object(
+                module, "dispatch_ready_batch", return_value=([], [], 0)
+            ), mock.patch.object(module.subprocess, "run", side_effect=fake_run):
+                result = module.tick(max_dispatch=1, dry_run=False)
+
+        self.assertEqual(result["demoted"], [])
+        self.assertFalse(any(c[:2] == [module.KANBAN_FLOW_BIN, "demote"] for c in seen),
+                         f"tracking epic must not be demoted; got {seen}")
+
+    def test_tick_skips_demote_missing_invariants_for_tracking_epic(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = make_db(Path(tmp))
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "INSERT INTO tasks(id, title, body, status, assignee, priority, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("t_epic2", "tracking epic with terminal lane assignee",
+                 "Goal: tracker — no invariants here.\n\nTracking-epic: true\n",
+                 "ready", "codex", 50, 1),
+            )
+            conn.commit(); conn.close()
+
+            seen: list[list[str]] = []
+            def fake_run(cmd, **kwargs):
+                seen.append(list(cmd))
+                if cmd[0] == module.KANBAN_FLOW_BIN and cmd[1] == "demote":
+                    return mock.Mock(returncode=0, stdout="", stderr="")
+                raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+            with mock.patch.object(module, "DB_PATH", db_path), mock.patch.object(
+                module, "run_invariant_repairs", return_value={"skipped": "test"}
+            ), mock.patch.object(
+                module, "dispatch_ready_batch", return_value=([], [], 0)
+            ), mock.patch.object(module.subprocess, "run", side_effect=fake_run):
+                result = module.tick(max_dispatch=1, dry_run=False)
+
+        self.assertEqual(result["demoted"], [])
+        self.assertFalse(any(c[:2] == [module.KANBAN_FLOW_BIN, "demote"] for c in seen),
+                         f"tracking epic must not be demoted; got {seen}")
+
     def test_missing_invariants_reason_accepts_singular_and_plural_boundary(self) -> None:
         # Locks in: the gate accepts both `Boundary:` (singular) and
         # `Boundaries:` (plural) so author choice never traps a ticket


### PR DESCRIPTION
## Summary

Adds a `Tracking-epic: true` body marker (case-insensitive, line-anchored) that opts a ticket out of the auto-dispatch lifecycle. Two integration points in chitin:

1. **`swarm/bin/clawta-poller`** — `is_tracking_epic(body)` short-circuits both demote gates: `demote_ungroomed` (missing terminal-lane assignee) and `demote_missing_invariants_and_boundaries` (missing the spec field). Tracking epics intentionally lack both — they're parent containers, not dispatchable work.
2. **`scripts/kanban-flow`** — `ready` subcommand refuses to promote a marked ticket from `triage|blocked` unless `--force` is passed. Operator can still move the epic explicitly; auto-tooling cannot.

## Why

Closes kanban ticket **t_6eba6ad2**. Without this exemption, tracking epics spin in a 40+/24h promote-demote loop with the watchdog (hermes auto-promotes → clawta-poller demotes for missing invariants → loop). The watchdog has been escalating ~6 chitin epics on this exact pattern for days.

## Test plan
- [x] `python3 -m unittest swarm.tests.test_clawta_poller` — all 18 tests pass (3 new, 15 pre-existing)
- [x] Bash smoke-test of `is_tracking_epic_id` — positive (true/yes/1), negative (false/no/missing), mid-sentence mention all behave correctly
- [x] Marker detection covers: header lines, case variations, multiple truthy values
- [x] Negative cases: `false`, `no`, `maybe`, mid-sentence references all return False

## Out of scope (followup)

`hermes-agent`'s `recompute_ready` (todo→ready dependency promote in `~/.hermes/hermes-agent/hermes_cli/kanban_db.py:1849`) lives in a separate repo and doesn't yet check the marker. The `kanban-flow ready` guard catches the LLM-driven path; the dependency-engine promote is uncovered until a hermes-agent PR ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)