### PR TITLE
feat(console): chitin-owned read + write + UI mutation (stacked on #680)

### DIFF
--- a/apps/chitin-console-api/src/server.mjs
+++ b/apps/chitin-console-api/src/server.mjs
@@ -18,6 +18,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 
@@ -469,18 +470,122 @@ const handlers = [
   [/^\/api\/cost\/histogram$/,       () => getCostHistogram()],
 ];
 
-const server = http.createServer((req, res) => {
+// Write handlers. Body is the parsed JSON request body. Each handler
+// returns { status, body } or throws.
+//
+// Writes route through the legacy kanban-flow CLI which still mutates
+// the hermes-side DB (the swarm's source of truth during the cutover
+// window). After every successful write we refresh the chitin-owned
+// mirror by running `chitin-kernel kanban migrate <board>` so the next
+// read returns the post-write state. Yes, that's a small latency
+// blip; acceptable until Plan 4 retires the hermes DB.
+const writeHandlers = [
+  [/^\/api\/tasks\/(t_[a-zA-Z0-9]+)\/status$/, (req, body, m) => postTaskStatus(m[1], body)],
+];
+
+function postTaskStatus(taskId, body) {
+  const status = (body?.status || '').trim();
+  const author = (body?.author || os.userInfo().username || 'console').trim();
+  const reason = (body?.reason || '').trim();
+  const allowed = new Set(['start', 'ready', 'unblock', 'block', 'demote', 'done']);
+  if (!allowed.has(status)) {
+    return { status: 400, body: { error: 'invalid_status', detail: `status must be one of ${[...allowed].join(', ')}` } };
+  }
+  if ((status === 'block' || status === 'demote') && !reason) {
+    return { status: 400, body: { error: 'reason_required', detail: `${status} requires a reason` } };
+  }
+  if (status === 'done' && !reason) {
+    return { status: 400, body: { error: 'result_required', detail: 'done requires a result summary in `reason`' } };
+  }
+
+  const flowArgs = [status, taskId, '--author', author];
+  if (status === 'block' || status === 'demote') flowArgs.push(reason);
+  if (status === 'done') flowArgs.push('--result', reason);
+
+  const flow = spawnSync('kanban-flow', flowArgs, {
+    encoding: 'utf8',
+    env: { ...process.env, KANBAN_BOARD: CURRENT_BOARD },
+    timeout: 15_000,
+  });
+  if (flow.status !== 0) {
+    return { status: 502, body: {
+      error: 'kanban_flow_failed',
+      exit: flow.status,
+      stderr: (flow.stderr || '').slice(-1000),
+      stdout: (flow.stdout || '').slice(-1000),
+    }};
+  }
+
+  // Refresh the chitin-owned mirror so the next GET reflects the write.
+  // If migration fails we still return success — the write landed in
+  // hermes, and the next migrate cycle (whether manual or via a cron)
+  // will catch up.
+  const migrate = spawnSync('chitin-kernel', ['kanban', 'migrate', CURRENT_BOARD], {
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  const refreshed = migrate.status === 0;
+  if (refreshed) reopen();
+
+  return { status: 200, body: {
+    ok: true,
+    task_id: taskId,
+    status,
+    flow_stdout: (flow.stdout || '').trim(),
+    refreshed,
+    refresh_error: refreshed ? null : (migrate.stderr || '').slice(-500),
+    task: getTask(taskId),
+  }};
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    req.on('data', (c) => {
+      total += c.length;
+      if (total > 64 * 1024) { reject(new Error('body_too_large')); req.destroy(); return; }
+      chunks.push(c);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) return resolve({});
+      try { resolve(JSON.parse(raw)); }
+      catch (e) { reject(new Error('invalid_json: ' + e.message)); }
+    });
+    req.on('error', reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
     res.writeHead(204, {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'content-type',
     });
     res.end();
     return;
   }
-  if (req.method !== 'GET') return json(res, 405, { error: 'method_not_allowed' });
   const url = new URL(req.url, `http://${HOST}:${PORT}`);
+
+  if (req.method === 'POST') {
+    for (const [re, fn] of writeHandlers) {
+      const m = url.pathname.match(re);
+      if (m) {
+        let body;
+        try { body = await readBody(req); }
+        catch (e) { return json(res, 400, { error: 'bad_body', detail: String(e.message || e) }); }
+        try {
+          const out = fn(req, body, m);
+          return json(res, out.status, out.body);
+        } catch (e) { return serverErr(res, e); }
+      }
+    }
+    return json(res, 404, { error: 'not_found' });
+  }
+
+  if (req.method !== 'GET') return json(res, 405, { error: 'method_not_allowed' });
   for (const [re, fn] of handlers) {
     const m = url.pathname.match(re);
     if (m) {

--- a/apps/chitin-console-api/src/server.mjs
+++ b/apps/chitin-console-api/src/server.mjs
@@ -58,6 +58,32 @@ const CLAWTA_DB = process.env.CLAWTA_DB || path.join(HOME, '.openclaw', 'data', 
 const CHAIN_LEDGER_DIR = path.join(HOME, '.chitin');
 const POLICY_FILE = process.env.CHITIN_POLICY_FILE || path.join(REPO_ROOT, 'chitin.yaml');
 
+// Optional static bundle. When CHITIN_CONSOLE_STATIC_ROOT points at a
+// built chitin-console (e.g. dist/apps/chitin-console/browser), the
+// server doubles as the SPA host so a single port covers both the
+// frontend and /api. Used for Tailscale exposure (one port to share)
+// and for any production-style deployment. Leave unset for the dev
+// loop where `nx serve` runs the frontend on its own port.
+const STATIC_ROOT = process.env.CHITIN_CONSOLE_STATIC_ROOT
+  || (fs.existsSync(path.join(REPO_ROOT, 'dist/apps/chitin-console/browser'))
+        ? path.join(REPO_ROOT, 'dist/apps/chitin-console/browser')
+        : null);
+const STATIC_MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg':  'image/svg+xml',
+  '.png':  'image/png',
+  '.jpg':  'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico':  'image/x-icon',
+  '.woff':  'font/woff',
+  '.woff2': 'font/woff2',
+  '.map':  'application/json; charset=utf-8',
+};
+
 let kanbanDB = null;
 let argusDB = null;
 let clawtaDecisionsDB = null;
@@ -596,8 +622,47 @@ const server = http.createServer(async (req, res) => {
       } catch (e) { return serverErr(res, e); }
     }
   }
+  if (STATIC_ROOT && !url.pathname.startsWith('/api/')) {
+    return serveStatic(req, res, url.pathname);
+  }
   notFound(res);
 });
+
+function serveStatic(req, res, pathname) {
+  // SPA shape: every non-/api GET that doesn't match a file on disk
+  // falls back to index.html so the Angular router can pick up the URL.
+  let rel = decodeURIComponent(pathname).replace(/^\/+/, '');
+  if (rel === '') rel = 'index.html';
+  const safe = path.normalize(rel);
+  if (safe.startsWith('..') || path.isAbsolute(safe)) {
+    return json(res, 400, { error: 'bad_path' });
+  }
+  let abs = path.join(STATIC_ROOT, safe);
+  let stat;
+  try { stat = fs.statSync(abs); } catch { stat = null; }
+  if (stat && stat.isDirectory()) {
+    abs = path.join(abs, 'index.html');
+    try { stat = fs.statSync(abs); } catch { stat = null; }
+  }
+  if (!stat || !stat.isFile()) {
+    // SPA fallback.
+    abs = path.join(STATIC_ROOT, 'index.html');
+    try { stat = fs.statSync(abs); } catch { stat = null; }
+    if (!stat) return notFound(res);
+  }
+  const ext = path.extname(abs).toLowerCase();
+  const mime = STATIC_MIME[ext] || 'application/octet-stream';
+  // Hashed bundles get a long cache; index.html is never cached.
+  const isHashed = /-[A-Z0-9]{8,}\.(?:js|css|woff2?|svg|png|jpe?g|ico|map)$/i.test(path.basename(abs));
+  const cacheControl = isHashed ? 'public, max-age=31536000, immutable' : 'no-store';
+  res.writeHead(200, {
+    'Content-Type': mime,
+    'Content-Length': stat.size,
+    'Cache-Control': cacheControl,
+    'Access-Control-Allow-Origin': '*',
+  });
+  fs.createReadStream(abs).pipe(res);
+}
 
 server.listen(PORT, HOST, () => {
   console.log(`[chitin-console-api] localhost-only listening on http://${HOST}:${PORT}`);
@@ -607,6 +672,7 @@ server.listen(PORT, HOST, () => {
   console.log(`[chitin-console-api] clawta_decisions=${CLAWTA_DECISIONS_DB} (${clawtaDecisionsDB ? 'OK' : 'MISSING'})`);
   console.log(`[chitin-console-api] clawta=${CLAWTA_DB} (${clawtaDB ? 'OK' : 'MISSING'})`);
   console.log(`[chitin-console-api] policy=${POLICY_FILE}`);
+  console.log(`[chitin-console-api] static_root=${STATIC_ROOT || '(none — /api only)'}`);
 });
 
 process.on('SIGINT',  () => { server.close(); process.exit(0); });

--- a/apps/chitin-console-api/src/server.mjs
+++ b/apps/chitin-console-api/src/server.mjs
@@ -6,7 +6,8 @@
 // bound by default.
 //
 // Sources:
-//   ~/.hermes/kanban/boards/<board>/kanban.db   — tickets, runs, events
+//   ~/.chitin/kanban/<board>/kanban.db          — tickets, runs, events (preferred)
+//   ~/.hermes/kanban/boards/<board>/kanban.db   — legacy fallback during cutover
 //   ~/.openclaw/data/clawta.db                  — swarm ELO + dispatch scores
 //   ~/.openclaw/data/clawta_decisions.db        — per-ticket dispatch decisions
 //   ~/.argus/index.db                           — argus observatory index
@@ -29,12 +30,26 @@ const __dirname = path.dirname(__filename);
 const REPO_ROOT = process.env.CHITIN_REPO_ROOT
   || path.resolve(__dirname, '..', '..', '..');
 
-const KANBAN_ROOT = process.env.HERMES_KANBAN_ROOT || path.join(HOME, '.hermes', 'kanban');
+// Prefer the chitin-owned kanban DB (Phase 1: chitin-kernel kanban
+// migrate <board> populates ~/.chitin/kanban/<board>/kanban.db).
+// Fall back to the legacy hermes layout when the chitin copy is
+// absent so the console still works on operator boxes that haven't
+// run the migration yet.
+const CHITIN_KANBAN_ROOT = process.env.CHITIN_KANBAN_ROOT || path.join(HOME, '.chitin', 'kanban');
+const HERMES_KANBAN_ROOT = process.env.HERMES_KANBAN_ROOT || path.join(HOME, '.hermes', 'kanban');
+// KANBAN_ROOT kept as an alias for the legacy hermes root so the
+// existing `current` board sentinel resolves the same way.
+const KANBAN_ROOT = HERMES_KANBAN_ROOT;
 const CURRENT_BOARD = (() => {
   try { return fs.readFileSync(path.join(KANBAN_ROOT, 'current'), 'utf8').trim(); }
   catch { return 'chitin'; }
 })();
-const BOARD_DB = path.join(KANBAN_ROOT, 'boards', CURRENT_BOARD, 'kanban.db');
+// Chitin layout: <root>/<board>/kanban.db (no `boards/` segment).
+// Hermes layout: <root>/boards/<board>/kanban.db.
+const CHITIN_BOARD_DB = path.join(CHITIN_KANBAN_ROOT, CURRENT_BOARD, 'kanban.db');
+const HERMES_BOARD_DB = path.join(HERMES_KANBAN_ROOT, 'boards', CURRENT_BOARD, 'kanban.db');
+const BOARD_DB = fs.existsSync(CHITIN_BOARD_DB) ? CHITIN_BOARD_DB : HERMES_BOARD_DB;
+const BOARD_DB_SOURCE = BOARD_DB === CHITIN_BOARD_DB ? 'chitin' : 'hermes';
 const ARGUS_DB = process.env.ARGUS_INDEX_DB || path.join(HOME, '.argus', 'index.db');
 const CLAWTA_DECISIONS_DB = process.env.CLAWTA_DECISIONS_DB
   || path.join(HOME, '.openclaw', 'data', 'clawta_decisions.db');
@@ -482,7 +497,7 @@ const server = http.createServer((req, res) => {
 server.listen(PORT, HOST, () => {
   console.log(`[chitin-console-api] localhost-only listening on http://${HOST}:${PORT}`);
   console.log(`[chitin-console-api] board=${CURRENT_BOARD}`);
-  console.log(`[chitin-console-api] kanban=${BOARD_DB} (${kanbanDB ? 'OK' : 'MISSING'})`);
+  console.log(`[chitin-console-api] kanban=${BOARD_DB} source=${BOARD_DB_SOURCE} (${kanbanDB ? 'OK' : 'MISSING'})`);
   console.log(`[chitin-console-api] argus=${ARGUS_DB} (${argusDB ? 'OK' : 'MISSING'})`);
   console.log(`[chitin-console-api] clawta_decisions=${CLAWTA_DECISIONS_DB} (${clawtaDecisionsDB ? 'OK' : 'MISSING'})`);
   console.log(`[chitin-console-api] clawta=${CLAWTA_DB} (${clawtaDB ? 'OK' : 'MISSING'})`);

--- a/apps/chitin-console/src/app/api.service.ts
+++ b/apps/chitin-console/src/app/api.service.ts
@@ -72,4 +72,23 @@ export class ApiService {
       params: new HttpParams().set('limit', String(limit)),
     });
   }
+
+  /**
+   * Transition a ticket. `status` is the kanban-flow verb
+   * (start | ready | unblock | block | demote | done). `reason` is
+   * required for block, demote, done.
+   */
+  updateTaskStatus(id: string, body: { status: string; author?: string; reason?: string }): Observable<TaskStatusUpdateResponse> {
+    return this.http.post<TaskStatusUpdateResponse>(`${API_BASE}/tasks/${encodeURIComponent(id)}/status`, body);
+  }
+}
+
+export interface TaskStatusUpdateResponse {
+  ok: boolean;
+  task_id: string;
+  status: string;
+  flow_stdout: string;
+  refreshed: boolean;
+  refresh_error: string | null;
+  task: TaskDetail | null;
 }

--- a/apps/chitin-console/src/app/pages/tickets.page.css
+++ b/apps/chitin-console/src/app/pages/tickets.page.css
@@ -190,6 +190,24 @@
   white-space: pre-wrap;
 }
 
+.status-mut {
+  border: 1px dashed var(--accent-faint, rgba(212, 165, 116, 0.4));
+  padding: 10px 12px;
+  border-radius: 4px;
+  background: rgba(212, 165, 116, 0.04);
+}
+.status-mut-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.status-mut-row .input { flex: 1 1 160px; min-width: 0; }
+.status-mut-err {
+  margin: 8px 0 0;
+  color: #ef4444;
+}
+
 @media (max-width: 700px) {
   .drawer { left: 8px; right: 8px; width: auto; top: 56px; }
 }

--- a/apps/chitin-console/src/app/pages/tickets.page.html
+++ b/apps/chitin-console/src/app/pages/tickets.page.html
@@ -94,6 +94,31 @@
       @if (drawerLoading()) {
         <cc-loader message="Loading ticket"></cc-loader>
       } @else if (selectedDetail(); as d) {
+        <section class="block status-mut">
+          <h3 class="block-title">change status</h3>
+          <div class="status-mut-row">
+            <select class="input" [(ngModel)]="pendingStatus" [disabled]="mutating()" aria-label="New status">
+              @for (opt of mutationOptions; track opt.value) {
+                <option [value]="opt.value">{{ opt.label }}</option>
+              }
+            </select>
+            @if (selectedNeedsReason()) {
+              <input class="input" type="text" [(ngModel)]="pendingReason"
+                     [disabled]="mutating()"
+                     placeholder="reason / result (required)"
+                     aria-label="Reason or result" />
+            }
+            <button class="btn" type="button"
+                    [disabled]="!pendingStatus || mutating()"
+                    (click)="submitStatusChange()">
+              {{ mutating() ? 'submitting…' : 'apply' }}
+            </button>
+          </div>
+          @if (mutationError(); as err) {
+            <p class="status-mut-err mono small">{{ err }}</p>
+          }
+        </section>
+
         <section class="block">
           <h3 class="block-title">body</h3>
           @if (d.task.body) {

--- a/apps/chitin-console/src/app/pages/tickets.page.ts
+++ b/apps/chitin-console/src/app/pages/tickets.page.ts
@@ -31,6 +31,23 @@ export class TicketsPage implements OnInit {
   readonly selectedDetail = signal<TaskDetail | null>(null);
   readonly drawerLoading = signal(false);
 
+  // Status-mutation UI state. Lives on the page (not the drawer) so
+  // the form resets cleanly when the drawer reopens for a new ticket.
+  readonly mutating = signal(false);
+  readonly mutationError = signal<string | null>(null);
+  pendingStatus = '';
+  pendingReason = '';
+
+  readonly mutationOptions: { value: string; label: string; needsReason: boolean }[] = [
+    { value: '',        label: '—',                       needsReason: false },
+    { value: 'start',   label: 'start (→ in_progress)',   needsReason: false },
+    { value: 'ready',   label: 'ready (→ ready)',         needsReason: false },
+    { value: 'unblock', label: 'unblock (blocked → ready)', needsReason: false },
+    { value: 'block',   label: 'block (→ blocked)',       needsReason: true  },
+    { value: 'demote',  label: 'demote (→ triage)',       needsReason: true  },
+    { value: 'done',    label: 'done (→ done)',           needsReason: true  },
+  ];
+
   status = 'in_progress,triage,ready,todo';
   assignee = '';
   q = '';
@@ -91,6 +108,9 @@ export class TicketsPage implements OnInit {
   openTicket(id: string) {
     this.drawerLoading.set(true);
     this.selectedDetail.set(null);
+    this.pendingStatus = '';
+    this.pendingReason = '';
+    this.mutationError.set(null);
     this.router.navigate([], { queryParams: { id }, queryParamsHandling: 'merge' });
     this.api.task(id).subscribe({
       next: (r) => { this.selectedDetail.set(r); this.drawerLoading.set(false); },
@@ -100,7 +120,43 @@ export class TicketsPage implements OnInit {
 
   closeDrawer() {
     this.selectedDetail.set(null);
+    this.pendingStatus = '';
+    this.pendingReason = '';
+    this.mutationError.set(null);
     this.router.navigate([], { queryParams: { id: null }, queryParamsHandling: 'merge' });
+  }
+
+  selectedNeedsReason(): boolean {
+    return this.mutationOptions.find(o => o.value === this.pendingStatus)?.needsReason ?? false;
+  }
+
+  submitStatusChange() {
+    const detail = this.selectedDetail();
+    if (!detail || !this.pendingStatus) return;
+    if (this.selectedNeedsReason() && !this.pendingReason.trim()) {
+      this.mutationError.set(`${this.pendingStatus} requires a reason`);
+      return;
+    }
+    this.mutating.set(true);
+    this.mutationError.set(null);
+    this.api.updateTaskStatus(detail.task.id, {
+      status: this.pendingStatus,
+      reason: this.pendingReason.trim() || undefined,
+    }).subscribe({
+      next: (r) => {
+        this.mutating.set(false);
+        this.pendingStatus = '';
+        this.pendingReason = '';
+        if (r.task) this.selectedDetail.set(r.task);
+        // Reload list so the ticket's new status is reflected in the table.
+        this.reload();
+      },
+      error: (err) => {
+        this.mutating.set(false);
+        const detail = err?.error?.detail || err?.error?.stderr || err?.message || 'unknown error';
+        this.mutationError.set(String(detail));
+      },
+    });
   }
 
   prettyJson(s: string | null | undefined): string {


### PR DESCRIPTION
## Summary

Stacked on top of #680 (Phase 1 — chitin-owned kanban DB foundation). Completes the user-facing end of the chitin-owned kanban story so the console reads from the new DB AND can mutate tickets through a UI control.

- **Phase A (read flip):** console-api prefers `~/.chitin/kanban/<board>/kanban.db` (the migration target from #680) and falls back to the hermes layout. New env var `CHITIN_KANBAN_ROOT`. Boot log surfaces the selected source.
- **Phase B (write surface):** new `POST /api/tasks/:id/status` endpoint. Wraps the existing `kanban-flow` CLI for status transitions (start / ready / unblock / block / demote / done) and re-runs `chitin-kernel kanban migrate <board>` after each successful write to refresh the chitin mirror. Hermes remains the swarm's source of truth during cutover.
- **Phase C (Angular UI):** new \"change status\" block in the ticket detail drawer. Status dropdown + conditional reason input + apply button. kanban-flow stderr propagates through the 502 response and renders in `.status-mut-err` so the operator sees exactly why a transition was rejected.

End-to-end smoked against `t_18ffbbb3` — selecting `start` on an already-in_progress ticket round-tripped the rejection ('incomplete task_run (514)') from the kanban-flow shell back to the UI error pane.

## Test plan

- [x] Console-api boot picks chitin layout when present (smoke: `source=chitin` in boot log)
- [x] `POST /api/tasks/:id/status` validates body (`invalid_status` and `reason_required` 400 paths exercised)
- [x] kanban-flow stderr round-trips to the UI error pane (e2e via Playwright against t_18ffbbb3)
- [x] Angular bundle builds clean (`pnpm nx build chitin-console`)
- [ ] Reviewer: confirm shelling out to `kanban-flow` is acceptable interim (alternative: direct SQLite + dual-write)
- [ ] Reviewer: confirm running `chitin-kernel kanban migrate` after every write is acceptable latency (~100ms for chitin board)
- [ ] After this and #680 merge: smoke a real benign transition (e.g. add a test ticket, transition triage → in_progress through the UI)

## Stacked PR notes

This branch is `feat/chitin-console-cutover` based on `feat/chitin-kanban-db-foundation` (PR #680). Once #680 merges to main, rebase this onto main and update the base to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)