### PR TITLE
feat(agent-bus): SessionStart inbox CLI (Phase 2)

### DIFF
--- a/services/agent-bus/README.md
+++ b/services/agent-bus/README.md
@@ -2,14 +2,20 @@
 
 Chitin-owned threaded message bus for agent-to-agent and human-in-the-loop comms across the swarm. Spec at [`.specify/specs/001-agent-bus/spec.md`](../../.specify/specs/001-agent-bus/spec.md).
 
-## What ships in this PR (Phase 1)
+## What ships across Phases 1 + 2
 
+**Phase 1 (PR #676, merged):**
 - `schema.sql` — sqlite schema (threads, messages, reads, attachments, agents).
 - `db.py` — connection bootstrap.
 - `server.py` — stdio MCP server speaking JSON-RPC 2.0. Zero external deps.
 - `tests/test_server.py` — 16 integration tests via the JSON-RPC dispatcher.
 
-Phases 2–5 (session-start hook, console UI, Discord mirror, attachment renderers) ship as separate PRs against this schema.
+**Phase 2 (this PR):**
+- `inbox.py` — CLI that prints unread messages in markdown. Silent when there's nothing to surface.
+- `tests/test_inbox.py` — 6 subprocess tests over the inbox CLI.
+- SessionStart hook docs (see below).
+
+Phases 3–5 (console UI, Discord mirror, attachment renderers) ship as separate PRs against this schema.
 
 ## Install for an agent
 
@@ -48,10 +54,34 @@ Audience semantics: `NULL` = public; comma-separated list (e.g. `"red,hermes"`) 
 
 `~/.chitin/agent-bus/bus.db` (sqlite, WAL). Override with `AGENT_BUS_DB`. Schema is additive-only — never repurpose a column (FR-008).
 
+## Human-in-the-loop: SessionStart inbox
+
+Wire the inbox into Claude Code so unread messages surface as soon as you start a session.
+
+1. Add to `~/.claude/settings.json` (idempotent — merge into any existing `hooks` block):
+
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [{
+         "hooks": [{
+           "type": "command",
+           "command": "python3 /home/red/workspace/chitin/services/agent-bus/inbox.py --agent red"
+         }]
+       }]
+     }
+   }
+   ```
+
+2. Next session start, you'll see a markdown summary of unread messages addressed to `red` (or `*`-broadcast). Silent when the inbox is empty.
+
+3. To auto-ack on display, append `--mark-read`. Default is OFF — listing the inbox doesn't clear it; you ack explicitly via `bus_mark_read`.
+
 ## Tests
 
 ```
-python3 services/agent-bus/tests/test_server.py
+python3 services/agent-bus/tests/test_server.py     # 16 server tests
+python3 services/agent-bus/tests/test_inbox.py      # 6 inbox tests
 ```
 
-16 tests, ~1.3s. Each gets a fresh sqlite via `AGENT_BUS_DB`.
+~1.5s total. Each gets a fresh sqlite via `AGENT_BUS_DB`.

--- a/services/agent-bus/inbox.py
+++ b/services/agent-bus/inbox.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Print the agent-bus inbox in markdown — meant for Claude Code SessionStart.
+
+Usage:
+  python3 inbox.py [--agent red] [--limit 10] [--mark-read]
+
+Behavior:
+- Silent (zero output, exit 0) when the DB doesn't exist or the inbox is
+  empty. SessionStart context shouldn't add noise when there's nothing to say.
+- Markdown output suitable for direct injection into the system context.
+- `--mark-read` is OFF by default — listing the inbox doesn't auto-ack
+  (we want the human to explicitly clear after reading).
+
+Wire into `~/.claude/settings.json`:
+
+  {
+    "hooks": {
+      "SessionStart": [{
+        "hooks": [{
+          "type": "command",
+          "command": "python3 /home/red/workspace/chitin/services/agent-bus/inbox.py --agent red"
+        }]
+      }]
+    }
+  }
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_DB = Path.home() / ".chitin" / "agent-bus" / "bus.db"
+
+
+def fmt_age(epoch: int) -> str:
+    delta = max(0, int(time.time()) - int(epoch))
+    if delta < 60:    return f"{delta}s ago"
+    if delta < 3600:  return f"{delta // 60}m ago"
+    if delta < 86400: return f"{delta // 3600}h ago"
+    return f"{delta // 86400}d ago"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agent", default=os.environ.get("AGENT_BUS_AGENT", "red"))
+    ap.add_argument("--limit", type=int, default=10)
+    ap.add_argument("--mark-read", action="store_true")
+    args = ap.parse_args()
+
+    db_path = Path(os.environ.get("AGENT_BUS_DB") or str(DEFAULT_DB))
+    if not db_path.exists():
+        return 0  # nothing to say
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+
+    # Pull recent unread messages addressed to the agent.
+    # Audience match: NULL=public, '*'=broadcast, CSV membership.
+    rows = conn.execute(
+        """
+        SELECT m.id, m.thread_id, m.author, m.audience, m.body, m.kind,
+               m.ack_required, m.created_at,
+               t.title AS thread_title, t.board AS thread_board
+        FROM messages m
+        JOIN threads t ON t.id = m.thread_id
+        WHERE m.author != ?
+          AND NOT EXISTS (SELECT 1 FROM reads r WHERE r.message_id = m.id AND r.agent_id = ?)
+        ORDER BY m.created_at DESC
+        LIMIT ?
+        """,
+        (args.agent, args.agent, args.limit * 4),
+    ).fetchall()
+
+    inbox: list[sqlite3.Row] = []
+    for r in rows:
+        if r["audience"]:
+            members = {m.strip() for m in r["audience"].split(",") if m.strip()}
+            if args.agent not in members and "*" not in members:
+                continue
+        inbox.append(r)
+        if len(inbox) >= args.limit:
+            break
+
+    if not inbox:
+        return 0
+
+    out = [f"## agent-bus inbox — {len(inbox)} unread for `{args.agent}`", ""]
+    for m in inbox:
+        board = f" `{m['thread_board']}`" if m["thread_board"] else ""
+        kind = f" `{m['kind']}`" if m["kind"] != "message" else ""
+        ack = " **(ack required)**" if m["ack_required"] else ""
+        out.append(
+            f"- **{m['thread_title']}**{board}{kind}{ack} "
+            f"— from `{m['author']}`, {fmt_age(m['created_at'])} "
+            f"(thread {m['thread_id']}, msg {m['id']})"
+        )
+        # First line of the body, truncated for the summary.
+        first_line = (m["body"] or "").splitlines()[0] if m["body"] else ""
+        if first_line:
+            snippet = first_line[:140] + ("…" if len(first_line) > 140 else "")
+            out.append(f"  > {snippet}")
+    out.append("")
+    out.append("Read full thread: `bus_read_thread(thread_id=N)` · "
+               "Ack: `bus_mark_read(agent_id='" + args.agent + "', message_id=N)`")
+    print("\n".join(out))
+
+    if args.mark_read:
+        now = int(time.time())
+        conn.executemany(
+            "INSERT OR IGNORE INTO reads(message_id, agent_id, read_at) VALUES(?,?,?)",
+            [(m["id"], args.agent, now) for m in inbox],
+        )
+        conn.commit()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent-bus/tests/test_inbox.py
+++ b/services/agent-bus/tests/test_inbox.py
@@ -1,0 +1,125 @@
+"""inbox.py tests — run via subprocess so we exercise the actual CLI behavior."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+SVC_DIR = Path(__file__).resolve().parents[1]
+INBOX_PY = SVC_DIR / "inbox.py"
+SCHEMA_SQL = SVC_DIR / "schema.sql"
+
+
+def _seed_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(SCHEMA_SQL.read_text())
+    conn.commit()
+    conn.close()
+
+
+def _post(db_path: Path, *, author: str, title: str, body: str,
+          audience: str | None = None, board: str | None = None,
+          kind: str = "message", ack_required: int = 0) -> tuple[int, int]:
+    conn = sqlite3.connect(str(db_path))
+    now = int(time.time())
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO threads(board, title, author, audience, created_at, updated_at) "
+        "VALUES(?,?,?,?,?,?)",
+        (board, title, author, audience, now, now),
+    )
+    tid = cur.lastrowid
+    cur.execute(
+        "INSERT INTO messages(thread_id, author, audience, body, kind, ack_required, created_at) "
+        "VALUES(?,?,?,?,?,?,?)",
+        (tid, author, audience, body, kind, ack_required, now),
+    )
+    mid = cur.lastrowid
+    conn.commit()
+    conn.close()
+    return tid, mid
+
+
+def _run_inbox(db_path: Path, *args: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "AGENT_BUS_DB": str(db_path)}
+    return subprocess.run(
+        [sys.executable, str(INBOX_PY), *args],
+        capture_output=True, text=True, env=env, timeout=10,
+    )
+
+
+class InboxCLITests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "bus.db"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_silent_when_db_missing(self) -> None:
+        # No DB at all; inbox should print nothing and exit 0.
+        result = _run_inbox(self.db, "--agent", "red")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_silent_when_inbox_empty(self) -> None:
+        _seed_db(self.db)
+        result = _run_inbox(self.db, "--agent", "red")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_renders_unread_addressed_to_agent(self) -> None:
+        _seed_db(self.db)
+        _post(self.db, author="hermes", title="watchdog ack",
+              body="cleared loop counter for the 4 epics",
+              audience="red", board="chitin")
+        _post(self.db, author="clawta", title="another for someone else",
+              body="not for red", audience="hermes")
+        _post(self.db, author="hermes", title="broadcast",
+              body="for everyone", audience="*")
+
+        result = _run_inbox(self.db, "--agent", "red")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("agent-bus inbox", result.stdout)
+        self.assertIn("watchdog ack", result.stdout)        # red-addressed
+        self.assertIn("broadcast", result.stdout)           # *-addressed
+        self.assertNotIn("another for someone else", result.stdout)  # hermes-only
+        self.assertIn("from `hermes`", result.stdout)
+        self.assertIn("cleared loop counter", result.stdout)
+
+    def test_excludes_own_posts(self) -> None:
+        _seed_db(self.db)
+        _post(self.db, author="red", title="self note", body="x",
+              audience="red,hermes")
+        result = _run_inbox(self.db, "--agent", "red")
+        self.assertEqual(result.stdout, "")
+
+    def test_mark_read_clears_inbox(self) -> None:
+        _seed_db(self.db)
+        _post(self.db, author="hermes", title="t", body="hi", audience="red")
+        first = _run_inbox(self.db, "--agent", "red", "--mark-read")
+        self.assertIn("agent-bus inbox", first.stdout)
+        # Second call should be silent now that the read was recorded.
+        second = _run_inbox(self.db, "--agent", "red")
+        self.assertEqual(second.stdout, "")
+
+    def test_limit_caps_results(self) -> None:
+        _seed_db(self.db)
+        for i in range(5):
+            _post(self.db, author="hermes", title=f"msg {i}",
+                  body=f"body {i}", audience="red")
+        result = _run_inbox(self.db, "--agent", "red", "--limit", "2")
+        # Each entry produces 2 lines (header + snippet); 2 entries = 4 list lines
+        list_lines = [l for l in result.stdout.splitlines() if l.startswith("- ")]
+        self.assertEqual(len(list_lines), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 2 of the **agent-bus**: surface unread messages addressed to the operator at Claude Code session start. Builds on Phase 1 (#676, merged). Phase 3 (console UI) and Phase 4 (Discord mirror) follow.

## What's in this PR

| File | Purpose |
|---|---|
| `services/agent-bus/inbox.py` | CLI that prints unread messages in markdown. Silent when empty. Supports `--agent`, `--limit`, `--mark-read`. |
| `services/agent-bus/tests/test_inbox.py` | 6 subprocess tests |
| `services/agent-bus/README.md` | Updated with SessionStart hook config |

## End-to-end smoke (live DB)

- `hermes` post + `audience='red'` → red's inbox renders entry with author, age, thread/msg ids, snippet, ack hint
- `--mark-read` clears entry; subsequent inbox returns silent
- `audience='*'` visible to hermes + clawta + everyone
- Own posts excluded from one's own inbox

## SessionStart wiring (already installed locally for the operator)

```json
{
  "hooks": {
    "SessionStart": [{
      "hooks": [{
        "type": "command",
        "command": "python3 /home/red/workspace/chitin/services/agent-bus/inbox.py --agent red"
      }]
    }]
  }
}
```

## Test plan

- [x] `python3 services/agent-bus/tests/test_inbox.py` — 6 tests pass
- [x] `python3 services/agent-bus/tests/test_server.py` — 16 Phase 1 tests still pass
- [x] `claude mcp list` shows `agent-bus ✓ Connected`
- [x] Hook idempotent

## Followups

- **Phase 3** — chitin-console `/threads` route
- **Phase 4** — Discord bidirectional mirror
- **Phase 5** — typed-attachment renderers (PR badge enrichment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)