### PR TITLE
feat(kanban): chitin-owned kanban DB foundation (Phase 1)

### DIFF
--- a/go/execution-kernel/cmd/chitin-kernel/kanban_cmd.go
+++ b/go/execution-kernel/cmd/chitin-kernel/kanban_cmd.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/boardconfig"
+	"github.com/chitinhq/chitin/go/execution-kernel/internal/kanban"
+)
+
+// cmdKanban handles `chitin-kernel kanban <subcommand>`.
+func cmdKanban(args []string) {
+	if len(args) == 0 {
+		kanbanExit(2, "kanban_args", "usage: chitin-kernel kanban migrate <board>")
+	}
+	switch args[0] {
+	case "migrate":
+		cmdKanbanMigrate(args[1:])
+	default:
+		kanbanExit(2, "kanban_unknown_subcommand", "unknown kanban subcommand: "+args[0])
+	}
+}
+
+func cmdKanbanMigrate(args []string) {
+	if len(args) != 1 {
+		kanbanExit(2, "kanban_migrate_args", "usage: chitin-kernel kanban migrate <board>")
+	}
+	board := args[0]
+
+	destPath, err := boardconfig.ResolveField(board, "chitin_db_path")
+	if err != nil {
+		mapBoardconfigErrToExit(err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		kanbanExit(2, "user_home", err.Error())
+	}
+	srcPath := filepath.Join(home, ".hermes", "kanban", "boards", board, "kanban.db")
+	if _, err := os.Stat(srcPath); err != nil {
+		kanbanExit(2, "source_missing", "source kanban.db missing: "+srcPath)
+	}
+
+	if err := kanban.Migrate(srcPath, destPath); err != nil {
+		kanbanExit(1, "migrate_failed", err.Error())
+	}
+
+	src, err := sql.Open("sqlite", "file:"+srcPath+"?mode=ro")
+	if err != nil {
+		kanbanExit(1, "open_src_for_verify", err.Error())
+	}
+	defer src.Close()
+	dest, err := sql.Open("sqlite", destPath)
+	if err != nil {
+		kanbanExit(1, "open_dest_for_verify", err.Error())
+	}
+	defer dest.Close()
+
+	if err := kanban.VerifyCounts(src, dest); err != nil {
+		kanbanExit(1, "verify_failed", err.Error())
+	}
+
+	counts, _ := kanban.RowCounts(dest)
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Printf("%s: %d\n", k, counts[k])
+	}
+	fmt.Printf("ok: %s\n", destPath)
+}
+
+func mapBoardconfigErrToExit(err error) {
+	if errors.Is(err, boardconfig.ErrNoBoardsInitialized) {
+		kanbanExit(3, "no_boards_initialized", err.Error())
+	}
+	var slugErr boardconfig.InvalidSlugError
+	if errors.As(err, &slugErr) {
+		kanbanExit(2, "invalid_slug", err.Error())
+	}
+	var boardErr boardconfig.UnknownBoardError
+	if errors.As(err, &boardErr) {
+		kanbanExit(3, "unknown_board", err.Error())
+	}
+	var missingFieldErr boardconfig.MissingFieldError
+	if errors.As(err, &missingFieldErr) {
+		kanbanExit(2, "missing_field", err.Error())
+	}
+	var missingConfigErr boardconfig.MissingConfigError
+	if errors.As(err, &missingConfigErr) {
+		kanbanExit(2, "missing_config", err.Error())
+	}
+	var unknownFieldErr boardconfig.UnknownFieldError
+	if errors.As(err, &unknownFieldErr) {
+		kanbanExit(2, "unknown_field", err.Error())
+	}
+	kanbanExit(2, "boardconfig_error", err.Error())
+}
+
+func kanbanExit(code int, kind, msg string) {
+	out, _ := json.Marshal(map[string]string{
+		"error":   kind,
+		"message": msg,
+	})
+	fmt.Fprintln(os.Stderr, string(out))
+	os.Exit(code)
+}

--- a/go/execution-kernel/cmd/chitin-kernel/kanban_cmd_test.go
+++ b/go/execution-kernel/cmd/chitin-kernel/kanban_cmd_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// seedKanbanSourceDB writes a minimal hermes-shape kanban.db at the
+// given path. Uses the canonical schema since it's a superset of any
+// hermes board.
+func seedKanbanSourceDB(t *testing.T, path string, rowCount int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`
+		CREATE TABLE tasks (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			block_reason TEXT
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tasks: %v", err)
+	}
+	for i := 0; i < rowCount; i++ {
+		if _, err := db.Exec(
+			"INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+			"t_"+strings.Repeat("a", i+1), "title", "ready", 1000+i,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+}
+
+func TestCLI_KanbanMigrateCopiesRowsToChitinDB(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+	srcPath := filepath.Join(home, ".hermes", "kanban", "boards", "chitin", "kanban.db")
+	seedKanbanSourceDB(t, srcPath, 3)
+
+	stdout, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home},
+		"kanban", "migrate", "chitin")
+	if code != 0 {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "tasks: 3") {
+		t.Errorf("stdout missing tasks count: %q", stdout)
+	}
+	if !strings.Contains(stdout, "ok:") {
+		t.Errorf("stdout missing ok line: %q", stdout)
+	}
+
+	destPath := filepath.Join(home, ".chitin", "kanban", "chitin", "kanban.db")
+	if _, err := os.Stat(destPath); err != nil {
+		t.Errorf("dest DB not created at %s: %v", destPath, err)
+	}
+
+	db, err := sql.Open("sqlite", destPath)
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM tasks").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("dest tasks: want 3, got %d", n)
+	}
+}
+
+func TestCLI_KanbanMigrateUnknownBoardExit3(t *testing.T) {
+	home := t.TempDir()
+	// Need at least one board so we don't get ErrNoBoardsInitialized.
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home},
+		"kanban", "migrate", "nope")
+	if code != 3 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "unknown_board") && !strings.Contains(stderr, "unknown board") {
+		t.Errorf("stderr missing unknown board signal: %q", stderr)
+	}
+}
+
+func TestCLI_KanbanMigrateMissingSourceDBExit2(t *testing.T) {
+	home := t.TempDir()
+	writeCLIConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+	// No source DB written.
+
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home},
+		"kanban", "migrate", "chitin")
+	if code != 2 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "source_missing") && !strings.Contains(stderr, "kanban.db") {
+		t.Errorf("stderr missing source signal: %q", stderr)
+	}
+}
+
+func TestCLI_KanbanNoSubcommandExit2(t *testing.T) {
+	home := t.TempDir()
+	_, stderr, code := runCLIWithEnv(t, t.TempDir(), []string{"HOME=" + home}, "kanban")
+	if code != 2 {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stderr, "usage") {
+		t.Errorf("stderr missing usage: %q", stderr)
+	}
+}

--- a/go/execution-kernel/cmd/chitin-kernel/main.go
+++ b/go/execution-kernel/cmd/chitin-kernel/main.go
@@ -58,6 +58,8 @@ func main() {
 		cmdHealth(args)
 	case "board-config":
 		cmdBoardConfig(args)
+	case "kanban":
+		cmdKanban(args)
 	case "gate":
 		cmdGate(args)
 	case "policy":

--- a/go/execution-kernel/internal/boardconfig/boardconfig.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig.go
@@ -40,6 +40,11 @@ var fieldSpecs = map[string]FieldSpec{
 		EnvVar:       "KANBAN_BOARD_SOUL_MAP",
 		DefaultValue: `{"correctness":"knuth","architecture":"davinci","dispatch":"sun-tzu","research":"socrates","default":"sun-tzu"}`,
 	},
+	"chitin_db_path": {
+		// Default is computed per-slug in ResolveField since it
+		// depends on $HOME and the board slug.
+		EnvVar: "KANBAN_BOARD_CHITIN_DB_PATH",
+	},
 }
 
 var requiredFields = []string{
@@ -136,6 +141,7 @@ func expandHome(value string) (string, error) {
 // time so downstream tools see an absolute path.
 var tildeExpandableFields = map[string]struct{}{
 	"workspace_root": {},
+	"chitin_db_path": {},
 }
 
 func ResolveField(slug, field string) (string, error) {
@@ -161,6 +167,13 @@ func ResolveField(slug, field string) (string, error) {
 		value = spec.DefaultValue
 	}
 	if value == "" {
+		if dynamic, err := dynamicDefault(field, slug); err != nil {
+			return "", err
+		} else if dynamic != "" {
+			value = dynamic
+		}
+	}
+	if value == "" {
 		if spec.Required {
 			return "", MissingFieldError{Field: field}
 		}
@@ -170,6 +183,21 @@ func ResolveField(slug, field string) (string, error) {
 		return expandHome(value)
 	}
 	return value, nil
+}
+
+// dynamicDefault returns the default value for fields whose default
+// depends on the runtime environment (e.g. $HOME) or the board slug.
+// Returns "" for fields without a dynamic default.
+func dynamicDefault(field, slug string) (string, error) {
+	switch field {
+	case "chitin_db_path":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("user home: %w", err)
+		}
+		return filepath.Join(home, ".chitin", "kanban", slug, "kanban.db"), nil
+	}
+	return "", nil
 }
 
 func loadConfig(slug string) (map[string]string, error) {

--- a/go/execution-kernel/internal/boardconfig/boardconfig_test.go
+++ b/go/execution-kernel/internal/boardconfig/boardconfig_test.go
@@ -252,6 +252,65 @@ func TestResolveFieldDoesNotExpandTildeForNonPathFields(t *testing.T) {
 	}
 }
 
+func TestResolveFieldChitinDBPathDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("chitin", "chitin_db_path")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	want := filepath.Join(home, ".chitin", "kanban", "chitin", "kanban.db")
+	if got != want {
+		t.Fatalf("chitin_db_path = %q, want %q", got, want)
+	}
+}
+
+func TestResolveFieldChitinDBPathPerBoardSlug(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "readybench", `{"repo":"chitinhq/readybench","default_branch":"main","workspace_root":"~/workspace/readybench","kernel_bin":"chitin-kernel"}`)
+
+	got, err := ResolveField("readybench", "chitin_db_path")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	want := filepath.Join(home, ".chitin", "kanban", "readybench", "kanban.db")
+	if got != want {
+		t.Fatalf("chitin_db_path = %q, want %q", got, want)
+	}
+}
+
+func TestResolveFieldChitinDBPathExplicitConfigOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel","chitin_db_path":"/var/run/chitin/kanban-chitin.db"}`)
+
+	got, err := ResolveField("chitin", "chitin_db_path")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	if got != "/var/run/chitin/kanban-chitin.db" {
+		t.Fatalf("chitin_db_path = %q, want explicit override", got)
+	}
+}
+
+func TestResolveFieldChitinDBPathExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeBoardConfig(t, home, "chitin", `{"repo":"chitinhq/chitin","default_branch":"main","workspace_root":"~/workspace/chitin","kernel_bin":"chitin-kernel","chitin_db_path":"~/custom/kanban.db"}`)
+
+	got, err := ResolveField("chitin", "chitin_db_path")
+	if err != nil {
+		t.Fatalf("ResolveField: %v", err)
+	}
+	want := filepath.Join(home, "custom", "kanban.db")
+	if got != want {
+		t.Fatalf("chitin_db_path = %q, want %q", got, want)
+	}
+}
+
 func writeBoardConfig(t *testing.T, home, slug, raw string) {
 	t.Helper()
 	dir := filepath.Join(home, ".hermes", "kanban", "boards", slug)

--- a/go/execution-kernel/internal/kanban/migrate.go
+++ b/go/execution-kernel/internal/kanban/migrate.go
@@ -136,6 +136,53 @@ func copyTable(src, dest *sql.DB, table string) error {
 	return tx.Commit()
 }
 
+// RowCounts returns a map of table -> row count for every canonical
+// table. Missing tables map to 0.
+func RowCounts(db *sql.DB) (map[string]int, error) {
+	out := map[string]int{}
+	for _, table := range migrationTables {
+		cols, err := tableColumns(db, table)
+		if err != nil {
+			return nil, err
+		}
+		if len(cols) == 0 {
+			out[table] = 0
+			continue
+		}
+		var n int
+		if err := db.QueryRow("SELECT count(*) FROM " + table).Scan(&n); err != nil {
+			return nil, fmt.Errorf("count %s: %w", table, err)
+		}
+		out[table] = n
+	}
+	return out, nil
+}
+
+// VerifyCounts compares row counts table-by-table between two DBs and
+// returns an error listing every mismatch. nil means the two DBs
+// agree on every canonical table.
+func VerifyCounts(src, dest *sql.DB) error {
+	srcCounts, err := RowCounts(src)
+	if err != nil {
+		return fmt.Errorf("src: %w", err)
+	}
+	destCounts, err := RowCounts(dest)
+	if err != nil {
+		return fmt.Errorf("dest: %w", err)
+	}
+	var mismatches []string
+	for _, table := range migrationTables {
+		if srcCounts[table] != destCounts[table] {
+			mismatches = append(mismatches,
+				fmt.Sprintf("%s: src=%d dest=%d", table, srcCounts[table], destCounts[table]))
+		}
+	}
+	if len(mismatches) > 0 {
+		return fmt.Errorf("row-count mismatch: %s", strings.Join(mismatches, "; "))
+	}
+	return nil
+}
+
 // tableColumns returns the ordered column names of a table, or an
 // empty slice if the table doesn't exist.
 func tableColumns(db *sql.DB, table string) ([]string, error) {

--- a/go/execution-kernel/internal/kanban/migrate.go
+++ b/go/execution-kernel/internal/kanban/migrate.go
@@ -1,0 +1,156 @@
+package kanban
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+// migrationTables is the ordered list of tables we copy. Parent rows
+// before child rows so the order is friendly to any future FK
+// constraint, though SQLite doesn't enforce them by default.
+var migrationTables = []string{
+	"tasks",
+	"task_links",
+	"task_comments",
+	"task_events",
+	"task_runs",
+	"kanban_notify_subs",
+}
+
+// Migrate creates destPath (overwriting any existing DB at that path),
+// applies the canonical schema, then copies every row from srcPath
+// table-by-table. Only columns that exist in both source and
+// canonical schemas are copied; canonical-only columns get their
+// default value on the destination.
+//
+// Full refresh, not incremental sync — calling it twice produces a
+// destination that matches the source.
+func Migrate(srcPath, destPath string) error {
+	src, err := sql.Open("sqlite", "file:"+srcPath+"?mode=ro")
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer src.Close()
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir dest: %w", err)
+	}
+	if err := os.Remove(destPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove dest: %w", err)
+	}
+
+	dest, err := sql.Open("sqlite", destPath)
+	if err != nil {
+		return fmt.Errorf("open dest: %w", err)
+	}
+	defer dest.Close()
+
+	if err := ApplySchema(dest); err != nil {
+		return fmt.Errorf("apply schema: %w", err)
+	}
+
+	for _, table := range migrationTables {
+		if err := copyTable(src, dest, table); err != nil {
+			return fmt.Errorf("copy %s: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// copyTable reads every row from src.<table> and inserts into
+// dest.<table>, mapping by column name. Columns present in source
+// but not in dest are skipped; columns in dest but not in source
+// get the schema default.
+func copyTable(src, dest *sql.DB, table string) error {
+	srcCols, err := tableColumns(src, table)
+	if err != nil {
+		return fmt.Errorf("src columns: %w", err)
+	}
+	if len(srcCols) == 0 {
+		return nil
+	}
+	destCols, err := tableColumns(dest, table)
+	if err != nil {
+		return fmt.Errorf("dest columns: %w", err)
+	}
+	destSet := map[string]bool{}
+	for _, c := range destCols {
+		destSet[c] = true
+	}
+
+	var cols []string
+	for _, c := range srcCols {
+		if destSet[c] {
+			cols = append(cols, c)
+		}
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+
+	colList := strings.Join(cols, ", ")
+	rows, err := src.Query("SELECT " + colList + " FROM " + table)
+	if err != nil {
+		return fmt.Errorf("select: %w", err)
+	}
+	defer rows.Close()
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?, ", len(cols)), ", ")
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", table, colList, placeholders)
+
+	tx, err := dest.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	stmt, err := tx.Prepare(insertSQL)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("scan: %w", err)
+		}
+		if _, err := stmt.Exec(vals...); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("insert: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("rows: %w", err)
+	}
+	return tx.Commit()
+}
+
+// tableColumns returns the ordered column names of a table, or an
+// empty slice if the table doesn't exist.
+func tableColumns(db *sql.DB, table string) ([]string, error) {
+	rows, err := db.Query("SELECT name FROM pragma_table_info(?)", table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}

--- a/go/execution-kernel/internal/kanban/migrate_test.go
+++ b/go/execution-kernel/internal/kanban/migrate_test.go
@@ -167,3 +167,55 @@ func TestMigrateAcceptsReadybenchShapeWithoutBlockReason(t *testing.T) {
 		t.Errorf("block_reason: want NULL, got %q", blockReason.String)
 	}
 }
+
+func TestRowCountsReturnsPerTableCounts(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.db")
+	dest := filepath.Join(dir, "dest.db")
+	seedHermesChitinShape(t, src)
+	if err := Migrate(src, dest); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	srcDB, _ := sql.Open("sqlite", src)
+	defer srcDB.Close()
+	destDB, _ := sql.Open("sqlite", dest)
+	defer destDB.Close()
+
+	srcCounts, err := RowCounts(srcDB)
+	if err != nil {
+		t.Fatalf("src counts: %v", err)
+	}
+	destCounts, err := RowCounts(destDB)
+	if err != nil {
+		t.Fatalf("dest counts: %v", err)
+	}
+
+	for _, table := range migrationTables {
+		if srcCounts[table] != destCounts[table] {
+			t.Errorf("%s: src=%d dest=%d", table, srcCounts[table], destCounts[table])
+		}
+	}
+}
+
+func TestVerifyCountsReturnsMismatchAsError(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.db")
+	b := filepath.Join(dir, "b.db")
+	seedHermesChitinShape(t, a)
+	seedHermesChitinShape(t, b)
+	bDB, _ := sql.Open("sqlite", b)
+	if _, err := bDB.Exec("DELETE FROM tasks WHERE id='t_bbb'"); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+	bDB.Close()
+
+	aDB, _ := sql.Open("sqlite", a)
+	defer aDB.Close()
+	bDB2, _ := sql.Open("sqlite", b)
+	defer bDB2.Close()
+
+	if err := VerifyCounts(aDB, bDB2); err == nil {
+		t.Fatal("VerifyCounts: want mismatch error, got nil")
+	}
+}

--- a/go/execution-kernel/internal/kanban/migrate_test.go
+++ b/go/execution-kernel/internal/kanban/migrate_test.go
@@ -1,0 +1,86 @@
+package kanban
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// seedHermesChitinShape creates a DB matching the chitin hermes board
+// schema (the wider schema with block_reason etc.) and inserts a few
+// representative rows across the major tables.
+func seedHermesChitinShape(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(CanonicalSchema); err != nil {
+		t.Fatalf("seed schema: %v", err)
+	}
+	_, err = db.Exec(`
+		INSERT INTO tasks (id, title, status, created_at, block_reason)
+		VALUES
+			('t_aaa', 'first', 'ready', 1000, NULL),
+			('t_bbb', 'second', 'blocked', 1001, 'no_pr');
+		INSERT INTO task_events (task_id, kind, created_at)
+		VALUES ('t_aaa', 'created', 1000), ('t_aaa', 'promoted', 1010);
+		INSERT INTO task_comments (task_id, author, body, created_at)
+		VALUES ('t_aaa', 'red', 'a comment', 1005);
+		INSERT INTO task_links (parent_id, child_id)
+		VALUES ('t_aaa', 't_bbb');
+		INSERT INTO task_runs (task_id, status, started_at)
+		VALUES ('t_aaa', 'running', 1020);
+	`)
+	if err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+}
+
+func TestMigrateCopiesAllRowsFromChitinShape(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.db")
+	dest := filepath.Join(dir, "dest.db")
+	seedHermesChitinShape(t, src)
+
+	if err := Migrate(src, dest); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dest)
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
+	defer db.Close()
+
+	for _, tc := range []struct {
+		table string
+		want  int
+	}{
+		{"tasks", 2},
+		{"task_events", 2},
+		{"task_comments", 1},
+		{"task_links", 1},
+		{"task_runs", 1},
+	} {
+		var got int
+		if err := db.QueryRow("SELECT count(*) FROM " + tc.table).Scan(&got); err != nil {
+			t.Fatalf("count %s: %v", tc.table, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s rows: want %d, got %d", tc.table, tc.want, got)
+		}
+	}
+
+	var blockReason sql.NullString
+	if err := db.QueryRow("SELECT block_reason FROM tasks WHERE id='t_bbb'").Scan(&blockReason); err != nil {
+		t.Fatalf("select block_reason: %v", err)
+	}
+	if !blockReason.Valid || blockReason.String != "no_pr" {
+		t.Errorf("block_reason: want 'no_pr', got %v", blockReason)
+	}
+}

--- a/go/execution-kernel/internal/kanban/migrate_test.go
+++ b/go/execution-kernel/internal/kanban/migrate_test.go
@@ -84,3 +84,86 @@ func TestMigrateCopiesAllRowsFromChitinShape(t *testing.T) {
 		t.Errorf("block_reason: want 'no_pr', got %v", blockReason)
 	}
 }
+
+// seedHermesReadybenchShape creates a DB matching the readybench
+// hermes board schema (narrower — no block_reason etc.) and inserts
+// representative rows.
+func seedHermesReadybenchShape(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`
+		CREATE TABLE tasks (
+			id                   TEXT PRIMARY KEY,
+			title                TEXT NOT NULL,
+			body                 TEXT,
+			assignee             TEXT,
+			status               TEXT NOT NULL,
+			priority             INTEGER DEFAULT 0,
+			created_by           TEXT,
+			created_at           INTEGER NOT NULL,
+			started_at           INTEGER,
+			completed_at         INTEGER,
+			workspace_kind       TEXT NOT NULL DEFAULT 'scratch',
+			workspace_path       TEXT,
+			claim_lock           TEXT,
+			claim_expires        INTEGER,
+			tenant               TEXT,
+			result               TEXT,
+			idempotency_key      TEXT,
+			spawn_failures       INTEGER NOT NULL DEFAULT 0,
+			worker_pid           INTEGER,
+			last_spawn_error     TEXT,
+			max_runtime_seconds  INTEGER,
+			last_heartbeat_at    INTEGER,
+			current_run_id       INTEGER,
+			workflow_template_id TEXT,
+			current_step_key     TEXT,
+			skills               TEXT,
+			consecutive_failures INTEGER NOT NULL DEFAULT 0,
+			last_failure_error   TEXT,
+			max_retries          INTEGER
+		);
+		INSERT INTO tasks (id, title, status, created_at)
+		VALUES ('t_rb1', 'rb only', 'ready', 2000);
+	`)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestMigrateAcceptsReadybenchShapeWithoutBlockReason(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "rb.db")
+	dest := filepath.Join(dir, "rb-chitin.db")
+	seedHermesReadybenchShape(t, src)
+
+	if err := Migrate(src, dest); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dest)
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRow("SELECT count(*) FROM tasks").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("tasks: want 1, got %d", count)
+	}
+
+	var blockReason sql.NullString
+	if err := db.QueryRow("SELECT block_reason FROM tasks WHERE id='t_rb1'").Scan(&blockReason); err != nil {
+		t.Fatalf("block_reason: %v", err)
+	}
+	if blockReason.Valid {
+		t.Errorf("block_reason: want NULL, got %q", blockReason.String)
+	}
+}

--- a/go/execution-kernel/internal/kanban/schema.go
+++ b/go/execution-kernel/internal/kanban/schema.go
@@ -1,0 +1,125 @@
+package kanban
+
+import "database/sql"
+
+// CanonicalSchema is the union of the chitin and readybench hermes
+// kanban schemas. Applied to a chitin-owned DB it must accept rows
+// migrated from either board verbatim. Indexes match hermes so query
+// patterns carry over unchanged.
+const CanonicalSchema = `
+CREATE TABLE IF NOT EXISTS tasks (
+    id                   TEXT PRIMARY KEY,
+    title                TEXT NOT NULL,
+    body                 TEXT,
+    assignee             TEXT,
+    status               TEXT NOT NULL,
+    priority             INTEGER DEFAULT 0,
+    created_by           TEXT,
+    created_at           INTEGER NOT NULL,
+    started_at           INTEGER,
+    completed_at         INTEGER,
+    workspace_kind       TEXT NOT NULL DEFAULT 'scratch',
+    workspace_path       TEXT,
+    claim_lock           TEXT,
+    claim_expires        INTEGER,
+    tenant               TEXT,
+    result               TEXT,
+    idempotency_key      TEXT,
+    spawn_failures       INTEGER NOT NULL DEFAULT 0,
+    worker_pid           INTEGER,
+    last_spawn_error     TEXT,
+    max_runtime_seconds  INTEGER,
+    last_heartbeat_at    INTEGER,
+    current_run_id       INTEGER,
+    workflow_template_id TEXT,
+    current_step_key     TEXT,
+    skills               TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    last_failure_error   TEXT,
+    max_retries          INTEGER,
+    block_reason         TEXT DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_links (
+    parent_id  TEXT NOT NULL,
+    child_id   TEXT NOT NULL,
+    PRIMARY KEY (parent_id, child_id)
+);
+
+CREATE TABLE IF NOT EXISTS task_comments (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT NOT NULL,
+    run_id     INTEGER,
+    kind       TEXT NOT NULL,
+    payload    TEXT,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_runs (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id             TEXT NOT NULL,
+    profile             TEXT,
+    step_key            TEXT,
+    status              TEXT NOT NULL,
+    claim_lock          TEXT,
+    claim_expires       INTEGER,
+    worker_pid          INTEGER,
+    max_runtime_seconds INTEGER,
+    last_heartbeat_at   INTEGER,
+    started_at          INTEGER NOT NULL,
+    ended_at            INTEGER,
+    outcome             TEXT,
+    summary             TEXT,
+    metadata            TEXT,
+    error               TEXT,
+    driver_id           TEXT,
+    repo_sha            TEXT,
+    lease_id            TEXT,
+    event_chain_hash    TEXT,
+    idempotency_key     TEXT,
+    model               TEXT NOT NULL DEFAULT '',
+    soul_id             TEXT NOT NULL DEFAULT '',
+    soul_hash           TEXT NOT NULL DEFAULT '',
+    agent_fingerprint   TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS kanban_notify_subs (
+    task_id          TEXT NOT NULL,
+    platform         TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    thread_id        TEXT NOT NULL DEFAULT '',
+    user_id          TEXT,
+    notifier_profile TEXT,
+    created_at       INTEGER NOT NULL,
+    last_event_id    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
+CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_tenant          ON tasks(tenant);
+CREATE INDEX IF NOT EXISTS idx_tasks_idempotency     ON tasks(idempotency_key);
+CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
+CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
+CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_run            ON task_events(run_id, id);
+CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
+CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+`
+
+// ApplySchema creates the canonical kanban tables and indexes if they
+// don't already exist. Idempotent.
+func ApplySchema(db *sql.DB) error {
+	_, err := db.Exec(CanonicalSchema)
+	return err
+}

--- a/go/execution-kernel/internal/kanban/schema_test.go
+++ b/go/execution-kernel/internal/kanban/schema_test.go
@@ -1,0 +1,114 @@
+package kanban
+
+import (
+	"database/sql"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestApplySchemaCreatesAllCanonicalTables(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if err := ApplySchema(db); err != nil {
+		t.Fatalf("ApplySchema: %v", err)
+	}
+
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+	if err != nil {
+		t.Fatalf("query tables: %v", err)
+	}
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, n)
+	}
+
+	want := []string{
+		"kanban_notify_subs",
+		"task_comments",
+		"task_events",
+		"task_links",
+		"task_runs",
+		"tasks",
+	}
+	sort.Strings(got)
+	if len(got) != len(want) {
+		t.Fatalf("tables: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("tables[%d]: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestApplySchemaIncludesUnionColumnsOnTasks(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if err := ApplySchema(db); err != nil {
+		t.Fatalf("ApplySchema: %v", err)
+	}
+
+	rows, err := db.Query("SELECT name FROM pragma_table_info('tasks')")
+	if err != nil {
+		t.Fatalf("query pragma: %v", err)
+	}
+	defer rows.Close()
+
+	cols := map[string]bool{}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		cols[n] = true
+	}
+
+	required := []string{
+		"id", "title", "body", "assignee", "status",
+		"block_reason", "consecutive_failures", "last_failure_error", "max_retries",
+		"skills", "current_run_id", "workflow_template_id", "current_step_key",
+	}
+	for _, c := range required {
+		if !cols[c] {
+			t.Errorf("tasks missing union column %q", c)
+		}
+	}
+}
+
+func TestApplySchemaIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if err := ApplySchema(db); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if err := ApplySchema(db); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

First slice of the chitin-owned kanban migration. Stands up `~/.chitin/kanban/<board>/kanban.db` as a verified mirror of the hermes kanban DBs, with a one-shot CLI to refresh it. Hermes remains source of truth — no cutover, no writes, no cron changes.

- New `internal/kanban` package: canonical union schema (chitin + readybench shapes), `Migrate(src, dest)` with column-intersection fallback, `RowCounts` + `VerifyCounts` helpers
- New `boardconfig` field `chitin_db_path` with per-slug default (`~/.chitin/kanban/<slug>/kanban.db`), tilde-expanded, overridable via config or `KANBAN_BOARD_CHITIN_DB_PATH`
- New `chitin-kernel kanban migrate <board>` subcommand — exit codes match the `board-config` precedent (0 ok, 1 migrate/verify fail, 2 args/missing-source, 3 unknown board)
- Live verification: migrated chitin (372 tasks, 9277 events, 3595 comments, 514 runs) and readybench (8 tasks, 266+ events, 119+ comments) — row counts cross-checked, known rows spot-verified (e.g. `t_8f4d2ee5` tracking epic preserved verbatim including `block_reason`)

Follow-up plans (separate PRs, not in this one):
- **Plan 2:** Console-api cutover — point reads at the chitin layout
- **Plan 3:** Write surface — kanban CRUD endpoints in console-api
- **Plan 4:** Retire hermes' DB as source of truth (cron-safe rollout)

Strategy ref: `docs/decisions/2026-05-13-swarm-readopted-composing-substrates.md` (chitin composes hermes + openclaw substrates) — this is the data-layer half of that boundary moving home.

Plan doc: `docs/superpowers/plans/2026-05-15-chitin-kanban-db-foundation.md`

## Test plan

- [x] Unit tests in `internal/kanban` (7 tests, schema + migration + verify)
- [x] Unit tests in `internal/boardconfig` (4 new tests for `chitin_db_path`)
- [x] CLI integration tests in `cmd/chitin-kernel` (4 tests covering happy path, unknown board, missing source, no subcommand)
- [x] Live migration smoke on both boards, row counts match post-migration
- [ ] Reviewer: confirm column-intersection logic handles any other source-shape drift you've seen
- [ ] Reviewer: confirm `~/.chitin/kanban/` is the right destination root (vs `~/.chitin/data/kanban/` or similar)

Pre-existing test failures in `internal/gov` and `cmd/chitin-kernel` related to `policy_signature_missing` / `chitin.yaml.sig` are unrelated to this branch (verified by stashing and re-running on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)