### PR TITLE
feat(agent-bus): Discord bidirectional mirror (Phase 4)

### DIFF
--- a/services/agent-bus/README.md
+++ b/services/agent-bus/README.md
@@ -48,10 +48,49 @@ Audience semantics: `NULL` = public; comma-separated list (e.g. `"red,hermes"`) 
 
 `~/.chitin/agent-bus/bus.db` (sqlite, WAL). Override with `AGENT_BUS_DB`. Schema is additive-only — never repurpose a column (FR-008).
 
+## Discord bidirectional mirror (Phase 4)
+
+`services/agent-bus/discord_mirror.py` bridges bus threads to a Discord channel.
+
+### Inbound (Discord → bus)
+
+Poll a channel and ingest new messages into a bus mirror thread.
+
+```
+export DISCORD_BOT_TOKEN=<bot-token>            # bot with read perms
+export DISCORD_MIRROR_CHANNEL_ID=<channel-id>   # e.g. 1503438297597350062
+
+python3 services/agent-bus/discord_mirror.py poll
+```
+
+Behavior:
+- First run creates a bus thread (board=chitin, author=discord-mirror, `discord_thread_id=<channel-id>`).
+- Each new message becomes a bus message with `discord_message_id` set — idempotent on replay.
+- Cursor persists in the `discord_cursors` table; subsequent polls use `?after=<last-id>`.
+
+Cron-friendly: one tick per invocation. Schedule via `hermes cron add` or system cron.
+
+### Outbound (bus → Discord)
+
+Post messages from a bus thread to a Discord webhook URL.
+
+```
+export DISCORD_WEBHOOK_URL=<webhook-url>
+
+# Post all messages of thread 5
+python3 services/agent-bus/discord_mirror.py push 5
+
+# Post only messages with id > 42
+python3 services/agent-bus/discord_mirror.py push 5 --after 42
+```
+
+Long messages auto-truncate at 2000 chars (Discord cap) with a `(…continued)` marker.
+
 ## Tests
 
 ```
-python3 services/agent-bus/tests/test_server.py
+python3 services/agent-bus/tests/test_server.py            # 16 server tests
+python3 services/agent-bus/tests/test_discord_mirror.py    # 8 Discord tests (HTTP mocked)
 ```
 
-16 tests, ~1.3s. Each gets a fresh sqlite via `AGENT_BUS_DB`.
+Each gets a fresh sqlite via `AGENT_BUS_DB`. No real network calls — `http_request` is the single chokepoint for HTTP and tests patch it directly.

--- a/services/agent-bus/discord_mirror.py
+++ b/services/agent-bus/discord_mirror.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""agent-bus ↔ Discord bidirectional mirror.
+
+Two directions:
+
+  outbound: post a bus message to a Discord webhook URL. No bot token
+            required; the URL itself authenticates. Operator provides the
+            URL per-channel via env (or via a bus_mirror_link tool later).
+
+  inbound:  poll a Discord channel and ingest new messages into a bus
+            thread. Requires a bot token + the channel id.
+
+Designed for cron-style invocation:
+  discord_mirror.py poll  — one-shot ingest of new messages
+  discord_mirror.py push <thread_id> [--after msg_id]
+                          — post bus thread messages to Discord
+
+Persistence:
+  Last-seen Discord message id per channel lives in the `discord_cursors`
+  table (created on first run if absent — keeps Phase 4 schema-additive).
+
+Env:
+  DISCORD_WEBHOOK_URL          # outbound (per-channel)
+  DISCORD_BOT_TOKEN            # inbound
+  DISCORD_MIRROR_CHANNEL_ID    # inbound channel id
+  DISCORD_MIRROR_THREAD_TITLE  # bus thread title for inbound (default: "Discord mirror — <channel>")
+  AGENT_BUS_DB                 # override DB path (test hook)
+
+All HTTP via stdlib urllib so the service stays zero-dep.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_DB = Path.home() / ".chitin" / "agent-bus" / "bus.db"
+DISCORD_API = "https://discord.com/api/v10"
+
+
+def db_path() -> Path:
+    return Path(os.environ.get("AGENT_BUS_DB") or str(DEFAULT_DB))
+
+
+def ensure_cursor_table(conn: sqlite3.Connection) -> None:
+    """Additive migration. Runs every connect — cheap if already present."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS discord_cursors (
+          channel_id     TEXT PRIMARY KEY,
+          last_message_id TEXT NOT NULL,
+          updated_at     INTEGER NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+
+def get_cursor(conn: sqlite3.Connection, channel_id: str) -> str | None:
+    row = conn.execute(
+        "SELECT last_message_id FROM discord_cursors WHERE channel_id=?",
+        (channel_id,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def set_cursor(conn: sqlite3.Connection, channel_id: str, message_id: str) -> None:
+    conn.execute(
+        "INSERT INTO discord_cursors(channel_id, last_message_id, updated_at) "
+        "VALUES(?,?,?) "
+        "ON CONFLICT(channel_id) DO UPDATE SET "
+        "  last_message_id=excluded.last_message_id, "
+        "  updated_at=excluded.updated_at",
+        (channel_id, message_id, int(time.time())),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# HTTP — small wrapper so tests can patch one symbol.
+# ---------------------------------------------------------------------------
+
+def http_request(url: str, *, method: str = "GET", headers: dict | None = None,
+                 body: bytes | None = None, timeout: float = 10.0) -> tuple[int, bytes]:
+    """Single chokepoint for all network IO; mockable in tests."""
+    req = urllib.request.Request(url, data=body, method=method,
+                                 headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+# ---------------------------------------------------------------------------
+# Outbound: post to a Discord webhook URL.
+# ---------------------------------------------------------------------------
+
+def post_to_discord_webhook(webhook_url: str, *, content: str,
+                            username: str | None = None) -> dict:
+    """POST to a Discord incoming webhook. Discord caps content at 2000 chars;
+    split politely if exceeded.
+    """
+    if len(content) > 2000:
+        content = content[:1990] + "\n(…continued)"
+    payload: dict = {"content": content}
+    if username:
+        payload["username"] = username
+    body = json.dumps(payload).encode("utf-8")
+    status, resp = http_request(
+        webhook_url, method="POST",
+        headers={"Content-Type": "application/json"},
+        body=body,
+    )
+    if status >= 400:
+        raise RuntimeError(f"discord webhook POST failed: {status} {resp[:200]!r}")
+    return {"status": status, "bytes": len(body)}
+
+
+# ---------------------------------------------------------------------------
+# Inbound: poll a Discord channel via bot token, ingest new messages.
+# ---------------------------------------------------------------------------
+
+def fetch_new_messages(channel_id: str, *, token: str,
+                       after: str | None = None, limit: int = 50) -> list[dict]:
+    """GET /channels/{id}/messages?after={cursor}. Discord returns newest
+    first; we flip to chronological so the bus stores them in order.
+    """
+    qs = f"limit={limit}"
+    if after:
+        qs += f"&after={after}"
+    url = f"{DISCORD_API}/channels/{channel_id}/messages?{qs}"
+    status, resp = http_request(
+        url, headers={"Authorization": f"Bot {token}",
+                      "User-Agent": "agent-bus-discord-mirror/0.1"},
+    )
+    if status >= 400:
+        raise RuntimeError(f"discord GET messages failed: {status} {resp[:200]!r}")
+    msgs = json.loads(resp)
+    msgs.sort(key=lambda m: int(m["id"]))  # chronological by snowflake
+    return msgs
+
+
+def ensure_mirror_thread(conn: sqlite3.Connection, *, channel_id: str,
+                         title: str) -> int:
+    """Find or create the bus thread that mirrors this Discord channel."""
+    row = conn.execute(
+        "SELECT id FROM threads WHERE discord_thread_id=?",
+        (channel_id,),
+    ).fetchone()
+    if row:
+        return row[0]
+    now = int(time.time())
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO threads(board, title, author, audience, "
+        "discord_thread_id, created_at, updated_at) "
+        "VALUES(?,?,?,?,?,?,?)",
+        ("chitin", title, "discord-mirror", None, channel_id, now, now),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def ingest_messages(conn: sqlite3.Connection, thread_id: int,
+                    messages: list[dict]) -> int:
+    """Append Discord messages into the bus thread. Idempotent via
+    discord_message_id uniqueness check.
+    """
+    count = 0
+    for m in messages:
+        # Skip if already ingested
+        already = conn.execute(
+            "SELECT 1 FROM messages WHERE discord_message_id=? LIMIT 1",
+            (m["id"],),
+        ).fetchone()
+        if already:
+            continue
+        author = (m.get("author") or {}).get("username", "discord")
+        body = m.get("content") or ""
+        # If a Discord message is empty (image-only / sticker), surface a stub
+        if not body:
+            atts = m.get("attachments") or []
+            embs = m.get("embeds") or []
+            body = f"(attachment x{len(atts)}, embed x{len(embs)})"
+        # Discord ts ('timestamp' is ISO; snowflake encodes epoch ms in id)
+        snowflake = int(m["id"])
+        epoch = ((snowflake >> 22) + 1420070400000) // 1000
+        conn.execute(
+            "INSERT INTO messages(thread_id, author, body, kind, "
+            "discord_message_id, created_at) VALUES(?,?,?,?,?,?)",
+            (thread_id, author, body, "message", m["id"], epoch),
+        )
+        count += 1
+    if count:
+        conn.execute(
+            "UPDATE threads SET updated_at=strftime('%s','now') WHERE id=?",
+            (thread_id,),
+        )
+        conn.commit()
+    return count
+
+
+def poll_once(conn: sqlite3.Connection, *, channel_id: str, token: str,
+              thread_title: str) -> dict:
+    """One-shot poll: fetch new messages, append to mirror thread, advance cursor."""
+    cursor = get_cursor(conn, channel_id)
+    msgs = fetch_new_messages(channel_id, token=token, after=cursor)
+    if not msgs:
+        return {"fetched": 0, "ingested": 0, "cursor": cursor}
+    thread_id = ensure_mirror_thread(conn, channel_id=channel_id,
+                                     title=thread_title)
+    ingested = ingest_messages(conn, thread_id, msgs)
+    new_cursor = max(msgs, key=lambda m: int(m["id"]))["id"]
+    set_cursor(conn, channel_id, new_cursor)
+    return {"fetched": len(msgs), "ingested": ingested,
+            "cursor": new_cursor, "thread_id": thread_id}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def cmd_poll(args) -> int:
+    token = os.environ.get("DISCORD_BOT_TOKEN", "")
+    channel = args.channel or os.environ.get("DISCORD_MIRROR_CHANNEL_ID", "")
+    if not token or not channel:
+        print("error: DISCORD_BOT_TOKEN and DISCORD_MIRROR_CHANNEL_ID required",
+              file=sys.stderr)
+        return 2
+    title = (args.title
+             or os.environ.get("DISCORD_MIRROR_THREAD_TITLE")
+             or f"Discord mirror — channel {channel}")
+    conn = sqlite3.connect(str(db_path()))
+    ensure_cursor_table(conn)
+    result = poll_once(conn, channel_id=channel, token=token, thread_title=title)
+    print(json.dumps(result))
+    return 0
+
+
+def cmd_push(args) -> int:
+    webhook = args.webhook or os.environ.get("DISCORD_WEBHOOK_URL", "")
+    if not webhook:
+        print("error: --webhook or DISCORD_WEBHOOK_URL required", file=sys.stderr)
+        return 2
+    conn = sqlite3.connect(str(db_path()))
+    conn.row_factory = sqlite3.Row
+    msgs = conn.execute(
+        "SELECT id, author, body FROM messages "
+        "WHERE thread_id=? AND id > ? ORDER BY id",
+        (args.thread_id, args.after or 0),
+    ).fetchall()
+    posted = 0
+    for m in msgs:
+        content = f"**{m['author']}**: {m['body']}"
+        post_to_discord_webhook(webhook, content=content)
+        posted += 1
+    print(json.dumps({"posted": posted, "last_id": msgs[-1]["id"] if msgs else None}))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_poll = sub.add_parser("poll", help="Ingest new Discord messages")
+    p_poll.add_argument("--channel", help="Channel id (else env)")
+    p_poll.add_argument("--title", help="Bus mirror thread title")
+    p_poll.set_defaults(func=cmd_poll)
+
+    p_push = sub.add_parser("push", help="Post bus messages to Discord webhook")
+    p_push.add_argument("thread_id", type=int)
+    p_push.add_argument("--after", type=int, help="Only messages > this msg id")
+    p_push.add_argument("--webhook", help="Webhook URL (else env)")
+    p_push.set_defaults(func=cmd_push)
+
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent-bus/tests/test_discord_mirror.py
+++ b/services/agent-bus/tests/test_discord_mirror.py
@@ -1,0 +1,191 @@
+"""Tests for discord_mirror.py. All HTTP is mocked via the http_request
+chokepoint — no real network calls.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SVC_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_SQL = SVC_DIR / "schema.sql"
+
+
+def _load(name: str):
+    if str(SVC_DIR) not in sys.path:
+        sys.path.insert(0, str(SVC_DIR))
+    if name in sys.modules:
+        del sys.modules[name]
+    return importlib.import_module(name)
+
+
+def _seed_db(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.executescript(SCHEMA_SQL.read_text())
+    conn.commit()
+    return conn
+
+
+class DiscordCursorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "bus.db"
+        self.conn = _seed_db(self.db)
+        self.mod = _load("discord_mirror")
+        self.mod.ensure_cursor_table(self.conn)
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.tmp.cleanup()
+
+    def test_cursor_roundtrip(self) -> None:
+        self.assertIsNone(self.mod.get_cursor(self.conn, "ch1"))
+        self.mod.set_cursor(self.conn, "ch1", "111")
+        self.assertEqual(self.mod.get_cursor(self.conn, "ch1"), "111")
+        self.mod.set_cursor(self.conn, "ch1", "222")  # upsert
+        self.assertEqual(self.mod.get_cursor(self.conn, "ch1"), "222")
+        # Other channel unaffected
+        self.mod.set_cursor(self.conn, "ch2", "999")
+        self.assertEqual(self.mod.get_cursor(self.conn, "ch1"), "222")
+        self.assertEqual(self.mod.get_cursor(self.conn, "ch2"), "999")
+
+
+class DiscordOutboundTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = _load("discord_mirror")
+
+    def test_post_to_webhook_includes_username_and_payload(self) -> None:
+        captured = {}
+        def fake_http(url, **kw):
+            captured["url"] = url
+            captured["body"] = json.loads(kw["body"])
+            captured["headers"] = kw["headers"]
+            return 204, b""
+        with mock.patch.object(self.mod, "http_request", fake_http):
+            self.mod.post_to_discord_webhook(
+                "https://discord.com/api/webhooks/123/abc",
+                content="hello bus", username="agent-bus",
+            )
+        self.assertEqual(captured["body"], {"content": "hello bus", "username": "agent-bus"})
+        self.assertEqual(captured["headers"]["Content-Type"], "application/json")
+
+    def test_post_to_webhook_truncates_at_2000(self) -> None:
+        captured = {}
+        def fake_http(url, **kw):
+            captured["body"] = json.loads(kw["body"])
+            return 204, b""
+        with mock.patch.object(self.mod, "http_request", fake_http):
+            self.mod.post_to_discord_webhook(
+                "https://x", content="x" * 5000,
+            )
+        # 1990 + "\n(…continued)" suffix
+        self.assertTrue(captured["body"]["content"].endswith("(…continued)"))
+        self.assertLessEqual(len(captured["body"]["content"]), 2010)
+
+    def test_post_to_webhook_raises_on_4xx(self) -> None:
+        with mock.patch.object(self.mod, "http_request",
+                                lambda *a, **k: (400, b"bad")):
+            with self.assertRaisesRegex(RuntimeError, "discord webhook POST failed: 400"):
+                self.mod.post_to_discord_webhook("https://x", content="y")
+
+
+class DiscordInboundTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "bus.db"
+        self.conn = _seed_db(self.db)
+        self.mod = _load("discord_mirror")
+        self.mod.ensure_cursor_table(self.conn)
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.tmp.cleanup()
+
+    def _fake_msgs(self, ids: list[str], author: str = "@hermes",
+                   text: str = "ping") -> list[dict]:
+        # Snowflake doesn't matter for ordering tests as long as ids are
+        # monotonic. The encoded timestamp is computed in the ingester;
+        # using small numbers means epoch = (id>>22)+1420070400 (Discord
+        # epoch ~ Jan 2015).
+        return [{"id": i, "content": f"{text} {i}",
+                 "author": {"username": author}} for i in ids]
+
+    def test_poll_once_creates_mirror_thread_and_ingests(self) -> None:
+        def fake_fetch(*a, **kw):
+            return self._fake_msgs(["10", "11", "12"])
+        with mock.patch.object(self.mod, "fetch_new_messages", fake_fetch):
+            result = self.mod.poll_once(self.conn, channel_id="C1",
+                                         token="t", thread_title="ChanMirror")
+        self.assertEqual(result["ingested"], 3)
+        self.assertEqual(result["cursor"], "12")
+        # Mirror thread exists with the right discord_thread_id
+        row = self.conn.execute(
+            "SELECT id, title, discord_thread_id FROM threads WHERE discord_thread_id='C1'"
+        ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row[1], "ChanMirror")
+        # 3 messages ingested with discord_message_id set
+        msgs = self.conn.execute(
+            "SELECT discord_message_id, author, body FROM messages WHERE thread_id=? ORDER BY id",
+            (row[0],),
+        ).fetchall()
+        self.assertEqual([m[0] for m in msgs], ["10", "11", "12"])
+        self.assertEqual(msgs[0][1], "@hermes")
+
+    def test_poll_idempotent_on_replay(self) -> None:
+        with mock.patch.object(self.mod, "fetch_new_messages",
+                                lambda *a, **kw: self._fake_msgs(["10", "11"])):
+            self.mod.poll_once(self.conn, channel_id="C2", token="t",
+                                thread_title="x")
+        # Second call with the same messages — should not duplicate
+        with mock.patch.object(self.mod, "fetch_new_messages",
+                                lambda *a, **kw: self._fake_msgs(["10", "11"])):
+            r = self.mod.poll_once(self.conn, channel_id="C2", token="t",
+                                    thread_title="x")
+        self.assertEqual(r["ingested"], 0)
+        count = self.conn.execute(
+            "SELECT COUNT(*) FROM messages "
+            "WHERE thread_id=(SELECT id FROM threads WHERE discord_thread_id='C2')"
+        ).fetchone()[0]
+        self.assertEqual(count, 2)
+
+    def test_poll_uses_cursor_for_subsequent_calls(self) -> None:
+        captured = {}
+        def fake_fetch(channel_id, *, token, after, limit=50):
+            captured["after"] = after
+            return self._fake_msgs(["10"])
+        with mock.patch.object(self.mod, "fetch_new_messages", fake_fetch):
+            self.mod.poll_once(self.conn, channel_id="C3", token="t",
+                                thread_title="x")
+        # First call: no cursor
+        self.assertIsNone(captured["after"])
+        # Second call should pass the cursor
+        with mock.patch.object(self.mod, "fetch_new_messages",
+                                lambda *a, **kw: (captured.update(after=kw.get("after")) or [])):
+            self.mod.poll_once(self.conn, channel_id="C3", token="t",
+                                thread_title="x")
+        self.assertEqual(captured["after"], "10")
+
+    def test_poll_handles_empty_message_with_attachment_stub(self) -> None:
+        msgs = [{"id": "100", "content": "",
+                 "author": {"username": "u"},
+                 "attachments": [{}, {}], "embeds": []}]
+        with mock.patch.object(self.mod, "fetch_new_messages",
+                                lambda *a, **kw: msgs):
+            self.mod.poll_once(self.conn, channel_id="C4", token="t",
+                                thread_title="x")
+        body = self.conn.execute(
+            "SELECT body FROM messages WHERE discord_message_id='100'"
+        ).fetchone()[0]
+        self.assertIn("attachment x2", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 4 of the **agent-bus**: bridge bus threads to a Discord channel in both directions. Operator can finally see Discord history alongside agent-to-agent threads, and bus messages can fan out to a Discord audience without ad-hoc cron-relay tricks (the very thing we used earlier this session to message hermes).

Builds on Phase 1 (#676, merged). Independent of Phase 2 (#677, in flight) — both can land in any order.

## What's in this PR

| File | Purpose |
|---|---|
| `services/agent-bus/discord_mirror.py` | `poll` (Discord→bus) + `push` (bus→Discord) CLI |
| `services/agent-bus/tests/test_discord_mirror.py` | 8 tests; all HTTP mocked via the `http_request` chokepoint |
| `services/agent-bus/README.md` | Discord setup + cron pattern + env vars |

## How it works

### Inbound (Discord → bus)

```
export DISCORD_BOT_TOKEN=<token>
export DISCORD_MIRROR_CHANNEL_ID=<channel-id>
python3 services/agent-bus/discord_mirror.py poll
```

- First run creates a bus thread keyed by `discord_thread_id=<channel-id>`
- Each new message ingested with `discord_message_id` set → idempotent on replay
- Cursor persists in new (additive) `discord_cursors` table
- Snowflake-decoded `created_at` preserves Discord's chronological order

### Outbound (bus → Discord)

```
export DISCORD_WEBHOOK_URL=<url>
python3 services/agent-bus/discord_mirror.py push <thread_id> [--after <msg_id>]
```

- No bot token needed for webhook (URL self-authenticates)
- 2000-char truncation with `(…continued)` suffix

Both halves are cron-friendly (one tick per invocation).

## Why no external deps

`http_request` is the single chokepoint over stdlib `urllib`. Tests patch that one symbol — no real network in CI. Production deploy is just env-vars + cron, matches the chitin pattern of zero-dep Python services (e.g., `swarm/bin/clawta-poller`).

## Test plan

- [x] `python3 services/agent-bus/tests/test_discord_mirror.py` — 8 tests pass in ~0.1s
- [x] Phase 1 tests (`test_server.py`) still pass — schema is additive (new `discord_cursors` table created on first connect; existing tables untouched)
- [x] HTTP fully mocked — zero real network calls
- [x] Cursor isolation across channels (no cross-contamination)
- [x] Idempotency on replay (re-running `poll` with the same messages → 0 new ingests)

## Followups

- **Phase 3** — chitin-console `/threads` route + chitin-console-api write endpoints (renders bus threads + Discord-mirror threads in the same UI)
- **Phase 5** — typed-attachment renderers (PR badge via GitHub API, spec preview, ticket status badge)
- `bus_link_discord` MCP tool — convenience wrapper so an agent can associate a bus thread with a Discord channel without invoking the CLI directly. Currently done by writing `discord_thread_id` directly to the threads row (which `ensure_mirror_thread()` already handles for new threads).
- Webhook URL inheritance — a `bus_mirror_link` table mapping `thread_id → webhook_url` so `push` doesn't need an env var per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)